### PR TITLE
Picking up token cancels rescue and elusion

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1003,11 +1003,7 @@ messages:
          ptSecondWind = $;
       }
 
-      if ptRescue <> $
-      {
-         DeleteTimer(ptRescue);
-         ptRescue = $;
-      }
+      Send(self,@CancelRescue);
 
       if ptAttackTimer <> $
       {
@@ -1416,11 +1412,7 @@ messages:
    EndRescue()
    "Deletes rescue timer if it exists and does the rescue operation."
    {
-      if ptRescue <> $
-      {
-         DeleteTimer(ptRescue);
-         ptRescue = $;
-      }
+      Send(self,@CancelRescue);
       
       if poOwner <> $
          AND Send(poOwner,@GetRoomNum) <> RID_OUTOFGRACE
@@ -1432,7 +1424,7 @@ messages:
    }
    
    CancelRescue()
-   "Cancels the rescue timer if it exist and does not execute the rescue operation."
+   "Cancels the rescue timer if it exists and does not execute the rescue operation."
    {
       if ptRescue <> $
       {
@@ -1981,11 +1973,7 @@ messages:
          ptMana = $;
       }
 
-      if ptRescue <> $
-      {
-         DeleteTimer(ptRescue);
-         ptRescue = $;
-      }
+      Send(self,@CancelRescue);
 
       % Tell others that we're leaving
       oRoom = Send(self, @GetOwner);
@@ -7771,11 +7759,7 @@ messages:
       }
 
       % Stop any rescue attempts that were going on.
-      if ptRescue <> $
-      {
-         DeleteTimer(ptRescue);
-         ptRescue = $;
-      }
+      Send(self,@CancelRescue);
       
       piLastDeathTime = getTime();
 

--- a/kod/object/item/passitem/token.kod
+++ b/kod/object/item/passitem/token.kod
@@ -253,9 +253,9 @@ messages:
            
       ptTortureTimer = CreateTimer(self,@TortureHolder,TOKEN_FATIGUE_TIME);
 
-      % Cancels rescue and elusion when a player pick up a token
-      send(poOwner,@BreakTrance);
-      send(poOwner,@CancelRescue);
+      % Cancels rescue and elusion when a player picks up a token
+      Send(poOwner,@BreakTrance);
+      Send(poOwner,@CancelRescue);
       
       if vrTokenOverlay <> $
       {

--- a/kod/object/passive/spell/rescue.kod
+++ b/kod/object/passive/spell/rescue.kod
@@ -26,6 +26,7 @@ resources:
    Rescue_Start = "You start your rescue preparations."
    Rescue_Success = "You feel a holy force rescue you from your current situation."
    Rescue_Already_Cast = "You are already being rescued."
+   Rescue_Token_Cancel = "You cannot rescue while holding a token."
    
    rescue_sound = srescue.wav
 
@@ -75,6 +76,8 @@ messages:
       
       if Send(who,@FindHolding,#class=&Token)
       {
+        send(who,@MsgSendUser,#message_rsc=Rescue_Token_Cancel);
+        
         return FALSE;
       }
 


### PR DESCRIPTION
As it is now players can cast elusion/rescue before picking up a token
to port to another location and quickly deliver it and other players
have very little chance to get there in time to stop them.

This change cancels elusion and rescue when a token is picked up and it
also makes so potion of deliverance and chalice of the rain does not
work when a token is "equipped"
