### PR TITLE
Update vampdrn.kod

### DIFF
--- a/kod/object/passive/spell/atakspel/vampdrn.kod
+++ b/kod/object/passive/spell/atakspel/vampdrn.kod
@@ -14,6 +14,8 @@ constants:
 
    include blakston.khd
 
+   MAX_HEAL = 50
+
 
 resources:
 
@@ -72,7 +74,7 @@ messages:
    % The chance to do something in addition to normal damage.
    DoSideEffect(who=$,victim=$,damage=0)
    {
-      local iToHeal, iMaxHeal;
+      local iToHeal;
       
       if who = $ OR victim = $
       {
@@ -92,7 +94,8 @@ messages:
               #parm1=Send(victim,@GetDef),#parm2=Send(victim,@GetName));
       }
 
-      if send(who,@GetHealth) < send(who,@GetMaxHealth)+50 % Cap health gained for Vamp Drain at Max + 50
+      % Cap health after gain at max + 50
+      if send(who,@GetHealth) + iToHeal > send(who,@GetMaxHealth)+ MAX_HEAL 
       {   
          Send(who,@GainHealth,#amount=iToHeal);
       }


### PR DESCRIPTION
As I continue on my quest to slightly change spells no one ever uses my mind landed on this one while at work today.

All I did is remove the stuff that divides the amount it heals you by half.

The spell, as splash spells go is still capped at way less damage then any other splash spell but now at least it has a decent trade off. If you do 11 damage, it'll heal you 11. If you kill something it will heal you max, 18.

It may sound like a lot but the spell still has the typical splash cost and delay.
