### PR TITLE
Angeled Hometown Sending

### DIFF
--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -225,8 +225,8 @@ messages:
 	  %  This helps get people out of continuous crash situations and mounting penalties.
 	  %  Hometown Penalties is intended to keep PvP players from being 'kept offline' by opponents.
       
-	  if Send(poGhostedPlayer,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
-		AND Send(Send(SYS, @GetSettings), @HometownPenaltiesEnabled)
+	  if NOT Send(poGhostedPlayer,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+		OR Send(Send(SYS, @GetSettings), @HometownPenaltiesEnabled)
 	  {
 	     Send(poGhostedPlayer,@AdminGoToSafety);
 	  }


### PR DESCRIPTION
Angeled characters will always be sent to their hometown if their ghost poofs (normal characters will still only be sent to their hometown if HometownPenaltiesEnabled is on).

The reasons for this requested fix are numerous. Just lots of little issues with characters that don't take penalties being able to stay / later log on anywhere. Scouting, boss rooms, puzzles, and so on.
