### PR TITLE
Boss bonus XP

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -5787,7 +5787,7 @@ messages:
 
    GetBonusXP()
    {
-       return piBossBonus;
+      return piBossBonus;
    }  
 
 end

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -283,6 +283,8 @@ properties:
    piHit_points = 1
    piMax_hit_points = 1
 
+   piBossBonus = 0
+
    % Who we are dealing with.
    poCustomer = $
 
@@ -5783,6 +5785,10 @@ messages:
       return;
    }
 
+   GetBonusXP()
+   {
+       return piBossBonus;
+   }  
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -7596,10 +7596,11 @@ messages:
    "their maxhealth to gain a HP.  This number is reduced by the player's"
    "stamina, all the way down to half for those with high staminas."
    {
-      local highmark, rand, dodgeskill, oSkill, monster_level, gain, gainmult, roll, iNumber, oWeapon;
+      local highmark, rand, dodgeskill, oSkill, monster_level, gain, gainmult, roll, iNumber, oWeapon, xpbonus;
             
       gain = 0;
       roll = FALSE;
+      xpbonus = send(what,@GetBonusXP); %Ask the Monster if it gives an XP bonus
 
       % Some things just never allow advancement.
       % Can advance in arena if realdeath is on in an arena.

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -661,6 +661,8 @@ resources:
    
    player_Debug_nokarma = "%s cannot learn %s due to karma restrictions."
    player_Debug_noway = "It is impossible for %s to ever get the %s spell."
+   
+   player_bonus = "~IYou have slain a mighty foe."
 
    player_sound_sword1 = sword1.wav
    player_sound_sword2 = sword2.wav
@@ -7626,6 +7628,13 @@ messages:
             {
                % Player took damage and landed killing blow
                gain = 2;
+               
+               if xpbonus > 0 % do the bonus XP here because this is as legit of a kill as you can get.
+               {
+                  gain = gain + xpbonus;
+                  Send(self,@MsgSendUser,#message_rsc=player_bonus);               
+               }
+               
                roll = TRUE;
             }
             else


### PR DESCRIPTION
This is the ground work for something bigger but I thought until I could work the math out for the rest of it maybe the admins could have some fun.

So the very basic idea here is to allow for monsters to give more then the standard 1-2 XP (Gainchance) that they currently do.

For someone at 20 hp killing a giant rat is the same as killing the ghost XP wise. For a person who is 149 hp killing a Mollusk create is the same as killing the luppog king.

So right now high level players only farm mollusks because they're the easiest end game monster to kill/exploit killing. In the future setting the harder monsters and boss monsters to have a slightly high number will balance the difficulty and we should see some variance in building.

Currently there aren't really any low end or mid-tier bosses to speak of but this can be corrected. The Orc Pitt Boss is the closest thing we have to that, but additional bosses can be added.

As I stated, I'm working on the math with a few other people and will push the addition of the specific pibossbonus numbers at a later time.

---

So here is how it works right now. Currently an admin must set pibossbonus on a monster. If a player is within normal range to gain XP from said monster and gets flagged for the normal 2 xp by both getting hit by and landing the killing blow of the monster they will see the message that they have killed a mighty foe. They are granted the normal 2 XP and the bonus.

The reason I put the bonus only at the point where players get both the normal XP is to avoid players cheesing stronger monsters and bosses by using things like firewalls.

---

I hope to add additional ways to gain XP like this in the future in attempt to move away from the bait/firewall abuse we see today. Making the game more interactive and removing the need/use of mules.
