### PR TITLE
Causing error when trying to compile the client

### DIFF
--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -85,7 +85,7 @@ extern "C" {
 // Use this #define to enable Miles Sound System version.  If not defined,
 // music is played through the default MIDI player, and sound goes through the
 // ancient wavemix DLL.
-#define M59_MSS
+//#define M59_MSS
 
 
 #ifdef M59_MSS


### PR DESCRIPTION
Because we do not have the miles sound system files we cannot compile with it.
