### PR TITLE
Shadow-ignore for tells

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3680,8 +3680,6 @@ messages:
    "Sent by client when they're blocking messages from a user, and that "
    "user Sends a message."
    {
-      % Send(what,@MsgSendUser,#message_rsc=user_blocked_send,
-      %      #parm1=Send(self,@GetTrueName));
 
       return;
    }


### PR DESCRIPTION
Commented out the line where ignored users are told "Player is ignoring
messages from you." Messages will still be blocked, but the ignored
player will not know.

This is a modern tweak to the ignore system following the upgrade that allowed the ignore list to cross accounts. Also, shadow-ignoring / shadow-banning in this manner has proven very effective on other games and social media sites.

Next step will be ignore lists affecting what a user sees from the newsglobes.
