### PR TITLE
Ranged Weapon Attributes Fix

### DIFF
--- a/kod/object/item/passitem/weapon/ranged.kod
+++ b/kod/object/item/passitem/weapon/ranged.kod
@@ -174,7 +174,7 @@ messages:
 
    GetBaseDamage(who=$,target=$)
    {
-      local iDamage, ammotype, i, oWeapAtt;
+      local iDamage, ammotype, i;
 
       if poOwner = $
       {
@@ -195,6 +195,8 @@ messages:
             }
          }
       }
+	  
+	  iDamage = iDamage + viWeaponDamage;
 	  
       return iDamage;
    }


### PR DESCRIPTION
Ranged weapons had a mistake in their GetDamage function - they haven't
taken into account item attributes for years. With this change, ranged
weapons can have attributes added to them once again.

The attributes in question don't normally drop in-game on ranged
weapons, but admins can create them for events now.
