### PR TITLE
Statue Annoyance Fix

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/lvstatue.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/lvstatue.kod
@@ -23,7 +23,7 @@ constants:
    SOLDIER_PERCENT = 20
 
    % What percent of the time do we wake up when someone is near?
-   WAKEUP_CHANCE = 70
+   WAKEUP_CHANCE = 100
 
    % How long are we dormant when someone tries to wake us up?
    DORMANT_DURATION = 2 * 60 * 1000  % 2 minutes (in ms)


### PR DESCRIPTION
Per much player request, changed living statues' wake up chance to 100%
instead of 70%.

Seriously, why would they do this to us? Waiting for statues to wake up
is the worst. Fail a few rolls and you can be sitting idle on the same
statue for 10 minutes or more. I see no reason to keep normal statues
this way, but if admins want to do something for an event with it, the
code is still there.
