### PR TITLE
RoomGive admin command

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
@@ -613,7 +613,7 @@ messages:
 
    UserSay(string = $,type = $)
    {
-      local i, lObjects, iNum, lTemplate, bFound, bAllowed, temp, oBard, oObject;
+      local i, lObjects, iNum, lTemplate, bFound, bAllowed, temp, oBard, oObject, iGiven;
 
       if type <> SAY_DM
       {
@@ -1406,28 +1406,22 @@ messages:
       if StringContain(string,dm_roomgive_command)
          OR StringContain(string,"roomgive")
       {
-         bFound = 0;
+         iGiven = 0;
          lTemplate = Send(SYS,@GetItemTemplates);
 
          for i in lTemplate
          {
-            if StringContain(string,"shillings")
-            {
-               bFound = Send(SYS,@RoomGive,#who=self,#classtype=&Money,#number=5000);
-               Send(self,@MsgSendUser,#message_rsc=dm_gave_to_number,#parm1=bFound);
-               return;
-            }
             if StringContain(string,Send(i,@GetName))
                AND NOT Send(i,@IsItemType,#type=ITEMTYPE_SPECIAL)
             {
-               bFound = Send(SYS,@RoomGive,#who=self,#classtype=GetClass(i),
+               iGiven = Send(SYS,@RoomGive,#who=self,#classtype=GetClass(i),
                            #number=Send(SYS,@GetNumberFromString,#string=string));
-               Send(self,@MsgSendUser,#message_rsc=dm_gave_to_number,#parm1=bFound);
+               Send(self,@MsgSendUser,#message_rsc=dm_gave_to_number,#parm1=iGiven);
                return;
             }
          }
 
-         if NOT bFound
+         if NOT iGiven
          {
             Send(self,@MsgSendUser,#message_rsc=dm_no_item);
          }

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -5050,7 +5050,6 @@ messages:
       if classtype <> $
       {
          if number = -1
-            OR number = $
          {
             oExample = Create(classtype);
          }
@@ -5727,9 +5726,10 @@ messages:
    }
 
    GetNumberFromString(string = $)
-   "Gets the lowest number found in a string."
+   "Gets the lowest number found in a string. Returns -1 if no number is found. "
+   "Only finds values zero to twelve, then ten, twenty, thirty... up to a hundred."
    {
-      if string = $ {return $;}
+      if string = $ {return -1;}
       if (StringContain(string,system_cardinal_0)) {return 0;}
       if (StringContain(string,system_cardinal_1)) {return 1;}
       if (StringContain(string,system_cardinal_2)) {return 2;}
@@ -5753,7 +5753,7 @@ messages:
       if (StringContain(string,system_cardinal_90)) {return 90;}
       if (StringContain(string,system_cardinal_100)) {return 100;}
 
-      return $;
+      return -1;
    }
 
    GetLogoffPenaltyEnable()


### PR DESCRIPTION
Gives all non-DM players in the room a reward, similar to GlobalGive.

who = a user. Users in that user's room will be given the items. Admin should
usually call it on himself. (It's easier to look up player #s than it is
room #s).

hp = min basemaxhealth required to receive the items. Default is 30.

example usage:
send o 0 roomgive classtype c Money number int 5000 who o [your obj #] hp int 120

This would give 5k to all players in your room that have 120+ hps.

Can also be called on others to give all players in the same room a reward. Might be useful for escaped convict events, chase events, etc.

Returns the number of players who receive the reward.
