### PR TITLE
Truce & Jig new room flag

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -1022,6 +1022,8 @@
    ROOM_TRIPLE_HEAL   = 0x2000
    % Jig (Jala spell) kills monster gen and disallows item use.
    ROOM_JIG           = 0x4000
+   % Prevents monsters from fighting, but doesn't stop players
+   ROOM_NO_MOB_COMBAT = 0x8000
 
    % Terrain constants, used to tell what type of terrain the room is.
    TERRAIN_GUILDHALL = 0x0000001

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -29,6 +29,7 @@ resources:
       "You cannot cast harmful spells here when someone else is present."
    room_no_pk_allowed = "You cannot attack another player here."
    room_guild_combat = "Only those in guilds may attack each other here."
+   room_no_mob_attack = "You cannot attack monsters here."
 
    room_no_magic_allowed = "You can't cast spells here."
    room_no_spell = "You can't cast spells here."
@@ -1218,6 +1219,17 @@ messages:
          % Anything else is legal in the Arena.
          return TRUE;
       }
+      
+      if (piRoom_flags & ROOM_NO_MOB_COMBAT)
+         AND (IsClass(what,&Monster)
+         OR IsClass(victim,&Monster))
+      {
+         if IsClass(what,&Player)
+         {
+            Send(what,@MsgSendUser,#message_rsc=room_no_mob_attack);
+         }
+         return FALSE;
+      }
 
       if (piRoom_flags & ROOM_NO_COMBAT)
       {
@@ -1319,6 +1331,11 @@ messages:
       {
          Send(who,@MsgSendUser,#message_rsc=room_no_magic_allowed);
 
+         return FALSE;
+      }
+      
+      if (piRoom_flags & ROOM_NO_MOB_COMBAT) AND IsClass(who,&Monster)
+      {
          return FALSE;
       }
 

--- a/kod/object/active/wallelem.kod
+++ b/kod/object/active/wallelem.kod
@@ -145,7 +145,10 @@ messages:
       }
 
       % Is room truced, or otherwise a NO_COMBAT area?
-      if Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
+      if (Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
+         AND IsClass(what,&Player))
+         OR (Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_MOB_COMBAT)
+         AND IsClass(what,&Monster))
       {
          return FALSE;
       }

--- a/kod/object/passive/spell/jala/jig.kod
+++ b/kod/object/passive/spell/jala/jig.kod
@@ -83,7 +83,7 @@ messages:
 
       oRoom = Send(who,@GetOwner);
       Send(oRoom,@SetRoomFlag,#Flag=ROOM_JIG,#value=TRUE);
-      Send(oRoom,@SetRoomFlag,#Flag=ROOM_NO_COMBAT,#value=TRUE);
+      Send(oRoom,@SetRoomFlag,#Flag=ROOM_NO_MOB_COMBAT,#value=TRUE);
 
       propagate;
    }
@@ -94,16 +94,16 @@ messages:
       
       Post(where,@SetRoomFlag,#Flag=ROOM_JIG,#value=FALSE);
 
-      if Send(where,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
+      if Send(where,@CheckRoomFlag,#flag=ROOM_NO_MOB_COMBAT)
       {
-         Send(where,@SetRoomFlagtoDefault,#flag=ROOM_NO_COMBAT);
+         Send(where,@SetRoomFlagtoDefault,#flag=ROOM_NO_MOB_COMBAT);
       }
       
       for i in Send(where,@GetEnchantmentList)
       {
          if Send(Nth(i,2),@GetSpellNum) = SID_TRUCE
          {
-            Send(where,@SetRoomFlag,#flag=ROOM_NO_COMBAT,#value=TRUE);
+            Send(where,@SetRoomFlag,#flag=ROOM_NO_MOB_COMBAT,#value=TRUE);
          }
       }
       

--- a/kod/object/passive/spell/roomench/truce.kod
+++ b/kod/object/passive/spell/roomench/truce.kod
@@ -19,16 +19,14 @@ resources:
    truce_name_rsc = "truce"
    truce_icon_rsc = itruce.bgf
    truce_desc_rsc = \
-      "The spirit of Shal'ille descends upon the area and "
-      "calms the minds of all present, preventing combat for "
+      "The spirit of Shal'ille calls upon her ally Faren, forming a truce with creatures of nature for "
       "several minutes.  "
       "Requires emerald and yrxl sap to cast."
 
-   truce_unnecessary = "Combat is already impossible here."
+   truce_unnecessary = "Combat with monsters is already impossible here."
 
    truce_on = \
-      "A numbing calm settles upon your mind, driving out all thought of "
-      "conflict and war.  You find yourself unable to lift a weapon."
+      "A numbing calm settles upon your mind. You find yourself unable to lift a weapon against nature."
    truce_off = \
       "The calm that had gripped your mind departs.  You feel ready for "
       "battle once more."
@@ -90,7 +88,8 @@ messages:
       oRoom = Send(who,@GetOwner);
 
       % check if combat already banned in room
-      if Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
+      if Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_MOB_COMBAT)
+         OR Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
       {
          Send(who,@MsgSendUser,#message_rsc=truce_unnecessary);
 
@@ -165,7 +164,7 @@ messages:
       Send(oRoom,@SomeoneSaid,#type=SAY_MESSAGE,#string=truce_on,#what=self);
       Send(oRoom,@RoomStartEnchantment,#what=self,#state=$,
            #time=Send(self,@GetDuration,#iSpellPower=iSpellPower));
-      Send(oRoom,@SetRoomFlag,#flag=ROOM_NO_COMBAT,#value=TRUE);
+      Send(oRoom,@SetRoomFlag,#flag=ROOM_NO_MOB_COMBAT,#value=TRUE);
 
       propagate;
    }
@@ -205,16 +204,16 @@ messages:
       local i;
 
       Send(where,@SomeoneSaid,#type=SAY_MESSAGE,#string=truce_off,#what=self);
-      if Send(where,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
+      if Send(where,@CheckRoomFlag,#flag=ROOM_NO_MOB_COMBAT)
       {
-         Send(where,@SetRoomFlagtoDefault,#flag=ROOM_NO_COMBAT);
+         Send(where,@SetRoomFlagtoDefault,#flag=ROOM_NO_MOB_COMBAT);
       }
 
       for i in Send(where,@GetEnchantmentList)
       {
          if Send(Nth(i,2),@GetSpellNum) = SID_JIG
          {
-            Send(where,@SetRoomFlag,#flag=ROOM_NO_COMBAT,#value=TRUE);
+            Send(where,@SetRoomFlag,#flag=ROOM_NO_MOB_COMBAT,#value=TRUE);
          }
       }
 


### PR DESCRIPTION
Added a new room flag, ROOM_NO_MOB_COMBAT. This flag prevents all combat
between monsters and players. Players can still fight each other as
normal.

This is a total solution for Truce and Jig. They no longer shut down PvP.
