### PR TITLE
Only change karma if good player does bad stuff (or vice versa).

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -6369,15 +6369,15 @@ messages:
    {
       local iBase, iChange;
 
-      % Do not change karma if player is good, act is good, but not as good as player.
-      % I.e. only change karma if good player does bad stuff (or vice versa).
-      if (karma_doer > 0 AND karma_act > 0 AND karma_doer > karma_act)
-      OR (karma_doer < 0 AND karma_act < 0 AND karma_doer < karma_act)
+      if karma_doer = $ OR karma_act = $
       {
          return 0;
       }
 
-      if karma_doer = $ OR karma_act = $
+      % Do not change karma if player is good, act is good, but not as good as player.
+      % I.e. only change karma if good player does bad stuff (or vice versa).
+      if (karma_doer > 0 AND karma_act > 0 AND karma_doer > karma_act)
+      OR (karma_doer < 0 AND karma_act < 0 AND karma_doer < karma_act)
       {
          return 0;
       }


### PR DESCRIPTION
If a +80 karma dude kills a -40 karma monster currently he will lose
karma towards +40, with this change he'd only lose karma if he kills a
good monster.
Works the same for evil people respectively.
