### PR TITLE
ChaosNight Upgrades

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -6364,6 +6364,16 @@ messages:
 
       return;
    }
+   
+   
+   ChangeKarma( amount = 0) 								% Command added to change karma to a specific amount.
+   "Changes karma directly to amount, other arguments add or lose karma."
+   {
+		piKarma = amount;
+		Send(self,@NewKarma);
+		
+		return;
+	}
 
    CalculateKarmaChangeFromAct( karma_doer=$, karma_act=$, Swing_factor = 1)
    {

--- a/kod/object/item/passitem/NKarmaPot.kod
+++ b/kod/object/item/passitem/NKarmaPot.kod
@@ -1,0 +1,115 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+NKarmaPot is PassiveItem
+
+constants:
+
+   include blakston.khd
+   
+resources:
+
+   NKarmaPot_icon_rsc = potion01.bgf
+
+   NKarmaPot_name_rsc = "NEGATIVE Karma Pot"
+   NKarmaPot_desc_rsc = "This potion is to facilitate negative karma during a Frenzy."
+   
+   NKarmaPot_drink = "You quaff the contents of the NEGATIVE KARMA POT in a single gulp."
+   NKarmaPot_NOdrink = "You can't use this potion when it is not a frenzy. DUMMY!"
+
+classvars:
+   
+   vrDesc = NKarmaPot_desc_rsc
+   vrName = NKarmaPot_name_rsc
+   vrIcon = NKarmaPot_icon_rsc
+
+   viBulk = 20
+   viWeight = 5000						% weighs more than a mortal can normally hold - ensures can only be given out via admin globally
+   viValue_average = 60
+
+   viUse_type = ITEM_SINGLE_USE
+
+   viPoisonPercent = 0
+   viGoBadDamage = 0
+
+properties:
+
+   piItem_flags = 77		% changes color to red to show difference for negative karma.
+
+
+messages:
+
+   Constructor()
+   {
+		piItem_flags = 77; 		% changes color to red to show difference for negative karma.
+		
+      propagate;
+   }
+   
+   
+    ApplyPotionEffects(apply_on = $)
+    {
+     if Send(SYS, @GetChaosNight)					% checks to see if ChaosNight is Active.
+	 {	
+		Send(apply_on,@ChangeKarma,#amount=-10000);
+	 }
+		
+	else
+	{
+		Send(apply_on,@MsgSendUser,#message_rsc=PKarmaPot_NOdrink);
+		Send(self,@Delete);								% deletes itslef if someone tries to use it outside frenzy.	
+    }
+      return;
+   }
+
+   
+      ReqNewApply(what = $,apply_on = $)
+   {
+      if what = apply_on
+      {
+         return TRUE;
+      }
+      
+      return FALSE;
+   }
+   
+   NewApplied(what = $,apply_on = $)
+   {
+      local oSpell;
+      if isClass(apply_on,&User) 
+      {
+         Send(apply_on,@waveSenduser,#wave_rsc=BetaPotion_gulp_sound);
+      }
+
+      Send(apply_on,@MsgSendUser,#message_rsc=PKarmaPot_drink);
+      Send(self,@ApplyPotionEffects,#apply_on=apply_on);
+
+      Send(self,@Delete);
+
+      return;
+   }
+
+   IsBeverage()
+   {
+      return TRUE;
+   }
+
+   CanIdentify()
+   {
+      return TRUE;
+   }
+
+   RevealHiddenAttributes()
+   {
+      return FALSE;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/PKarmaPot.kod
+++ b/kod/object/item/passitem/PKarmaPot.kod
@@ -1,0 +1,116 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+PKarmaPot is PassiveItem
+
+constants:
+
+   include blakston.khd
+   
+resources:
+
+   PKarmaPot_icon_rsc = potion01.bgf
+
+   PKarmaPot_name_rsc = "POSITIVE Karma Pot"
+   PKarmaPot_desc_rsc = "This potion is to facilitate positive karma during a Frenzy."
+   
+   PKarmaPot_drink = "You quaff the contents of the POSITIVE KARMA POT in a single gulp."
+   PKarmaPot_NOdrink = "You can't use this potion when it is not a frenzy. DUMMY!"
+
+classvars:
+   
+   vrDesc = PKarmaPot_desc_rsc
+   vrName = PKarmaPot_name_rsc
+   vrIcon = PKarmaPot_icon_rsc
+
+   viBulk = 20
+   viWeight = 5000						% weighs more than a mortal can normally hold - ensures can only be given out via admin globally
+
+   viValue_average = 60
+
+   viUse_type = ITEM_SINGLE_USE
+
+   viPoisonPercent = 0
+   viGoBadDamage = 0
+
+properties:
+
+   piItem_flags = 79		% changes color to green to show difference for positive karma.
+
+
+messages:
+
+   Constructor()
+   {
+		piItem_flags = 79;			% changes color to green to show difference for positive karma.
+		
+      propagate;
+   }
+   
+   
+    ApplyPotionEffects(apply_on = $)
+    {
+     if Send(SYS, @GetChaosNight)					% checks to see if ChaosNight is Active.
+	 {	
+		Send(apply_on,@ChangeKarma,#amount=10000);
+	 }
+		
+	else
+	{
+		Send(apply_on,@MsgSendUser,#message_rsc=PKarmaPot_NOdrink);
+		Send(self,@Delete);												% deletes itslef if someone tries to use it outside frenzy.
+    }
+      return;
+   }
+
+   
+      ReqNewApply(what = $,apply_on = $)
+   {
+      if what = apply_on
+      {
+         return TRUE;
+      }
+      
+      return FALSE;
+   }
+   
+   NewApplied(what = $,apply_on = $)
+   {
+      local oSpell;
+      if isClass(apply_on,&User) 
+      {
+         Send(apply_on,@waveSenduser,#wave_rsc=BetaPotion_gulp_sound);
+      }
+
+      Send(apply_on,@MsgSendUser,#message_rsc=PKarmaPot_drink);
+      Send(self,@ApplyPotionEffects,#apply_on=apply_on);
+
+      Send(self,@Delete);
+
+      return;
+   }
+
+   IsBeverage()
+   {
+      return TRUE;
+   }
+
+   CanIdentify()
+   {
+      return TRUE;
+   }
+
+   RevealHiddenAttributes()
+   {
+      return FALSE;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/makefile
+++ b/kod/object/item/passitem/makefile
@@ -17,6 +17,6 @@ BOFS = attmod.bof defmod.bof healer.bof key.bof \
 	prism.bof orecheap.bof neclettr.bof taxlettr.bof ncwrnlet.bof potaphro.bof \
 	warlettr.bof factflag.bof bardnote.bof mystpot.bof mystwand.bof lablpot.bof \
 	lablwand.bof roomkeyc.bof hstone.bof spelitem.bof specwand.bof warjoin.bof \
-	betap.bof specgift.bof manacrys.bof spcgift2.bof
+	betap.bof specgift.bof manacrys.bof spcgift2.bof pkarmapot.bof nkarmapot.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/item/passitem/numbitem/food/chaosfd.kod
+++ b/kod/object/item/passitem/numbitem/food/chaosfd.kod
@@ -1,0 +1,84 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% ambrosia, for supercharging administrators
+% dumbed down a bit to make suitable for quest prizes.
+
+chaosfd is Food
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   chaosfd_name_rsc = "Frenzy Food"
+   chaosfd_name_plural_rsc = "Frenzy Food"
+   chaosfd_icon_rsc = mushroom.bgf
+   chaosfd_desc_rsc = \
+      "At first glance, these mushrooms appear common, but look at the psychedelic colors!  "
+      "This is actually Frenzy Food! No Stomache No Problem!"
+	  
+	chaosfd_NoEat = "You can't eat this potion when it is not a frenzy. DUMMY!"
+
+classvars:
+
+   vrName = chaosfd_name_rsc
+   vrName_plural = chaosfd_name_plural_rsc
+   vrIcon = chaosfd_icon_rsc
+   vrDesc = chaosfd_desc_rsc
+
+   viIndefinite = ARTICLE_AN
+
+   viBulk = 10
+   viWeight = 5000				% Increased weight dramatically to ensure no mortal is able to pick these up outside of a frenzy / global give.
+   viValue_average = 1
+
+properties:
+		
+   piItem_flags = 118			% Change the color appearance of the inkycap to differentiate.	
+   viFilling = 0                 % Ignore's the characters stomache to allow for constant frenzy killing...
+   viNutrition = 200               % Brings vigor to character max
+   piNumber = 1
+
+messages:
+
+   Constructor()
+   {
+      % NOTE: If you change these colors, change the xlat in OrnamentalObject.
+      %       Search for OO_MUSEUM_INKYCAP
+      piItem_flags = 118;
+      
+      propagate;
+   }
+   
+  NewApplied(what = $,apply_on = $)
+   {
+	if Send(SYS, @GetChaosNight)					% checks to see if ChaosNight is Active.
+		{
+			Send(self,@SendTaste,#what=what,#apply_on=apply_on);
+			Send(what,@WaveSendUser,#wave_rsc=vrEat_wav);
+			Send(apply_on,@EatSomething,#nutrition=viNutrition,#filling=viFilling);
+			Send(self,@SubtractNumber,#number=1);
+		}
+	else
+		{
+			Send(apply_on,@MsgSendUser,#message_rsc=chaosfd_NoEat);
+			Send(self,@Delete);											% deletes itslef if someone tries to use it outside frenzy.	
+
+		}
+		
+	return;
+	}
+
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/numbitem/food/makefile
+++ b/kod/object/item/passitem/numbitem/food/makefile
@@ -8,6 +8,6 @@ DEPEND = ..\food.bof
 BOFS = inkycap.bof snack.bof watrskin.bof meatpie.bof apple.bof \
        bread.bof mug.bof spideye.bof drumstik.bof pork.bof \
        grapes.bof ftncooky.bof soup.bof goblet.bof gobletst.bof stew.bof \
-       gobletwn.bof kocmug.bof cheese.bof mint.bof turkyleg.bof
+       gobletwn.bof kocmug.bof cheese.bof mint.bof turkyleg.bof chaosfd.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/util/chaosnight.kod
+++ b/kod/util/chaosnight.kod
@@ -143,7 +143,10 @@ messages:
       % Reset the loot list if it's niled out.
       if plChaosNightLoot = $
       {
-         plChaosNightLoot = [ Create(&Inkycap,#number=50),
+         plChaosNightLoot = [ 
+							  Create(&PKarmaPot),
+							  Create(&NKarmaPot),
+							  Create(&chaosfd,#number=100),
                               Create(&Mint,#number=100),
                               Create(&Scimitar),
                               Create(&Longsword),
@@ -155,7 +158,13 @@ messages:
                               Create(&NeruditeArrow,#number=150),
                               Create(&JewelOfFroz),
                               Create(&JewelOfFroz),
-                              Create(&Gift)
+                              Create(&Gift),
+							  Create(&Helm),
+							  Create(&Neruditebow),
+							  Create(&Platearmor),
+							  Create(&Guildshield),
+							  Create(&Mysticsword),
+							  Create(&Scimitar)							  
                             ];
       }
 


### PR DESCRIPTION
Added New items.

1) Frenzy Food - chaosfd.kod
- Increases vigor of player to 200 ignoring stomach
- Checks ChaosNight is active, if not active will not work and delete
  itself.
- Weighs more than a mortal can hold, so can only be given out via admin
  globally
- Color differentiated from a regular Mushroom.

2) Positive/Negative Karma Pot - PKarmaPot.kod & NKarmaPot.kod
- Changes karma of player to -100 or + 100 ignoring stomach
- Checks ChaosNight is active, if not active will not work and delete
  itself.
- Weighs more than a mortal can hold, so can only be given out via admin
  globally
- Color differentiated from a regular Potion.

3) Changes to Chaosnight.kod
- All changes to the loot table for Chaos Night.
- Removed now obsolete (during frenzy) inkycap.
- Added new potions + food
- Added MSH, Nerudite Bow, Plate Armor (etc)

4) Changed player.kod:
- Added new message ChangeKarma
  All other messages regarding karma were either add or lose karma, there
  was not a method to simply send a message to change karma.
  ChangeKarma amount 10000 = now changes Karma directly to +100

*\* All compile without errors, no server errors and all tested
thorougly.
