### PR TITLE
Remove Guardian Angel after 2 months. V2

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -148,7 +148,7 @@ resources:
    player_spits = "You spit on the corpse of your unworthy foe."
    player_regain_angel = \
       "Due to your weakness, your protective guardian angel returns."
-   player_no_angel = "You suddenly feel more vulnerable."
+   player_no_angel = "`BYou suddenly feel more vulnerable."
 
    player_join_faction = \
       "~IYour name is entered on the roll of membership for %s%s's political "
@@ -1837,7 +1837,7 @@ messages:
 
    UserLogonHook()
    {
-      local i, oGame, oCaramo, oSnoop, oRoom;
+      local i, oGame, oCaramo, oSnoop, oRoom, age;
       
       for i in plPassive
       {
@@ -1923,6 +1923,19 @@ messages:
          Send(oRoom, @SomethingWaveRoom, #what=self, 
               #wave_rsc=player_logged_on_wav_rsc);
       }
+	  
+      % Check to see how old character is if atleast 2 months old
+      % Remove guardian angel, send vulnerable message and game mail.
+      age = Send(SYS,@GetYear) - Send(self,@GetBirthYear);
+	  
+      if age >= 2
+         AND NOT (piFlags & PFLAG_PKILL_ENABLE)
+         AND NOT (piFlags & PFLAG_OUTLAW)
+         AND NOT (piFlags & PFLAG_MURDERER)
+      {
+        send(self,@PkillEnable);
+        debug(send(self,@GetName)," over 2 months old sent PkillEnable message.");
+      }	  
 
       return;
    }


### PR DESCRIPTION
Each time a character logs on this runs a quick check of their age. 

If over 2 months and not already pkill enabled then it sends the player a message that removes Guardian Angel, sends "Vulnerable" message, and sends Game Mail advising them that their guardian angel is no longer needed.

Also changed the "Vulnerable" message to be bold, I think thats an important message and should be bolded.

Thanks Oriumpor

Notes:

As well as other benefits...
- This removes the ability for mules to be used as scouts.
- Removes the ability for mules to just die to move around the world.
- Makes leaving mules around more dangerous
- Makes mules required to logoff in safe areas....

*\* Compiles without errors, no server errors, tested thoroughly.
