### PR TITLE
Fury of Nature spell

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -1960,6 +1960,7 @@
    SID_MIRTH = 179
    SID_MELANCHOLY = 180
    SID_CRYSTALIZE_MANA = 181
+   SID_FURY_OF_NATURE = 182
 
    % Depreciated spell IDs
    SID_LIGHTNING = 1                   % use SID_LIGHTNING_BOLT

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1179,6 +1179,16 @@ messages:
       {
          return TRUE;
       }
+      
+      % Check for Fury of Nature, which prevents fizzles
+      if IsClass(self,&AttackSpell)
+         AND viSchool = SS_FAREN
+      {         
+         if Send(who,@IsEnchanted,#what=Send(SYS,@FindSpellByNum,#NUM=SID_FURY_OF_NATURE))
+         {
+            return TRUE;
+         }
+      }
 
       iRequisiteStat = Send(self,@GetRequisiteStat,#who=who);
       num = ((100-iRequisiteStat)*iSpellpower/100) + iRequisiteStat;

--- a/kod/object/passive/spell/atakspel.kod
+++ b/kod/object/passive/spell/atakspel.kod
@@ -22,6 +22,8 @@ resources:
    attack_spell_no_self_rsc = "You can't cast %s on yourself."
    attack_spell_out_of_range = "%s%s is too far away to hit with %s."
 
+   furyofnature_spell_boost_rsc = "Your spell surges with elemental energies!"
+   
 classvars:
 
    viAttack_type = 0
@@ -150,6 +152,19 @@ messages:
                % Bonus damage is 1 to piManaFocusBonus, scaled by the power of iManaFocus.
                iDamage = iDamage + ((iManaFocus * piManaFocusBonus) / SPELLPOWER_MAXIMUM) + 1;
             }
+         }
+         
+         % Check for Fury of Nature boost
+         if Send(who,@IsEnchanted,#what=Send(SYS,@FindSpellByNum,#NUM=SID_FURY_OF_NATURE))
+         {
+            % Inform caster the boost is working
+            Send(who,@MsgSendUser,#message_rsc=furyofnature_spell_boost_rsc);
+            
+            % Fury cost is 2 mana per cast
+            Send(who,@LoseMana,#amount=2);
+            
+            % Adds 2 damage
+            iDamage = iDamage + 2;
          }
       }
      

--- a/kod/object/passive/spell/persench/furyofnature.kod
+++ b/kod/object/passive/spell/persench/furyofnature.kod
@@ -1,0 +1,90 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+FuryOfNature is PersonalEnchantment
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   furyofnature_name_rsc = "fury of nature"
+   furyofnature_icon_rsc = imanafoc.bgf
+   furyofnature_desc_rsc = \
+      "Draws from the raging elements themselves to empower the caster's attack spells.  "
+      "Requires purple mushrooms to cast."
+
+   furyofnature_on_rsc = "Your spirit surges with elemental energy."
+   furyofnature_off_rsc = "Nature's wrath departs, leaving your spirit bereft and weak."
+   
+classvars:
+
+   viSpell_num = SID_FURY_OF_NATURE
+   viSchool = SS_FAREN
+   viMana = 12
+   viSpell_Exertion = 12
+   viSpell_level = 6
+
+   viChance_To_Increase = 5
+
+   vrName = furyofnature_name_rsc
+   vrIcon = furyofnature_icon_rsc
+   vrDesc = furyofnature_desc_rsc
+
+   vrEnchantment_On = furyofnature_on_rsc
+   vrEnchantment_Off = furyofnature_off_rsc
+   
+   vbCanCastonOthers = FALSE
+
+properties:
+
+
+messages:
+
+   ResetReagents()
+   {
+      plReagents = $;
+      plReagents = Cons([&PurpleMushroom,2],plReagents);
+
+      return;
+   }
+
+   GetDuration(iSpellPower = 0)
+   {
+      local iDuration;
+
+      % Spellpower affects duration drastically
+      % All other effects are spellpower-independent
+      iDuration = 20 + (iSpellPower*3);
+      iDuration = iDuration * 1000;
+
+      return random(iDuration/2,iDuration);
+   }
+
+   GetStateValue(who = $, iSpellPower = 0)      
+   {
+      return iSpellPower;
+   }
+
+   SuccessChance(who=$)
+   "Designed to fight fizzles, should not fizzle itself."
+   {
+      return TRUE;
+   }
+   
+   CanBeRemovedByPlayer()
+   {
+      % Cannot be purged.
+      return FALSE;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/persench/makefile
+++ b/kod/object/passive/spell/persench/makefile
@@ -7,6 +7,6 @@
 DEPEND = ..\persench.bof
 BOFS = haste.bof detinvis.bof detgood.bof denial.bof detevil.bof respois.bof cloak.bof freeact.bof\
        eavesdrp.bof eagleyes.bof bless.bof gort.bof mshield.bof nightv.bof shadform.bof\
-       strength.bof resist.bof invis.bof deflect.bof touchatk.bof gaze.bof karahol.bof 
+       strength.bof resist.bof invis.bof deflect.bof touchatk.bof gaze.bof karahol.bof furyofnature.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -2967,6 +2967,8 @@ messages:
       Send(self,@CreateOneSpellIfNew,#num=SID_MELANCHOLY,#class=&Melancholy);
 
       Send(self,@CreateOneSpellIfNew,#num=SID_CRYSTALIZE_MANA,#class=&CrystalizeMana);
+      
+      Send(self,@CreateOneSpellIfNew,#num=SID_FURY_OF_NATURE,#class=&FuryOfNature);
 
       % Trance may be searched for frequently, leave at end of list
       Send(self,@CreateOneSpellIfNew,#num=SID_TRANCE,#class=&Trance);


### PR DESCRIPTION
Created a new Faren 6 spell that will hopefully solve quite a few
problems for the magic attack school. "Fury of Nature" is a simple self-only
PE that cannot be purged and cannot fizzle.

It has a flat effect tradeoff: it prevents fizzles for Faren attack
spells and adds 2 damage, at the cost of 2 extra mana per cast. Attack
spells already lose damage if their spellpower is weak (down to half),
and mana costs go up as well, so this spell works very will with the
existing inherent balances. It just lets Faren mages do _something_
rather than _nothing_ the moment an Anti-magic Aura goes up or a Dement
hits them.
