### PR TITLE
Armor Tweaks

### DIFF
--- a/kod/object/item/passitem/defmod/armor/chain.kod
+++ b/kod/object/item/passitem/defmod/armor/chain.kod
@@ -56,9 +56,9 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_THRUST,-5],
-               [ATCK_WEAP_PIERCE,-25],
-               [ATCK_WEAP_BLUDGEON,-15],
+      return [ [ATCK_WEAP_THRUST,5],
+               [ATCK_WEAP_PIERCE,25],
+               [ATCK_WEAP_BLUDGEON,15],
                [ATCK_WEAP_SLASH,20]
              ];
    }

--- a/kod/object/item/passitem/defmod/armor/leather.kod
+++ b/kod/object/item/passitem/defmod/armor/leather.kod
@@ -40,7 +40,7 @@ classvars:
    viWeight = 100
    viBulk = 150
 
-   viSpell_modifier = -10
+   viSpell_modifier = 0
 
 
    vrIcon_male = Leatherarmor_male_icon_rsc

--- a/kod/object/item/passitem/defmod/armor/scale.kod
+++ b/kod/object/item/passitem/defmod/armor/scale.kod
@@ -58,7 +58,7 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_BLUDGEON,-10]
+      return [ [ATCK_WEAP_BLUDGEON,10]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/shield/goldshld.kod
+++ b/kod/object/item/passitem/defmod/shield/goldshld.kod
@@ -56,7 +56,8 @@ messages:
    GetResistanceModifiers()
    {
       return [ [ATCK_WEAP_SLASH,10],
-               [ATCK_WEAP_BLUDGEON,10]
+               [ATCK_WEAP_BLUDGEON,10],
+               [ATCK_WEAP_THRUST,10]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/shield/metlshld.kod
+++ b/kod/object/item/passitem/defmod/shield/metlshld.kod
@@ -44,7 +44,7 @@ classvars:
    viGround_group = 3
    viInventory_group = 1
 
-   viDefense_base = 0
+   viDefense_base = 5
    viDamage_base = 1
 
 properties:

--- a/kod/object/item/passitem/defmod/shield/orcshld.kod
+++ b/kod/object/item/passitem/defmod/shield/orcshld.kod
@@ -50,8 +50,8 @@ classvars:
    viGround_group = 3
    viInventory_group = 1
 
-   viDefense_base = 15
-   viDamage_base = 1
+   viDefense_base = 20
+   viDamage_base = 2
 
 properties:
 
@@ -86,9 +86,8 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_THRUST,-20],
-               [-ATCK_SPELL_SHOCK,15],
-               [-ATCK_SPELL_HOLY,20]
+      return [ [ATCK_WEAP_PIERCE,15],
+               [-ATCK_SPELL_HOLY,-20]
              ];
    }
 


### PR DESCRIPTION
Made a series of very conservative changes to the armors and shields
that players never use, in the hopes of getting people to try them.

Chain Armor - had severe vulnerabilities that made it worse than
useless. It may now find a niche as comparable to plate vs arrows.

Leather - changed spellpower penalty from -10 to 0. May find a use as
caster armor, compared to +20 spellpower from robes.

Scale - flipped minor vulnerability

Gold Shield - added thrust resistance to match other resists. Might find
use vs skeletons for builders.

Small Round Shield - did virtually nothing. Added a tiny defense.

Orc Shield - gave it stats on par with the only worthwhile shield
(Herald Shield). Formerly, it was an incredible liability, taking
enormous damage from the most common weapons. It is now also vulnerable
to Holy damage. Qors might use this shield now (but unfortunately
Soldier Shields still override shield choice for many players...)
