### PR TITLE
Changed truce reagents

### DIFF
--- a/kod/object/passive/spell/roomench/truce.kod
+++ b/kod/object/passive/spell/roomench/truce.kod
@@ -21,7 +21,7 @@ resources:
    truce_desc_rsc = \
       "The spirit of Shal'ille calls upon her ally Faren, forming a truce with creatures of nature for "
       "several minutes.  "
-      "Requires emerald and yrxl sap to cast."
+      "Requires emerald and elderberry to cast."
 
    truce_unnecessary = "Combat with monsters is already impossible here."
 
@@ -71,7 +71,7 @@ messages:
    {
       plReagents = $;
       plReagents = Cons([&Emerald,1],plReagents);
-      plReagents = Cons([&Yrxlsap,1],plReagents);
+      plReagents = Cons([&ElderBerry,1],plReagents);
 
       return;
    }


### PR DESCRIPTION
Change from a yrxl sap to a elderberry. There is really no reason for
truce to require such expensive reagent as yrxl sap when it is only
effective against monsters (PvE).
