### PR TITLE
Frenzy No-cost spells

### DIFF
--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -581,6 +581,7 @@ messages:
    CanPayManaVigor(who = $, lTargets = $, iSpellPower = 0)
    {
       if Send(who,@PlayerIsImmortal)
+         OR Send(SYS,@GetChaosNight)
       {
          return TRUE;
       }
@@ -613,6 +614,7 @@ messages:
             oUserObject, iNum, oOwner, oSpell, oRing;
 
       if Send(who,@PlayerIsImmortal)
+         OR Send(SYS,@GetChaosNight)
       {
          return TRUE;
       }
@@ -1176,6 +1178,7 @@ messages:
       }
 
       if Send(who,@PlayerIsImmortal)
+         OR Send(SYS,@GetChaosNight)
       {
          return TRUE;
       }
@@ -1251,6 +1254,7 @@ messages:
             iNumNeeded, oUserObject;
       
       if NOT IsClass(who,&Player)
+         OR Send(SYS,@GetChaosNight)
       {
          return TRUE;
       }


### PR DESCRIPTION
During a frenzy, spells no longer require reagents, vigor, or mana, and
never fizzle.

Seems we're doing a large number of tweaks to frenzies, giving players
thousands of every reagent and super-food on automated timers, when
we could really just eliminate the combat delays at their source.
The super-food and the gear handed out automatically are still useful, though.
