### PR TITLE
Global Treasure give

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
@@ -105,6 +105,9 @@ resources:
 
    dm_roomgive_command = "roomgive"
    dm_gave_to_number = "%s players received reward!"
+   
+   dm_globaltreasure_command = "globaltreasure"
+   dm_gave_to_monsters = "Monsters are now holding a reward globally."
 
    dm_stealth_on = "You are now in stealth mode."
    dm_stealth_off = "You are no longer in stealth mode."
@@ -1416,6 +1419,32 @@ messages:
                iGiven = Send(SYS,@RoomGive,#who=self,#classtype=GetClass(i),
                            #number=Send(SYS,@GetNumberFromString,#string=string));
                Send(self,@MsgSendUser,#message_rsc=dm_gave_to_number,#parm1=iGiven);
+               return;
+            }
+         }
+
+         if NOT iGiven
+         {
+            Send(self,@MsgSendUser,#message_rsc=dm_no_item);
+         }
+         
+         return;
+      }
+
+      if StringContain(string,dm_globaltreasure_command)
+         OR StringContain(string,"globaltreasure")
+      {
+         iGiven = 0;
+         lTemplate = Send(SYS,@GetItemTemplates);
+
+         for i in lTemplate
+         {
+            if StringContain(string,Send(i,@GetName))
+               AND NOT Send(i,@IsItemType,#type=ITEMTYPE_SPECIAL)
+            {
+               iGiven = Send(SYS,@GlobalTreasure,#who=self,#classtype=GetClass(i),
+                           #number=Send(SYS,@GetNumberFromString,#string=string));
+               Send(self,@MsgSendUser,#message_rsc=dm_gave_to_monsters);
                return;
             }
          }

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -5121,6 +5121,65 @@ messages:
       return num_rewarded;
    }
 
+   GlobalTreasure(classtype=$, number=-1)
+   "Admin supported.\n"
+   "Give one of said item to every monster in the world. If num <> -1 and the object "
+   "is a number item, give that many of the item to each monster.  GlobalTreasure ignores all "
+   "reqnewhold requirements (such as bulk or weight restrictions)."
+   {
+      local i, n, lGiveList, oExample, oRoom, each_obj, num_rewarded;
+
+      num_rewarded = 0;
+
+      if classtype <> $
+      {
+         if number = -1
+         {
+            oExample = Create(classtype);
+         }
+         else
+         {
+            oExample = Create(classtype,#number=number);
+         }
+
+         if NOT isClass(oExample,&item)
+         {
+            Debug("Tried to GlobalTreasure something that was not an item!");
+
+            return 0;
+         }
+
+         for n in plRooms
+         {
+            if IsClass(n,&MonsterRoom)
+            {
+               Send(n,@TryCreateMonster);
+               Send(n,@TryCreateMonster);
+               Send(n,@TryCreateMonster);
+               
+               lGiveList = Send(n,@GetHolderActive);
+
+               for i in lGiveList
+               {
+                  each_obj = send(n,@HolderExtractObject,#data=i);
+                  if IsClass(each_obj,&Monster)
+                  {
+                     if number <> -1
+                     {
+                        Send(each_obj,@NewHold,#what=Create(Classtype,#number=number));
+                     }
+                     else
+                     {
+                        Send(each_obj,@NewHold,#what=Create(Classtype));
+                     }
+                  }
+               }
+            }
+         }
+      }
+      return 1;
+   }
+
    AddChestToList(oChest=$)
    "Adds chest objects or box objects to list of chests and boxes."
    {


### PR DESCRIPTION
Admin command to give items to all monsters in the world. For monster
rooms that have nobody in them, the command attempts to spawn up to 3
monsters with respect to the room's limits.

I made it spawn up to 3 monsters because rooms without players in them
don't actually have any monsters. Phil requested this with the intent
to functionally replace giving items to all players in the game. Instead of a large
number of mules and afk players simply receiving items, the items are instead
intended to end up on monsters globally, so that players must kill them to
reap the rewards. Thus, it needs to spawn monsters in unused rooms. They
are also normal monsters, so they won't last indefinitely.
