### PR TITLE
Cv roomflag update

### DIFF
--- a/kod/object/active/holder/room/monsroom/castle1b.kod
+++ b/kod/object/active/holder/room/monsroom/castle1b.kod
@@ -29,7 +29,6 @@ classvars:
 
    viTerrain_type = TERRAIN_CASTLE
 
-   viPermanent_Flags = ROOM_GUILD_PK_ONLY
 
 properties:
 


### PR DESCRIPTION
The reason is simple, ppl over 100 HPs are camping there to get easy and safe imps and of course with a armee of mules and of course unattackable. The game is about pvp and CV is a big part of balance it. The dmg is capped by 33% of the full HPs. So it doesnt matter if someone has 30 or 99 HPs cause of the capped dmg. If its nassary to protect the noobs set the guardianangle up to 100 HPs, but even then it would take 4 hits.

CV is a premium buildingspot, cause of the spawn rate and the fast progress you can make. There is no reason why such a spot should be PKfree.
