### PR TITLE
Morph compromise - The Ghost is a boss

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/ghost.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/ghost.kod
@@ -218,6 +218,11 @@ messages:
       return;
    }
 
+      CanMorphTo()
+   {
+      % Is a boss mob, this is a nono
+      return FALSE;
+   }      
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
We don't want to allow players to morph in to bosses so I added the tag to the only boss level boss you can still morph in to.

I honestly could take or leave this part of the change, but I added it anyway.
