### PR TITLE
Evil Twin - Change alone

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -14,9 +14,6 @@ constants:
 
    include blakston.khd
 
-   MANA_DRAIN_DELAY = 5000
-   MANA_DRAIN_AMOUNT = 1
-
 resources:
  
 
@@ -48,15 +45,12 @@ classvars:
 
    viTreasure_type = TID_NONE
 
-   viSpeed = SPEED_AVERAGE
+   viSpeed = SPEED_VERY_FAST
    viAttack_types = ATCK_WEAP_SLASH
    viAttributes = 0
-   viLevel = 45
-   viDifficulty = 4
-   viKarma = $
-
-   viManaDrain = 10     % Drain is amount used every viDrainTime milliseconds
-   viDrainTime = 5000    % Drain some mana every viDrainTime milliseconds
+   viLevel = 1
+   viDifficulty = 9
+   viKarma = 0
 
    vrSound_hit = EvilTwin_sound_hit
    vrSound_miss = EvilTwin_sound_miss

--- a/kod/object/passive/spell/SUMMTWIN.KOD
+++ b/kod/object/passive/spell/SUMMTWIN.KOD
@@ -1,9 +1,6 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 SummonEvilTwin is Spell
 
-% TODO: Fix it so that if someone actually KILLS the evil twin, the spell goes
-%  away.
-
 constants:
 
    include blakston.khd
@@ -21,7 +18,7 @@ resources:
    summonEvilTwin_cast_rsc = \
       "An evil twin mysteriously appears beside your target."
    summonEvilTwin_failed_rsc = \
-      "There is too much summoning magic focused here to summon an evil twin."
+      "There is already an Evil Twin lurking in this room."
    summonEvilTwin_bad_target = "You can't cast evil twin on %s%s"
    summonEvilTwin_no_self = \
       "You decide you really don't want to summon your evil against yourself."
@@ -37,12 +34,10 @@ classvars:
    viSpell_num = SID_EVIL_TWIN
    viSchool = SS_RIIJA
    viSpell_level = 5
-   viMana = 20
-   viManaDrain = 10
-   viDrainTime = 5000
+   viMana = 10
 
-   viSpellExertion = 15
-   viCast_time = 1000
+   viSpellExertion = 20
+   viCast_time = 500
    viHarmful = TRUE
    viNoNewbieOffense = TRUE
 
@@ -106,7 +101,7 @@ messages:
       oRoom = Send(SYS,@UtilGetRoom,#what=who);
 
       if Send(oRoom,@CountHoldingHowMany,#class=&Monster) > 25
-         OR Send(oRoom,@CountHoldingHowMany,#class=&EvilTwin) > 10
+         OR Send(oRoom,@CountHoldingHowMany,#class=&EvilTwin) > 0
          OR Send(oRoom,@CountHoldingSummoned) > Send(SYS,@GetPlayerSummonedObjectLimit)
       {
          Send(who,@MsgSendUser,#message_rsc=summonEvilTwin_failed_rsc);
@@ -139,9 +134,7 @@ messages:
       Send(who,@MsgSendUser,#message_rsc=summonEvilTwin_cast_rsc);
 
       Send(SYS,@AddReflection,#who=oTarget,#oReflection=oTwin);
-
-      Send(who,@StartEnchantment,#what=self,#time=viDrainTime,
-           #state=[oTwin,oRoom],#addicon=True,#lastcall=False);
+	  
 
       propagate;
    }
@@ -153,56 +146,7 @@ messages:
       return;
    }
 
-   StartPeriodicEnchantment( who = $, state = $ )
-   {
-      % If caster runs out of mana or loses trance, spell ends.
-      if Send(who,@GetMana) < viManaDrain * 2
-      {
-         Send(who,@StartEnchantment,#what=self,#time=viDrainTime,
-              #state=state,#addicon=FALSE,#lastcall=TRUE);
-      }
-      else
-      {      
-         Send(who,@StartEnchantment,#what=self,#time=viDrainTime,
-              #state=state,#addicon=FALSE,#lastcall=FALSE);
-      }
-      
-      Send(who,@LoseMana,#amount=viManaDrain);
-      
-      return;
-   }
-
-   BreakTrance( who = $, state = $, event = $ )
-   {
-      % If caster runs out of mana or loses trance, spell ends.
-      if event = EVENT_NEWOWNER
-      {
-         if Send(First(state),@GetOwner) = Nth(state,2)
-         {
-            Send(First(state),@Delete);   
-            Send(who,@RemoveEnchantment,#what=self,#state=state);
-         }
-         else
-         {
-            SetNth(state,2,$);
-         }
-
-         propagate;
-      }
-
-      Post(First(state),@Delete);
-      Send(who,@RemoveEnchantment,#what=self,#state=state);
-      
-      propagate;
-   }
-
-   SetSpellPlayerFlag(who=$,state=$)
-   {
-      Send(who,@SetTranceFlag);
-      
-      return;
-   }
-
+ 
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
It attacks very fast. 
It dies in 1 or 2 hits and doesn't change your karma. 
There is a limit of one per room and I actually think that's the best way to limit it. Sort of like earthquake. If another team wants to get a twin up all they have to do is kill the current twin and take over. 

I tested it a lot now and I think this is the sweet spot. It takes awhile for it to kill a built player and that player can easily turn around and mange it, but I feel as if it's a neat little distraction that adds a bit of damage. The proc rate can be nutty because of how fast it attacks but because it's hitting you with your weapon I feel like that's on you. 
