### PR TITLE
Removed improvement impairing code.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -901,8 +901,6 @@ properties:
    % Action, such as "smiling", that player is currently doing
    piAction = 1
 
-   piAdvancement_points = 0
-
    % piNodeList is a bitvector of all of the mana nodes that the player has
    %  successfully melded with.  List of available nodelists in the
    %  blakston.khd constants file.
@@ -1485,8 +1483,6 @@ messages:
          Send(self,@InformHunters);
       }
 
-      % Player moved to a new location, give them a break on the botting imp cap.
-      piAdvancement_points = bound((piAdvancement_points - 2),0,$);
       
       return;
    }
@@ -2354,8 +2350,6 @@ messages:
       % percent stomach is full
       piStomach = 0;
       piTimeLastStomachUpdate = 0;
-
-      piAdvancement_points = 0;
 
       piKill_count = 0;
       piKill_count_decay = 0;
@@ -6160,12 +6154,6 @@ messages:
 
       iToAdd = amount;
 
-      % Give a penalty for sitting at the botting imp cap.
-      if NOT Send(self,@CheckAdvancementPoints)
-      {
-         iToAdd = iToAdd / 2;
-      }
-
       SetNth(plSchoolCasts,school,(Nth(plSchoolCasts,school)+iToAdd));
 
       return;
@@ -6650,11 +6638,6 @@ messages:
               #wave_rsc=player_improved_wav_rsc);
       }
       
-      if iChange > 0 
-      {
-         Send(self,@AddAdvancementPoints,#number=amount);
-      }
-      
       Send(self,@PlayerIsIntriguing);
 
       if refigureschools
@@ -6900,8 +6883,7 @@ messages:
          AND NOT initial
       {  
           Send(self,@AddToSchools,#school=Send(oSpell,@GetSchool),\
-               #change=iBoundAbility);     
-          Send(self,@AddAdvancementPoints,#number=2);
+               #change=iBoundAbility);
       }
 
       if poOwner <> $
@@ -7070,12 +7052,9 @@ messages:
       % Must get below highmark for atrophy to activate
       iAmount = -2;
 
-      highmark = piAdvancement_points + ((50-bound(Send(self,@GetIntellect),1,50))
-                 * piAdvancement_Points)/20; 
-
       for i in plSpells
       {
-         if i < 0 AND Random(1,200) < highmark               
+         if i < 0              
          {
             iAbility = Send(self,@DecodeSpellAbility,#compound=i);
             if iAbility > 2                                                         
@@ -7219,11 +7198,6 @@ messages:
               #wave_rsc=player_improved_wav_rsc);
       }
       
-      if iChange > 0 
-      {
-         Send(self,@AddAdvancementPoints,#number=amount);
-      }
-      
       Send(self,@PlayerIsIntriguing);
 
       if refigureschools
@@ -7350,7 +7324,6 @@ messages:
       {  
          Send(self,@AddToSchools,#school=Send(oSkill,@GetSchool),
               #change=iBoundAbility);     
-         Send(self,@AddAdvancementPoints,#number=4);
       }
       
       return True;
@@ -7436,11 +7409,10 @@ messages:
       local i, j, iability, lSchoolsUsed, aSkill, bSkill, bFound, highmark, iAmount;
 
       iAmount = -2;
-      highmark = piAdvancement_points + ((50-bound(Send(self,@GetIntellect),1,50))*piAdvancement_Points)/20;
 
       for i in plSkills
       {
-         if i < 0 AND Random(1,200) < highmark           
+         if i < 0
          {
             iAbility = Send(self,@decodeSkillability,#compound=i);
             if iAbility > 2                                                         
@@ -7493,42 +7465,16 @@ messages:
       return;
    }
 
-   AddAdvancementPoints(number=1)
-   "A player can only gain so many advancement points per hour, in spells"
-   "And skills combined."
-   {
-      local iTime;
-      
-      if ptAdvancement = $
-      {
-         iTime = random(ADVANCE_TIMER_MIN,ADVANCE_TIMER_MAX);
-         ptAdvancement = CreateTimer(self,@AdvancementTimer,iTime);
-      }
-      
-      piAdvancement_points = piAdvancement_points + number;
-      
-      return;
-   }
 
-   CheckAdvancementPoints()
-   "Checks to be sure a player isn't at the limit yet."
-   {
-      if piAdvancement_points < ADVANCEMENT_LIMIT
-      {
-         return TRUE;
-      }
-      
-      return FALSE;
-   }
 
    AdvancementTimer()
-   "This does a few things when it goes off.  It clears advancement points, "
-   "so people can learn again.  It also checks for spell or skill atrophy, "
+
+   "This checks for spell or skill atrophy, "
    "and resets the atrophy flags."
    {
       ptAdvancement = $;
 
-      if piAdvancement_points > 0 AND pbLogged_on
+      if pbLogged_on
       {
          if Send(Send(SYS, @GetSettings), @IsAtrophyOn)
          {
@@ -7538,8 +7484,6 @@ messages:
          
          Send(self,@ResetAtrophyFlags);
       }
-      
-      piAdvancement_Points = 0;
       
       return;
    }
@@ -7582,7 +7526,7 @@ messages:
    "their maxhealth to gain a HP.  This number is reduced by the player's"
    "stamina, all the way down to half for those with high staminas."
    {
-      local highmark, rand, dodgeskill, oSkill, monster_level, gain, gainmult, roll, iNumber, oWeapon;
+      local rand, dodgeskill, oSkill, monster_level, gain, gainmult, roll, iNumber, oWeapon, highmark;
             
       gain = 0;
       roll = FALSE;
@@ -7928,7 +7872,6 @@ messages:
          }
 
          % Atrophy of skills or learning progress.
-         piAdvancement_points = 0;
          piGain_chance = piGain_chance/2;
          Send(self,@ResetGainFlags);
          Send(self,@ResetAtrophyFlags);

--- a/kod/object/passive/skill.kod
+++ b/kod/object/passive/skill.kod
@@ -319,11 +319,6 @@ messages:
          return FALSE;
       }
 
-      if NOT Send(who,@CheckAdvancementPoints)
-      {
-         Return FALSE;
-      }
-
       % Can advance in real death arenas
       if Send(Send(who,@GetOwner),@CheckRoomFlag,#flag=ROOM_SAFE_DEATH)
          AND NOT Send(Send(who,@GetOwner),@ArenaRealDeath)

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1606,12 +1606,6 @@ messages:
          return FALSE;
       }
 
-      % No advancing if you've already gotten all your improves so far.
-      if NOT Send(who,@CheckAdvancementPoints)
-      {
-         Return FALSE;
-      }
-
       oOwner = Send(who,@GetOwner);
 
       % Can advance in real death arenas


### PR DESCRIPTION
Removed piAdvacementPoints and all references to it.

This removes the artificial imp cap that has been impairing the real improvement advancement code and creates a fluid improvement rate rather than a stop and go building experience.

With the constant added to allow adjusting improvement rate this can now be managed.

It also allows players to do things they couldn't before, like work weaponscraft skills and spells at the same time without completely impacting both, only slightly impacting the rate (as the improve code clearly intends.)
