### PR TITLE
Mirth & Melancholy fix

### DIFF
--- a/kod/object/passive/spell/jala/melcholy.kod
+++ b/kod/object/passive/spell/jala/melcholy.kod
@@ -150,7 +150,7 @@ messages:
    ModifyHitRoll(who = $,what = $,hit_roll = $)
    {
       % Only affect the good ones...
-      if Send(what,@GetKarma,#detect=TRUE) > 0
+      if Send(what,@GetKarma,#detect=TRUE) < 0
       {
          % Give a small bonus
          return hit_roll + 100;
@@ -162,7 +162,7 @@ messages:
    ModifyDamage(who = $,what = $,damage = $)
    {
       % Only affect the good ones...
-      if Send(what,@GetKarma,#detect=TRUE) > 0
+      if Send(what,@GetKarma,#detect=TRUE) < 0
       {
          % Roughly equal to Killing Fields
          return damage + Random(1,5);

--- a/kod/object/passive/spell/jala/mirth.kod
+++ b/kod/object/passive/spell/jala/mirth.kod
@@ -150,7 +150,7 @@ messages:
    ModifyHitRoll(who = $,what = $,hit_roll = $)
    {
       % Only affect the evil ones...
-      if Send(what,@GetKarma,#detect=TRUE) < 0
+      if Send(what,@GetKarma,#detect=TRUE) > 0
       {
          % Give a small bonus
          return hit_roll + 100;
@@ -162,7 +162,7 @@ messages:
    ModifyDamage(who = $,what = $,damage = $)
    {
       % Only affect the evil ones...
-      if Send(what,@GetKarma,#detect=TRUE) < 0
+      if Send(what,@GetKarma,#detect=TRUE) > 0
       {
          % Roughly equal to Killing Fields
          return damage + Random(1,5);


### PR DESCRIPTION
The karma checks were reversed in the code. Players have been gaining no
benefit from these spells all this time due to their incorrect
function. I changed the karma check to match each spell's description and theme.
