### PR TITLE
Nil karma fix / Zero karma change

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -4885,7 +4885,7 @@ messages:
       {
          % This means that the monster has no Karma.  This is used for event
          %  monsters like Xeos and admin-created beasties.
-         return $;
+         return 0;
       }
       
       return viKarma;

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -6394,6 +6394,12 @@ messages:
          return 0;
       }
 
+      % Neutral mobs and event mobs do not change karma
+      if karma_act = 0
+      {
+         return 0;
+      }
+
       % Do not change karma if player is good, act is good, but not as good as player.
       % I.e. only change karma if good player does bad stuff (or vice versa).
       if (karma_doer > 0 AND karma_act > 0 AND karma_doer > karma_act)


### PR DESCRIPTION
- $ changed to zero for event monsters (returned due to pbDontDispose).
- Zero karma monsters no longer swing karma when killed.

Right now, zero karma kills reduce every player's karma, since zero is not handled in the checks that prevent karma reduction if the killer and monster are of the same alignment. With this change, zero karma kills will no longer reduce anyone's karma.

That also lets us change pbDontDispose from returning $ to returning 0. In testing with these changes, admin created monsters did not change karma and soldiers did not change karma as intended. The Lupogg King, Slime, Yeti, and Narthyl Worm have natural zero karma and thus will also be affected, but I think that's actually appropriate for boss monsters & truly neutral creatures.
