### PR TITLE
Jala Overhaul Streamlined

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -872,6 +872,9 @@ properties:
    % Defense modifiers to defense roll & damage (includes items & spells)
    plDefense_modifiers = $
    
+   % Jala modifiers do a variety of things (all will be songs currently affecting the player)
+   plJala_modifiers = $
+   
    piGender = GENDER_MALE
 
    piVigor_rest_threshold = 80
@@ -3161,6 +3164,102 @@ messages:
       return;
    }
 
+   AddJalaModifier(what = $, iVolume = 0, singer = $)
+   "Adds what and volume to plJala_modifiers, which carry out song effects."
+   {
+      plJala_modifiers = Cons([what,iVolume,singer],plJala_modifiers);
+      Send(self,@ShowAddEnchantment,#what=what,#type=ENCHANTMENT_ROOM);
+      
+      return;
+   }
+   
+   GetJalaModifiers()
+   {
+      return plJala_modifiers;
+   }
+   
+   RemoveJalaModifier(what = $, iVolume = 0, singer = $)
+   "Removes <what> from plJala_modifiers."
+   {
+      local i, bFound;
+
+      bFound = FALSE ;
+      for i in plJala_modifiers
+      {
+         if Nth(i,1) = what
+            AND Nth(i,2) = iVolume
+            AND Nth(i,3) = singer
+         {
+            Send(self,@ShowRemoveEnchantment,#what=Nth(i,1),#type=ENCHANTMENT_ROOM);
+            plJala_modifiers = DelListElem(plJala_modifiers,i);
+            bFound = TRUE;
+         }
+      }
+
+      if NOT bFound
+      {
+         Debug(self,"Tried to remove Jala modifier",what,"but not in list",
+               plJala_modifiers);
+      }
+
+      return;
+   }
+
+   IsAffectedByJalaModifier(what = $, byClass = &Jala)
+   "Returns whether or not currently enchanted by <what> song."
+   {
+      local i;
+      
+      if plJala_modifiers = $
+      {
+         return FALSE;
+      }
+
+      if what = $
+      {
+         for i in plJala_modifiers
+         {
+            if IsClass(Nth(i,1),byClass)
+            {
+               return TRUE;
+            }
+         }
+      }
+      else
+      {
+         for i in plJala_modifiers
+         {
+            if Nth(i,1) = what
+            {
+               return TRUE;
+            }
+         }      
+      }
+      
+      return FALSE;
+   }
+   
+   GetLoudestJalaModifierState(byClass=&Jala)
+   {
+      local i, oLoudestVolume, oLoudestState;
+
+      oLoudestVolume = 0;
+
+      for i in plJala_modifiers
+      {
+         if IsClass(Nth(i,1),byClass)
+         {
+            if Nth(i,2) > oLoudestVolume
+            {
+               oLoudestVolume = Nth(i,2);
+               oLoudestState = i;
+            }
+         }
+      }    
+
+      return oLoudestState;
+   }
+   
    AddDefenseModifier(what = $)
    "Adds <what> to plDefense_modifiers, which can modify defense strength "
    "and damage."
@@ -3902,7 +4001,7 @@ messages:
 
    TryAttack(what = $,use_weapon = $,stroke_obj=$)
    {
-      local iRange, oWinds, oSandstorm;
+      local i, iRange, oWinds, oSandstorm, iAttackTime;
 
       % Can't target self.
       if what = self
@@ -3911,10 +4010,17 @@ messages:
          
          return FALSE;
       }
-
+      
+      % Check for Jala songs that may warp time
+      iAttackTime=1;
+      for i in Send(self,@GetJalaModifiers)
+      {
+         iAttackTime = Send(Nth(i,1),@ModifyAttackTime,#who=self,#state=i,#time=iAttackTime,#originalValue=1);
+      }
+      
       % Check attack time.
-      % IsOkayAttackTime defaults to 1 second
-      if NOT Send(self,@IsOkayAttackTime) 
+      % IsOkayAttackTime defaults to 1 second, can be warped up to 3 seconds
+      if NOT Send(self,@IsOkayAttackTime,#seconds=iAttackTime)
       {
          return FALSE;
       }  
@@ -4030,6 +4136,15 @@ messages:
 
          if Send(poOwner,@IsEnchanted,#what=oSandstorm)
             AND Send(oSandstorm,@WindsRuinShot,#who=self)
+         {
+            return FALSE;
+         }
+      }
+      
+      % Check for Jala songs that prevent attacks
+      for i in Send(self,@GetJalaModifiers)
+      {
+         if Send(Nth(i,1),@TryPreventAttack,#who=self,#state=i,#stroke_obj=stroke_obj)
          {
             return FALSE;
          }
@@ -4169,7 +4284,7 @@ messages:
    % This returns the battler's ability to-hit.  Ranges from 1 to 1000
    GetOffense(what = $, stroke_obj=$)
    {
-      local i, oWeapon, iStroke, iProficiency, iAim, iOffense, oMonster;
+      local i, oWeapon, iStroke, iProficiency, iAim, iOffense, iModifiedOffense, oMonster;
 
       oWeapon = $;
 
@@ -4212,9 +4327,16 @@ messages:
          iOffense = Send(i,@ModifyHitRoll,#who=self,#what=what,
                          #hit_roll=iOffense,#stroke_obj=stroke_obj);
       }
+      
+      % Check for Jala songs that affect chance-to-hit
+      iModifiedOffense = iOffense;
+      for i in Send(self,@GetJalaModifiers)
+      {
+         iModifiedOffense = Send(Nth(i,1),@ModifyHitRoll,#who=self,#what=what,#state=i,
+                                 #hit_roll=iModifiedOffense,#stroke_obj=stroke_obj,#originalValue=iOffense);
+      }
 
-      iOffense = iOffense + Send(Send(SYS,@GetParliament),
-                                 @GetFactionHitrollBonus,#who=self);
+      iOffense = iModifiedOffense + Send(Send(SYS,@GetParliament),@GetFactionHitrollBonus,#who=self);
 
       % If we're using a ranged weapon and don't have a clear line of sight,
       %  then half our offense.
@@ -4236,7 +4358,7 @@ messages:
    % This returns the battler's ability to avoid being hit.  Ranges from 1 to 1000.
    GetDefense(what = $, stroke_obj=$)
    {
-      local i, oWeapon, oShield, iParry, iDodge, iBlock, iAgility, iDefense, oMonster;
+      local i, oWeapon, oShield, iParry, iDodge, iBlock, iAgility, iDefense, iModifiedDefense, oMonster;
 
       % Morphed?
       oMonster = Send(self,@GetIllusionForm);
@@ -4268,7 +4390,15 @@ messages:
          iDefense = Send(i,@ModifyDefensePower,#who=self,#what=what,#defense_power=iDefense);
       }
 
-      iDefense = iDefense + Send(Send(SYS,@GetParliament),@GetFactionDefenseBonus,#who=self);
+      % Check for Jala songs that affect defense
+      iModifiedDefense = iDefense;
+      for i in Send(self,@GetJalaModifiers)
+      {
+         iModifiedDefense = Send(Nth(i,1),@ModifyDefense,#who=self,#what=what,#state=i,
+                                 #defense=iModifiedDefense,#stroke_obj=stroke_obj,#originalValue=iDefense);
+      }
+
+      iDefense = iModifiedDefense + Send(Send(SYS,@GetParliament),@GetFactionDefenseBonus,#who=self);
 
       % The universal modifier.
       iDefense = iDefense + ((iDefense * piFlags3) / 100);
@@ -4351,7 +4481,7 @@ messages:
    % This returns the damage done to target "what" before resistances.
    GetDamage(what = $, stroke_obj=$)
    {
-      local i, iDamage, oStroke, oWeapon, iStrokeNum, iModBonus, iDamageBonus,
+      local i, iDamage, oStroke, oWeapon, iStrokeNum, iModBonus, iDamageBonus, iModifiedDamage,
             oSpell, oMonster;
 
       % Morphed?
@@ -4402,9 +4532,16 @@ messages:
 
          Send(i,@WeaponHitTarget);
       }
+      
+      % Check for Jala songs that modify damage
+      iModifiedDamage = iDamageBonus;
+      for i in Send(self,@GetJalaModifiers)
+      {
+         iModifiedDamage = Send(Nth(i,1),@ModifyDamage,#who=self,#what=what,#state=i,
+                                #damage=iModifiedDamage,#stroke_obj=oStroke,#originalValue=iDamageBonus);
+      }
                
-      iDamageBonus = iDamageBonus + Send(Send(SYS,@GetParliament),
-                                         @GetFactionDamageBonus,#who=self);
+      iDamageBonus = iModifiedDamage + Send(Send(SYS,@GetParliament),@GetFactionDamageBonus,#who=self);
 
       iDamage = iDamage + iDamageBonus;
 
@@ -4417,31 +4554,43 @@ messages:
    % This is the type of damage done.
    GetDamageType(what = $, use_weapon = $)
    {
-      local oWeapon, oMonster;
+      local i, oWeapon, oMonster, oAttackType;
 
       % Morphed?
       oMonster = Send(self,@GetIllusionForm);
       if oMonster <> $ AND Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
       {
-         return Send(oMonster,@GetDamageType,#what=what);
-      } 
-
-      if use_weapon = $
-      {
-         oWeapon = Send(self,@GetWeapon);
+         oAttackType = Send(oMonster,@GetDamageType,#what=what);
       }
       else
       {
-         oWeapon = use_weapon;
+          if use_weapon = $
+          {
+             oWeapon = Send(self,@GetWeapon);
+          }
+          else
+          {
+             oWeapon = use_weapon;
+          }
+          
+          if oWeapon = $
+          {
+             % No weapon means we are punching
+             oAttackType = ATCK_WEAP_UNARMED+ATCK_WEAP_PUNCH;
+          }
+          else
+          {
+             oAttackType = Send(oWeapon,@GetAttackType);
+          }
       }
       
-      if oWeapon = $
+      % Check for Jala songs that affect damage type
+      for i in Send(self,@GetJalaModifiers)
       {
-         % No weapon means we are punching
-         return ATCK_WEAP_UNARMED+ATCK_WEAP_PUNCH;
+         oAttackType = Send(Nth(i,1),@ModifyAttackType,#who=self,#what=what,#state=i,#attack_type=oAttackType);
       }
 
-      return Send(oWeapon,@GetAttackType);
+      return oAttackType;
    }
 
    GetSpellType(what = $, use_weapon = $)
@@ -4501,7 +4650,7 @@ messages:
               report = True, report_resistance = TRUE, absolute = FALSE)
    {
       local i, iResistance, oSoldierShield, gainchance, color_rsc, iDuration, oSpell,
-            iLimit;
+            iLimit, iModifiedDefenseDamage;
 
       color_rsc = player_hit_color_none;
       
@@ -4518,7 +4667,15 @@ messages:
                           #atype=atype,#aspell=aspell);
             Send(i,@DefendingHit,#who=self,#what=what);
          }
-      
+
+         iModifiedDefenseDamage = damage;
+         for i in Send(self,@GetJalaModifiers)
+         {
+            iModifiedDefenseDamage = Send(Nth(i,1),@ModifyDefenseDamage,#who=self,#what=what,#state=i,
+                                 #damage=iModifiedDefenseDamage,#atype=atype,#aspell=aspell,
+                                 #stroke_obj=stroke_obj,#originalValue=damage);
+         }
+
          iResistance = Send(self,@ResistanceCheck,#atype=atype,#aspell=aspell);                             
          damage = Send(self,@GetDamageFromResistance,#what=damage,#value=iResistance);
 
@@ -5541,7 +5698,7 @@ messages:
    CalculateHealthTime()
    "Calculate # of milliseconds until user will gain a health point"
    {
-      local iTime, iMaxHealth, lJalaInfo, oJalaSpell, iJalaPower;
+      local i, iTime, iMaxHealth, oSongState;
       
       % Faster regen with higher vigor
       iTime = ((200-piVigor)*(200-piVigor))/6 + 1000;
@@ -5552,30 +5709,24 @@ messages:
 
       iTime = iTime - Send(Send(SYS,@GetParliament),@GetFactionRegenBonus,
                            #who=self,#hpregen=TRUE);
-      
+
+      iTime = bound(iTime,1000,60000);
+
       if poOwner <> $
       {
-         lJalaInfo = Send(poOwner,@GetJalaInfo);
-
-         if lJalaInfo <> $
+         for i in Send(self,@GetJalaModifiers)
          {
-            oJalaSpell = Nth(lJalaInfo,2);
-            if IsClass(oJalaSpell,&Restorate)
-            {
-               iJalaPower = Nth(Nth(lJalaInfo,3),3);
-               iTime = Send(oJalaSpell,@AdjustHealthTime,#time=iTime,
-                            #iSpellPower=iJalaPower);
-            }
+            iTime = Send(Nth(i,1),@ModifyHealthTime,#state=i,#time=iTime);
          }
       }
 
-      return bound(iTime,1000,60000);
+      return iTime;
    }
 
    CalculateManaTime()
    "Calculate # of milliseconds until user will gain a mana point"
    {
-      local iTime, lJalaInfo, oJalaSpell, iJalaPower, oSpell;
+      local i, iTime, oSongState;
 
       if piMana > piMax_mana
       {
@@ -5594,27 +5745,10 @@ messages:
 
          if poOwner <> $
          {
-            lJalaInfo = Send(poOwner,@GetJalaInfo);
-
-            if lJalaInfo <> $
+            for i in Send(self,@GetJalaModifiers)
             {
-               oJalaSpell = Nth(lJalaInfo,2);
-               if IsClass(oJalaSpell,&Rejuvenate)
-               {
-                  iJalaPower = Nth(Nth(lJalaInfo,3),3);
-                  iTime = Send(oJalaSpell,@AdjustManaTime,#time=iTime,
-                               #iSpellPower=iJalaPower);
-               }
+               iTime = Send(Nth(i,1),@ModifyManaTime,#state=i,#time=iTime);
             }
-         
-            iTime = bound(iTime,500,60000);
-         }
-
-         % Mana Focus will adjust mana regen time based on its spellpower.
-         oSpell = Send(SYS,@FindSpellByNum,#Num=SID_MANA_FOCUS);
-         if Send(self,@IsEnchanted,#what=oSpell)
-         {
-            iTime = Send(oSpell,@AdjustManaTime,#who=self,#time=iTime);
          }
       }
 
@@ -9811,22 +9945,15 @@ messages:
 
    GetRestTime()
    {
-      local iTime, lJalaInfo, oJalaSpell, iJalaPower;
+      local i, iTime, oSongState;
 
       iTime = 1000 + (30* (51-Send(self,@getStamina))); 
 
       if poOwner <> $
       {
-         lJalaInfo = Send(poOwner,@GetJalaInfo);
-
-         if lJalaInfo <> $
+         for i in Send(self,@GetJalaModifiers)
          {
-            oJalaSpell = Nth(lJalaInfo,2);
-            if IsClass(oJalaSpell,&Invigorate)
-            {
-               iJalaPower = Nth(Nth(lJalaInfo,3),3);
-               iTime = Send(oJalaSpell,@AdjustVigorTime,#time=iTime,#iSpellPower=iJalaPower);
-            }
+            iTime = Send(Nth(i,1),@ModifyVigorTime,#state=i,#time=iTime);
          }
       }
       
@@ -10151,6 +10278,17 @@ messages:
          }
          
          plDefense_modifiers = $;
+      }
+
+      if plJala_modifiers <> $
+      {
+         for i in plJala_modifiers
+         {
+            Debug("Recalibrating: player",Send(self,@GetTrueName),self,
+                  "still had jalamods",Send(i,@GetName));
+         }
+         
+         plJala_modifiers = $;
       }
       
       if plResistances <> $

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -71,9 +71,6 @@ resources:
       "Shal'ille frowns upon your assitance to unlawful citizens."
 
    spell_failed_by_chance = "You were unsuccessful in casting %s."
-   spell_spellbane_stopped = \
-      "The notes of %s's song tangle with the words of your spell, unraveling "
-      "it faster than your tongue can weave it."
 
    spell_advanced = "You advanced in %s!  Your ability is now at %s."
    spell_guardian = \
@@ -489,7 +486,7 @@ messages:
    CanCastHere(who = $, where = $, lTargets = $, iSpellPower = 0,
                bItemCast = FALSE, report = TRUE)
    {
-      local oSpell, lState, iJalaPower, oTarget;
+      local i, oSpell, lState, oTarget;
 
       if IsClass(who,&DM)
       {
@@ -504,26 +501,11 @@ messages:
 
       if NOT bItemCast
       {
-         oSpell = Send(SYS,@FindSpellByNum,#num=SID_SPELLBANE);
-         if (Send(where,@IsEnchanted,#what=oSpell))
+         % Spellbane check
+         for i in Send(who,@GetJalaModifiers)
          {
-            % The spell's spellpower is the third element of the state, which
-            %  is the third element of Jala info stored by room.
-            iJalaPower = Nth(Nth(Send(where,@GetJalaInfo),3),3);
-
-            % Does Spellbane overpower the spell?
-            % Spellbane always works on monsters that can be silenced
-            if iJalaPower > iSpellPower
-               OR (IsClass(who,&Monster) AND Send(who,@CanBeSilenced))
+            if Send(Nth(i,1),@TryPreventSpell,#who=who,#state=i,#iSpellPower=iSpellPower)
             {
-               if report
-               {
-                  % 2nd element in state is the original caster.
-                  lState = Send(where,@GetEnchantmentState,#what=oSpell);
-                  Send(who,@MsgSendUser,#message_rsc=spell_spellbane_stopped,
-                       #parm1=Send(Nth(lState,2),@GetName));
-               }
-         
                return FALSE;
             }
          }
@@ -690,7 +672,7 @@ messages:
                bMade = FALSE)
    {
       local iLists, oUserObject, iNum, i, oOwner, oVictim, oRoom, iRand,
-            oSpell;
+            oSpell, oSongState, iModified_PostCast_Time;
       
       if NOT IsClass(who,&Player)
       {
@@ -741,8 +723,15 @@ messages:
             return FALSE;
          }
       }
+
+      % Warp Time can double or triple postcast timers
+      iModified_PostCast_Time = viPostCast_Time;
+      for i in Send(who,@GetJalaModifiers)
+      {
+         iModified_PostCast_Time= Send(Nth(i,1),@ModifyPostCastTime,#who=who,#state=i,#time=iModified_PostCast_Time,#originalValue=viPostCast_time);
+      }
       
-      if NOT Send(who,@IsOkayAttackTime,#seconds=viPostCast_Time)
+      if NOT Send(who,@IsOkayAttackTime,#seconds=iModified_PostCast_Time)
       {
          return FALSE;
       }
@@ -1165,7 +1154,7 @@ messages:
    "This is always TRUE for touch attack spells, because touch attacks"
    "figure their success in player.kod."
    {
-      local num, iRequisiteStat, iability, lJalaInfo, oJalaSpell, lJalaState,
+      local num, iRequisiteStat, iability,
       iDistance, oTarget, oRing;
 
       oRing = Send(who,@FindHolding,#class=&ReagentRing);
@@ -1182,22 +1171,6 @@ messages:
 
       iRequisiteStat = Send(self,@GetRequisiteStat,#who=who);
       num = ((100-iRequisiteStat)*iSpellpower/100) + iRequisiteStat;
-
-      % Modify chance to succeed due to Jala's hinder spells.
-      lJalaInfo = Send(Send(who,@GetOwner),@GetJalaInfo);
-
-      if lJalaInfo <> $
-      {
-         % lJalaInfo is of form: [room timer, spell object, state]
-         oJalaSpell = Nth(lJalaInfo,2);
-         if IsClass(oJalaSpell,&HinderSpell)
-         {
-            lJalaState = Nth(lJalaInfo,3);
-            % Jala State is of the form: [volume, caster, spellpower]
-            num = Send(oJalaSpell,@GetAlteredChance,#chance=num,#what=self,
-                       #iSpellPower=Nth(lJalaState,3));
-         }
-      }
 
       num = bound(num,5,95);
 
@@ -1858,7 +1831,7 @@ messages:
 
    GetTranceTime(iSpellpower=0,who=$)
    {
-      local iPercent;
+      local i, iPercent, iModifiedPercent;
       
       if iSpellpower = 0
       {
@@ -1872,9 +1845,15 @@ messages:
       }
 
       % 51% for high, 149% for low
-      iPercent = 150 - iSpellPower;   
+      iPercent = 150 - iSpellPower;
       
-      return (viCast_time*iPercent)/100;
+      iModifiedPercent = iPercent;
+      for i in Send(who,@GetJalaModifiers)
+      {
+         iModifiedPercent = Send(Nth(i,1),@ModifyTranceTime,#who=who,#state=i,#percent=iModifiedPercent,#originalValue=iPercent);
+      }
+      
+      return (viCast_time*iModifiedPercent)/100;
    }
 
    DoPreTranceEffects(who=$,lTargets=$,iSpellpower=$)
@@ -2178,15 +2157,31 @@ messages:
            
       if Send(oRoom,@CheckRoomFlag,#flag=ROOM_ANTI_MAGIC)
       {
-         oModifierSpell = Send(SYS,@FindspellByNum,#num=SID_ANTIMAGIC_AURA);
-         iAbilityLoss = Send(oModifierSpell,@ModifySpellPower,#oRoom=oRoom,#oSpell=self);
+         % Mana Convergence song not affected by AMA
+         if NOT IsClass(self,&ManaConvergence)
+         {
+            oModifierSpell = Send(SYS,@FindspellByNum,#num=SID_ANTIMAGIC_AURA);
+            iAbilityLoss = Send(oModifierSpell,@ModifySpellPower,#oRoom=oRoom,#oSpell=self);
 
-         oModifierSpell = Send(SYS,@FindspellByNum,#num=SID_MANA_CONVERGENCE);
-         iAbilityGain = Send(oModifierSpell,@ModifySpellPower,#oRoom=oRoom,#oSpell=self);
-
-         iSpellPower = (iSpellpower - iAbilityLoss + iAbilityGain);
+            iSpellPower = iSpellpower - iAbilityLoss;
+         }
       }
 
+      % Affected by the Dement spell?
+      oModifierSpell = Send(SYS,@FindSpellByNum,#num=SID_DEMENTIA);
+      if Send(who,@IsEnchanted,#what=oModifierSpell)
+      {
+         iAbilityLoss = first(Send(who,@GetEnchantedState,#what=oModifierSpell));
+         iAbilityLoss = Random(iAbilityLoss, iAbilityLoss*2);
+         iSpellpower = iSpellpower - iAbilityLoss;
+      }
+
+      % Check for Jala power changes
+      for i in Send(who,@GetJalaModifiers)
+      {
+         iSpellPower = Send(Nth(i,1),@ModifySpellPower,#who=who,#what=self,#state=i,#iSpellPower=iSpellPower);
+      }
+      
       % Bound the lower end so that the stuff that follows is truly a bonus.
       iSpellPower = bound(iSpellPower,0,$);
 
@@ -2198,15 +2193,6 @@ messages:
 
       % Then, add bonus from the system object, set by admins
       iSpellPower = iSpellPower + Send(SYS,@GetBonusSpellpower,#school=viSchool);
-
-      % Affected by the Dement spell?
-      oModifierSpell = Send(SYS,@FindSpellByNum,#num=SID_DEMENTIA);
-      if Send(who,@IsEnchanted,#what=oModifierSpell)
-      {
-         iAbilityLoss = first(Send(who,@GetEnchantedState,#what=oModifierSpell));
-         iAbilityLoss = Random(iAbilityLoss, iAbilityLoss*2);
-         iSpellpower = iSpellpower - iAbilityLoss;
-      }
 
       % The personal universal modifier.
       iSpellpower = iSpellpower

--- a/kod/object/passive/spell/atakspel.kod
+++ b/kod/object/passive/spell/atakspel.kod
@@ -115,7 +115,7 @@ messages:
 
    CastSpell(who = $, lTargets = $, iSpellPower = 0, bItemCast = FALSE)
    {
-      local iDamage, iManaFocus, oRoom, oTarget;
+      local i, iDamage, iManaFocus, oRoom, oTarget, iModifiedSpellType, iModifiedDamage, iModifiedAbsolute;
 
       oTarget = First(lTargets);
 
@@ -152,11 +152,22 @@ messages:
             }
          }
       }
-     
+      
+      % Check for Jala songs that modify attack spell statistics
+      iModifiedDamage=iDamage;
+      iModifiedSpellType=viAttack_type;
+      iModifiedAbsolute=pbAbsolute;
+      for i in Send(who,@GetJalaModifiers)
+      {
+         iModifiedDamage = Send(Nth(i,1),@ModifySpellDamage,#state=i,#iSpellPower=iSpellPower,#damage=iModifiedDamage,#originalValue=iDamage);
+         iModifiedSpellType = Send(Nth(i,1),@ModifySpellType,#state=i,#iSpellPower=iSpellPower,#spell_type=iModifiedSpellType,#originalValue=viAttack_type);
+         iModifiedAbsolute = Send(Nth(i,1),@ModifySpellAbsolute,#state=i,#iSpellPower=iSpellPower,#absolute=iModifiedAbsolute,#originalValue=pbAbsolute);
+      }
+      
       % After figuring damage, do an AssessDamage.  This will handle the necessary
       %  attack messages.
-      iDamage = Send(oTarget,@AssessDamage,#what=who,#damage=iDamage,
-                     #atype=viAttack_type,#aspell=Send(self,@GetAttackSpell),
+      iDamage = Send(oTarget,@AssessDamage,#what=who,#damage=iModifiedDamage,
+                     #atype=iModifiedSpellType,#aspell=Send(self,@GetAttackSpell),
                      #absolute=pbAbsolute);
 
       Send(who,@AssessHit,#what=oTarget,#damage=iDamage,#use_weapon=self);

--- a/kod/object/passive/spell/jala.kod
+++ b/kod/object/passive/spell/jala.kod
@@ -10,17 +10,33 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Jala is Spell
 
-% Jala Spells are effect spells that last so long as the player remains in a
-% trance.  There can only be one Jala spell per room.
+% Jala Spells are radius spells that last as long as the player remains in a trance.
+%
+% Mechanically, there is a state here of the form [time elapsed, players enchanted, volume, range].
+% This should not be altered. It is used to track the radius and who should be affected.
+% Volume and Range have their own Calculate functions if they need to be modified.
+%
+% EnterSong and LeaveSong add or remove from a player's plJala_modifiers list.
+% Jala modifiers are states of the form [song object, volume, singer].
+% These states should be used when effects are actually being performed.
+%
+% Useful Jala functions to call (these are in Player.kod):
+% IsAffectedByJalaModifier(what=$,byClass=&Jala) -- returns TRUE or FALSE
+% GetLoudestJalaModifierState(byClass=&Jala)     -- returns [song object, volume, singer] with highest volume
+% GetJalaModifiers()                             -- returns player's list of [song object, volume, singer]
 
 constants:
 
    include blakston.khd
+   
+   SONG_CHECK_TIME = 500   %Time between checks for who is affected, no worse than an active object lag-wise
 
 resources:
 
-   jala_song_ends = "The song sung by a nearby bard of Jala ends."
-   jala_song_starts = "A nearby bard of Jala starts to sing a song."
+   jala_default_ends = "The song sung by a nearby bard of Jala ends."
+   jala_default_starts = "A nearby bard of Jala starts to sing a song."
+   jala_default_enter = "The bard's song begins to affect you."
+   jala_default_leave = "The song's notes fade from your ears."
    jala_song_failed = \
       "A nearby bard of Jala begins to sing a song, but quits when they "
       "realize they can't be heard over the song sung by another."
@@ -29,10 +45,19 @@ resources:
    jala_no_newbie = \
       "Your guardian angel tells you, \"You are not ready to cast spells "
       "which may hinder other players.\""
+      
+   jala_already_being_sung = "You are already singing a song."
 
    jala_default = jala1.mid
 
 classvars:
+
+   jala_song_already_singing = jala_already_being_sung
+   
+   jala_song_ends = jala_default_ends
+   jala_song_starts = jala_default_starts
+   jala_song_enter = jala_default_enter
+   jala_song_leave = jala_default_leave
 
    viSchool = SS_JALA
    % viMana is amount used upon inititiation
@@ -46,14 +71,23 @@ classvars:
    % viPostCast_time is in seconds, since it works off GetTime()
    viPostCast_time = 1
 
-   % Can non-PK characers use this song?
-   vbCanNewbieSing = TRUE     
+   % If harmful, don't affect people we can't hit
+   viHarmful = FALSE
+
+   % Ranges goes up to double base, based on spellpower
+   viBaseRange = 5
+   
+   % If FALSE, affects caster only
+   viAffectsOthers = TRUE
+   
+   % If TRUE, a harmful spell will still affect guildmates
+   % Important for balance in guild war situations
+   viAffectsGuildmates = FALSE
 
 properties:
 
-   % Do we need to Send removeenchantment to every user in the room on
-   %  spell termination?
-   pbUserEffects = FALSE  
+   ptDrainTimer = $
+   ptDrainNow = FALSE
 
 messages:
 
@@ -69,90 +103,177 @@ messages:
 
    CanPayCosts(who=$, lTargets=$)  
    {
-      if NOT vbCanNewbieSing
-         AND NOT Send(who,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
-      {
-         Send(who,@MsgSendUser,#message_rsc=jala_no_newbie);
-         
-         return FALSE;
-      }
-
-
       if Send(who,@GetInstrumentLevel) = 0
       { 
          Send(who,@MsgSendUser,#message_rsc=jala_need_instrument);
          return FALSE; 
       }
-      
+
       propagate;
-   }
-
-   CalculateVolume(who=$, iSpellPower=25)
-   {
-      local iVolume;
-
-      % This should be a funcion of the spellpower AND the amount of mana
-      %  used to upkeep the spell AND quality of the instrument.
-      % Multiply the numerator by 1000 to break viDrainTime down to seconds
-      %  without risking a divide by for small durations.
-      iVolume = iSpellPower * viManaDrain * 1000 / viDrainTime;
-
-      return iVolume;
    }
 
    CastSpell(who=$, iSpellPower=0)
    "Initiation point for the spell."
    {
-      local oRoom, oldVolume, thisVolume, i, iJalaInfo;
+      local i, iSinging, iSongState, oObj, oUser, oCasterGuild, oRoom, iElapsed, lEnchanted, iVolume, iRange;
+
+      iElapsed = 0;
+      lEnchanted = $;
+      iVolume = Send(self,@CalculateVolume,#iSpellPower=iSpellPower);
+      iRange = Send(self,@CalculateRange,#iSpellPower=iSpellPower);
+      
+      if Send(who,@IsEnchanted,#byClass=&Jala)
+      {
+         iSinging = Send(who,@GetEnchantmentsByClass,#enchClass=&Jala);
+         for i in iSinging
+         {
+            iSongState = Send(who,@GetEnchantedState,#what=Nth(i,2));
+            Send(Nth(i,2),@BreakTrance,#who=who,#state=iSongState,#event=EVENT_STEER);
+         }
+      }
 
       oRoom = Send(who,@GetOwner);
+      Send(oRoom,@SomeoneSaid,#type=SAY_MESSAGE,#string=jala_song_starts);
+      
+      oCasterGuild = Send(who,@GetGuild);
 
-      iJalaInfo = Send(oRoom,@GetJalaInfo);
-      oldVolume = 0;
-
-      if iJalaInfo <> $
+      for oObj in send(oRoom,@GetplActive)
       {
-         % Our state information is the third item return from JalaInfo
-         oldVolume = Nth(Nth(iJalaInfo,3),1);
+         oUser = Send(oRoom,@HolderExtractObject,#data=oObj);
+
+         % Important note: FindListElem returns nil on a passed nil value, not zero.
+         if IsClass(oUser,&User)
+            AND (lEnchanted = $ OR FindListElem(lEnchanted,oUser) = 0)
+            AND Send(who,@SquaredDistanceTo,#what=oUser) <= (iRange * iRange)
+         {
+            if NOT viHarmful
+               OR oUser=who
+               OR (Send(who,@CheckStatusAndSafety,#victim=oUser,#report=FALSE)
+                  AND Send(Send(who,@GetOwner),@AllowGuildAttack,#what=who,#victim=oUser)
+                  AND Send(who,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE))
+               OR (viAffectsGuildmates
+                  AND oCasterGuild <> $
+                  AND oCasterGuild = Send(oUser,@GetGuild))
+            {
+               if viAffectsOthers
+                  OR (NOT viAffectsOthers AND oUser=who)
+               {
+                  send(self,@EnterSong,#who=oUser,#iVolume=iVolume,#singer=who);
+                  lEnchanted = cons(oUser,lEnchanted);
+               }
+            }
+         }
       }
 
-      thisVolume = Send(self,@CalculateVolume,#who=who,
-                        #iSpellPower=iSpellPower);
-      thisVolume = bound(thisVolume,1,$);
-      if thisVolume < oldVolume
-         OR thisVolume = oldVolume
-      {
-         Send(oRoom,@SomeoneSaid,#type=SAY_MESSAGE,#string=jala_song_failed,
-              #what=self);
-         
-         return;
-      }
-      else
-      {
-         Send(oRoom,@RoomStartEnchantment,#what=self,
-              #state=Send(self,@BuildState,#thisVolume=thisVolume,#who=who,
-                          #iSpellPower=iSpellPower),
-              #time=viDrainTime,#iSpellPower=iSpellPower,#lastcall=FALSE);
-         Send(oRoom,@SomeoneSaid,#type=SAY_MESSAGE,#string=jala_song_starts,
-              #what=self);
-         Send(self,@StartMusic,#oCaster=who,#rMusic=prMusic);
-         Send(who,@SetTranceFlag);
-         Send(oRoom,@EnchantAllOccupants,#what=self);
-      }
+      % Put spell maintenance info in casters enchantment list.
+      Send(who,@StartEnchantment,#what=self,#time=SONG_CHECK_TIME,
+           #state=[iElapsed,lEnchanted,iVolume,iRange]);      
+
+      % Set up mana drain
+      ptDrainTimer = CreateTimer(self,@DrainTimer,viDrainTime);
 
       propagate;
    }
 
-   BuildState(thisVolume=0,who=$,iSpellPower=0)
-   {
-      return [thisVolume,who,iSpellPower];
+   EnterSong(who=$,iVolume=0,singer=$)
+   {      
+      local i,each_obj;
+      
+      Send(who,@AddJalaModifier,#what=self,#iVolume=iVolume,#singer=who);
+      Send(who,@MsgSendUser,#message_rsc=jala_song_enter);
+
+      return;
+   }
+   
+   LeaveSong(who=$,iVolume=0,singer=$)
+   {      
+      Send(who,@RemoveJalaModifier,#what=self,#iVolume=iVolume,#singer=who);
+      Send(who,@MsgSendUser,#message_rsc=jala_song_leave);
+      
+      return;
    }
 
-   BreakTrance(who=$, event=$, state=$, location=$)
+   EndEnchantment( who = $, state = $ )
+   "Called only for caster. Refreshes itself to recalculate affected players."
+   {
+      local iElapsed, lEnchanted, iVolume, iRange, oUser, oCasterGuild, oRoom, lActive;
+
+      iElapsed = Nth(state,1);
+      lEnchanted = Nth(state,2);
+      iVolume = Nth(state,3);
+      iRange = Nth(state,4);
+
+      oRoom = Send(who,@GetOwner);
+      oCasterGuild = Send(who,@GetGuild);
+
+      % Do test.
+      for oUser in lEnchanted
+      {
+         if Send(who,@SquaredDistanceTo,#what=oUser) > (iRange * iRange)
+            OR Send(who,@GetOwner) <> Send(oUser,@GetOwner)
+         {
+            Send(self,@LeaveSong,#who=oUser,#iVolume=iVolume,#singer=who);
+            lEnchanted = DelListElem(lEnchanted,oUser);
+         }
+      }
+      
+      for lActive in send(oRoom,@GetplActive)
+      {
+         oUser = Send(oRoom,@HolderExtractObject,#data=lActive);
+
+         if IsClass(oUser,&User)
+            AND (lEnchanted = $ OR FindListElem(lEnchanted,oUser) = 0)
+            AND Send(who,@SquaredDistanceTo,#what=oUser) <= (iRange * iRange)
+         {
+            if NOT viHarmful
+               OR oUser=who
+               OR (Send(who,@CheckStatusAndSafety,#victim=oUser,#report=FALSE)
+                  AND Send(Send(who,@GetOwner),@AllowGuildAttack,#what=who,#victim=oUser)
+                  AND Send(who,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE))
+               OR (viAffectsGuildmates
+                  AND oCasterGuild <> $
+                  AND oCasterGuild = Send(oUser,@GetGuild))
+            {
+               if viAffectsOthers
+                  OR (NOT viAffectsOthers AND oUser=who)
+               {
+                  send(self,@EnterSong,#who=oUser,#iVolume=iVolume,#singer=who);
+                  lEnchanted = cons(oUser,lEnchanted);
+               }
+            }
+         }
+      }
+
+      Send(who,@StartEnchantment,#what=self,#time=SONG_CHECK_TIME,
+          #state=[iElapsed,lEnchanted,iVolume,iRange],#Report=FALSE);
+              
+      if ptDrainNow = TRUE
+      {
+         if Send(who,@GetMana) >= viManaDrain
+         {
+            Send(who,@LoseMana,#amount=viManaDrain);
+            ptDrainNow = FALSE;
+         }
+         else
+         {
+            Send(self,@BreakTrance,#who=who,#state=state,#event=EVENT_STEER);
+         }
+      }
+
+      return;
+   }
+
+   RemoveEnchantment(who = $, state=$)
+   "Remove enchantment effects on this occupant"
+   {
+      return;
+   }
+   
+   BreakTrance(who=$, event=$, state=$, location=$, iVolume=$)
    "If caster runs out of mana or loses trance, spell ends."
    {
-      local oRoom;
-      
+      local oUser, lEnchanted;
+            
       % Check for Necklace of Jala first
       if Send(who,@IsUsingA,#class=&JalaNecklace)
       {
@@ -160,31 +281,35 @@ messages:
          if event = EVENT_DAMAGE
             OR event = EVENT_ATTACK
             OR event = EVENT_RUN
+            OR event = EVENT_DISRUPT
             OR (event = EVENT_CAST AND Send(Send(SYS, @GetSettings), @CanRecastJalaWithNecklace))
          {
             return FALSE;
          }
+      }
+   
+      iVolume = Nth(state,3);
 
-         % Chance to keep going through a disruption
-         if event = EVENT_DISRUPT
-            AND Send(self,@CheckDisruptWithNecklace)
-         {
-            return FALSE;
-         }
-      }
-
-      if location = $
+      % Clean up Trance.
+      Send(who,@ClearTranceFlag);
+      Send(who,@RemoveEnchantment,#what=self);
+      Send(Send(who,@GetOwner),@SomeoneSaid,#type=SAY_MESSAGE,#string=jala_song_ends);
+      lEnchanted = Nth(state,2);
+      for oUser in lEnchanted
       {
-         oRoom = Send(who,@GetOwner);
+         Send(self,@LeaveSong,#who=oUser,#iVolume=iVolume);
       }
-      else
-      {
-         oRoom = location;
-      }
-      
-      Send(oRoom,@RemoveEnchantment,#what=self,#state=state);
+      DeleteTimer(ptDrainTimer);
+      ptDrainTimer=$;
 
       propagate;
+   }
+   
+   DrainTimer(who=$)
+   {
+      ptDrainNow = TRUE;
+      ptDrainTimer = CreateTimer(self,@DrainTimer,viDrainTime);
+      return;
    }
 
    CheckDisruptWithNecklace()
@@ -199,126 +324,9 @@ messages:
       return FALSE;
    }
 
-   StartEnchantment(who = $, state=$)
-   "Does enchantment effect on one player"
+   SetSpellPlayerFlag(who=$)
    {
-      return;
-   }
-
-   RemoveEnchantment(who = $, state=$)
-   "Remove enchantment effects on this occupant"
-   {
-      return;
-   }
-
-   StartPeriodicEnchantment(where=$, state=$)
-   "Sends enchantment message to room like CastSpell for most room "
-   "enchantments, but silent, and done as often as necessary."
-   {
-      local oCaster;
-      
-      oCaster = Nth(state,2);
-   
-      % If caster runs out of mana or loses trance, spell ends.
-      if Send(oCaster,@GetMana) < viManaDrain * 2
-      {
-         Send(where,@RoomStartEnchantment,#what=self,#time=viDrainTime,
-              #state=state,#addicon=FALSE,#lastcall=TRUE);
-
-      }
-      else
-      {      
-         Send(where,@RoomStartEnchantment,#what=self,#time=viDrainTime,
-              #state=state,#addicon=FALSE,#lastcall=FALSE);
-      }
-      
-      Send(oCaster,@LoseMana,#amount=viManaDrain);
-      
-      return;
-   }
-
-   StartEnchantmentNewOccupant(who=$, state=$)
-   "Called on new occupants of the enchanted room."
-   {
-      Send(self,@StartEnchantment,#who=who);
-      Send(who,@MsgSendUser,#message_rsc=jala_song_playing);
-      Post(who,@MidiSendUser,#midi_rsc=prMusic);
-      
-      return;
-   }
-
-   EndRoomEnchantment(who=$, state=$)
-   "Ends enchantment effect on one player, generally for players leaving the "
-   "room."
-   {
-      Send(who,@RemoveEnchantment,#what=self,#state=state);
-      
-      return;
-   }
-
-   EndSpell(where=$, state=$)  
-   "Called by room when spell expires."
-   {
-      local oCaster, lActive, each_obj, oRoom, i;
-      oCaster = Nth(state,2);
-
-      if pbUserEffects
-      {
-         if where = $
-         {
-            oRoom = Send(oCaster,@GetOwner);
-         }
-         else
-         {
-            oRoom = where;
-         }
-         
-         lActive = Send(oRoom,@GetHolderActive);
-         for i in lActive
-         {
-            each_obj = Send(oRoom,@HolderExtractObject,#Data=i);
-            Send(self,@RemoveEnchantment,#who=each_obj,#state=state);
-         }
-      }
-
-      Send(where,@SomeoneSaid,#type=SAY_MESSAGE,#string=jala_song_ends,
-           #what=self);
-      % Send $ as midi_rsc to end music and resume default.
-      Send(self,@StartMusic,#oCaster=oCaster,#rMusic=$);
-      Send(oCaster,@ClearTranceFlag);
-      
-      return;
-   }
-
-   StartMusic(oCaster=$, rMusic=$)
-   {
-      local oRoom, i;
-      
-      if oCaster = $
-      {
-         debug("BAD MUSIC SETUP, MAN!");
-
-         return FALSE;
-      }
-
-      oRoom = Send(oCaster,@GetOwner);
-      for i in Send(oRoom,@GetHolderActive)
-      {
-         if IsClass(first(i),&user)
-         {
-            Send(first(i),@MidiSendUser,#midi_rsc=rMusic);
-         }
-      }
-      
-      return;
-   }
-
-   SetSpellPlayerFlag(who=$, state=$)
-   {
-      if who = Nth(state,2)
-      {
-         Send(who,@SetTranceFlag);
-      }
+      Send(who,@SetTranceFlag);
       
       return;
    }
@@ -328,7 +336,151 @@ messages:
       % Jala plays midis for songs, not wavs.  Just return.
       return;
    }
+   
+   RemoveEnchantmentEffects()
+   "Need to override spell.kod's thing, since we do this ourselves specially."
+   {
+      return;
+   }
 
+   % Replace this to modify volume by spellpower calculations - currently on 0 to 99 scale
+   CalculateVolume(who=$, iSpellPower=25)
+   {
+      return iSpellPower;
+   }
+
+   % Replace this to modify range by spellpower calculations
+   CalculateRange(who=$, iSpellPower=25)
+   {
+      local iRange;
+
+      % Default is up to twice base range      
+      iRange = viBaseRange + ((viBaseRange*iSpellPower)/99);
+      
+      return iRange;
+   }
+      
+   CanBeRemovedByPlayer()
+   "Returns if a spell can be removed by normal Purge/Purify"
+   {
+      return FALSE;
+   }
+
+   %%% Modifier functions.
+   %%% All songs do their effect. Use bounds to avoid song-stacking problems.
+
+   ModifyHitRoll(who = $,what = $,state = $,hit_roll = $,stroke_obj = $,originalValue = 0)
+   {
+      return hit_roll;
+   }
+
+   ModifyDamage(who = $,what = $,state = $,damage = $,stroke_obj = $,originalValue = 0)
+   {
+      return damage;
+   }
+
+   ModifyDefense(who = $,what = $,state = $,defense = $,stroke_obj = $,originalValue = 0)
+   {
+      return defense;
+   }
+
+   ModifyDefenseDamage(who = $,what = $,state = $,damage = $,atype = $,aspell = $,stroke_obj = $,originalValue = 0)
+   {
+      return damage;
+   }
+   
+   % Add or replace elements in a weapon attack
+   ModifyAttackType(who = $,what = $,state = $,attack_type = $)
+   {
+      return attack_type;
+   }
+
+   % Power of outgoing spell attacks
+   ModifySpellPower(who=$,what=$,state=$,iSpellPower=0)
+   {
+      return iSpellPower;
+   }
+
+   % Damage of outgoing spell attacks
+   ModifySpellDamage(who = $,what = $,state=$,iSpellPower=0,damage=$,originalValue=$)
+   {
+      return damage;
+   }
+   
+   % Element type of outgoing spell attacks
+   ModifySpellType(who = $,what = $,state=$,iSpellPower=0,spell_type=$,originalValue=$)
+   {
+      return spell_type;
+   }
+      
+   % The absolute flag causes an attack spell to ignore resists and vulnerabilities
+   ModifySpellAbsolute(who = $,what = $,state=$,iSpellPower=0,absolute=$,originalValue=$)
+   {
+      return absolute;
+   }
+   
+   ModifyVigorTime(state = $,time = 1000)
+   {
+      return time;
+   }
+      
+   ModifyHealthTime(state = $,time = 1000)
+   {
+      return time;
+   }
+
+   ModifyManaTime(state = $,time = 1000)
+   {
+      return time;
+   }
+   
+   % Usual post-attack delay is 1
+   ModifyAttackTime(state=$,time=1,originalValue=1)
+   {
+      return time;
+   }
+   
+   % Replace this to modify postcast times
+   ModifyPostCastTime(state=$,time=1,originalValue=1)
+   {
+      return time;
+   }
+   
+   % Modifies focus times. Passed percent may be 51% - 149% already based on initial spellpower
+   ModifyTranceTime(who=$,state=$,percent=100,iSpellPower=0,originalValue=100)
+   {
+      return percent;
+   }
+   
+   % This is a Spellbane type effect
+   TryPreventSpell(who=$,state=$,iSpellPower=0)
+   {
+      % False = spell not blocked
+      return FALSE;
+   }
+   
+   % This is a Winds type effect
+   TryPreventAttack(who=$,state=$,iSpellPower=0)
+   {
+      % False = attack not blocked
+      return FALSE;
+   }
+
+   % Use in EnterSong to add resists to a player
+   % Must also remove same resists in LeaveSong
+   AddResistances(who=$,state=$,value=$)
+   {
+      Send(who,@AddResistance,#what=-ATCK_SPELL_ALL,#value=value);
+
+      return;
+   }
+
+   RemoveResistances(who=$,state=$,value=$)
+   {
+      Send(who,@RemoveResistance,#what=-ATCK_SPELL_ALL,#value=value);
+
+      return;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/jala/crysmana.kod
+++ b/kod/object/passive/spell/jala/crysmana.kod
@@ -33,11 +33,17 @@ resources:
       "You stop singing once you realize you won't be able to hold the mana "
       "crystal."
 
+   crystalizemana_enter_rsc = "You concentrate your spirit into a physical crystal structure."
+   crystalizemana_leave_rsc = "The crystallization process ends."
+
 classvars:
 
    vrName = CrystalizeMana_name_rsc
    vrIcon = CrystalizeMana_icon_rsc
    vrDesc = CrystalizeMana_desc_rsc
+   
+   jala_song_enter = crystalizemana_enter_rsc
+   jala_song_leave = crystalizemana_leave_rsc
 
    viSpell_num = SID_CRYSTALIZE_MANA
    viSchool = SS_JALA
@@ -51,11 +57,11 @@ classvars:
    viChance_To_Increase = 25
 
    viHarmful = FALSE
+   viAffectsOthers = FALSE
 
 properties:
 
    prMusic = CrystalizeMana_song
-   pbUserEffects = TRUE
       
 messages:
 
@@ -67,53 +73,47 @@ messages:
 
       return;
    }
-
-   StartPeriodicEnchantment(where=$, state=$)
+   
+   EndEnchantment(who=$,state=$)
    {
-      local oCaster, iSpellpower, oCrystal, iAmount;
+      local oCrystal, iVolume, iAmount;
 
-      % The caster is the second element of state.
-      oCaster = Nth(state,2);
-
-      % Our spellpower is in the third element of state.
-      iSpellpower = Nth(state,3);
-
-      % Find/create mana crystal.
-      oCrystal = Send(oCaster,@FindHolding,#class=&ManaCrystal);
+      iVolume = Nth(state,3);
+      
+      oCrystal = Send(who,@FindHolding,#class=&ManaCrystal);
 
       if oCrystal = $
       {
-         oCrystal = Create(&ManaCrystal,#oCaster=oCaster);
-         if Send(oCaster,@ReqNewHold,#what=oCrystal)
+         oCrystal = Create(&ManaCrystal,#oCaster=who);
+         if Send(who,@ReqNewHold,#what=oCrystal)
          {
-            Send(oCaster,@NewHold,#what=oCrystal);
+            Send(who,@NewHold,#what=oCrystal);
          }
          else
          {
             % We couldn't hold it for some reason.  Destroy crystal.
             Send(oCrystal,@Delete);
-            Send(oCaster,@MsgSendUser,#message_rsc=CrystalizeMana_no_room);
+            Send(who,@MsgSendUser,#message_rsc=CrystalizeMana_no_room);
 
             % Stop the spell, use EVENT_STEER because we want it to break.
-            Post(oCaster,@BreakTrance,#event=EVENT_STEER);
+            Post(who,@BreakTrance,#event=EVENT_STEER);
          }
       }
-
+      
       % Increment mana amount in crystal.
       % Add at least 1 mana.
       iAmount = 1;
 
       % Add another one if we have enough spellpower.
-      if random(1,99) <= iSpellpower
+      if random(1,99) <= iVolume
       {
          iAmount = iAmount + 1;
       }
 
       Send(oCrystal,@IncreaseMana,#amount=iAmount);
-
+      
       propagate;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/jala/hinder.kod
+++ b/kod/object/passive/spell/jala/hinder.kod
@@ -27,34 +27,27 @@ classvars:
 
    viSchool = SS_JALA
 
-   vbCanNewbieSing = FALSE     % Newbies cannot use this song
-   viHarmful = TRUE
-
    viHinderedSchool = SS_JALA  % What school does this song hinder?
 
    vbCastable_in_HappyLand = FALSE
+   
+   viHarmful = TRUE
+   viBaseRange = 8
+   viAffectsGuildmates = TRUE
 
 properties:
 
-   pbUserEffects = TRUE
       
 messages:
 
-   GetAlteredChance(chance = 0, what = $, iSpellPower = 0)
+   ModifySpellPower(who=$,what=$,state=$,iSpellPower=0)
    {
-      local altChance;
-   
-      if what = $ OR send(what,@GetSchool) <> viHinderedSchool
+      if Send(what,@GetSchool) = viHinderedSchool
       {
-         return chance;
+         return (iSpellPower - Nth(state,2));
       }
-
-      altChance = chance - random(iSpellPower/2,(iSpellPower*2)/3);
-      
-      % Don't worry about bounding, that's done the level above us.
-      return altChance;
+      return iSpellPower;
    }
-
 
 end
 

--- a/kod/object/passive/spell/jala/hinder/civility.kod
+++ b/kod/object/passive/spell/jala/hinder/civility.kod
@@ -20,15 +20,21 @@ resources:
    Civility_icon_rsc = icivilty.bgf
    Civility_desc_rsc = \
       "This song hinders the casting of the spells of the master of the elements, Faren.  "
-      "A ruby and a mushroom are required to begin performing this song."
+      "A mushroom is required to begin performing this song."
 
    Civility_song = jala3.mid
- 
+
+   civility_enter_rsc = "The nearby aria seems to bring a sense of civility to the area."
+   civility_leave_rsc = "As the aria fades, the living sounds of nature return."
+
 classvars:
 
    vrName = Civility_name_rsc
    vrIcon = Civility_icon_rsc
    vrDesc = Civility_desc_rsc
+   
+   jala_song_enter = civility_enter_rsc
+   jala_song_leave = civility_leave_rsc
 
    viMana = 5          % Mana is amount used upon inititiation
    viManaDrain = 3     % Drain is amount used every viDrainTime milliseconds
@@ -37,9 +43,6 @@ classvars:
 
    viSchool = SS_JALA
    viSpell_level = 2
-
-   vbCanNewbieSing = FALSE     % Newbies cannot use this song
-   viHarmful = TRUE
 
    viHinderedSchool = SS_FAREN
 
@@ -52,7 +55,6 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Ruby,1],plReagents);
       plReagents = Cons([&Mushroom,1],plReagents);
 
       return;

--- a/kod/object/passive/spell/jala/hinder/concil.kod
+++ b/kod/object/passive/spell/jala/hinder/concil.kod
@@ -20,16 +20,22 @@ resources:
    Conciliation_icon_rsc = iconcil.bgf
    Conciliation_desc_rsc = \
       "This song hinders the casting of the spells the warrior god Kraanan the Fist.  "
-      "A ruby and some elderberries are required to begin performing this song."
+      "An elderberry is required to begin performing this song."
 
    Conciliation_song = neutfor.mid
  
+   conciliation_enter_rsc = "The nearby lullaby harkens to years past, weakening your will to fight."
+   conciliation_leave_rsc = "As the lullaby fades, you suddenly remember why you hate them all so much."
+   
 classvars:
 
    vrName = Conciliation_name_rsc
    vrIcon = Conciliation_icon_rsc
    vrDesc = Conciliation_desc_rsc
 
+   jala_song_enter = conciliation_enter_rsc
+   jala_song_leave = conciliation_leave_rsc
+   
    viMana = 5          % Mana is amount used upon inititiation
    viManaDrain = 3     % Drain is amount used every viDrainTime milliseconds
    viDrainTime = 5000    % Drain some mana every viDrainTime milliseconds
@@ -37,9 +43,6 @@ classvars:
 
    viSchool = SS_JALA
    viSpell_level = 2
-
-   vbCanNewbieSing = FALSE     % Newbies cannot use this song
-   viHarmful = TRUE
 
    viHinderedSchool = SS_KRAANAN
 
@@ -52,7 +55,6 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Ruby,1],plReagents);
       plReagents = Cons([&Elderberry,1],plReagents);
 
       return;

--- a/kod/object/passive/spell/jala/hinder/disharm.kod
+++ b/kod/object/passive/spell/jala/hinder/disharm.kod
@@ -28,12 +28,18 @@ resources:
 
    Disharmony_song = bridge.mid
  
+   disharmony_enter_rsc = "Those discordant notes, that painful excuse for a tune! It's insufferable!"
+   disharmony_leave_rsc = "With that amateur bard out of the way, you feel as if you can finally put on your own show."
+
 classvars:
 
    vrName = Disharmony_name_rsc
    vrIcon = Disharmony_icon_rsc
    vrDesc = Disharmony_desc_rsc
 
+   jala_song_enter = disharmony_enter_rsc
+   jala_song_leave = disharmony_leave_rsc
+   
    viMana = 5
    viManaDrain = 3
    viDrainTime = 5000
@@ -41,9 +47,6 @@ classvars:
 
    viSchool = SS_JALA
    viSpell_level = 4
-
-   vbCanNewbieSing = FALSE     % Newbies cannot use this song
-   viHarmful = TRUE
 
    viHinderedSchool = SS_JALA
 

--- a/kod/object/passive/spell/jala/hinder/profnres.kod
+++ b/kod/object/passive/spell/jala/hinder/profnres.kod
@@ -20,15 +20,21 @@ resources:
    ProfaneResonance_icon_rsc = iprofres.bgf
    ProfaneResonance_desc_rsc = \
       "The foreboding sound of this song hinders the casting the holy spells of Shal'ille.  "
-      "A ruby and some herbs are required to begin performing this song."
+      "An herb is required to begin performing this song."
 
    ProfaneResonance_song = nec02.mid
- 
+
+   profaneres_enter_rsc = "The nearby chant touches on the hypocrisy of those who purport to serve good."
+   profaneres_leave_rsc = "As the chant fades, your self-righteous sense of purity returns."
+
 classvars:
 
    vrName = ProfaneResonance_name_rsc
    vrIcon = ProfaneResonance_icon_rsc
    vrDesc = ProfaneResonance_desc_rsc
+   
+   jala_song_enter = profaneres_enter_rsc
+   jala_song_leave = profaneres_leave_rsc
 
    viMana = 5          % Mana is amount used upon inititiation
    viManaDrain = 3     % Drain is amount used every viDrainTime milliseconds
@@ -37,9 +43,6 @@ classvars:
 
    viSchool = SS_JALA
    viSpell_level = 3
-
-   vbCanNewbieSing = FALSE     % Newbies cannot use this song
-   viHarmful = TRUE
 
    viHinderedSchool = SS_SHALILLE
 
@@ -52,7 +55,6 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Ruby,1],plReagents);
       plReagents = Cons([&Herbs,1],plReagents);
 
       return;

--- a/kod/object/passive/spell/jala/hinder/sacrdres.kod
+++ b/kod/object/passive/spell/jala/hinder/sacrdres.kod
@@ -20,15 +20,21 @@ resources:
    SacredResonance_icon_rsc = isacrres.bgf
    SacredResonance_desc_rsc = \
       "The music of this song hinders the casting of the dark spells of Qor.  "
-      "A ruby and an entroot berry are required to begin performing this song."
+      "An entroot berry is required to begin performing this song."
 
    SacredResonance_song = goodfor.mid
- 
+
+   sacredres_enter_rsc = "The nearby hymn forces a certain introspective guilt."
+   sacredres_leave_rsc = "As the hymn fades, your killer instinct returns."
+
 classvars:
 
    vrName = SacredResonance_name_rsc
    vrIcon = SacredResonance_icon_rsc
    vrDesc = SacredResonance_desc_rsc
+   
+   jala_song_enter = sacredres_enter_rsc
+   jala_song_leave = sacredres_leave_rsc
 
    viMana = 5          % Mana is amount used upon inititiation
    viManaDrain = 3     % Drain is amount used every viDrainTime milliseconds
@@ -37,9 +43,6 @@ classvars:
 
    viSchool = SS_JALA
    viSpell_level = 3
-
-   vbCanNewbieSing = FALSE     % Newbies cannot use this song
-   viHarmful = TRUE
 
    viHinderedSchool = SS_QOR
 
@@ -52,7 +55,6 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Ruby,1],plReagents);
       plReagents = Cons([&EntrootBerry,1],plReagents);
 
       return;

--- a/kod/object/passive/spell/jala/hinder/truth.kod
+++ b/kod/object/passive/spell/jala/hinder/truth.kod
@@ -20,8 +20,10 @@ resources:
    truth_icon_rsc = itruth.bgf
    truth_desc_rsc = \
       "This song hinders the spells of the master of the illusionary arts, Riija.  "
-      "A ruby and some rainbow ferns are required to begin performing this song."
+      "A rainbow fern is required to begin performing this song."
 
+   truth_enter_rsc = "The nearby melody brings a certain clarity of thought."
+   truth_leave_rsc = "As the melody fades, you feel your awareness return to normal."
    truth_song = song.mid
  
 classvars:
@@ -30,6 +32,9 @@ classvars:
    vrIcon = truth_icon_rsc
    vrDesc = truth_desc_rsc
 
+   jala_song_enter = truth_enter_rsc
+   jala_song_leave = truth_leave_rsc
+   
    viMana = 5          % Mana is amount used upon inititiation
    viManaDrain = 3     % Drain is amount used every viDrainTime milliseconds
    viDrainTime = 5000    % Drain some mana every viDrainTime milliseconds
@@ -37,9 +42,6 @@ classvars:
 
    viSchool = SS_JALA
    viSpell_level = 1
-
-   vbCanNewbieSing = FALSE     % Newbies cannot use this song
-   viHarmful = TRUE
 
    viHinderedSchool = SS_RIIJA
 
@@ -52,8 +54,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Ruby,1],plReagents);
-      plReagents = Cons([&RainbowFern,2],plReagents);
+      plReagents = Cons([&RainbowFern,1],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/jala/invigor.kod
+++ b/kod/object/passive/spell/jala/invigor.kod
@@ -23,13 +23,19 @@ resources:
       "Requires one diamond and an edible mushroom to cast."
 
    Invigorate_song = song11.mid
- 
+
+   invigorate_enter_rsc = "The nearby ballad seems to magically soothe your aching muscles."
+   invigorate_leave_rsc = "As the ballad fades, the magical invigoration ebbs."
+
 classvars:
 
    vrName = Invigorate_name_rsc
    vrIcon = Invigorate_icon_rsc
    vrDesc = Invigorate_desc_rsc
 
+   jala_song_enter = invigorate_enter_rsc
+   jala_song_leave = invigorate_leave_rsc
+   
    viSpell_num = SID_INVIGORATE
    viSchool = SS_JALA
    viSpell_level = 1
@@ -42,6 +48,8 @@ classvars:
    viChance_To_Increase = 20
 
    viHarmful = FALSE
+   
+   viBaseRange = 20
 
 properties:
 
@@ -58,14 +66,10 @@ messages:
       return;
    }
 
-   AdjustVigorTime(time=0, iSpellPower=0)
-   "Reduces time passed in so that vigor regens faster.  Returns reduced time."
+   ModifyVigorTime(state = $, time = 1000)
+   "Reduces time passed in so that health regens faster.  Returns reduced time."
    {
-      local iTime;
-
-      iTime = (time * (200-iSpellPower)) / 200;
-
-      return iTime;
+      return bound(((time * (200 - Nth(state,2))) / 200),1,60000);
    }
 
 

--- a/kod/object/passive/spell/jala/jig.kod
+++ b/kod/object/passive/spell/jala/jig.kod
@@ -24,30 +24,37 @@ resources:
 
    jig_song = jala2.mid
  
+   jig_enter_rsc = "The nearby ditty compels you to begin dancing with yourself."
+   jig_leave_rsc = "As the ditty fades, you resume your wallflower status with a sigh of relief."
+   
+   jig_prevented_rsc = "Your urge to dance causes you to misfire completely!" 
+
 classvars:
 
    vrName = jig_name_rsc
    vrIcon = jig_icon_rsc
    vrDesc = jig_desc_rsc
 
-   viMana = 10
+   jala_song_enter = jig_enter_rsc
+   jala_song_leave = jig_leave_rsc
+   
+   viMana = 18
    viManaDrain = 10
    viDrainTime = 5000
    viSpell_num = SID_JIG
-   viSpellExertion = 10      
+   viSpellExertion = 18      
    viChance_To_Increase = 40
 
    viSchool = SS_JALA
    viSpell_level = 4
 
-   viHarmful = FALSE
+   viHarmful = TRUE   
+   viBaseRange = 2
+   viAffectsGuildmates = TRUE
 
 properties:
 
    prMusic = jig_song
-   pbUserEffects = TRUE
-
-   piMinHitPoints = 30
       
 messages:
 
@@ -59,116 +66,33 @@ messages:
       return;
    }
 
-   CanPayCosts(who = $, lTargets = $)
-   {
-      % Stop unguilded casting of Jig in towns.
-      if NOT (IsClass(who,&DM) AND Send(who,@PlayerIsImmortal))
-         AND Send(Send(who,@GetOwner),@CheckRoomFlag,#flag=ROOM_GUILD_PK_ONLY)
-         AND (Send(who,@GetGuild) = $
-              OR NOT Send(who,@CheckPlayerFlag,#flag=PFLAG_MURDERER))
-      {
-         Send(who,@MsgSendUser,#message_rsc=spell_bad_location,
-              #parm1=Send(self,@GetName));
-
-         return FALSE;
-      }
-
-      propagate;
-   }
-
-   CastSpell(who = $,spellpower = 0)
-   "Called at beginning of spellcast"
-   {
-      local oRoom, each_obj, i;
-
-      oRoom = Send(who,@GetOwner);
-      Send(oRoom,@SetRoomFlag,#Flag=ROOM_JIG,#value=TRUE);
-      Send(oRoom,@SetRoomFlag,#Flag=ROOM_NO_MOB_COMBAT,#value=TRUE);
-
-      propagate;
-   }
-
-   EndSpell(where = $, state = $)
-   {
-      local i;
-      
-      Post(where,@SetRoomFlag,#Flag=ROOM_JIG,#value=FALSE);
-
-      if Send(where,@CheckRoomFlag,#flag=ROOM_NO_MOB_COMBAT)
-      {
-         Send(where,@SetRoomFlagtoDefault,#flag=ROOM_NO_MOB_COMBAT);
-      }
-      
-      for i in Send(where,@GetEnchantmentList)
-      {
-         if Send(Nth(i,2),@GetSpellNum) = SID_TRUCE
-         {
-            Send(where,@SetRoomFlag,#flag=ROOM_NO_MOB_COMBAT,#value=TRUE);
-         }
-      }
-      
-      propagate;
-   }
-
-   StartEnchantment( who = $ )
-   "Starts enchantment effect on one player"
-   {
-      local lState;
-      
-      lState = Send(Send(who,@GetOwner),@GetEnchantmentState,#what=self);
-      if lState = $ { DEBUG("Jig got $ state."); propagate; }
-      if Nth(lState,2) = who
-      {
-         Send(who,@ResetPlayerFlagList);
-
-         propagate;
-      }
-      
+   EnterSong(who=$,iVolume=0)
+   {   
       Send(who,@FreeHands);
       Send(who,@DoDance);
-      
       propagate;
    }
 
-   StartEnchantmentNewOccupant( who = $ )
-   "Called on new occupants of the enchanted room."
-   {
-      Send(self,@StartEnchantment,#who=who);
-
-      return;
-   }
-
-   EndRoomEnchantment(who = $, state = $)
-   "Called when user leaves the room."
-   {
-      Send(self,@RemoveEnchantment,#who=who);
+   LeaveSong(who=$,iVolume=0)
+   {   
+      Send(who,@StopDancing);
 
       propagate;
    }
 
-   RemoveEnchantment(who=$)
-   "Called instead of EndEnchantment when trance is broken"
+   TryPreventAttack(who=$, state=$, stroke_obj=$)
    {
-      if IsClass(who,&Player)
+      local oWeapon;
+      oWeapon = Send(who,@GetWeapon);
+         
+      if IsClass(oWeapon,&RangedWeapon)
+         AND random(1,100) <= ((Nth(state,2)+1)/2)
       {
-         Post(who,@StopDancing);
+         Send(who,@MsgSendUser,#message=jig_prevented_rsc);
+         return TRUE;
       }
-
-      propagate;
-   }
-
-   CheckDisruptWithNecklace()
-   "Checks the chance to disrupt the spell with a Necklace of Jala on. "
-   "Due to annoyance factor, this can always be disrupted."
-   {
       return FALSE;
    }
-
-   SpellBannedInArena()
-   {
-      return TRUE;
-   }
-
-
+   
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/jala/manaconv.kod
+++ b/kod/object/passive/spell/jala/manaconv.kod
@@ -24,14 +24,17 @@ resources:
 
    ManaConvergence_song = jala5.mid
 
-   ManaConvergence_on = "The flow of magic in this place suddenly becomes stronger."
-   ManaConvergence_new_occupant = "You can feel a strong flow of magic in this place."
- 
+   manacon_enter_rsc = "You begin murmuring arcane words of power, converging mana within your spirit."
+   manacon_leave_rsc = "As your murmuring stops, the convergence of mana within your spirit dissipates."
+
 classvars:
 
    vrName = ManaConvergence_name_rsc
    vrIcon = ManaConvergence_icon_rsc
    vrDesc = ManaConvergence_desc_rsc
+
+   jala_song_enter = manacon_enter_rsc
+   jala_song_leave = manacon_leave_rsc
 
    viMana = 10          % Mana is amount used upon inititiation
    viManaDrain = 9      % Drain is amount used every viDrainTime milliseconds
@@ -42,6 +45,7 @@ classvars:
    viSpell_level = 5
 
    viHarmful = FALSE
+   viAffectsOthers = FALSE
 
 properties:
 
@@ -57,63 +61,10 @@ messages:
       return;
    }
 
-   CastSpell( who = $, iSpellPower = 0 )
-   "Initiation point for the spell."
+   ModifySpellPower(who=$,what=$,state=$,iSpellPower=0)
    {
-      local oRoom;
-
-      oRoom = Send(who,@GetOwner);
-      
-      % global effects of the enchantment
-      Send(oRoom,@SomeoneSaid,#type=SAY_MESSAGE,#string=ManaConvergence_on,#what=self);
-      
-      propagate;
+      return (iSpellPower + ((Nth(state,2)/2)+25));
    }
-
-   BuildState(thisVolume=0,who=$,iSpellPower=0)
-   {
-      return [thisVolume,who,((iSpellPower/2)+25)];
-   }
-
-   StartEnchantmentNewOccupant( who = $ )
-   "Called on new occupants of the enchanted room."
-   {
-      Send(who,@MsgSendUser,#message_rsc=ManaConvergence_new_occupant);
-
-      return;
-   }
-
-   AffectsSpellPower()
-   {
-      return TRUE;
-   }
-
-   ModifySpellPower(oRoom = $, oSpell = $)
-   {
-      local iChange;
-
-      iChange = 0;
-
-      if oRoom <> $
-      {
-         iChange = send(oRoom,@GetEnchantedState,#what=self);
-         if iChange <> $
-         {
-            iChange = nth(iChange,3);
-         }
-      }
-
-      % Spell won't affect Anti-Magic Aura
-      if iChange = $
-         OR IsClass(oSpell,&AntiMagicAura)
-      {
-         iChange = 0;
-      }
-
-      % This is added to spell power in spell.kod
-      return iChange;
-   }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/jala/melcholy.kod
+++ b/kod/object/passive/spell/jala/melcholy.kod
@@ -25,7 +25,8 @@ resources:
       "fighting against the forces of good.  "
       "It requires 1 sapphire to cast."
 
-   Melancholy_on = "%s%s's melancholy song makes your heart feel heavy."
+   melancholy_enter_rsc = "The nearby dirge brings a wistful sense of longing and sorrow."
+   melancholy_leave_rsc = "The melancholy mood passes."
 
    Melancholy_song = ksong.mid
  
@@ -35,6 +36,9 @@ classvars:
    vrIcon = Melancholy_icon_rsc
    vrDesc = Melancholy_desc_rsc
 
+   jala_song_enter = melancholy_enter_rsc
+   jala_song_leave = melancholy_leave_rsc
+   
    viSpell_num = SID_MELANCHOLY
    viSchool = SS_JALA
    viSpell_level = 1
@@ -47,11 +51,11 @@ classvars:
    viChance_To_Increase = 25
 
    viHarmful = FALSE
+   viBaseRange = 5
 
 properties:
 
    prMusic = Melancholy_song
-   pbUserEffects = TRUE
       
 messages:
 
@@ -63,26 +67,12 @@ messages:
       return;
    }
 
-   StartEnchantment(who = $)
-   "Starts enchantment effect on one player"
+   % Begin the song's effects
+   EnterSong(who=$,iVolume=0,singer=$)
    {
-      local lState, oCaster, iSpellpower;
-
-      lState = Send(Send(who,@GetOwner),@GetEnchantmentState,#what=self);
-
-      % The caster is the second element of state.
-      oCaster = Nth(lState,2);
-
-      % Our spellpower is in the third element of state.
-      iSpellpower = Nth(lState,3);
-
-      if random(1,100) < iSpellPower
+      if random(1,100) < iVolume
       {
-         Send(who,@SetAction,#action=UA_SAD);
-         Send(who,@MsgSendUser,#message_rsc=Melancholy_on,
-              #parm1=Send(oCaster,@GetCapDef),
-              #parm2=Send(oCaster,@GetName));
-         Send(who,@AddAttackModifier,#what=self);       
+         Send(who,@SetAction,#action=UA_SAD);       
       }
       else
       {
@@ -92,80 +82,27 @@ messages:
             Send(who,@SetAction,#action=UA_NORMAL);
          }
       }
-
-      propagate;
-   }
-
-   StartEnchantmentNewOccupant(who = $, state = $)
-   "Called on new occupants of the enchanted room."
-   {
-      Send(self,@StartEnchantment,#who=who,#state=state);
-
-      return;
-   }
-
-   EndRoomEnchantment(who = $, state = $)
-   "Called when user leaves the room."
-   {
-      Send(self,@RemoveEnchantment,#who=who);
-
-      propagate;
-   }
-
-   RemoveEnchantment(who=$)
-   "Called instead of EndEnchantment when trance is broken"
-   {
-      if IsClass(who,&Player)
-      {
-         % We try to remove ourselves from everyone, even though it's possible
-         %  that not everyone was enchanted.
-         Send(who,@RemoveAttackModifier,#what=self);
-      }
-
-      propagate;
-   }
-
-   StartPeriodicEnchantment(where=$, state=$)
-   {
-      local lActive, i, oObject;
-
-      lActive = Send(where,@GetHolderActive);
-      for i in lActive
-      {
-         oObject = Send(where,@HolderExtractObject,#data=i);
-
-         % Affect NPCs in room.
-         if IsClass(oObject,&Monster)
-            AND (Send(oObject,@GetBehavior) & AI_NPC)
-         {
-            Send(oObject,@ChangeMood,#amount=-1);
-         }
-      }
       
       propagate;
    }
 
-   % Stuff we handle to be an attack modifier.
-
-   ModifyHitRoll(who = $,what = $,hit_roll = $)
+   ModifyHitRoll(who = $,what = $,state = $,hit_roll = $,stroke_obj = $,originalValue = 0)
    {
-      % Only affect the good ones...
+      % Only add hit against good targets.
       if Send(what,@GetKarma,#detect=TRUE) > 0
       {
-         % Give a small bonus
-         return hit_roll + 100;
+         return bound(hit_roll + Nth(state,2),originalValue,originalValue+100);
       }
-
       return hit_roll;
    }
    
-   ModifyDamage(who = $,what = $,damage = $)
+   ModifyDamage(who = $,what = $,state = $,damage = $,stroke_obj = $,originalValue = 0)
    {
-      % Only affect the good ones...
+      % Only add damage against good targets.
       if Send(what,@GetKarma,#detect=TRUE) > 0
       {
          % Roughly equal to Killing Fields
-         return damage + Random(1,5);
+         return bound((damage + Random(1,((Nth(state,2)+1)/20))),originalValue,originalValue+5);
       }
 
       return damage;

--- a/kod/object/passive/spell/jala/mirth.kod
+++ b/kod/object/passive/spell/jala/mirth.kod
@@ -25,7 +25,8 @@ resources:
       "to fight evil more effectively.  "
       "It requires 1 sapphire to cast."
 
-   Mirth_on = "%s%s's mirthful song lifts your spirits a bit."
+   mirth_enter_rsc = "The nearby shanty brings an undeniable cheer to the area."
+   mirth_leave_rsc = "The mirthful mood passes."
 
    Mirth_song = main.mid
  
@@ -35,6 +36,9 @@ classvars:
    vrIcon = Mirth_icon_rsc
    vrDesc = Mirth_desc_rsc
 
+   jala_song_enter = mirth_enter_rsc
+   jala_song_leave = mirth_leave_rsc
+   
    viSpell_num = SID_MIRTH
    viSchool = SS_JALA
    viSpell_level = 1
@@ -47,11 +51,11 @@ classvars:
    viChance_To_Increase = 25
 
    viHarmful = FALSE
+   viBaseRange = 5
 
 properties:
 
    prMusic = Mirth_song
-   pbUserEffects = TRUE
       
 messages:
 
@@ -63,26 +67,11 @@ messages:
       return;
    }
 
-   StartEnchantment(who = $)
-   "Starts enchantment effect on one player"
+   EnterSong(who=$,iVolume=0,singer=$)
    {
-      local lState, oCaster, iSpellpower;
-
-      lState = Send(Send(who,@GetOwner),@GetEnchantmentState,#what=self);
-
-      % The caster is the second element of state.
-      oCaster = Nth(lState,2);
-
-      % Our spellpower is in the third element of state.
-      iSpellpower = Nth(lState,3);
-
-      if random(1,100) < iSpellPower
+      if random(1,100) < iVolume
       {
-         Send(who,@SetAction,#action=UA_HAPPY);
-         Send(who,@MsgSendUser,#message_rsc=Mirth_on,
-              #parm1=Send(oCaster,@GetCapDef),
-              #parm2=Send(oCaster,@GetName));
-         Send(who,@AddAttackModifier,#what=self);       
+         Send(who,@SetAction,#action=UA_HAPPY);    
       }
       else
       {
@@ -92,80 +81,27 @@ messages:
             Send(who,@SetAction,#action=UA_NORMAL);
          }
       }
-
-      propagate;
-   }
-
-   StartEnchantmentNewOccupant(who = $, state = $)
-   "Called on new occupants of the enchanted room."
-   {
-      Send(self,@StartEnchantment,#who=who,#state=state);
-
-      return;
-   }
-
-   EndRoomEnchantment(who = $, state = $)
-   "Called when user leaves the room."
-   {
-      Send(self,@RemoveEnchantment,#who=who);
-
-      propagate;
-   }
-
-   RemoveEnchantment(who=$)
-   "Called instead of EndEnchantment when trance is broken"
-   {
-      if IsClass(who,&Player)
-      {
-         % We try to remove ourselves from everyone, even though it's possible
-         %  that not everyone was enchanted.
-         Send(who,@RemoveAttackModifier,#what=self);
-      }
-
-      propagate;
-   }
-
-   StartPeriodicEnchantment(where=$, state=$)
-   {
-      local lActive, i, oObject;
-
-      lActive = Send(where,@GetHolderActive);
-      for i in lActive
-      {
-         oObject = Send(where,@HolderExtractObject,#data=i);
-
-         % Affect NPCs in room.
-         if IsClass(oObject,&Monster)
-            AND (Send(oObject,@GetBehavior) & AI_NPC)
-         {
-            Send(oObject,@ChangeMood,#amount=1);
-         }
-      }
       
       propagate;
    }
 
-   % Stuff we handle to be an attack modifier.
-
-   ModifyHitRoll(who = $,what = $,hit_roll = $)
+   ModifyHitRoll(who = $,what = $,state = $,hit_roll = $,stroke_obj = $,originalValue = 0)
    {
-      % Only affect the evil ones...
+      % Only add hit against evil targets.
       if Send(what,@GetKarma,#detect=TRUE) < 0
       {
-         % Give a small bonus
-         return hit_roll + 100;
+         return bound(hit_roll + Nth(state,2),originalValue,originalValue+100);
       }
-
       return hit_roll;
    }
    
-   ModifyDamage(who = $,what = $,damage = $)
+   ModifyDamage(who = $,what = $,state = $,damage = $,stroke_obj = $,originalValue = 0)
    {
-      % Only affect the evil ones...
+      % Only add damage against evil targets.
       if Send(what,@GetKarma,#detect=TRUE) < 0
       {
          % Roughly equal to Killing Fields
-         return damage + Random(1,5);
+         return bound((damage + Random(1,((Nth(state,2)+1)/20))),originalValue,originalValue+5);
       }
 
       return damage;

--- a/kod/object/passive/spell/jala/rejuven.kod
+++ b/kod/object/passive/spell/jala/rejuven.kod
@@ -23,12 +23,18 @@ resources:
       "Requires one diamond and a raw, uncut seraphym to cast."
 
    Rejuvenate_song = song04.mid
- 
+
+   rejuvenate_enter_rsc = "The nearby ballad brings a refreshing energy, suffusing your spirit."
+   rejuvenate_leave_rsc = "As the ballad fades, the magical suffusion ebbs."
+
 classvars:
 
    vrName = Rejuvenate_name_rsc
    vrIcon = Rejuvenate_icon_rsc
    vrDesc = Rejuvenate_desc_rsc
+   
+   jala_song_enter = rejuvenate_enter_rsc
+   jala_song_leave = rejuvenate_leave_rsc
 
    viSpell_num = SID_REJUVENATE
    viSchool = SS_JALA
@@ -42,6 +48,7 @@ classvars:
    viChance_To_Increase = 20
 
    viHarmful = FALSE
+   viBaseRange = 10
 
 properties:
 
@@ -58,14 +65,10 @@ messages:
       return;
    }
 
-   AdjustManaTime(time=0, iSpellPower=0)
-   "Reduces time passed in so that mana regens faster.  Returns reduced time."
+   ModifyManaTime(state = $, time = 1000)
+   "Reduces time passed in so that health regens faster.  Returns reduced time."
    {
-      local iTime;
-
-      iTime = (time * (200-iSpellPower)) / 200;
-
-      return iTime;
+      return bound(((time * (200 - Nth(state,2))) / 200),500,60000);
    }
 
 

--- a/kod/object/passive/spell/jala/restorat.kod
+++ b/kod/object/passive/spell/jala/restorat.kod
@@ -20,16 +20,22 @@ resources:
    Restorate_icon_rsc = irestor.bgf
    Restorate_desc_rsc = \
       "This song allows all listeners to regain health at an accelerated rate.  "
-      "Requires one diamond and several herbs to cast."
+      "Requires one diamond and some herbs to cast."
 
    Restorate_song = song05.mid
  
+   restorate_enter_rsc = "The nearby ballad seems to help knit your battle wounds."
+   restorate_leave_rsc = "As the ballad fades, the magical restoration ebbs."
+
 classvars:
 
    vrName = Restorate_name_rsc
    vrIcon = Restorate_icon_rsc
    vrDesc = Restorate_desc_rsc
 
+   jala_song_enter = restorate_enter_rsc
+   jala_song_leave = restorate_leave_rsc
+   
    viSpell_num = SID_RESTORATE
    viSchool = SS_JALA
    viSpell_level = 3
@@ -42,6 +48,7 @@ classvars:
    viChance_To_Increase = 20
 
    viHarmful = FALSE
+   viBaseRange = 10
 
 properties:
 
@@ -53,19 +60,15 @@ messages:
    {
       plReagents = $;
       plReagents = Cons([&Diamond,1],plReagents);
-      plReagents = Cons([&Herbs,5],plReagents);
+      plReagents = Cons([&Herbs,2],plReagents);
 
       return;
    }
 
-   AdjustHealthTime(time=0, iSpellPower=0)
+   ModifyHealthTime(state = $, time = 1000)
    "Reduces time passed in so that health regens faster.  Returns reduced time."
    {
-      local iTime;
-
-      iTime = (time * (200-iSpellPower)) / 200;
-
-      return iTime;
+      return bound(((time * (200 - Nth(state,2))) / 200),500,60000);
    }
 
 

--- a/kod/object/passive/spell/jala/spelbane.kod
+++ b/kod/object/passive/spell/jala/spelbane.kod
@@ -26,13 +26,23 @@ resources:
    Spellbane_no_towns = "You are prevented from singing this song currently."
 
    Spellbane_song = jala1.mid
- 
+   
+   spellbane_enter_rsc = "The nearby psalm seems to weave the mana field together in a binding pattern."
+   spellbane_leave_rsc = "As the psalm departs, the mana field begins flowing once more."
+   
+   spellbane_prevented_rsc = \
+      "The notes of the song tangle with the words of your spell, unraveling "
+      "it faster than your tongue can weave it."
+      
 classvars:
 
    vrName = Spellbane_name_rsc
    vrIcon = Spellbane_icon_rsc
    vrDesc = Spellbane_desc_rsc
 
+   jala_song_enter = spellbane_enter_rsc
+   jala_song_leave = spellbane_leave_rsc
+   
    viSpell_num = SID_SPELLBANE
    viSchool = SS_JALA
    viSpell_level = 3
@@ -43,34 +53,15 @@ classvars:
 
    viSpell_Exertion = 6
 
-   vbCanNewbieSing = FALSE     % Newbies cannot use this song
    viHarmful = TRUE
+   viBaseRange = 2
+   viAffectsGuildmates = TRUE
 
 properties:
 
    prMusic = Spellbane_song
       
 messages:
-
-   CanPayCosts(who = $, lTargets = $)
-   {
-      local oRoom, i, oActive;
-
-      oRoom = send(who,@GetOwner);
-
-      % Check to see if the room restricts guild attacks.
-      if NOT send(oRoom,@AllowGuildAttack,#what=who)
-         AND Send(SYS,@IsPKAllowed)
-         AND NOT IsClass(who,&DM)
-      {
-         % Tried to cast unguilded in town.  Denied!
-         Send(who,@MsgSendUser,#message_rsc=Spellbane_no_towns);
-
-         return FALSE;
-      }
-
-      propagate;
-   }
 
    ResetReagents()
    {
@@ -79,19 +70,16 @@ messages:
 
       return;
    }
-
-   StartEnchantment(who = $)
-   "Starts enchantment effect on one player"
+   
+   TryPreventSpell(who=$, state=$, iSpellPower=0)
    {
-      propagate;
+      if Nth(state,2) >= iSpellPower
+      {
+         Send(who,@MsgSendUser,#message=spellbane_prevented_rsc);
+         return TRUE;
+      }
+      return FALSE;
    }
-
-   RemoveEnchantment()
-   "Called instead of EndEnchantment when trance is broken"
-   {
-      propagate;
-   }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/jala/warptime.kod
+++ b/kod/object/passive/spell/jala/warptime.kod
@@ -19,16 +19,14 @@ resources:
    WarpTime_name_rsc = "warp time"
    WarpTime_icon_rsc = iwarptim.bgf
    WarpTime_desc_rsc = \
-      "The words of this song form an enchantment which increases the time "
-      "that a spellcaster must hold trance to cast a spell."
-   WarpTime_StartEnchantment = \
-      "A woozy feeling passes through your head, slowing your mental spell preparations, "
-      "your thoughts dripping like honey through your brain."
-   WarpTime_RemoveEnchantment = \
-      "A rushing sensation passes through your head, speeding your mental spell preparations "
-      "back to normal."
+      "The words of this song form an enchantment which slows time."
 
    Warptime_song = jala4.mid
+
+   warptime_enter_rsc = "A woozy feeling passes through your head as time slows to a crawl."
+   warptime_leave_rsc = "A rushing sensation passes through your head as time speeds back up."
+   
+   warptime_slowed_rsc = "Your actions seem to happen in slow motion."
  
 classvars:
 
@@ -36,19 +34,23 @@ classvars:
    vrIcon = WarpTime_icon_rsc
    vrDesc = WarpTime_desc_rsc
 
+   jala_song_enter = warptime_enter_rsc
+   jala_song_leave = warptime_leave_rsc
+
    viMana = 5          % Mana is amount used upon inititiation
-   viManaDrain = 5     % Drain is amount used every viDrainTime milliseconds
-   viDrainTime = 5000    % Drain some mana every viDrainTime milliseconds
+   viManaDrain = 10     % Drain is amount used every viDrainTime milliseconds
+   viDrainTime = 10000    % Drain some mana every viDrainTime milliseconds
    viSpell_num = SID_WARP_TIME
 
    viSchool = SS_JALA
    viSpell_level = 2
 
-   viHarmful = False
+   viHarmful = TRUE
+   viBaseRange = 2
+   viAffectsGuildmates = TRUE
 
 properties:
-   
-   pbUserEffects = TRUE
+
    prMusic= warptime_song
 
 messages:
@@ -59,101 +61,60 @@ messages:
 
       return;
    }
-
-   StartEnchantment( who = $ )
-   "Starts enchantment effect on one player"
-   {
-      local i, oEnch, state, bFound, tranceTimeLeft;
-
-      if who = $ or not isClass(who,&Player) { propagate; }
-
-      bFound = FALSE;
-      for i in send(who,@GetEnchantmentsByClass,#enchClass=&Trance)
-      {
-         bFound = TRUE;
-         oEnch = Nth(i,2);
-         state = $;
-
-         if Length(i) >= 3
-         {
-            state = Nth(i,3);
-         }
-         
-         tranceTimeLeft = getTimeRemaining(first(i));
-         tranceTimeLeft = send(self,@GetStretchedTime,#oldTime=tranceTimeLeft,#oRoom=send(who,@getOwner));
-
-         % break the old trance
-         Send(oEnch,@BreakTrance,#who=who,#state=state,#event=EVENT_STEER);
-         
-         % start a new one, identical save for the stretched time
-         Send(who,@StartEnchantment,#what=oEnch,#time=tranceTimeLeft,#addicon=FALSE,#state=state);            
-      }
-
-      if bFound
-      {
-         send(who,@MsgSendUser,#message_rsc=warptime_StartEnchantment);
-      }
-      
-      propagate;
-   }
-
-   GetStretchedTime(oldtime=0, iSpellPower=0, oRoom=$)
-   {
-      if oRoom <> $
-      {
-         iSpellPower = nth(send(oRoom,@GetEnchantmentState,#what=self),3);
-      }
-      
-      return oldtime*(100+iSpellPower)/100;
-   }
    
-   GetUnstretchedTime(oldtime=0, iSpellPower=0, oRoom=$)
+   ModifyAttackTime(who=$,state=$,time=1,originalValue=1)
    {
-      if oRoom <> $
+      if time > (originalValue * 3)
       {
-         iSpellPower = nth(send(oRoom,@GetEnchantmentState,#what=self),3);
+         return time;
       }
-      
-      return oldtime*100/(100+iSpellPower);
+
+      if time = originalValue
+      {
+         Send(who,@MsgSendUser,#message=warptime_slowed_rsc);
+      }
+
+      time = ((time * Nth(state,2))/33);
+      time = bound(time, originalValue, originalValue*3);
+
+      return time;
    }
 
-   RemoveEnchantment(who = $)
-   "Called instead of EndEnchantment when trance is broken"
+   ModifyPostCastTime(who=$,state=$,time=1,originalValue=1)
    {
-      local i, oEnch, state, bFound, tranceTimeLeft;
-
-      if who = $ or not isClass(who,&Player) { propagate; }
-
-      bFound = FALSE;
-      for i in send(who,@GetEnchantmentsByClass,#enchClass=&Trance)
+      if time > (originalValue * 3)
       {
-         oEnch = Nth(i,2);
-         bFound = TRUE;
-         state = $;
-
-         if Length(i) >= 3
-         {
-            state = Nth(i,3);
-         }
-
-         tranceTimeLeft = GetTimeRemaining(first(i));
-         tranceTimeLeft = send(self,@GetUnstretchedTime,#oldTime=tranceTimeLeft,#oRoom=send(who,@GetOwner));
-
-         % break the old trance
-         Send(oEnch,@BreakTrance,#who=who,#state=state,#event=EVENT_STEER);
-
-         % start a new one, identical save for the unstretched time
-         Send(who,@StartEnchantment,#what=oEnch,#time=tranceTimeLeft,#addicon=FALSE,#state=state);            
+         return time;
       }
 
-      if bFound
+      if time = originalValue
       {
-         send(who,@MsgSendUser,#message_rsc=warptime_RemoveEnchantment);
+         Send(who,@MsgSendUser,#message=warptime_slowed_rsc);
       }
-      
-      propagate;
+
+      time = ((time * Nth(state,2))/33);
+      time = bound(time, originalValue, originalValue*3);
+
+      return time;
    }
 
+   ModifyTranceTime(who=$,state=$,percent=100,iSpellPower=0,originalValue=100)
+   {
+      if percent > (originalValue * 3)
+      {
+         return percent;
+      }
 
+      percent = ((percent * Nth(state,2))/33);
+      percent = bound(percent, originalValue, originalValue*3);
+
+      return percent;
+   }
+
+   % Offer up to 2 damage reduction based on spellpower due to slowed attacks
+   ModifyDefenseDamage(who = $,what = $,state = $,damage = $,atype = $,aspell = $,stroke_obj = $,originalValue = 0)
+   {
+      return bound((damage-((Nth(state,2)+1)/50)),originalValue-2,originalValue);
+   }
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Per much conversation and advice, I redid the code to make Jala songs
much more powerful and easier to implement. They now keep original
caster information in their state, and all songs are called every time
any song might be called, so that any song can do any effect.

This allows new song contributors to simply copy a blank function from
jala.kod, fill it out, and have it work immediately and exactly as
intended. There are also many function-specific variables passed along,
giving the effects far more information and options.

For example, a single song could warp time, increase mana regen, and modify hit roll. No dependency on being a certain class or having a certain call added elsewhere in the code. This should simplify the Jala expansion process significantly - instead of adding code in whatever random place a song might be called, I went ahead and put calls in all the relevant places. New contributors now only have to create a song file and fill out a function.
