### PR TITLE
Update kod/object/active/holder/nomoveon/battler/player.kod

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4230,7 +4230,7 @@ messages:
       % The universal modifier.
       iOffense = iOffense + ((iOffense * piFlags3) / 100);
 
-      return bound(iOffense,1,1000);
+      return bound(iOffense,1,1500);
    }
 
    % This returns the battler's ability to avoid being hit.  Ranges from 1 to 1000.
@@ -4273,7 +4273,7 @@ messages:
       % The universal modifier.
       iDefense = iDefense + ((iDefense * piFlags3) / 100);
 
-      return bound(iDefense,1,1000);
+      return bound(iDefense,1,1500);
    }
 
    % The next three messages deal with the three defense skills.  These messages return the relative values of the three


### PR DESCRIPTION
The idea behind doubling the weight of agility and aim in regards to offense is defense is to increase the weight of the stat while lowering the importance of kraanan spells that often lead to capping offense and defense without making those spell obsolete. The cap remains at 1000 so the character with kraanan and low agility and/or aim are unaffected so long as they keep their kraanan buffs. Magic shield takes a hit because it only adds defense (a boat load) to the character; However it is still useful because the player can use it to offset the penalty of wearing heavy armor. Eagle eyes and bless are still useful because of their damage bonus and eagle eye's blind resistance.

Current characters who use low stats are untouched because they already rely on kraanan to get them close to cap and characters with higher stats who gain those stats by losing other stats who have a higher weight in the current system become better post the building period but not better then the other character because of kraanan and the 1000 point cap.  
