### PR TITLE
Hunts sends location when casting complete

### DIFF
--- a/kod/object/passive/spell/multicst/hunt.kod
+++ b/kod/object/passive/spell/multicst/hunt.kod
@@ -122,6 +122,8 @@ messages:
          Send(i,@MsgSendUser,#message_rsc=hunt_is_on);
       }
 
+      Send(oTarget,@InformHunters);
+      
       return;
    }
 


### PR DESCRIPTION
One problem when casting hunt is if your target is not moving you will
never know where the player is. With this change it will  send the
location of the hunted players once the spell is complete.
