### PR TITLE
Changing edible mushrooms to viFilling = 5

### DIFF
--- a/kod/object/item/passitem/numbitem/food/snack.kod
+++ b/kod/object/item/passitem/numbitem/food/snack.kod
@@ -42,7 +42,7 @@ classvars:
 properties:
 
    viNutrition = 5
-   viFilling = 3
+   viFilling = 5
    piNumber = 3
 
 messages:


### PR DESCRIPTION
This change would allow new players to keep up their vigor by eating the mushrooms they find while fighting. Edibles still wouldn't be viable for built characters, since they weigh 7.5 times as much as inkies per vigor restored. The Nutrition/Filling ratio would remain a lot worse than inkies, but pull slightly ahead of cheese which can be bought from vendors. (edibles:1, inkies:2, cheese:0.75)
