### PR TITLE
Webs instant cast

### DIFF
--- a/kod/object/passive/spell/walspell/summweb.kod
+++ b/kod/object/passive/spell/walspell/summweb.kod
@@ -41,7 +41,7 @@ classvars:
    viSpell_level = 3
    viMana = 15
    viSpellExertion = 10
-   viCast_time = 3000
+   viCast_time = 0
 
    vrSucceed_wav = SummonWeb_sound
    viChance_To_Increase = 25


### PR DESCRIPTION
Changed the spell Spider Web to instant cast, down from 3 seconds.

After the zoning-deletion change to walls, Spider Web has been left very underpowered. There seems to be a strong bi-partisan interest in upgrading it.

I'd like to start by making the spell instant, thus allowing mid-battle casting, and then observing what happens from there. We have several balancing options if it turns out to be too powerful, but it already has several inherent limitations that should keep it interesting rather than problematic.
