### PR TITLE
[Fix] Dement Duration

### DIFF
--- a/kod/object/passive/spell/dement.kod
+++ b/kod/object/passive/spell/dement.kod
@@ -129,7 +129,7 @@ messages:
       }
       
       Send(oDementia,@MakeSick,#who=oTarget,#iAmount=(iSpellPower/3+1),
-           #duration=send(self,@GetDuration,#iSpellPower=iSpellPower));
+           #iDuration=send(self,@GetDuration,#iSpellPower=iSpellPower));
 
       propagate;
    }


### PR DESCRIPTION
Currently dement uses the fixed duration found in 
.\kod\object\passive\sickness\disease\dementia.kod

DEMENTIA_DURATION=600000 (10 mins).

This will fix the duration set by the spell.
