### PR TITLE
Players with newbie tag loses nothing upon death

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -7832,8 +7832,7 @@ messages:
       % Don't drop anything or take any penalties.
       if Send(SYS,@GetChaosNight)
         OR (iRoom >= RID_NEWB_BASE AND iRoom <= RID_NEWB_MAX)
-        OR (piBase_Max_health < PKILL_ENABLE_HP
-            AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE))
+        OR StringEqual(psHonor,player_newbie_honor_string)
       {
          bNo_drop_death = TRUE;
          piDeathCost = FALSE;    


### PR DESCRIPTION
This will make so players with the newbie tag loses nothing when they
die, but those who do not have this tag dies a normal death.

As it is now mules can just die and get a cheap version of elusion, die
and lose nothing. Now they can run to Trading Post and buy arrows and if
they die it does not matter, they lose nothing, they can just try again.
I do not think mules should be considered newbies, I think players with
the newbie tag should be considered newbies.
