### PR TITLE
Boss zones restricted to mules

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -11524,6 +11524,7 @@ messages:
       }
       
       if IsClass(oRoom,&GuildHall)
+         OR Send(oRoom,@IsRestrictedToMules)
          AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
       {
          Send(self,@MsgSendUser,#message_rsc=player_no_enter);

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1916,6 +1916,15 @@ messages:
       % over all players became far too expensive.
       Send(self,@ComputeMaxMana);
 
+      % If player is a mule and log online in a boss zone
+      % we teleport them back to their hometown
+      oRoom = Send(self, @GetOwner);
+      if Send(oRoom,@IsRestrictedToMules)
+         AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+      {
+         Send(self,@AdminGoToSafety);
+      }
+      
       % Tell others that we're here
       oRoom = Send(self, @GetOwner);
       if oRoom <> $ AND NOT IsClass(self, &DM) 

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3872,6 +3872,13 @@ messages:
 
       return FALSE;
    }
+   
+   IsRestrictedToMules()
+   "Returns if mules are allowed into a zone"
+   {
+      % Most zones are not restricted
+      return FALSE;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3874,7 +3874,7 @@ messages:
    }
    
    IsRestrictedToMules()
-   "Returns if mules are allowed into a zone"
+   "Returns if a zone is restricted to mules"
    {
       % Most zones are not restricted
       return FALSE;

--- a/kod/object/active/holder/room/monsroom/bossroom/orcpit1.kod
+++ b/kod/object/active/holder/room/monsroom/bossroom/orcpit1.kod
@@ -301,7 +301,7 @@ messages:
    }
    
    IsRestrictedToMules()
-   "Returns if mules are allowed into a zone"
+   "Returns if a zone is restricted to mules"
    {
       % Most zones are not restricted
       return TRUE;

--- a/kod/object/active/holder/room/monsroom/bossroom/orcpit1.kod
+++ b/kod/object/active/holder/room/monsroom/bossroom/orcpit1.kod
@@ -299,6 +299,13 @@ messages:
 
       propagate;
    }
+   
+   IsRestrictedToMules()
+   "Returns if mules are allowed into a zone"
+   {
+      % Most zones are not restricted
+      return TRUE;
+   }
 
 
 end

--- a/kod/object/active/holder/room/monsroom/bossroom/sewking.kod
+++ b/kod/object/active/holder/room/monsroom/bossroom/sewking.kod
@@ -474,7 +474,7 @@ messages:
    }
    
    IsRestrictedToMules()
-   "Returns if mules are allowed into a zone"
+   "Returns if a zone is restricted to mules"
    {
       % Most zones are not restricted
       return TRUE;

--- a/kod/object/active/holder/room/monsroom/bossroom/sewking.kod
+++ b/kod/object/active/holder/room/monsroom/bossroom/sewking.kod
@@ -472,6 +472,13 @@ messages:
       }
       propagate;
    }
+   
+   IsRestrictedToMules()
+   "Returns if mules are allowed into a zone"
+   {
+      % Most zones are not restricted
+      return TRUE;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/room/monsroom/marcry3a.kod
+++ b/kod/object/active/holder/room/monsroom/marcry3a.kod
@@ -969,7 +969,6 @@ messages:
       {
          Send(SYS,@UtilGoNearSquare,#what=what,#where=self,
               #new_row=viTrap1_row,#new_col=viTrap1_col);
-
          propagate;
       }
 
@@ -1160,7 +1159,7 @@ messages:
    }
    
    IsRestrictedToMules()
-   "Returns if mules are allowed into a zone"
+   "Returns if a zone is restricted to mules"
    {
       % Most zones are not restricted
       return TRUE;

--- a/kod/object/active/holder/room/monsroom/marcry3a.kod
+++ b/kod/object/active/holder/room/monsroom/marcry3a.kod
@@ -1158,6 +1158,13 @@ messages:
       % Don't allow portals into this room, bypassing puzzle
       return false;
    }
+   
+   IsRestrictedToMules()
+   "Returns if mules are allowed into a zone"
+   {
+      % Most zones are not restricted
+      return TRUE;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Players are abusing mules to make boss zones much easier than they were
designed to be, one example:

Player X wants to do chest runs in trashers, he places his mules in each
"trap room" so the doors will never close, he can then easily run
through and keep doing just the chest without killing all the trashers
on the way.

Boss zones is supposed to be hard and not easy to do solo as it is now.

If a player needs a mule to carry items they can just place them outside
the side, so for trashers they can just place them within the wall
outside the door and just run in there and handover the loot they
collected.