### PR TITLE
Jig change

### DIFF
--- a/kod/object/passive/spell/jala/jig.kod
+++ b/kod/object/passive/spell/jala/jig.kod
@@ -83,7 +83,6 @@ messages:
 
       oRoom = Send(who,@GetOwner);
       Send(oRoom,@SetRoomFlag,#Flag=ROOM_JIG,#value=TRUE);
-      Send(oRoom,@SetRoomFlag,#Flag=ROOM_NO_COMBAT,#value=TRUE);
 
       propagate;
    }
@@ -93,19 +92,6 @@ messages:
       local i;
       
       Post(where,@SetRoomFlag,#Flag=ROOM_JIG,#value=FALSE);
-
-      if Send(where,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
-      {
-         Send(where,@SetRoomFlagtoDefault,#flag=ROOM_NO_COMBAT);
-      }
-      
-      for i in Send(where,@GetEnchantmentList)
-      {
-         if Send(Nth(i,2),@GetSpellNum) = SID_TRUCE
-         {
-            Send(where,@SetRoomFlag,#flag=ROOM_NO_COMBAT,#value=TRUE);
-         }
-      }
       
       propagate;
    }


### PR DESCRIPTION
Jig (the other Truce-like spell) also had a No_Combat flag attached to
it. I just removed that aspect of the spell. It still makes players
dance, and it still prevents equipping of items, it just doesn't stop
combat anymore (which was the problematic abuse we've been seeing).

I think there are some rather interesting applications for preventing
gear switching (which the spell still does) but not enough for it to be
worth abusing from a mule. So this spell should be alright now.
