### PR TITLE
Typo in Lute Equip sound

### DIFF
--- a/kod/object/item/passitem/instrum/lute.kod
+++ b/kod/object/item/passitem/instrum/lute.kod
@@ -23,7 +23,7 @@ resources:
    lute_overlay_rsc = luteov.bgf
    lute_desc_rsc = "The simple lute is the instrument of choice among the meridian bards.  "
 		  "Its rosewood construction offers a rich tone in the hands of an expert."
-   lute_used_wav_rsc = lute_eqip.wav
+   lute_used_wav_rsc = lute_equip.wav
 
 classvars:
 


### PR DESCRIPTION
Khan and Shakrune found this typo.
It should say "lute_equip.wav" not "lute_eqip.wav" to match the sound in
the resource folder

Khan posted it as a issue @ https://github.com/Meridian59/Meridian59/issues/174
