### PR TITLE
Illusionary Form / Morph Cap

### DIFF
--- a/kod/object/passive/spell/illform.kod
+++ b/kod/object/passive/spell/illform.kod
@@ -152,8 +152,7 @@ messages:
          {
             % Be sure the player deserves to be able to 
             %  'steer' to this monster.
-            if (Send(i,@GetLevel) >= (iSpellPower - random(0,10))
-               AND iSpellPower < 99)
+            if Send(i,@GetLevel) >= (iSpellPower - random(0,10))
                AND NOT bDM
             {
                return;

--- a/kod/object/passive/spell/morph.kod
+++ b/kod/object/passive/spell/morph.kod
@@ -230,10 +230,8 @@ messages:
          {
             iLevel = Send(i,@GetLevel);
 
-            % Be sure the player deserves to be able to 'steer' to this monster
-            % But, always let player select monster if they have max spellpower.
-            if (iSpellPower <= (iLevel + random(0,10))
-                AND iSpellPower < SPELLPOWER_MAXIMUM)
+            % Be sure the player deserves to be able to 'steer' to this monster.
+            if iSpellPower <= (iLevel + random(0,10))
                AND NOT bDM
             {
                return;


### PR DESCRIPTION
Both Illusionary Form and Morph have accidental logic problems at
exactly 99 spellpower that allow players to morph into almost any
monster, including level 200 monsters that are otherwise specifically
referred to as 'boss monsters' and restricted in the rest of Illusionary
Form and Morph's code. By eliminating the 99-power bypass, the spells
will accurately compare their spellpower to a chosen monster's level at
all spellpowers.

Realistically, this will eliminate a long-time abuse that many mules and
PKs use - by morphing into a Shadowbeast, or other very strong
creatures, Riija 5 characters can bypass every player statistic and
immediately become very strong. ~200 HP, high to-hit and damage, as well
as skipping all typical offense and defense player code. Buffs don't
matter, skills don't matter, stats don't matter, it's all skipped in the
combat code if Morphed.

This tactic is so strong, many PKs don't bother building any HP, skills,
or spells, except Riija 5 to turn into a Shadowbeast and attack players
that way.

Furthermore, Morph makes players attackable by anyone without penalty,
so innocent players can't really use it. Finally fixing this won't
impact gameplay for the majority of players.
