### PR TITLE
Truce changed to Planar Calm

### DIFF
--- a/kod/object/passive/spell/roomench/truce.kod
+++ b/kod/object/passive/spell/roomench/truce.kod
@@ -16,36 +16,26 @@ constants:
 
 resources:
 
-   truce_name_rsc = "truce"
-   truce_icon_rsc = itruce.bgf
-   truce_desc_rsc = \
-      "The spirit of Shal'ille descends upon the area and "
-      "calms the minds of all present, preventing combat for "
-      "several minutes.  "
+   planarcalm_name_rsc = "planar calm"
+   planarcalm_icon_rsc = itruce.bgf
+   planarcalm_desc_rsc = \
+      "The spirit of Shal'ille descends upon the area, "
+      "calming disturbances and aggressions. This spell will close spacial rifts and "
+      "momentarily relax monsters. "
       "Requires emerald and yrxl sap to cast."
 
-   truce_unnecessary = "Combat is already impossible here."
+   planarcalm_cast = \
+      "A numbing panacea washes across the area."
 
-   truce_on = \
-      "A numbing calm settles upon your mind, driving out all thought of "
-      "conflict and war.  You find yourself unable to lift a weapon."
-   truce_off = \
-      "The calm that had gripped your mind departs.  You feel ready for "
-      "battle once more."
 
-   truce_guardian = \
-      "Your guardian angel tells you, \"You are not ready to cast this spell "
-      "so it hinders other players or logoff ghosts.\""
-   truce_no_towns = "Shal'ille does not permit you to interfere right now."
-
-   truce_sound = shalille.wav
+   planarcalm_sound = shalille.wav
 
 classvars:
 
-   vrIcon = truce_icon_rsc
-   vrDesc = truce_desc_rsc
-   vrName = truce_name_rsc
-   vrSucceed_wav = truce_sound
+   vrIcon = planarcalm_icon_rsc
+   vrDesc = planarcalm_desc_rsc
+   vrName = planarcalm_name_rsc
+   vrSucceed_wav = planarcalm_sound
 
    viSpell_num = SID_TRUCE
    viSchool = SS_SHALILLE
@@ -53,9 +43,6 @@ classvars:
    viSpellExertion = 10
    viSpell_level = 4
    viChance_To_Increase = 15
-
-   % in seconds, since it works off GetTime()
-   viPostCast_time = 3
 
    % Default animation speed for icon in ms
    viAnimationSpeed = 200
@@ -83,149 +70,47 @@ messages:
       return 0;
    }
 
-   CanPayCosts(who = $, lTargets = $)
-   {
-      local oRoom, i, oActive;
-
-      oRoom = Send(who,@GetOwner);
-
-      % check if combat already banned in room
-      if Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
-      {
-         Send(who,@MsgSendUser,#message_rsc=truce_unnecessary);
-
-         return FALSE;
-      }
-
-      if NOT Send(who,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
-      {
-         for i in Send(oRoom,@GetHolderActive)
-         {
-            % Can't be cast by an unangeled character if there's another
-            %  character in the room that's attacked another player too
-            %  recently, or if there's a logoff ghost in the room.
-            oActive = Send(oRoom,@HolderExtractObject,#data=i);
-            if (IsClass(oActive,&Player)
-                AND oActive <> who
-                AND NOT Send(oActive,@CanHelpPlayer))
-               OR isClass(oActive,&LogoffGhost)
-            {
-               Send(who,@MsgSendUser,#message_rsc=truce_guardian);
-
-               return FALSE;
-            }
-         }
-      }
-
-      % Check to see if the room restricts guild attacks.
-      % Check to see if the person is attackable in the area, is on a PvP
-      %  server, or is a DM.
-      if (NOT Send(oRoom,@AllowGuildAttack,#what=who))
-         AND Send(SYS,@IsPKAllowed)
-         AND NOT IsClass(who,&DM)
-      {
-         for i in Send(oRoom,@GetHolderActive)
-         {
-            % Only allow to be cast in towns unguilded if a monster is there.
-            % Unless monster is something a player can trigger/summon.
-            oActive = Send(oRoom,@HolderExtractObject,#data=i);
-            if IsClass(oActive,&Monster)
-               AND NOT ((Send(oActive,@GetBehavior) & AI_NPC)
-                        OR Send(oActive,@IsIllusion)
-                        OR Send(oActive,@IsSummoned)
-                        OR IsClass(oActive,&Revenant))
-            {
-               propagate;
-            }
-         }
-
-         % Tried to cast unguilded in town with no monsters.  Denied!
-         Send(who,@MsgSendUser,#message_rsc=truce_no_towns);
-
-         return FALSE;
-      }
-
-      propagate;
-   }
-
    CastSpell( who = $, iSpellPower = 0 )
    "Initiation point for the spell."
    {
-      local oRoom;
+      local oRoom, i, oObject, iChance, iRoll, oHold, iCalmDuration;
 
       oRoom = Send(who,@GetOwner);
-
-      % keep tabs on guides/bards, but not admins.
-      if GetClass(who) = &DM
+      Send(who,@MsgSendUser,#message_rsc=planarcalm_cast);
+            
+      % spell's chance to close a portal                                               
+      iChance = bound(iSpellPower,5,95);
+      
+      % will calm monsters up to 4 seconds
+      iCalmDuration = iSpellPower/25;
+      
+      % Find the hold spell to temporarily calm monsters
+      oHold = send(SYS,@FindSpellByNum,#num=SID_HOLD);
+      
+      for i in send(oRoom,@GetHolderActive) 
       {
-         Debug(Send(who,@GetTrueName),"cast truce in",Send(oRoom,@GetName));
-      }
-
-      % global effects of the enchantment
-      Send(oRoom,@SomeoneSaid,#type=SAY_MESSAGE,#string=truce_on,#what=self);
-      Send(oRoom,@RoomStartEnchantment,#what=self,#state=$,
-           #time=Send(self,@GetDuration,#iSpellPower=iSpellPower));
-      Send(oRoom,@SetRoomFlag,#flag=ROOM_NO_COMBAT,#value=TRUE);
-
-      propagate;
-   }
-
-   GetDuration(iSpellPower=0)
-   {
-      local iDur;
-
-      % 10-20 seconds at 1 spellpower
-      % 60-120 seconds at 99 spellpower.
-      iDur = (20 + iSpellPower) * 1000;
-      iDur = random(iDur/2, iDur);
-
-      return iDur;
-   }
-
-   StartEnchantmentNewOccupant( who = $ )
-   "Called on new occupants of the enchanted room."
-   {
-      Send(who,@MsgSendUser,#message_rsc=truce_on);
-
-      return;
-   }
-
-   EndRoomEnchantment( who = $, state = $ )
-   "Sent to each user as they leave the room.  Since we didn't enchant them, "
-   "nothing to undo."
-   {
-      Send(who,@MsgSendUser,#message_rsc=truce_off);
-
-      return;
-   }
-
-   EndSpell(where = $, state = $)
-   "Called when spell expires."
-   {
-      local i;
-
-      Send(where,@SomeoneSaid,#type=SAY_MESSAGE,#string=truce_off,#what=self);
-      if Send(where,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
-      {
-         Send(where,@SetRoomFlagtoDefault,#flag=ROOM_NO_COMBAT);
-      }
-
-      for i in Send(where,@GetEnchantmentList)
-      {
-         if Send(Nth(i,2),@GetSpellNum) = SID_JIG
+         oObject = Send(oRoom,@HolderExtractObject,#data=i);
+      
+         if isClass(oObject,&NecropolisPortal)
          {
-            Send(where,@SetRoomFlag,#flag=ROOM_NO_COMBAT,#value=TRUE);
+            iRoll = random(1,100);
+            if iRoll < iChance 
+            {
+               % close the portal
+               send(oObject,@ClosePortal);
+            }
+         }
+         else
+         {
+            if isClass(oObject,&Monster)
+            {
+               send(oHold,@DoHold,#what=who,#otarget=oObject,#iDurationSecs=iCalmDuration,#bAllowFreeAction=FALSE);
+            }
          }
       }
 
-      return;
+      propagate;
    }
-
-   SpellBannedInArena()
-   {
-      return TRUE;
-   }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Replaced Truce with a spell called Planar Calm. This new spell has a spellpower-based chance to close any Shadow Rift portals in the room, and also calms monsters for up to 4 seconds.

This replacement serves the dual purpose of eliminating Truce and also giving us a utility spell to close pesky Shadow Rift portals. I modified and renamed the existing Truce spell to avoid any issues deleting and replacing the spell might cause.
