### PR TITLE
Fixed error message when non-newbie dies

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -7854,7 +7854,7 @@ messages:
       if Send(SYS,@GetChaosNight)
         OR (iRoom >= RID_NEWB_BASE AND iRoom <= RID_NEWB_MAX)
         OR psHonor <> $
-        AND StringEqual(psHonor,player_newbie_honor_string)
+           AND StringEqual(psHonor,player_newbie_honor_string)
       {
          bNo_drop_death = TRUE;
          piDeathCost = FALSE;    


### PR DESCRIPTION
I must have missed this when testing, it generates an error if a player
without a string dies.

I changed so it checks first if the player actually has a string set, if
that is the case then it will check if it is the newbie string.
