### PR TITLE
Change---Spell-Seance

### DIFF
--- a/kod/object/passive/spell/seance.kod
+++ b/kod/object/passive/spell/seance.kod
@@ -156,7 +156,8 @@ messages:
       }
 
       % Strength varies from 15 to 99% chance to be right.
-      iPower = iSpellpower/2 + send(who,@GetKarma)/3 + Bound(send(who,@getmaxhealth),1,100)/4; % Added maxhealth to give an additional chance for built hunters but not mules.
+      % Maxhealth is added to spell power to give an additional chance for built hunters but not mules.
+      iPower = iSpellpower/2 + send(who,@GetKarma)/3 + Bound(send(who,@getmaxhealth),1,100)/4; 
       iPower = bound(iPower,15,99);
 
       return iPower;


### PR DESCRIPTION
Just buffs the success rate of seance a bit to help hunters.

I removed the flat +15 and in it's place but maxhealth/5 so it might end up as a nerf to mules but a pretty big buff to built players looking to hunter pkers.
