### PR TITLE
Troop karma

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/troop.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/troop.kod
@@ -220,7 +220,6 @@ messages:
       plResistances = [ ];
       
       send(self,@SetGender);
-      send(self,@SetKarma);
       send(self,@SetHair);
       send(self,@SetFace);
       send(self,@SetSkinColor);
@@ -251,12 +250,6 @@ messages:
          vrSound_death = FactionTroop_female_sound_death;
       }
 
-      return;
-   }
-
-   SetKarma()
-   {
-      viKarma = random(-20,30);
       return;
    }
 


### PR DESCRIPTION
Should fix guards so they don't change karma when you kill them.

Removing the need to have to fix your karma after fixing your faction shield rank.
