### PR TITLE
Reduce the "griefness" of Truce

### DIFF
--- a/kod/object/passive/spell/roomench/truce.kod
+++ b/kod/object/passive/spell/roomench/truce.kod
@@ -49,13 +49,14 @@ classvars:
 
    viSpell_num = SID_TRUCE
    viSchool = SS_SHALILLE
-   viMana = 20
-   viSpellExertion = 10
+   viMana = 30
+   viSpellExertion = 20
    viSpell_level = 4
+   viCast_time = 1000
    viChance_To_Increase = 15
 
    % in seconds, since it works off GetTime()
-   viPostCast_time = 3
+   viPostCast_time = 4
 
    % Default animation speed for icon in ms
    viAnimationSpeed = 200
@@ -72,8 +73,8 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Emerald,1],plReagents);
-      plReagents = Cons([&Yrxlsap,1],plReagents);
+      plReagents = Cons([&Emerald,3],plReagents);
+      plReagents = Cons([&Yrxlsap,2],plReagents);
 
       return;
    }


### PR DESCRIPTION
Truce changes:
1. Added same focus time as discord.
2. Added mana, reagent and vigor cost
3. This is important I think to add a little balance to this really
   powerful spell. You have a spell that stops all combat in a room dead
   and doesn't have any focus time and quite cheap for its power.
   Discordance has a focus timer and truce did not leads me to the opinion
   it was incredibly un balanced. Now with a little extra cost - will make
   people less likely and less able to cast it continuously.
