### PR TITLE
Lupogg King Lair Fix

### DIFF
--- a/kod/object/active/holder/room/monsroom/bossroom/sewking.kod
+++ b/kod/object/active/holder/room/monsroom/bossroom/sewking.kod
@@ -134,7 +134,7 @@ messages:
    Constructor()
    {
       plMonsters = [ [&Lupogg, 100] ];
-      plGenerators = [ [19,19], [23,44], [23,31] ];
+      plGenerators = [ [11,37], [21,28], [23,31] ];
 
       poDoor1 = Create(&MovingSector,#sectorroom=self,#sectorID=SECTOR_DOOR1,
                         #upH=H_DOOR1_UP,#downH=H_DOOR1_DN,#upspeed=DOOR_UP_SPEED,


### PR DESCRIPTION
The most abused location in the game -

Problems with the generator locations made this room very broken. There
are only three generators, one of which was placed in a wall, thereby
preventing spawns. One of the generators is (and remains) in a tightly
confined space, preventing spawns after a short time when the lupoggs
pile up.

This led the third generator actually _outside_ the Lupogg King Lair to
spawn continually in a single hallway with a safespot right next to it.
It has become one of the most abused spots in the game, nearly always
occupied by someone botting weaponcraft (strictly illegal) in what is a
rarely visited zone otherwise. The trick is, the Lupogg King has aggro
priority, so it's easy to set yourself up in that spot so that the lupoggs
don't fight back at all. Furthermore, often these characters are angeled or
using an autologger to prevent untimely death while they bot. That is why
I call this the most abused spot in the game.

The fact that the spot has at least one illegal botter in it every day is clear
evidence the room needs fixed. The abuse is bipartisan and widespread,
a prime case of 'everybody is doing it'.

This commit simply moves the generators. The one in the wall is now in
the king's tunnel, adding to the cluster of dangerous lupoggs one must
pass through as part of the Lupogg King experience, and the abused
generator point is now in the King chamber itself. The space is large enough
to prevent any 'piling up', so anyone trying to bot the dangerous tunnel
will eventually have the room spawn maxed by lupoggs in the chamber
itself, and they will stop receiving lupoggs at their location.
