### PR TITLE
Hidden Admin no longer murmurs or spell sound

### DIFF
--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1402,13 +1402,13 @@ messages:
          if isClass(who,&Admin)
             AND Send(who, @IsHidden)
          {
-             if isClass(oTarget, &Player)
+             if oTarget = $
              {
-                 Debug("ADMIN:",Send(who,@GetTrueName),"cast ",Send(self,@GetName),"on",Send(oTarget,@GetTrueName),"while hidden.");
+                 Debug("ADMIN:",Send(who,@GetTrueName),"cast",Send(Self,@GetName),"while hidden.");
              }               
              else
              {
-                 Debug("ADMIN:",Send(who,@GetTrueName),"cast",Send(Self,@GetName),"while hidden.");
+                 Debug("ADMIN:",Send(who,@GetTrueName),"cast ",Send(self,@GetName),"on",Send(oTarget,@GetTrueName),"while hidden.");
              }
               
             return;


### PR DESCRIPTION
Just removes the Murmur message to the room when a caster casts if an
ADMIN is hidden if not still shows the message. Does not work for DM.

When NOT DM Hidden:
ADMIN murmurs something under his breath and points a finger at ADMIN.
- Spell sound plays in room

When DM Hidden:
Nothing
No sounds.
