### PR TITLE
Dragonfly Queen change

### DIFF
--- a/kod/object/active/holder/room/monsroom/kcforest/kb5.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/kb5.kod
@@ -16,7 +16,7 @@ constants:
 
 resources:
 
-   room_name_OutdoorsKB5 ="Into the Jungle"
+   room_name_OutdoorsKB5 ="Jungle Pathways"
    room_OutdoorsKB5 = KB5.roo
    OutdoorsKB5_music = orcbeg.mid
 
@@ -60,7 +60,7 @@ messages:
 
    Constructed()
    {
-      plMonsters = [ [&Dragonfly, 100] ];
+      plMonsters = [ [&DragonflyQueen, 100] ];
       plGenerators = [ [34,27], [37,13], [18,23], [25,29], [18,8] ];
 
       propagate;


### PR DESCRIPTION
Changed all spawns of Dragonflies next to the Mad Scientist Hut into
Dragonfly Queens. Players _really_ hate the problematic Queen fetch
quest. I mean _really really_ hate it. This makes it nearly trivial
without disrupting the quest engine.

Also, renamed "Into the Jungle" to "Jungle Pathways" because it had the
same name as another area.
