### PR TITLE
Rescue Modifications

### DIFF
--- a/kod/object/passive/spell/rescue.kod
+++ b/kod/object/passive/spell/rescue.kod
@@ -89,12 +89,12 @@ messages:
 
       % Start with the base time.  Reduce time by spellpower.
       iDelay = 1000 * Send(Send(SYS, @GetSettings), @RescueBaseDelaySec);
-      iDelay = iDelay - (iSpellPower * iDelay) / 100 / 4;
+      iDelay = iDelay - (iSpellPower * (iDelay-3000)) / 100;
 
       % Add a little delay in sometimes.
-      if random(1,2) = 1
+      if random(1,4) = 1
       {
-         iDelay = iDelay + random(5000, 10000);
+         iDelay = iDelay + random(0, 5000);
       }
 
       send(who,@StartRescueTimer,#time=iDelay);


### PR DESCRIPTION
Spell was taking, at max power, 11s + (5-10s half of the time).

Spell now takes, at max power, 3s + (0-5s a quarter of the time).

Should improve the spell for regular use, but still leave a quarter
chance for an up to 8 second delay.
