### PR TITLE
Eagle Eyes instant cast

### DIFF
--- a/kod/object/passive/spell/persench/Eagleyes.kod
+++ b/kod/object/passive/spell/persench/Eagleyes.kod
@@ -57,8 +57,9 @@ classvars:
    viMana = 5
    viSpellExertion = 10
 
-   viCast_time = 2000
    viChance_To_Increase = 20
+   
+   vbCanCastOnOthers = FALSE
 
 properties:
 


### PR DESCRIPTION
Changed EE to be self-only and instant cast, so that players have a much
better chance of recasting it in battle. Per Gilroy's discussions.

This is the smallest tweak we've come up with that might make a major shift in the power of Purge. Blind and Dazzle are too strong on unbuffed players, and Purge removes Eagle Eyes, so enabling twitch recasting of Eagle Eyes should shift the system away from Purge.
