### PR TITLE
Mana Convergence: Lower Mana Cost

### DIFF
--- a/kod/object/passive/spell/jala/manaconv.kod
+++ b/kod/object/passive/spell/jala/manaconv.kod
@@ -34,7 +34,7 @@ classvars:
    vrDesc = ManaConvergence_desc_rsc
 
    viMana = 10          % Mana is amount used upon inititiation
-   viManaDrain = 9     % Drain is amount used every viDrainTime milliseconds
+   viManaDrain = 9      % Drain is amount used every viDrainTime milliseconds
    viDrainTime = 5000    % Drain some mana every viDrainTime milliseconds
    viSpell_num = SID_MANA_CONVERGENCE
 


### PR DESCRIPTION
This spell acts as AMA's counter but lets break it down.
- Song form (requires focus)
- Only takes a Gnarl Staff to break it
- Similar regs to AMA
- Costs more mana than AMA.

Lowering the mana cost won't make this spell 100% better, but will give Jala a little boost.
