### PR TITLE
Show colors of murderers & outlaws in "Who's online list"

### DIFF
--- a/clientd3d/ownerdrw.c
+++ b/clientd3d/ownerdrw.c
@@ -421,16 +421,11 @@ void DrawOwnerListItem(const DRAWITEMSTRUCT *lpdis, Bool selected, Bool combo)
 
    SelectObject(lpdis->hDC, GetFont(FONT_LIST));
 
-	if (style & OD_COLORTEXT)
-	{		
-
-		// get the color we'd prefer for this particular obj
-		if (style & OD_COLORTEXT)
-			crColorText = GetPlayerNameColor(obj->flags,NULL);
-	}
-
    if (style & OD_COLORTEXT)
    {
+   	// get the color we'd prefer for this particular obj
+   	crColorText = GetPlayerNameColor(obj->flags,NULL);
+   	
 	// draw a black halo around the text just to ensure it is visible
 	SetTextColor(lpdis->hDC, RGB(0, 0, 0));
         OffsetRect(&r, 1, 0);


### PR DESCRIPTION
See gilroy forum thread:
Open Source / Small patch suggestion (ObjectFlags/WhoList)

First commit in pullreq is the original patch from forum thread.
Second one is a slightly cleaned up variant.

If you don't like it, don't add it :-)
But I suggest applying solution B from forumthread then to not send this information to the client.
