### PR TITLE
Fix curse weapon bgf.

### DIFF
--- a/kod/object/passive/spell/cursewp.kod
+++ b/kod/object/passive/spell/cursewp.kod
@@ -22,7 +22,7 @@ resources:
    
    
    curseweapon_name_rsc = "curse weapon"
-   curseweapon_icon_rsc = iunholyw.bgf
+   curseweapon_icon_rsc = icurswpn.bgf
    curseweapon_desc_rsc = \
       "Makes the target weapon nearly ineffective for a time, "
       "and curses the user to wield it until he or she gains "


### PR DESCRIPTION
Unholy Weapon bgf is used for curse weapon.
