### PR TITLE
Enable quick logoff and default hotkey alias

### DIFF
--- a/clientd3d/gameuser.c
+++ b/clientd3d/gameuser.c
@@ -413,7 +413,6 @@ void UserToggleMusic(Bool music_on)
  */
 void UserQuit(void)
 {
-   if (AreYouSure(hInst, hMain, NO_BUTTON, IDS_QUIT))
       RequestQuit();   
 }
 /************************************************************************/

--- a/module/merintr/alias.c
+++ b/module/merintr/alias.c
@@ -48,7 +48,7 @@ static HotkeyAlias aliases[] =
    { VK_F9,   "point",    True, },
    { VK_F10,  "addgroup", True, },
    { VK_F11,  "mail",     True, },
-   { VK_F12,  "help",     True, },
+   { VK_F12,  "quit",     True, },
 };
 
 static VerbAlias* _apVerbAliases = NULL;


### PR DESCRIPTION
Example youtube video:
http://www.youtube.com/watch?v=nk1aHizz1rU&feature=youtu.be

This change removes the dialog box that says "Are you sure you want to
quit?" when sending a typed "quit" command. It also changes the default
F12 hotkey alias from "help" to "quit."

Having a dialog box that asks you if you really want to logoff makes no
sense in the current implementation. Logging is the most important
ability any character has. Many players have figured out how to write
macros to alt-f4, putting other players at a disadvantage. Logging off
by accident has almost no downside, while not logging off in time can
mean death so the confirmation question can be removed.

This change evens the playing field. If you are being attacked you can
hit F12 and log. Everyone gets the same ability and it streamlines the
user interface by removing an unecessary prompt.

F1 and F12 by default have the same hotkey alias bind (help) so
replacing F12 with quit makes sense.
