### PR TITLE
Evil Twin rebalance

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -45,7 +45,7 @@ classvars:
 
    viTreasure_type = TID_NONE
 
-   viSpeed = SPEED_VERY_FAST
+   viSpeed = SPEED_AVERAGE
    viAttack_types = ATCK_WEAP_SLASH
    viAttributes = 0
    viLevel = 1


### PR DESCRIPTION
Evil twin is ridiculous overpowered for smaler battles. The attackspeed is like the double of the speed a normal player could hit its target. When the evil twin zones over, it will hits the target twice in the time, cause its zones direct on the target. Typical task for someone who wants to use evil twin atm is blind someone and cast evil twin and hold im blind, the evil twin will logg or kill the target. I changed it to a normal attackspeed to make it more balance. Even if the evil twin is only a one hit, but if your target is purged, blind and or spamholded it can only logg off or die. Imagin two players hits you with the same dmg. Then the dmg input of the oppenent... that is a clear 3 vs 1. Really like a HP drop of like 40-60 HPs in one second (together with the oppenent) and the evil twin will never fails to hit.

<b>The spell should be disabled until the pullrequest is merged and live.</b>

Edit: That Gar and me feel the same way on Evil Twin makes the rebalance nassary.
Edit2: Normal attackspeed means something like it hits in the same ratio as a player could hit.
