### PR TITLE
[Fix] Enfeeble Duration

### DIFF
--- a/kod/object/passive/spell/enfeeble.kod
+++ b/kod/object/passive/spell/enfeeble.kod
@@ -129,7 +129,7 @@ messages:
       }
       
       Send(oPalsy,@MakeSick,#who=oTarget,#iAmount=(iSpellPower/3+1),
-           #duration=send(self,@GetDuration,#iSpellPower=iSpellPower));
+           #iDuration=send(self,@GetDuration,#iSpellPower=iSpellPower));
            
       propagate;
    }


### PR DESCRIPTION
Currently enfeeble uses the fixed duration found in 
.\kod\object\passive\sickness\disease\palsy.kod

PALSY_DURATION=600000 (10 mins).

This will fix the duration set by the spell.
