### PR TITLE
Opt-in Combat Time

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -107,10 +107,6 @@ constants:
    %  than logoff ghost time (currently 10 mins)
    ATTACKED_PLAYER_WAIT = 15 * 60
    
-   % This is how long we should wait after an opt-in combat interaction
-   % before we consider the player no longer fighting.
-   OPT_IN_COMBAT_WAIT = 2 * 60
-
    % Damage is capped at piBase_Max_Health divided by this number.  Reduces
    %  newbie slaughter.
    MAX_HEALTH_DAMAGE_FRACTION = 3
@@ -951,8 +947,6 @@ properties:
    
    % piOptInCombatTime tracks the last time a player engaged in willful combat,
    % which includes soldier shields, guild wars, and outlaws/murderers.
-   % Used in conjunction with OPT_IN_COMBAT_WAIT to determine whether the
-   % player is currently engaged in combat.
    piOptInCombatTime = 0
 
    % piDeathcost is used to tell the underworld what percent of normal
@@ -3919,6 +3913,11 @@ messages:
    GetOptInCombatTime()
    "Returns the last time the player was involved in opt-in combat."
    {
+      if piOptInCombatTime > GetTime()
+      {
+         piOptInCombatTime = 0;
+      }
+
       return piOptInCombatTime;
    }
 


### PR DESCRIPTION
Records the last time a player engaged in opt-in combat, which includes
soldier shields, guild wars, and outlaws/murderers.

This will be very useful for future mechanics. This will give us the
capability to differentiate between opt-in combat that players chose to
be part of versus opt-out combat involving PKs attacking unwilling
victims, _and_ it will give us a metric for whether a player is actually
currently in such combat.

This would, for example, allow us to change penalties or ghost times
for opt-in pvpers actually engaged in combat, but without changing
how innocents experience the game.
