### PR TITLE
Token is no longer allowed in the Arena of Kraanan

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -11369,8 +11369,8 @@ messages:
 
       if what = $
          OR NOT ((IsClass(poOwner,&GuildHall)
-                 OR IsClass(poOwner,&OutofGrace))
-                 OR IsClass(poOwner,&TosArena)))
+                 OR IsClass(poOwner,&OutofGrace)
+                 OR Send(poOwner,@IsArena)))
       {
          return;
       }


### PR DESCRIPTION
People have taken up tokens and went to the Arena of Kraanan so nobody
can get the token unless they log off. This fix will make you drop the
token of you go through the door into the arena (not the foyer) just
like you drop a token when you enter a guildhall.
