### PR TITLE
Increase Range of Melee Weapons

### DIFF
--- a/kod/object/item/passitem/weapon.kod
+++ b/kod/object/item/passitem/weapon.kod
@@ -50,8 +50,8 @@ constants:
 
    % Range of reach
    WEAPON_RANGE_LOW  = 2
-   WEAPON_RANGE_MID  = 2
-   WEAPON_RANGE_HIGH = 3
+   WEAPON_RANGE_MID  = 3
+   WEAPON_RANGE_HIGH = 4
 
    % Quality mods to number of hits
    WEAPON_LOW_QUALITY_HITS  = -50


### PR DESCRIPTION
Increased high range to 4. (Similar to touch spells.)

Increased middle range to 3. Not sure why low and mid is both set to 2.
