### PR TITLE
Jig does not make players drop token

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8263,6 +8263,7 @@ messages:
       {
          if (Send(i,@GetItemUseType) & ITEM_USE_HAND)
             AND Send(i,@ReqUnuse)
+            AND NOT IsClass(i,&Token)
          {
             Send(self,@UnuseItem,#what=i);
          }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8263,7 +8263,6 @@ messages:
       {
          if (Send(i,@GetItemUseType) & ITEM_USE_HAND)
             AND Send(i,@ReqUnuse)
-            AND NOT IsClass(i,&Token)
          {
             Send(self,@UnuseItem,#what=i);
          }

--- a/kod/object/item/passitem/token.kod
+++ b/kod/object/item/passitem/token.kod
@@ -268,13 +268,6 @@ messages:
          return;
       }
       
-      if Send(poOwner,@GetVigor) <= 1
-      {
-        ptTortureTimer=$;
-        Send(poOwner,@TryUnuseItem,#what=self);
-        return;
-      }
-      
       if ptTortureTimer<>$
       {
          ptTortureTimer=$;
@@ -287,6 +280,13 @@ messages:
       
       send(poOwner,@MsgSendUser,#message_rsc=token_use_rsc);
       send(poOwner,@AddExertion,#amount = viVigorDrop/2+Random(0,viVigorDrop/2));
+      
+      % Players will drop the token if vigor reaches 1
+      if Send(poOwner,@GetVigor) <= 1
+      {
+        Send(poOwner,@TryUnuseItem,#what=self);
+        return;
+      }
       
       ptTortureTimer = CreateTimer(self,@TortureHolder,TOKEN_FATIGUE_TIME);
       

--- a/kod/object/item/passitem/token.kod
+++ b/kod/object/item/passitem/token.kod
@@ -281,7 +281,10 @@ messages:
       send(poOwner,@MsgSendUser,#message_rsc=token_use_rsc);
       send(poOwner,@AddExertion,#amount = viVigorDrop/2+Random(0,viVigorDrop/2));
       
-      % Players will drop the token if vigor reaches 1
+      % This prevents players from hoarding tokens in a safe zone,
+      % making other players unable to retrive the tokens.
+      % Players will drop the token when their vigor drops down to 1
+      
       if Send(poOwner,@GetVigor) <= 1
       {
         Send(poOwner,@TryUnuseItem,#what=self);

--- a/kod/object/item/passitem/token.kod
+++ b/kod/object/item/passitem/token.kod
@@ -268,6 +268,13 @@ messages:
          return;
       }
       
+      if Send(poOwner,@GetVigor) <= 1
+      {
+        ptTortureTimer=$;
+        Send(poOwner,@TryUnuseItem,#what=self);
+        return;
+      }
+      
       if ptTortureTimer<>$
       {
          ptTortureTimer=$;

--- a/kod/object/passive/spell/jala/jig.kod
+++ b/kod/object/passive/spell/jala/jig.kod
@@ -124,7 +124,12 @@ messages:
          propagate;
       }
       
-      Send(who,@FreeHands);
+      % Jig does not make players drop tokens
+      if Send(who,@FindHolding,#class=&Token) = $
+      {
+         Send(who,@FreeHands);
+      }
+      
       Send(who,@DoDance);
       
       propagate;


### PR DESCRIPTION
Jig is to powerful and players can to easily steal tokens by casting it
and then cancelling it.

This makes jig no longer causing a player drop a token they are holding
in their hands.
And to stop people from holding onto tokens forever they will drop the
token when they reach 1 vigor.