### PR TITLE
Revert: invisibility nerf

### DIFF
--- a/kod/object/passive/spell/persench/invis.kod
+++ b/kod/object/passive/spell/persench/invis.kod
@@ -55,7 +55,6 @@ classvars:
 
    vrSucceed_wav = invisibility_sound
 
-   vbCanCastOnOthers = FALSE
 
 properties:
 
@@ -71,11 +70,6 @@ messages:
 
    CastSpell(who = $,iSpellPower=0, lTargets = $)
    {
-      % If it's only self cast, spoof self as target for following code
-      if NOT vbCanCastonOthers
-      {
-         lTargets = Cons(who, lTargets);
-      }
 
       Send(first(lTargets),@ResetPlayerFlagList);
       Send(first(lTargets),@AddDefenseModifier,#what=self);


### PR DESCRIPTION
Invisibility was one of the mayorspells Qor had as a team buff. Qor has also spell names "fade" which works as a focus spell and as a selftarget. The revert has more todo with the following scenario: If you camp a area durring pvp, you need to be invis or a safespot or the mobs will hitting you. Otherwise ppl could say, hey use a invis ring, but the duration of the rings are unaccaptable for camping a area. So back to a spell which was perfect balanced back in the days.
