### PR TITLE
Reblance: Wedding Ring

### DIFF
--- a/kod/object/item/passitem/ring/ringwedd.kod
+++ b/kod/object/item/passitem/ring/ringwedd.kod
@@ -157,21 +157,6 @@ messages:
       return FALSE;
    }
 
-   % Things we handle to be a defense modifier:
-   ModifyDefensePower(who = $,what = $,defense_power = 0)
-   "Increase or decrease the defense of the defender."
-   {
-      % Add a small amount of defense.  Only added as a defmod if the user is
-      %  One of the original 2 users, and both user slots are filled.
-      return defense_power + viDefense_bonus;
-   }
-
-   ModifyDefenseDamage(who = $,what = $,damage = $,atype = 0,aspell = 0)
-   "Increase or decrease damage done to defender."
-   {
-      return damage;
-   }
-
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
The wedding ring is more a roleplayitem and was rarely used by the players, cause nobody knew about the defense boon before the game went open source. The item is simple overpowered on casters or hybrid-toons, with high agility, robe and cess-faction. Even a Purefighter will allways miss the caster/hybrid-toon over the half of the time.

Otherwise we had to create a perma "war-ring" which gives the same boon on offense.
