### PR TITLE
[Fix] BondedPlayer = to incorrect index number

### DIFF
--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -392,7 +392,7 @@ messages:
       {
          lData = Send(self,@GetAttributeData,#ItemAtt=IA_BONDED);
          Send(Send(SYS,@FindSpellByNum,#num=SID_BOND),@BondedItemReport,
-              #BondedItem=self,#BondedPlayer=Nth(lData,3),
+              #BondedItem=self,#BondedPlayer=Nth(lData,2),
               #BondedItemOwner=what);
       }      
 


### PR DESCRIPTION
In case BondItemReport is used in the future. This is the fix.

Index 2 is equal to oPlayer.
