### PR TITLE
Mark of Dishonor can be casted on monsters

### DIFF
--- a/kod/object/passive/spell/dishonor.kod
+++ b/kod/object/passive/spell/dishonor.kod
@@ -101,6 +101,7 @@ messages:
       }
 
       if NOT IsClass(target,&Player)
+         AND NOT IsClass(target,&Monster)
       {
          if NOT bItemCast
          {
@@ -132,40 +133,54 @@ messages:
       local oTarget, iKarma, iVigorRestThreshold, iVigorRestThresholdChange;
 
       oTarget = First(lTargets);
-      iKarma = Send(oTarget,@GetKarma);
-
-      % Shal'ille only takes vigor from evil people.
-      if iKarma < 0
+      
+      if IsClass(oTarget,&Player)
       {
-         iVigorRestThreshold = Send(oTarget,@GetVigorRestThreshold);
-         iVigorRestThresholdChange = iKarma * ( iVigorRestThreshold -
+        iKarma = Send(oTarget,@GetKarma);
+
+        % Shal'ille only takes vigor from evil people.
+        if iKarma < 0
+
+        {
+            iVigorRestThreshold = Send(oTarget,@GetVigorRestThreshold);
+            iVigorRestThresholdChange = iKarma * ( iVigorRestThreshold -
                                      DISHONOR_LOWEST_VIGOR_REST_THRESHOLD )
                                      / MAX_EVIL;
 
-         % Make sure we aren't going to lower target's VigorRestThreshold
-         %  below 10, otherwise we could end up increasing the player's
-         %  VigorRestThreshold (see player.kod for reason why)
-         if (iVigorRestThreshold - iVigorRestThresholdChange) < 10
-         {
-            iVigorRestThresholdChange = iVigorRestThreshold - 10;
-         }
+            % Make sure we aren't going to lower target's VigorRestThreshold
+            %  below 10, otherwise we could end up increasing the player's
+            %  VigorRestThreshold (see player.kod for reason why)
+            if (iVigorRestThreshold - iVigorRestThresholdChange) < 10
+            {
+                iVigorRestThresholdChange = iVigorRestThreshold - 10;
+            }
 
-         Send(oTarget,@AddExertion,#amount=200000);
-         Send(oTarget,@SetVigorRestThreshold,
-              #amount=iVigorRestThreshold-iVigorRestThresholdChange);
-      }
+            Send(oTarget,@AddExertion,#amount=200000);
+            Send(oTarget,@SetVigorRestThreshold,
+                #amount=iVigorRestThreshold-iVigorRestThresholdChange);
+        }
 
-      Send(oTarget,@StartEnchantment,#what=self,
-           #time=Send(self,@GetDuration,#iSpellPower=iSpellPower),
-           #state=iVigorRestThresholdChange);
-      Send(oTarget,@MsgSendUser,#message_rsc=MarkOfDishonor_start);
-      Send(who,@MsgSendUser,#message_rsc=MarkOfDishonor_success,
-           #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
+        Send(oTarget,@StartEnchantment,#what=self,
+            #time=Send(self,@GetDuration,#iSpellPower=iSpellPower),
+            #state=iVigorRestThresholdChange);
+        Send(oTarget,@MsgSendUser,#message_rsc=MarkOfDishonor_start);
+        Send(who,@MsgSendUser,#message_rsc=MarkOfDishonor_success,
+            #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
 
-      % Make sure hps aren't over maximum.  Post this so enchantment is finished.
-      post(oTarget,@NewHealth);
-
-      propagate;
+        % Make sure hps aren't over maximum.  Post this so enchantment is finished.
+        post(oTarget,@NewHealth);
+        }
+        else
+        {
+            % EnterStateWait will make the monster stop aggro players and put
+            % them on wait-state waiting to aggro again
+            Send(oTarget,@EnterStateWait);
+            Send(oTarget,@StartEnchantment,#what=self,
+                #time=Send(self,@GetDuration));
+            Send(who,@MsgSendUser,#message_rsc=MarkOfDishonor_success,
+                #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
+        }
+        propagate;
    }
 
    GetDuration(iSpellPower=0)
@@ -181,15 +196,18 @@ messages:
    EndEnchantment(who = $, state = 0, report = TRUE)
    {
       local iVigorRestThreshold;
-
-      iVigorRestThreshold = Send(who,@GetVigorRestThreshold);
-      Send(who,@SetVigorRestThreshold,#amount=iVigorRestThreshold+state);
-
-      if report
+      
+      % If we end enchantment on a player reset VigorRestThreshold
+      if isClass(who,&Player)
       {
-         Send(who,@MsgSendUser,#message_rsc=MarkOfDishonor_stop);
-      }
+        iVigorRestThreshold = Send(who,@GetVigorRestThreshold);
+        Send(who,@SetVigorRestThreshold,#amount=iVigorRestThreshold+state);
 
+        if report
+        {
+            Send(who,@MsgSendUser,#message_rsc=MarkOfDishonor_stop);
+        }
+      }
       return;
    }
 


### PR DESCRIPTION
A level four spell that cannot be improved by casting it on monsters is
a bit to hard, it can now be casted on monsters.
If casted it on a monster who aggro a player the monster will stop its
aggro towards that player.
