### PR TITLE
Umbrella Fix

### DIFF
--- a/kod/object/passive/spell/umbrella.kod
+++ b/kod/object/passive/spell/umbrella.kod
@@ -104,7 +104,6 @@ messages:
       {
          oUser = Send(oRoom,@HolderExtractObject,#data=oObj);
 
-         % Important note: FindListElem returns nil on a passed nil value, not zero.
          if IsClass(oUser,&User)
             AND (lEnchanted = $ OR FindListElem(lEnchanted,oUser) = 0)
             AND Send(who,@SquaredDistanceTo,#what=oUser) <= (UMBRELLA_RANGE * UMBRELLA_RANGE)


### PR DESCRIPTION
Umbrella's problem all these years was that FindListElem called on a nil
value returns nil, not 0. I fixed that, and standardized its distance
measurement function. It now functions completely as intended.

It adds 500 defense and up to 100% resistance to all magic to those within the umbrella. If this is something somebody else wants to balance or fix, we can do that later, but this is just a bug fix pull.
