### PR TITLE
Just an idea to counter wallspells

### DIFF
--- a/kod/object/passive/spell/persench/deflect.kod
+++ b/kod/object/passive/spell/persench/deflect.kod
@@ -114,7 +114,7 @@ messages:
       if Send(oSpell,@IsHarmful)
          AND Send(oSpell,@GetNumSpellTargets) = 1
          AND IsClass(oSpell,&AttackSpell)
-         AND IsClass(oSpell,&WallSpell)
+         OR IsClass(oSpell,&WallSpell)
       {
          chance = Send(caster,@GetEnchantedState,#what=self);
          if Random(0,100) > chance


### PR DESCRIPTION
Aslong ppl abuse wallspells - why not counter them with deflect? It will work even when the caster is not in the zone. But together with a change, when the wall disapears when the caster leave the zone it would be a really solid change. This would really add more risk for the caster of wallspells.
