### PR TITLE
Ghost Time Setting Refinement

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -666,7 +666,15 @@ messages:
                   AND NOT Send(poOwner,@InFoyer,#who=self))
       {
          theTime = GetTime();
-         iPenaltyTime = Send(SYS,@GetLogoffPenaltyGhostTime);
+         if Send(self,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
+            OR Send(self,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
+         {
+            iPenaltyTime = Send(SYS,@GetOutlawMurdererLogoffPenaltyGhostTime);
+         }
+         else
+         {
+            iPenaltyTime = Send(SYS,@GetLogoffPenaltyGhostTime);
+         }
 
          % If we've already passed our penalty time OR we have been on for
          %  1/5 the penalty time, then set the logoff penalty time to 90-110%

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -90,8 +90,11 @@ properties:
    % Rescue always takes at least this long to cast
    piRescueBaseDelaySec = 15
    
-   % Time in seconds that ghosts will last before taking a penalty
+   % Time in seconds that innocent ghosts will last before taking a penalty
    piLogoffPenaltyGhostTime = 600
+   
+   % Time in seconds that outlaw & murderer ghosts will last before taking a penalty
+   piOutlawMurdererLogoffPenaltyGhostTime = 600
 
    %
    % Guild hall settings
@@ -331,6 +334,11 @@ messages:
    GetLogoffPenaltyGhostTime()
    {
       return piLogoffPenaltyGhostTime;
+   }
+   
+   GetOutlawMurdererLogoffPenaltyGhostTime()
+   {
+      return piOutlawMurdererLogoffPenaltyGhostTime;
    }
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -5814,6 +5814,11 @@ messages:
    {
       return Send(Send(self,@GetSettings),@GetLogoffPenaltyGhostTime);
    }
+   
+   GetOutlawMurdererLogoffPenaltyGhostTime()
+   {
+      return Send(Send(self,@GetSettings),@GetOutlawMurdererLogoffPenaltyGhostTime);
+   }
 
    TempDisableLogoffPenalties()
    {


### PR DESCRIPTION
A former pull (#152) added the ability for administrators to change logoff
ghost times. This commit adds a refinement: outlaws and murderers get
their own ghost time setting, allowing innocents and PKs to have
different adjusted times.

This could be a very strong tool for balancing the PK / hunter scenario.
In many discussions, it's clear that PKs have total initiative, but giving
innocents ghosts allows hunters a chance to respond. However, that
still means PKs have the initiative _and_ a chance to respond with their
own alt or guild or mules. The imbalance remains. Simply reducing
all ghost times for everyone doesn't change the imbalance.

This new setting will allow an administrator to test out different values -
innocents could have five or ten minute ghosts, while PKs could have
much shorter ghosts, bringing parity to the situation.

This pull defaults both values to their current setting of 10 minutes.
No gameplay changes included.
