### PR TITLE
Remove Guardian Angel after 2 months.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1560,7 +1560,7 @@ messages:
       age = Send(SYS,@GetYear) - Send(self,@GetBirthYear);
 
       % No more tutorial messages and bonuses if you've been around for about 2 months.
-      % Clear the newbie string, too.
+      % Clear the newbie string, and remove gaurdian angel.
       % Do a bit flag check instead of a function call since this is called EVERY time
       %  someone gets looked at.
       if age >= 2
@@ -1570,7 +1570,7 @@ messages:
          if StringEqual(psHonor,player_newbie_honor_string)
          {
             Send(self,@SetHonorString);
-			Send(self,@SetPlayerFlag,#flag=PFLAG_PKILL_ENABLE,#value=TRUE);			% If character is over 2 months old, remove their guardian angel to make mules more dangerous.
+            Send(self,@SetPlayerFlag,#flag=PFLAG_PKILL_ENABLE,#value=TRUE);
          }
       }      
 
@@ -1579,20 +1579,18 @@ messages:
    
    MuleCheck()
    "Message sent to players to check if they are older than 2 months and have PKILL Enable set to true"
-	% Added to check current character's ages and if they are over 
-	% 2 months old confirm that their PKILL_ENABLE flag is set to true.
-   {
-		local MuleAge;
+   {   
+      local MuleAge;
 		
-		MuleAge = Send(SYS,@GetYear) - Send(self,@GetBirthYear);
+      MuleAge = Send(SYS,@GetYear) - Send(self,@GetBirthYear);
 		
-		if MuleAge >= 2
-			{
-				Send(self,@SetPlayerFlag,#flag=PFLAG_PKILL_ENABLE,#value=TRUE);
-			}
-	
-		return;
-	}
+      if MuleAge >= 2
+		{
+           Send(self,@SetPlayerFlag,#flag=PFLAG_PKILL_ENABLE,#value=TRUE);
+        }
+	   
+	   return;
+    }
 
    SetAge(age = 0)
    "Admin supported."


### PR DESCRIPTION
1) Automatically removes Guardian Angel from (new) characters after 2 months (2 meridian years).

2) Added "CheckMule" message. Sends all current players a message that checks their age, if > 2 years then removes their Guardian Angel.

Notes:

When a player is born they get an honor string that says "This soul is new to the
lands of Meridian 59."

That lasts for 2 months (2 meridian years). Once that 2 months is over
that is removed from their bio and now they lose their guardian angel.

As well as other benefits...
- This removes the ability for mules to be used as scouts
- Removes the ability for mules to just die to move around the world
- Makes leaving mules around more dangerous
- Makes mules required to logoff in safe areas....

*\* Compiles without errors, no server errors, tested thoroughly.
