### PR TITLE
Blind & Dazzle fix

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2965,7 +2965,7 @@ messages:
 
          iAngle = iAngle mod MAX_ANGLE;
 
-         if iChanceTurn < 30
+         if iChanceTurn < 70
          {
             Send(poOwner,@SomethingTurned,#what=self,#new_angle=iAngle);
          }

--- a/kod/object/passive/spell/Dazzle.kod
+++ b/kod/object/passive/spell/Dazzle.kod
@@ -19,14 +19,14 @@ resources:
    Dazzle_name_rsc = "dazzle"
    Dazzle_icon_rsc = idazzle.bgf
    Dazzle_desc_rsc = \
-      "Dazzles the target with the blinding light of Shal'ille's goodness.  "
+      "Pacifies the target with the blinding light of Shal'ille's goodness.  "
       "Requires emeralds and purple mushrooms."
    
    Dazzle_caster = "%s%s is now dazzled."
    Dazzle_already_enchanted = "%s%s is already dazzled."
 
-   Dazzle_on = "The world is washed away in a flood of pure light."
-   Dazzle_off = "Your vision begins to clear."
+   Dazzle_on = "Your will is momentarily washed away in a flood of pure light."
+   Dazzle_off = "Your willpower returns."
 
    Dazzle_sound = sDazzle.wav
 
@@ -155,8 +155,7 @@ messages:
       if IsClass(oTarget,&Player)
       {
          Send(oTarget,@MsgSendUser,#message_rsc=Dazzle_on);
-         Send(oTarget,@EffectSendUserDuration,#effect=EFFECT_WHITEOUT,
-              #duration=iDuration);
+         Send(oTarget,@EffectSendUserDuration,#effect=EFFECT_WHITEOUT,#duration=1000);
       }
       else
       {
@@ -203,8 +202,8 @@ messages:
             Send(who,@MsgSendUser,#message_rsc=Dazzle_off);
          }
 
-         Send(who,@EffectSendUserDuration,#effect=EFFECT_PAIN,#duration=8000);
-         Send(who,@EffectSendUserXLat,#xlat=0);
+%         Send(who,@EffectSendUserDuration,#effect=EFFECT_PAIN,#duration=8000);
+%         Send(who,@EffectSendUserXLat,#xlat=0);
       } 
       else  
       {

--- a/kod/object/passive/spell/blind.kod
+++ b/kod/object/passive/spell/blind.kod
@@ -16,20 +16,19 @@ constants:
 
 resources:
 
-   blind_name_rsc = "blind"
+   blind_name_rsc = "bind"
    blind_icon_rsc = iblind.bgf
    blind_desc_rsc = \
-      "The magical force of Qor burns the target's eyes, "
-      "taking away all sight for a brief period.  "
+      "The magical force of Qor binds the target's muscles, "
+      "causing them to stumble and lose the ability to fight for an extended period.  "
       "Requires entroot berries and purple mushrooms to cast."
    
-   blind_caster = "%s%s is now blind."
-   blind_already_enchanted = "%s%s is already blind."
+   blind_caster = "%s%s is now bound."
+   blind_already_enchanted = "%s%s is already bound."
 
    blind_on = \
-      "Something burns in your eyes, causing excruciating pain and a loss "
-      "of vision."
-   blind_off = "Your eyes begin to function again."
+      "Something burns in your muscles, causing excruciating pain."
+   blind_off = "You regain control of your body."
 
    blind_sound = qblind.wav
 
@@ -170,7 +169,9 @@ messages:
          if NOT (IsClass(oTarget,&DM) AND Send(oTarget,@PlayerIsImmortal))
          {
             Send(oTarget,@MsgSendUser,#message_rsc=blind_on);
-            Send(oTarget,@EffectSendUser,#what=self,#effect=EFFECT_BLIND_ON);
+            Send(oTarget,@EffectSendUserDuration,#effect=EFFECT_PAIN,#duration=1200);
+            Send(oTarget,@EffectSendUserXLat,#xlat=0);
+%           Send(oTarget,@EffectSendUser,#what=self,#effect=EFFECT_BLIND_ON);
          }
       }
       else  
@@ -199,7 +200,7 @@ messages:
    {
       if IsClass(who,&Player)
       {
-         Send(who,@EffectSendUser,#what=self,#effect=EFFECT_BLIND_OFF);
+%        Send(who,@EffectSendUser,#what=self,#effect=EFFECT_BLIND_OFF);
          if report
          {
             Send(who,@MsgSendUser,#message_rsc=blind_off);
@@ -224,7 +225,7 @@ messages:
    RestartEnchantmentEffect(who=$,state=$)
    {
       Send(who,@MsgSendUser,#message_rsc=blind_on);
-      Send(who,@EffectSendUser, #what=self, #effect=EFFECT_BLIND_ON);
+%     Send(who,@EffectSendUser, #what=self, #effect=EFFECT_BLIND_ON);
       
       return;
    }


### PR DESCRIPTION
There is a widespread cheat to ignore the visual component of these
flagship spells. This commit therefore largely eliminates those effects,
reducing the visual components to one second (retained as a way to
succinctly inform players they have been cast upon).

This necessitated a few text changes in dazzle, re-explaining the dazzle
effect as a pacification effect due to Shal'ille's light.

Blind was more complicated. I renamed it "Bind" and increased the
stumbling effect from 30% to 70% to compensate for the loss of blinding.
The new lore explanation is that it burns the target's muscles, in keeping
with Qor's bodily disablement theme. This should affect the movement of normal players and cheaters alike in
the manner blind was originally intended to. The spell still prevents the use of doors.

These lore edits keep the spells properly themed while removing the see-through-blind cheat entirely and actually enhancing Blind's effects. In testing, the 70% chance to change direction every second (while moving) is highly disorienting - and if cheaters do manage to bypass the effect, it will be **very** obvious, unlike the current see-through bypass, which is totally unobservable by other players.

Definitely open to changing the stumbling effect in the future if it proves to be by-passable or unpopular. All that really matters right now is equalizing the playing field between cheaters and normal players. Normal players are completely dominated by Blind and Dazzle, while cheaters can almost ignore their effects and continue running around with full sight - and there is no simple way to enforce cheat detection otherwise.
