### PR TITLE
Faction Shield Rank change.

### DIFF
--- a/kod/object/item/passitem/defmod/shield/soldshld.kod
+++ b/kod/object/item/passitem/defmod/shield/soldshld.kod
@@ -20,10 +20,10 @@ constants:
    DEFENDING = 3
 
    % Max rank you can get from killing factioned NPCs
-   MAX_RANK_FROM_MONSTERS = 4
+   MAX_RANK_FROM_MONSTERS = 10
 
    % How many meridian days (approximate) before you lose a rank.
-   DAYS_PER_RANK_LOSS = 100
+   DAYS_PER_RANK_LOSS = 60
 
 resources:
 


### PR DESCRIPTION
With this change players can get to max faction shield rank by farming soldiers.

Right now players use mules to farm up to max rank by killing them over and over and using another mule to portal of life the shield mule.

Obviously this puts players not using mules at a disadvantage. And while this doesn't fix the abuse of mules for rank it does level the playing field.

Also I cut the rank degeneration over time down to 5 real life days per rank so players have to be more actively farming to maintain max rank.
