### PR TITLE
Newbie Constraints / Streamlining

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -11543,7 +11543,7 @@ messages:
          return FALSE;
       }
       
-      if IsClass(oRoom,&GuildHall)
+      if NOT Send(oRoom,@AllowNewbies)
          AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
       {
          Send(self,@MsgSendUser,#message_rsc=player_no_enter);

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -152,6 +152,9 @@ resources:
 
    no_use_jig = \
       "You can't wield that - it would interfere with your funky moves!"
+      
+   guardian_angel_returned_to_marion = \
+      "Your guardian angel intervenes, returning you to safety."
 
 classvars:
 
@@ -265,6 +268,8 @@ properties:
    % Don't set this.  It is set automatically.
    % Instead, override something in SetFarenBonus.
    piFaren_Bonus
+   
+   pbAllowNewbies = FALSE
 
 messages:
 
@@ -1699,7 +1704,7 @@ messages:
            fine_row = FINENESS/2, fine_col = FINENESS/2, session = $,
            merge = TRUE)
    {
-      local i,each_obj,bUser, lLoopSound;
+      local i,each_obj,bUser, lLoopSound, oTargetRoom;
 
       if what = $
       {
@@ -1743,6 +1748,19 @@ messages:
          
          Send(Send(SYS, @GetStatistics), @PlayerEnteredRoom,
               #oRoom = self, #who = what);
+      
+         % Newbies always go to Marion Inn if they somehow end up outside their bounds.
+         if NOT Send(what,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+            AND NOT Send(self,@AllowNewbies)
+            AND NOT (Send(self,@GetRegion) = RID_NEWB_BASE
+                     OR Send(self,@GetRegion) = RID_OUTOFGRACE
+                     OR Send(self,@GetRegion) = RID_GUEST_BASE)
+         {
+            oTargetRoom = send(SYS,@FindRoomByNum,#num=RID_MAR_INN);
+            post(oTargetRoom,@Teleport,#what=what);
+            post(what,@MsgSendUser,#message_rsc=guardian_angel_returned_to_marion);
+            return;
+         }
       }
 
       Send(self,@NewHoldObject,#what=what,
@@ -3935,6 +3953,12 @@ messages:
          }
       }
       return;
+   }
+   
+   AllowNewbies()
+   "Returns true if angeled characters are allowed within. Default false for most rooms."
+   {
+      return pbAllowNewbies;
    }
 
 end

--- a/kod/object/active/holder/room/badland2.kod
+++ b/kod/object/active/holder/room/badland2.kod
@@ -39,6 +39,8 @@ properties:
    piRoom_num = RID_BADLAND2
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/crnthrm/corgroc.kod
+++ b/kod/object/active/holder/room/crnthrm/corgroc.kod
@@ -41,6 +41,8 @@ properties:
    piOutside_factor = 3
 
    prMusic = corgroc_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/crnthrm/corhall.kod
+++ b/kod/object/active/holder/room/crnthrm/corhall.kod
@@ -44,6 +44,8 @@ properties:
    piOutside_factor = 3
 
    prMusic = corhall_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/crnthrm/corinn.kod
+++ b/kod/object/active/holder/room/crnthrm/corinn.kod
@@ -42,6 +42,8 @@ properties:
    piOutside_factor = 3
 
    prMusic = corinn_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/crnthrm/cornoth.kod
+++ b/kod/object/active/holder/room/crnthrm/cornoth.kod
@@ -49,6 +49,9 @@ properties:
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
    prMusic = cor_music
+      
+   pbAllowNewbies = TRUE
+   
 messages:
 
    CreateStandardExits()

--- a/kod/object/active/holder/room/crnthrm/cortail.kod
+++ b/kod/object/active/holder/room/crnthrm/cortail.kod
@@ -41,6 +41,8 @@ properties:
    piOutside_factor = 3
 
    prMusic = cortail_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/crnthrm/corwepm.kod
+++ b/kod/object/active/holder/room/crnthrm/corwepm.kod
@@ -43,6 +43,8 @@ properties:
    piOutside_factor = 3
 
    prMusic = weaponsmaster_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/guest1.kod
+++ b/kod/object/active/holder/room/guest1.kod
@@ -65,6 +65,8 @@ properties:
    viTerrain_type = TERRAIN_CITY | TERRAIN_SHOP
 
    prMusic = guest1_music
+   
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/guest2.kod
+++ b/kod/object/active/holder/room/guest2.kod
@@ -70,6 +70,8 @@ properties:
    prMusic = guest2_music
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/guest3.kod
+++ b/kod/object/active/holder/room/guest3.kod
@@ -64,6 +64,8 @@ properties:
    piOutside_factor = OUTDOORS_SOME
 
    prMusic = guest3_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/guest4.kod
+++ b/kod/object/active/holder/room/guest4.kod
@@ -62,6 +62,8 @@ properties:
    piOutside_factor = OUTDOORS_SOME
 
    prMusic = guest4_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/guest5.kod
+++ b/kod/object/active/holder/room/guest5.kod
@@ -60,6 +60,8 @@ properties:
    piOutside_factor = OUTDOORS_SOME
 
    prMusic = guest5_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/guest7.kod
+++ b/kod/object/active/holder/room/guest7.kod
@@ -61,6 +61,8 @@ properties:
    piOutside_factor = OUTDOORS_SOME
 
    prMusic = guest7_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/guest8.kod
+++ b/kod/object/active/holder/room/guest8.kod
@@ -99,6 +99,8 @@ properties:
    piOutside_factor = OUTDOORS_SOME
 
    prMusic = guest8_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/marnrm/marhall.kod
+++ b/kod/object/active/holder/room/marnrm/marhall.kod
@@ -138,6 +138,8 @@ properties:
    piOutside_factor = 3
 
    prMusic = marhall_music
+   
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/marnrm/marhlshp.kod
+++ b/kod/object/active/holder/room/marnrm/marhlshp.kod
@@ -42,6 +42,8 @@ properties:
    piOutside_factor = 3
 
    prMusic = MarionHealerShop_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/marnrm/marion.kod
+++ b/kod/object/active/holder/room/marnrm/marion.kod
@@ -85,6 +85,8 @@ properties:
    piRoom_num = RID_MARION
 
    prMusic = mar_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/badland1.kod
+++ b/kod/object/active/holder/room/monsroom/badland1.kod
@@ -36,6 +36,8 @@ properties:
    piRoom_num = RID_BADLAND1
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
+      
+   pbAllowNewbies = TRUE
 
 
 messages:

--- a/kod/object/active/holder/room/monsroom/c4.kod
+++ b/kod/object/active/holder/room/monsroom/c4.kod
@@ -45,6 +45,8 @@ properties:
 
    piGen_time = 80000
    piGen_percent = 80
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/d4.kod
+++ b/kod/object/active/holder/room/monsroom/d4.kod
@@ -48,6 +48,8 @@ properties:
    % Give users a healthy mix of creatures when entering room.
    piInit_count_min = 5
    piInit_count_max = 10
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/d5.kod
+++ b/kod/object/active/holder/room/monsroom/d5.kod
@@ -51,6 +51,8 @@ properties:
    piInit_count_max = 9
 
    piMonster_count_max = 12
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/e4.kod
+++ b/kod/object/active/holder/room/monsroom/e4.kod
@@ -48,6 +48,8 @@ properties:
 
    piInit_count_min = 5
    piInit_count_max = 7
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/f3.kod
+++ b/kod/object/active/holder/room/monsroom/f3.kod
@@ -50,6 +50,8 @@ properties:
    piInit_count_max = 5
 
    piMonster_count_max = 7
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/f4.kod
+++ b/kod/object/active/holder/room/monsroom/f4.kod
@@ -50,6 +50,8 @@ properties:
    piInit_count_max = 3
 
    piMonster_count_max = 6
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/g4.kod
+++ b/kod/object/active/holder/room/monsroom/g4.kod
@@ -52,6 +52,8 @@ properties:
    piInit_count_max = 4
 
    piMonster_count_max = 7
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/guest6.kod
+++ b/kod/object/active/holder/room/monsroom/guest6.kod
@@ -166,6 +166,8 @@ properties:
    ptDoor = $
 
    pbColumn_down = FALSE
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/h3.kod
+++ b/kod/object/active/holder/room/monsroom/h3.kod
@@ -50,6 +50,8 @@ properties:
    piInit_count_max = 4
 
    piMonster_count_max = 6
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/h5.kod
+++ b/kod/object/active/holder/room/monsroom/h5.kod
@@ -48,6 +48,8 @@ properties:
 
    piInit_count_min = 1
    piInit_count_max = 5
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/h6.kod
+++ b/kod/object/active/holder/room/monsroom/h6.kod
@@ -57,7 +57,8 @@ properties:
    piInit_count_max = 7  % maximum # of monsters loaded by initial load
 
    piMonster_count_max = 7 % temporarily reduced from 13
-
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/h7.kod
+++ b/kod/object/active/holder/room/monsroom/h7.kod
@@ -50,6 +50,8 @@ properties:
    piInit_count_max = 9
 
    piMonster_count_max = 12
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/i3.kod
+++ b/kod/object/active/holder/room/monsroom/i3.kod
@@ -51,6 +51,8 @@ properties:
    piInit_count_max = 2
 
    piMonster_count_max = 7
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/marcryp1.kod
+++ b/kod/object/active/holder/room/monsroom/marcryp1.kod
@@ -93,6 +93,8 @@ properties:
    ptNecroDoor = $
 
    pbDoorDownActive = TRUE
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/nest1.kod
+++ b/kod/object/active/holder/room/monsroom/nest1.kod
@@ -52,6 +52,8 @@ properties:
    piGen_percent = 60
 
    ptQueen_gen = $
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/objroom/b6.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/b6.kod
@@ -50,6 +50,8 @@ properties:
    piInit_count_max = 8
 
    piMonster_count_max = 13
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/objroom/c5.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/c5.kod
@@ -51,6 +51,8 @@ properties:
    piInit_count_max = 4
 
    piMonster_count_max = 6
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/objroom/cave2.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/cave2.kod
@@ -47,6 +47,8 @@ properties:
    piGen_Object_Time = 1200000
 
    ptIllusionResetTimer = $
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/objroom/h4.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/h4.kod
@@ -53,6 +53,8 @@ properties:
    piInit_count_max = 5
 
    piMonster_count_max = 8
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/objroom/marelder.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/marelder.kod
@@ -40,6 +40,8 @@ properties:
 
 
    prMusic = MarionElderHut_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/objroom/marinn.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/marinn.kod
@@ -51,6 +51,8 @@ properties:
    piOutside_factor = OUTDOORS_SOME
 
    prMusic = marinn_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/objroom/marsmith.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/marsmith.kod
@@ -41,6 +41,8 @@ properties:
    piOutside_factor = OUTDOORS_SOME
 
    prMusic = marsmith_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/objroom/tosinn.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/tosinn.kod
@@ -49,6 +49,8 @@ properties:
    piOutside_factor = OUTDOORS_SOME
 
    prMusic = tosinn_music
+   
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/toscrypt.kod
+++ b/kod/object/active/holder/room/monsroom/toscrypt.kod
@@ -36,6 +36,8 @@ properties:
    prMusic = music_toscrypt
 
    piBaseLight = LIGHT_VERY_DARK
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/tosgrave.kod
+++ b/kod/object/active/holder/room/monsroom/tosgrave.kod
@@ -42,6 +42,8 @@ properties:
 
    plTombstones = $
    viTerrain_type = TERRAIN_CITY | TERRAIN_MYSTICAL
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/outgrace.kod
+++ b/kod/object/active/holder/room/outgrace.kod
@@ -39,6 +39,8 @@ properties:
 
    piBaseLight = LIGHT_NICE
    piOutside_factor = OUTDOORS_3
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/rentroom.kod
+++ b/kod/object/active/holder/room/rentroom.kod
@@ -221,6 +221,8 @@ properties:
    piBlueHeartstone = 4
    piBrownHeartstone = 4
    piSkyHeartstone = 4
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/temple.kod
+++ b/kod/object/active/holder/room/temple.kod
@@ -47,6 +47,8 @@ properties:
 
    piBaseLight = LIGHT_NICE
    piOutside_factor = 3
+   
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/tosrm/easttos.kod
+++ b/kod/object/active/holder/room/tosrm/easttos.kod
@@ -42,6 +42,8 @@ properties:
    piBaseLight = LIGHT_NICE
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
+      
+   pbAllowNewbies = TRUE
 
 
 messages:

--- a/kod/object/active/holder/room/tosrm/tos.kod
+++ b/kod/object/active/holder/room/tosrm/tos.kod
@@ -48,6 +48,8 @@ properties:
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
    prMusic = tos_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/tosrm/tosapoth.kod
+++ b/kod/object/active/holder/room/tosrm/tosapoth.kod
@@ -164,6 +164,8 @@ properties:
    piOutside_factor = 3
 
    prMusic = tosapoth_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/tosrm/tosaren2.kod
+++ b/kod/object/active/holder/room/tosrm/tosaren2.kod
@@ -41,6 +41,8 @@ properties:
    prMusic = TosArena2_music
 
    piBaseLight = LIGHT_NICE
+      
+   pbAllowNewbies = TRUE
 
 
 messages:

--- a/kod/object/active/holder/room/tosrm/tosarena.kod
+++ b/kod/object/active/holder/room/tosrm/tosarena.kod
@@ -116,6 +116,8 @@ properties:
 
    pbLocked = FALSE
    pbRealdeath = FALSE
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/tosrm/tosbank.kod
+++ b/kod/object/active/holder/room/tosrm/tosbank.kod
@@ -45,6 +45,8 @@ properties:
    piOutside_factor = 3
 
    prMusic = tosbank_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 

--- a/kod/object/active/holder/room/tosrm/toshall.kod
+++ b/kod/object/active/holder/room/tosrm/toshall.kod
@@ -44,6 +44,8 @@ properties:
    piOutside_factor = 3
 
    prMusic = corhall_music
+      
+   pbAllowNewbies = TRUE
 
 messages:
 


### PR DESCRIPTION
Created a new AllowNewbies property for rooms, defaults to false. This
change will restrict angeled characters to rooms specifically set to
allow them. I have set the most relevant newbie rooms to true. They can
reach Marion, Cor Noth, Tos, Rook, Shal temple, Faren temple, Icky
caves, and the connecting low level areas where newbies commonly build.

Any angeled character ending up outside of the bounds by any means -
portal, rescue, elusion, or otherwise - will instead be teleported to
Marion Inn. That list includes dying. Similar to deaths in Raza, angeled
deaths will skip the underworld altogether. Since angeleds don't take
death penalties, going to the underworld doesn't make sense (and people
were just using the underworld portals as a form of fast travel).

Finally, all newbies leaving Raza now have Marion as their hometown
instead of a random choice. Marion is the best place for a newbie to
start, and has a familiar dungeon. We can build on the newbie experience
from here.

This whole thing is killing two birds with one stone. First, we need a better
newbie experience, and many have agreed Marion is the best place to start
building it. Second, there are endless abuses, exploits, and problems
based on invincible characters running about all over the world. Guardian
angels are there as a newbie protection mechanic, not as blanket
protection for characters that are 4-school masters and 200 years old,
yet left at 20 hp to remain invincible.

Instead of chasing down problem after problem cropping up because of
guardian angels, this new direction will just eliminate the issue altogether
while giving us a platform to increase newbie retention and education.
