### PR TITLE
Thrashers truce bug fix

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/thrasher.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/thrasher.kod
@@ -238,7 +238,7 @@ messages:
       lFinalTargets = Send(self,@GetFinalTargets);
       If Length(lFinalTargets) > 1
          AND NOT Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
-
+         And NOT Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_MOB_COMBAT)
       {
          Send(self,@StartSpin);
 


### PR DESCRIPTION
Thrashers were still able to do their special spin attack with truce up
because of the flag change.
