### PR TITLE
Preventing denial from killing you

### DIFF
--- a/kod/object/passive/spell/persench/denial.kod
+++ b/kod/object/passive/spell/persench/denial.kod
@@ -122,7 +122,7 @@ messages:
       
          if send(who,@GetHealth) < 1
 	      {
-	         send(who,@Killed,#what=who);
+	         send(who,@GainHealthNormal,#amount=1);
 	      }
       }
       


### PR DESCRIPTION
Making denial killing you if it goes off and you have less then 1 hp makes this spell useless and people barley use it, making it not kill you might actually make it useful for players.
One cast of dispel illusion or purge can kill you, it is a level 4 spell and should be a bit more useful and not making people scared of using it.
