### PR TITLE
hotfix for the bad arrow overlay

### DIFF
--- a/resource/graphics/arrowfir.BBG
+++ b/resource/graphics/arrowfir.BBG
@@ -6,7 +6,7 @@
 #* arrows
 -s 5
 11
-arrowfir.bgf_frame0.bmp     [0, -250] 
+arrowfir.bgf_frame0.bmp     [0, -200] 
 arrowfir.bgf_frame1.bmp     [0, -200] 
 arrowfir.bgf_frame2.bmp     [0, -200] 
 arrowfir.bgf_frame3.bmp     [0, -200] 
@@ -14,9 +14,9 @@ arrowfir.bgf_frame4.bmp     [0, -200]
 arrowfir.bgf_frame5.bmp     [0, -200] 
 arrowfir.bgf_frame6.bmp     [0, -200] 
 arrowfir.bgf_frame7.bmp     [0, -200] 
-arrowfir.bgf_frame8.bmp     [0, -200] 
-arrowfir.bgf_frame9.bmp     [0, -200] 
-arrowfir.bgf_frame10.bmp    [0, -200] 
+arrowfir.bgf_frame8.bmp     [0, 0] 
+arrowfir.bgf_frame9.bmp     [0, 0] 
+arrowfir.bgf_frame10.bmp    [0, 0] 
 4
  8   1 2 3 4 5 6 7 8 
  1   9 

--- a/resource/graphics/arrowner.BBG
+++ b/resource/graphics/arrowner.BBG
@@ -6,7 +6,7 @@
 #* arrows
 -s 5
 11
-arrowner.bgf_frame0.bmp     [0, -250] 
+arrowner.bgf_frame0.bmp     [0, -200] 
 arrowner.bgf_frame1.bmp     [0, -200] 
 arrowner.bgf_frame2.bmp     [0, -200] 
 arrowner.bgf_frame3.bmp     [0, -200] 
@@ -14,9 +14,9 @@ arrowner.bgf_frame4.bmp     [0, -200]
 arrowner.bgf_frame5.bmp     [0, -200] 
 arrowner.bgf_frame6.bmp     [0, -200] 
 arrowner.bgf_frame7.bmp     [0, -200] 
-arrowner.bgf_frame8.bmp     [0, -200] 
-arrowner.bgf_frame9.bmp     [0, -200] 
-arrowner.bgf_frame10.bmp    [0, -200] 
+arrowner.bgf_frame8.bmp     [0, 0] 
+arrowner.bgf_frame9.bmp     [0, 0] 
+arrowner.bgf_frame10.bmp    [0, 0] 
 4
  8   1 2 3 4 5 6 7 8 
  1   9 

--- a/resource/graphics/arrowsil.BBG
+++ b/resource/graphics/arrowsil.BBG
@@ -6,7 +6,7 @@
 #* arrows
 -s 5
 11
-arrowsil.bgf_frame0.bmp     [0, -250] 
+arrowsil.bgf_frame0.bmp     [0, -200] 
 arrowsil.bgf_frame1.bmp     [0, -200] 
 arrowsil.bgf_frame2.bmp     [0, -200] 
 arrowsil.bgf_frame3.bmp     [0, -200] 
@@ -14,9 +14,9 @@ arrowsil.bgf_frame4.bmp     [0, -200]
 arrowsil.bgf_frame5.bmp     [0, -200] 
 arrowsil.bgf_frame6.bmp     [0, -200] 
 arrowsil.bgf_frame7.bmp     [0, -200] 
-arrowsil.bgf_frame8.bmp     [0, -200] 
-arrowsil.bgf_frame9.bmp     [0, -200] 
-arrowsil.bgf_frame10.bmp    [0, -200] 
+arrowsil.bgf_frame8.bmp     [0, 0] 
+arrowsil.bgf_frame9.bmp     [0, 0] 
+arrowsil.bgf_frame10.bmp    [0, 0] 
 4
  8   1 2 3 4 5 6 7 8 
  1   9 


### PR DESCRIPTION
Im sorry, but the original bbg which is used as template had the wrong AppendY coordinats at the first and the last 3 frames.
