### PR TITLE
Gnarled Staff does not message about admin

### DIFF
--- a/kod/object/item/passitem/specwand/joltstaf.kod
+++ b/kod/object/item/passitem/specwand/joltstaf.kod
@@ -155,8 +155,12 @@ messages:
             continue;
          }
 
+         if isClass(first(i),&DM)
+         {
+             return FALSE;
+         }
+         
          if send(first(i),@BreakTrance,#event=EVENT_DISRUPT)
-            AND NOT isClass(first(i),&DM)
          {
             for j in send(oRoom,@GetHolderActive)
             {


### PR DESCRIPTION
This change stops the Gnarled Staff from sending a message to the room
that a DM or Admin has lost concentration.

Currently when a DM is in blank mode, people can find out if an admin is hidden
via a gnarled staff.
