### PR TITLE
Fixed DM (Hidden, Blank, Plain, Disguise)

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
@@ -692,6 +692,157 @@ messages:
 
       if pbActor
       {
+         if StringEqual(string,dm_hidden_command)
+            OR StringEqual(string,"hidden")
+         {
+            if NOT (piDMFlags & DMFLAG_HIDDEN)
+            {
+               piDMFlags = piDMFlags | DMFLAG_HIDDEN;
+               Send(self,@MsgSendUser,#message_rsc=dm_hidden);
+
+               % Make it look like we just logged off without really logging off.
+               Send(SYS,@SystemUserLogoffAdvertise,#what=self,#bTrue=FALSE);
+            }
+            else
+            {
+               piDMFlags = piDMFlags & ~DMFLAG_HIDDEN;
+               Send(self,@MsgSendUser,#message_rsc=dm_not_hidden);
+
+               % Make it look like we just logged back on.
+               Send(SYS,@SystemUserLogonAdvertise,#what=self,#bTrue=FALSE);
+            }
+
+            % Do this so that our name changes properly.
+            Send(poOwner,@SomethingChanged,#what=self);
+
+            return;
+         }
+
+         if StringEqual(string,dm_blank_command)
+            OR StringEqual(string,"blank")
+         {
+            % Make everyone think we left the room.
+            lObjects = Send(poOwner,@GetHolderActive);
+
+            for i in lObjects
+            {
+               oObject = Send(poOwner,@HolderExtractObject,#data=i);
+
+               if IsClass(oObject,&User)
+                  AND oObject <> self
+               {
+                  Send(oObject,@SomethingLeft,#what=self);
+               }
+            }
+
+            vrIcon = admin_icon_blank;
+            pbMorph = TRUE;
+            piMove_start = 1;
+            piMove_end = 1;
+            piMove_delay = 500;
+            piAttack_start = 1;
+            piAttack_end = 1;
+            piAttack_delay = 500;
+
+            Send(self,@MsgSendUser,#message_rsc=dm_blank);
+            Send(self,@SetPlayerFlag,#flag=PFLAG_INVISIBLE,#value=TRUE);
+            Send(self,@SetPlayerFlag,#flag=PFLAG_ANONYMOUS,#value=TRUE);
+            piDMFlags = piDMFlags | DMFLAG_INVISIBLE;
+            Send(self,@ResetPlayerFlagList); 
+ 
+            return;
+         }
+         
+         if StringContain(string,dm_disguise_command)
+            OR StringContain(string,"disguise")
+         {
+           StringSubstitute(string,dm_disguise_command," ");
+           StringSubstitute(string,"disguise"," ");
+         
+           % Checks art archive, if no matches goes to NPCs.
+           temp = Send(Send(SYS,@GetArtArchive),@FindArchiveByString,#string=string);
+
+           % Nothing in art archive?  Check for NPCs.
+           if temp = $
+           {
+
+              % Checks NPC list, if no matches, goes to monsters.
+              oObject = Send(SYS,@FindNPCByString,#string=string);
+              if oObject <> $
+              {
+                 temp = Send(oObject,@GetIcon);
+              }
+                                           
+              if oObject = $
+              {
+                 % Checks Monster list, if no matches, return.
+                 oObject = Send(SYS,@FindMonsterByString,#string=string);
+                 if oObject <> $               
+                 {
+                    temp = Send(oObject,@GetIcon);
+                 }    
+        
+                 if oObject = $
+                 {
+                    return;
+                 }            
+              } 
+           }
+
+           vrIcon = temp;
+           pbMorph = TRUE;
+           piMove_start = 1;
+           piMove_end = 1;
+           piMove_delay = 500;
+           piAttack_start = 1;
+           piAttack_end = 1;
+           piAttack_delay = 500;
+           Send(self,@ResetPlayerDrawfx,#drawfx=DRAWFX_NO);
+           piDMFlags = piDMFlags & ~DMFLAG_INVISIBLE;
+           piDMFlags = piDMFlags & ~DMFLAG_SHADOW;
+           Send(self,@ResetPlayerFlagList);
+
+           return;
+        }
+
+        if StringEqual(string,dm_plain_command) OR StringEqual(string,dm_human_command)
+           OR StringEqual(string,"plain") OR StringEqual(string,"human")
+        {
+           Send(self,@ResetPlayerIcon,#alldone=FALSE);
+           pbMorph = FALSE;
+
+           % For characters we want to have a non-standard icon
+           if prStandardIcon <> $
+           {
+              vrIcon = prStandardIcon;
+              pbMorph = TRUE;
+           }
+
+           Send(self,@MsgSendUser,#message_rsc=dm_plain);
+           Send(self,@SetPlayerFlag,#flag=PFLAG_INVISIBLE,#value=FALSE);
+           Send(self,@SetPlayerFlag,#flag=PFLAG_ANONYMOUS,#value=FALSE);
+           Send(self,@ResetPlayerDrawfx,#drawfx=DRAWFX_NO);
+
+           piDMFlags = piDMFlags & ~DMFLAG_INVISIBLE;
+           piDMFlags = piDMFlags & ~DMFLAG_SHADOW;
+
+           Send(self,@ResetPlayerFlagList); 
+
+           lObjects = Send(poOwner,@GetHolderActive);
+
+           for i in lObjects
+           {
+              oObject = Send(poOwner,@HolderExtractObject,#data=i);
+
+              if IsClass(oObject,&User)
+              {
+                 Send(oObject,@ToCliRoomContents);
+              }
+           }
+
+           return;
+        }
+         
          if (StringEqual(string,dm_rumble_command) OR StringEqual(string,"rumble"))
          {
             Send(poOwner,@Rumble);
@@ -752,67 +903,6 @@ messages:
             Send(poOwner,@SomeoneSaid,#what=self,#type=SAY_MESSAGE,
                  #string=dm_baddie,#parm1=vrName);
          }
-
-         return;
-      }
-
-      if StringEqual(string,dm_hidden_command)
-         OR StringEqual(string,"hidden")
-      {
-         if NOT (piDMFlags & DMFLAG_HIDDEN)
-         {
-            piDMFlags = piDMFlags | DMFLAG_HIDDEN;
-            Send(self,@MsgSendUser,#message_rsc=dm_hidden);
-
-            % Make it look like we just logged off without really logging off.
-            Send(SYS,@SystemUserLogoffAdvertise,#what=self,#bTrue=FALSE);
-         }
-         else
-         {
-            piDMFlags = piDMFlags & ~DMFLAG_HIDDEN;
-            Send(self,@MsgSendUser,#message_rsc=dm_not_hidden);
-
-            % Make it look like we just logged back on.
-            Send(SYS,@SystemUserLogonAdvertise,#what=self,#bTrue=FALSE);
-         }
-
-         % Do this so that our name changes properly.
-         Send(poOwner,@SomethingChanged,#what=self);
-
-         return;
-      }
-
-      if StringEqual(string,dm_blank_command)
-         OR StringEqual(string,"blank")
-      {
-         % Make everyone think we left the room.
-         lObjects = Send(poOwner,@GetHolderActive);
-
-         for i in lObjects
-         {
-            oObject = Send(poOwner,@HolderExtractObject,#data=i);
-
-            if IsClass(oObject,&User)
-               AND oObject <> self
-            {
-               Send(oObject,@SomethingLeft,#what=self);
-            }
-         }
-
-         vrIcon = admin_icon_blank;
-         pbMorph = TRUE;
-         piMove_start = 1;
-         piMove_end = 1;
-         piMove_delay = 500;
-         piAttack_start = 1;
-         piAttack_end = 1;
-         piAttack_delay = 500;
-
-         Send(self,@MsgSendUser,#message_rsc=dm_blank);
-         Send(self,@SetPlayerFlag,#flag=PFLAG_INVISIBLE,#value=TRUE);
-         Send(self,@SetPlayerFlag,#flag=PFLAG_ANONYMOUS,#value=TRUE);
-         piDMFlags = piDMFlags | DMFLAG_INVISIBLE;
-         Send(self,@ResetPlayerFlagList); 
 
          return;
       }
@@ -1270,97 +1360,6 @@ messages:
             if isClass(first(i),&Monster)
             {
                Send(first(i),@RandomTimer,#test=TRUE);
-            }
-         }
-
-         return;
-      }
-
-      if StringContain(string,dm_disguise_command)
-         OR StringContain(string,"disguise")
-      {
-         StringSubstitute(string,dm_disguise_command," ");
-         StringSubstitute(string,"disguise"," ");
-         
-         % Checks art archive, if no matches goes to NPCs.
-         temp = Send(Send(SYS,@GetArtArchive),@FindArchiveByString,#string=string);
-
-         % Nothing in art archive?  Check for NPCs.
-         if temp = $
-         {
-
-            % Checks NPC list, if no matches, goes to monsters.
-            oObject = Send(SYS,@FindNPCByString,#string=string);
-            if oObject <> $
-            {
-               temp = Send(oObject,@GetIcon);
-            }
-                
-                            
-            if oObject = $
-            {
-               % Checks Monster list, if no matches, return.
-               oObject = Send(SYS,@FindMonsterByString,#string=string);
-               if oObject <> $               
-               {
-                  temp = Send(oObject,@GetIcon);
-               }    
-        
-               if oObject = $
-               {
-                  return;
-               }            
-            } 
-         }
-
-         vrIcon = temp;
-         pbMorph = TRUE;
-         piMove_start = 1;
-         piMove_end = 1;
-         piMove_delay = 500;
-         piAttack_start = 1;
-         piAttack_end = 1;
-         piAttack_delay = 500;
-         Send(self,@ResetPlayerDrawfx,#drawfx=DRAWFX_NO);
-         piDMFlags = piDMFlags & ~DMFLAG_INVISIBLE;
-         piDMFlags = piDMFlags & ~DMFLAG_SHADOW;
-         Send(self,@ResetPlayerFlagList);
-
-         return;
-      }
-
-      if StringEqual(string,dm_plain_command) OR StringEqual(string,dm_human_command)
-         OR StringEqual(string,"plain") OR StringEqual(string,"human")
-      {
-         Send(self,@ResetPlayerIcon,#alldone=FALSE);
-         pbMorph = FALSE;
-
-         % For characters we want to have a non-standard icon
-         if prStandardIcon <> $
-         {
-            vrIcon = prStandardIcon;
-            pbMorph = TRUE;
-         }
-
-         Send(self,@MsgSendUser,#message_rsc=dm_plain);
-         Send(self,@SetPlayerFlag,#flag=PFLAG_INVISIBLE,#value=FALSE);
-         Send(self,@SetPlayerFlag,#flag=PFLAG_ANONYMOUS,#value=FALSE);
-         Send(self,@ResetPlayerDrawfx,#drawfx=DRAWFX_NO);
-
-         piDMFlags = piDMFlags & ~DMFLAG_INVISIBLE;
-         piDMFlags = piDMFlags & ~DMFLAG_SHADOW;
-
-         Send(self,@ResetPlayerFlagList); 
-
-         lObjects = Send(poOwner,@GetHolderActive);
-
-         for i in lObjects
-         {
-            oObject = Send(poOwner,@HolderExtractObject,#data=i);
-
-            if IsClass(oObject,&User)
-            {
-               Send(oObject,@ToCliRoomContents);
             }
          }
 


### PR DESCRIPTION
Currently a DM without SayCommands (ability to make items) can dm blank
himself, but he does not have the permission to DM PLAIN, same thing for
DM DISGUISE.

Also, a DM without SayCommands can DM Hidden and DM Blank regardless
of any settings.

I moved them to require a TRUE pbActor. Now a DM with a FALSE SayCommands but
with a TRUE pbActor can:
DM Hidden
DM Blank
DM Plain
DM Disguise

If pbActor is FALSE - none of these commands are available. This gives us
more flexibility with these commands rather than just allowing an DM to
go hidden, now we can add and remove these commands as we see fit by
toggling the pbActor flag.

The DM Plain - required to return from Blank or Disguise
The DM Disguise - This never made any sense to me, if you're an "actor" have the actor flag as true, wouldn't it make sense that you can disguise yourself?? lol

P.S. - None of this is my code, I just cut and pasted it from the areas
that made no sense, to the areas that made sense.
