### PR TITLE
Maingate TOS Roomflag back to normal

### DIFF
--- a/kod/object/active/holder/room/monsroom/h6.kod
+++ b/kod/object/active/holder/room/monsroom/h6.kod
@@ -29,8 +29,6 @@ classvars:
 
    viTerrain_type = TERRAIN_FOREST | TERRAIN_ROAD | TERRAIN_FIELDS
 
-   viPermanent_Flags = ROOM_GUILD_PK_ONLY
-
    viFlag_row = 24
    viFlag_col = 31
 


### PR DESCRIPTION
Since we have the change on the wallspells, there is no reason why that should be in the game. Otherwise we had to change all Maingates (Cor Noth, Barloque, Marion, Jasper) to ROOM_GUILD_PK_ONLY.
