### PR TITLE
Prevent deguilding while ghosted

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -953,6 +953,9 @@ properties:
    % Used to construct a string for their description.
    plDonationYears = $
 
+   % The player's ghost object
+   poLogoffGhost = $
+
 messages:
 
    Constructor()
@@ -1915,6 +1918,8 @@ messages:
       % We used to do this when the mana nodes changed, but iterating
       % over all players became far too expensive.
       Send(self,@ComputeMaxMana);
+      
+      Send(self,@SetGhost,#what=$);
 
       % Tell others that we're here
       oRoom = Send(self, @GetOwner);
@@ -12338,6 +12343,16 @@ messages:
       return;
    }
 
+   GetGhost()
+   {
+      return poLogoffGhost;
+   }
+
+   SetGhost(what = $)
+   {
+      poLogoffGhost = what;
+      return;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -152,11 +152,14 @@ messages:
          }
       }
 
+      Send(poGhostedPlayer,@SetGhost,#what=self);
+
       propagate;
    }
 
    Delete()
    {
+      Send(poGhostedPlayer,@SetGhost,#what=$);
       poGhostedPlayer = $;
 
       if ptPenaltyTimer <> $

--- a/kod/object/passive/guildcmd/gcexile.kod
+++ b/kod/object/passive/guildcmd/gcexile.kod
@@ -34,6 +34,8 @@ resources:
    guildexile_necro_nak = "~BEvery member of The Order is bound by a blood oath.  The only way "
       "out is death."
 
+   guild_cannot_remove_while_ghosted = "You cannot exile a player while they are ghosted."
+
 classvars:
 
    vrName = guildexile_name_rsc
@@ -60,7 +62,7 @@ messages:
    DoCommand(who=$, otarget = $)
    "Kicks the target out of the guild!"
    {
-      local yourGuild,myguild,i,lmembers;
+      local yourGuild,myguild,i,lmembers,oGhost;
 
       if not isClass(oTarget,&player)
         {
@@ -104,6 +106,17 @@ messages:
 
       if isClass(myGuild,&NecromancerGuild) {
          Send(who,@MsgSendUser,#message_rsc=guildexile_necro_nak );
+         return FALSE;
+      }
+
+      oGhost = Send(oTarget,@GetGhost);
+      if oGhost <> $
+      {
+         if who <> $
+            AND IsClass(who,&User)
+         {
+            Send(who,@MsgSendUser,#message_rsc=guild_cannot_remove_while_ghosted);
+         }
          return FALSE;
       }
 


### PR DESCRIPTION
A player may no longer be exiled from a guild while they have an active logoff ghost.

In addition, this adds a new poLogoffGhost object to a player's data,
giving us the ability to quickly access a player's ghost. Previously,
a ghost knew who its player was, but not the other way around.
