### PR TITLE
Remove Angel for Skilled Players

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1923,6 +1923,38 @@ messages:
          Send(oRoom, @SomethingWaveRoom, #what=self, 
               #wave_rsc=player_logged_on_wav_rsc);
       }
+      
+      % Remove guardian angel protection for skilled players
+      if NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+      {
+          for i in plSpells
+          {
+             oSpell = Send(SYS,@FindSpellByNum,#num=Send(self,@DecodeSpellNum,#compound=i));
+             oSchool = Send(oSpell,@GetSchool);
+             oLevel = Send(oSpell,@GetLevel);
+             
+             if oSchool = SS_RIIJA
+             {
+                 % Angeled Riija characters are the vast majority of mules,
+                 % and newbies don't just stumble into such a hard-to-acquire school.
+                 if oLevel >= 2
+                 {
+                    Send(self,@PkillEnable);
+                    Send(self,@PkillLock);
+                    break;
+                 }
+             }
+             else
+             {
+                 if oLevel >= 5
+                 {
+                    Send(self,@PkillEnable);
+                    Send(self,@PkillLock);
+                    break;
+                 }
+             }
+          }
+      }
 
       return;
    }


### PR DESCRIPTION
Characters with 5 or greater in a spell school or 2 or greater in Riija
will be stripped of guardian angel protection when they log in. Spell
school masters are obviously not newbies, and characters with >= Riija 2
while angeled are obviously mules (and the most abusive mules at that).

This should make the vast majority of existing abusive mules lose their guardian angel without inconveniencing new players. Truly new players reaching level 5 in a spell school or doing Riija while angeled really just doesn't happen. Note weaponcraft skills are not considered when making this check.
