### PR TITLE
Blood Inheritance Fix

### DIFF
--- a/kod/object/passive/spell/multicst/bldinher.kod
+++ b/kod/object/passive/spell/multicst/bldinher.kod
@@ -71,8 +71,8 @@ messages:
    
    CastSpell(who = $, lTargets = $, iSpellPower = 0)
    {
-      % Gotta be a melee weapon. This spell will only create weapons that can
-      % normally be obtained, so don't allow ranged weapon procs.
+      % Gotta be a melee weapon. This spell will only create magical weapons that
+      % can normally be obtained, so don't allow ranged weapon to be given procs.
       if not isClass(first(lTargets),&Weapon)
          OR isClass(first(lTargets),&RangedWeapon)
       {
@@ -96,9 +96,9 @@ messages:
 
       for oCaster in lCasters
       {
-            Send(oCaster,@MsgSendUser,#message_rsc=BloodInheritance_succeeded,
-                     #parm1=send(first(lTargets),@GetIndef),
-                       #parm2=send(first(lTargets),@GetName));
+         Send(oCaster,@MsgSendUser,#message_rsc=BloodInheritance_succeeded,
+                  #parm1=send(first(lTargets),@GetIndef),
+                    #parm2=send(first(lTargets),@GetName));
       }
 
       iRandom = Random(1,10);


### PR DESCRIPTION
A typo prevented the application of weaponatts (#what -> #oItem).

Furthermore, the application of permanent unholy damage failed for no
discernible reason a huge percentage of the time. I simply replaced this
bad outcome with 'cursed' weapons instead, which are equally useless.

I also made the spell not work on ranged weapons (now that mods on
ranged weapons function). Then, I fixed typos that sent incorrect text
messages in various circumstances.
