### PR TITLE
Loyalty Potion + Signet Ring Quest

### DIFF
--- a/kod/object/item/passitem/LoyaltyPotion.kod
+++ b/kod/object/item/passitem/LoyaltyPotion.kod
@@ -1,0 +1,134 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% Code written for this item by Phillip H.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+LoyaltyPotion is PassiveItem
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   LoyaltyPotion_icon_rsc = potion01.bgf
+
+   LoyaltyPotion_name_rsc = "Loyalty Potion"
+   LoyaltyPotion_desc_rsc = "This potion is a reward for your dedication and loyalty to the Quest."
+
+
+   LoyaltyPotion_worked = "You quaff down the potion in a single gulp and feel a rush of energy throughout your body.\n"						  
+						  "`B`IYou suddenly feel a little tougher."
+   
+   LoyaltyPotion_NOdrink = "You quaff down the potion in a single gulp and feel `B`Iabsolutely nothing.\n"
+						   "`n`rAdvanced, Outlaws or Murderers may not use this potion."
+						   
+classvars:
+   
+   vrDesc = LoyaltyPotion_desc_rsc
+   vrName = LoyaltyPotion_name_rsc
+   vrIcon = LoyaltyPotion_icon_rsc
+   
+   viBulk = 20
+   viWeight = 20
+   viValue_average = 0
+
+   viItem_type = ITEMTYPE_POTION | ITEMTYPE_SUNDRY
+   viUse_type = ITEM_SINGLE_USE
+   
+   PotionHPBoost = 1
+
+   viPoisonPercent = 0
+   viGoBadDamage = 0
+
+properties:
+
+   
+   piGoBadTime = 0
+   piItem_flags = PT_GRAY_TO_RED
+   
+   
+
+messages:
+
+   Constructor()
+   {
+      propagate;
+   }
+
+
+   ApplyPotionEffects(apply_on = $)
+   {
+      
+	  
+	  
+		if Send(apply_on,@GetBaseMaxHealth) < 40								% check to make sure they are over 40 HP.
+		AND NOT Send(apply_on,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)				% check to make sure they are not an outlaw
+	    AND NOT Send(apply_on,@CheckPlayerFlag,#flag=PFLAG_MURDERER)			% check to make sure they are not a murderer
+			{		
+				Send(apply_on,@GainBaseMaxHealth,#amount=PotionHPBoost);
+				Send(apply_on,@MsgSendUser,#message_rsc=LoyaltyPotion_worked);
+				Send(self,@Delete);
+			}				
+					
+		else 
+			{
+						Send(apply_on,@MsgSendUser,#message_rsc=LoyaltyPotion_NOdrink);
+						Send(self,@Delete);												% deletes itslef if someone tries to use potion that is ineligble..
+			}					
+			
+      return;
+    }
+  
+  
+
+   %%% Old Potion stuff
+
+   ReqNewApply(what = $,apply_on = $)
+   {
+      if what = apply_on
+      {
+         return TRUE;
+      }
+      
+      return FALSE;
+   }
+   
+   NewApplied(what = $,apply_on = $)
+   {
+      local oSpell;
+      if isClass(apply_on,&User) 
+      {
+         Send(apply_on,@waveSenduser,#wave_rsc=BetaPotion_gulp_sound);
+      }
+
+      Send(self,@ApplyPotionEffects,#apply_on=apply_on);      
+
+      return;
+   }
+
+   IsBeverage()
+   {
+      return TRUE;
+   }
+
+   CanIdentify()
+   {
+      return TRUE;
+   }
+
+   RevealHiddenAttributes()
+   {
+      return FALSE;
+   }
+
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/makefile
+++ b/kod/object/item/passitem/makefile
@@ -17,6 +17,7 @@ BOFS = attmod.bof defmod.bof healer.bof key.bof \
 	prism.bof orecheap.bof neclettr.bof taxlettr.bof ncwrnlet.bof potaphro.bof \
 	warlettr.bof factflag.bof bardnote.bof mystpot.bof mystwand.bof lablpot.bof \
 	lablwand.bof roomkeyc.bof hstone.bof spelitem.bof specwand.bof warjoin.bof \
-	betap.bof specgift.bof manacrys.bof spcgift2.bof
+	betap.bof specgift.bof manacrys.bof spcgift2.bof pkarmapot.bof nkarmapot.bof \
+	loyaltypotion.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/item/passitem/ring/ringsgnt.kod
+++ b/kod/object/item/passitem/ring/ringsgnt.kod
@@ -91,28 +91,13 @@ messages:
 
    RewardReturner(who = $)
    {
-      local iValue, oMoney;
-
-      % PAYOFF: newbie=10*value, oldbie=value
-      iValue = Send(self,@GetValue);
-
-      if NOT Send(who,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
-      {
-         iValue = iValue * 10;
-      }
-
-      oMoney = Send(who,@GetMoneyObject);
-
-      if oMoney = $
-      {
-         oMoney = Create(&Money,#number=iValue);
-         Send(who,@NewHold,#what=oMoney);
-      }
-      else
-      {
-         Send(oMoney,@AddNumber,#number=iValue);
-      }
-
+		
+	
+      local oPotion;
+         oPotion = Create(&LoyaltyPotion);
+         Send(who,@NewHold,#what=oPotion);
+	  
+	  
       return;
    }
 


### PR DESCRIPTION
This idea was dreamed up by Mark.

1) Created Loyalty Potion:
- Will increase HP by 1 if player is < 40 HP
- If player is > 40 HP, or Outlaw, or Murderer then it will just delete itself and not increase HP.

2) Changed Signet Ring quest to reward this Potion.
- Both Mark and I believe that this is a trivial change that will make the signet ring quest useful again. Signet rings are not created often enough to farm and make an army of 40 HP characters. This will be a fun dynamic for newbies and oldies to work and bring the signet ring back to "life" per se.
