### PR TITLE
Ghost duration cut to 3 minutes

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -103,9 +103,9 @@ constants:
    SWINGS_PER_IMPROVE_CHECK = 75    
 
    % What's the length after having a player attacked before we let "mules" 
-   %  cast on them again.  Currently set to 5 minutes.  Should be bigger 
-   %  than logoff ghost time (currently 3 mins)
-   ATTACKED_PLAYER_WAIT = 5 * 60
+   %  cast on them again.  Currently set to 15 minutes.  Should be bigger 
+   %  than logoff ghost time (currently 10 mins)
+   ATTACKED_PLAYER_WAIT = 15 * 60
 
    % Damage is capped at piBase_Max_Health divided by this number.  Reduces
    %  newbie slaughter.

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -89,6 +89,9 @@ properties:
 
    % Rescue always takes at least this long to cast
    piRescueBaseDelaySec = 15
+   
+   % Time in seconds that ghosts will last before taking a penalty
+   piLogoffPenaltyGhostTime = 600
 
    %
    % Guild hall settings
@@ -325,6 +328,10 @@ messages:
       return pbDamageCapProtectionMurderersEnable;
    }
 
+   GetLogoffPenaltyGhostTime()
+   {
+      return piLogoffPenaltyGhostTime;
+   }
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -340,11 +340,6 @@ properties:
    %  death.
    piLogoffPenaltyEquivDeath = 10
 
-   % How long do ghosts stick around, on average?
-   % If this changes, alter ATTACKED_PLAYER_WAIT in player.kod
-   % Time: Three minutes (in seconds)
-   piLogoffPenaltyGhostTime = 3 * 60
-
    ptLogoffPenaltyTempDisable = $
    ptServerPopulationMonitor = $
    piLastServerPopulation = 0
@@ -5817,7 +5812,7 @@ messages:
 
    GetLogoffPenaltyGhostTime()
    {
-      return piLogoffPenaltyGhostTime;
+      return Send(Send(self,@GetSettings),@GetLogoffPenaltyGhostTime);
    }
 
    TempDisableLogoffPenalties()
@@ -5830,7 +5825,7 @@ messages:
          ptLogoffPenaltyTempDisable = $;
       }
 
-      iDisableDuration = (piLogoffPenaltyGhostTime*150)/100;
+      iDisableDuration = (Send(Send(self,@GetSettings),@GetLogoffPenaltyGhostTime)*150)/100;
       iDisableDuration = iDisableDuration * 1000;   % convert to ms
 
       ptLogoffPenaltyTempDisable = createTimer(self,@LogoffPenaltyTempDisableTrigger,iDisableDuration);


### PR DESCRIPTION
Logoff ghosts are a very contentious mechanic. This is a tentative first
step to see how combat evolves with shorter ghosts - all other arguments
aside, 10 minutes is way too long.

There are many groups with many different ideas about ghosts, but most agree that staring at a ghosted player for 10 minutes is way too long and way too boring.
