### PR TITLE
MSH boost

### DIFF
--- a/kod/object/item/passitem/defmod/helmet/helm.kod
+++ b/kod/object/item/passitem/defmod/helmet/helm.kod
@@ -40,7 +40,7 @@ classvars:
 
    viUse_type = ITEM_USE_HEAD
    viUse_amount = 1
-   viSpell_modifier = -8
+   viSpell_modifier = -5
 
    viGround_group = 2
    viInventory_group = 2


### PR DESCRIPTION
I think we can agree MSH's for how rare they are -- are essentially a
useless item used for looks. I would like to increase the attributes of
an MSH from a slight increase from a regular helmet to that of a much
better helmet.
- Decreased durability slightly - it is a golden / intricate delicate helmet....
- Increased Defense Base to act more like a good piece of armor -
  increases dodge chance.
- Doubled it's attack spell reduction from 15 to 30 since it is
  considered an Anti Magic piece of Armor.

This should make the risk of losing or using an MSH worth while.

One thing I am not 100% on, existing helms - will this change their
makeup?? Or does somehting special have to happen? Does it need a new call or a new constructor?

How will existing MSH's get the updated "stats" ? On test's the new helms have the updates but older helmets do not?
