### PR TITLE
Change appeal user message to include history

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -273,9 +273,9 @@ resources:
    user_cant_deposit_items = "You can't deposit items here!"
    user_cant_balance = "You can't check any balance here!"
 
-   user_appeal = "%s appeals: %q"
+   user_appeal = "%s appeals, \"%q~n\""
    user_first_time_appeal = "### %s has just logged on for the first time."
-   user_did_appeal = "You appeal: %q"
+   user_did_appeal = "You appeal, \"%q~n\""
 
    user_kill_zone = \
       "Your guardian angel whispers to you, \"I cannot defend you here.\""


### PR DESCRIPTION
Currently when a player sends a message via appeal it shows the following:
"If you do not get a timely response, please send game mail to Help for
further assistance."

This makes keeping track of a conversation with an admin difficult.

I changed the appeal message to be more like the tell, say, and other
communication messages.

This is what is seen in the player's message history after an appeal:
"You appeal: [sent message]"
