### PR TITLE
Dements Duration

### DIFF
--- a/kod/object/passive/spell/dement.kod
+++ b/kod/object/passive/spell/dement.kod
@@ -138,8 +138,8 @@ messages:
    {
       local iDuration;
 
-      % 5-30 minutes
-      iDuration = (300 + 16*iSpellPower) * 1000;
+      % 1-3 minutes
+      iDuration = (300 + 16*iSpellPower) * 100;
 
       return random(iDuration/2,iDuration);
    }


### PR DESCRIPTION
Cuts the duration of dement from between 5 and 30 minutes to between 50 seconds and 3 minutes.

The spell currently completely shuts down casters and 3 minutes is still longer then most battles. So dement is sill nasty strong but at least now you don't have to camp online after a fight waiting for it to fade if you're not shal.
