### PR TITLE
Faren ranged upgrade

### DIFF
--- a/kod/object/passive/spell/atakspel/boltspel.kod
+++ b/kod/object/passive/spell/atakspel/boltspel.kod
@@ -40,7 +40,7 @@ properties:
    piRange = $
 
    % Maximum amount of bonus damage mana focus gives us for casting this spell.
-   piManaFocusBonus = 10
+   piManaFocusBonus = 5
 
 messages:
 

--- a/kod/object/passive/spell/atakspel/boltspel/fireball.kod
+++ b/kod/object/passive/spell/atakspel/boltspel/fireball.kod
@@ -54,8 +54,8 @@ classvars:
 
 properties:
    
-   piDamageMin = 8
-   piDamageMax = 12
+   piDamageMin = 13
+   piDamageMax = 17
    prSpellHit = fireball_hit_rsc
 
 messages:

--- a/kod/object/passive/spell/atakspel/boltspel/lightnin.kod
+++ b/kod/object/passive/spell/atakspel/boltspel/lightnin.kod
@@ -53,8 +53,8 @@ classvars:
 
 properties:
 
-   piDamageMin = 13
-   piDamageMax = 18
+   piDamageMin = 18
+   piDamageMax = 23
    prSpellHit = lightning_hit_rsc
 
 messages:


### PR DESCRIPTION
On closer inspection, I realized that one of the reasons Faren ranged
spells are so bad is that their superclass has a Mana Focus bonus of 10
damage, instead of 5 like splash spells. Lightning Bolt and Fireball
were probably given very low damage ranges because they were 'intended'
to be used with Mana Focus. Since that didn't work out in practice, the
spells were left severely underpowered. I took 5 of that Mana Focus
bonus away and simply put it back into the spells.

Before -
Fireball did 8-12
Lightning Bolt did 13-18
Mana Focus gave +10

Now -
Fireball does 13-17
Lightning Bolt does 18-23
Mana Focus gives +5

Now these two spells are something I would actually use as a Faren player. But one note - Lightning Bolt's damage being similar to a splash spell's damage now is kind of a red herring. Shock is the worst element, given the current gear setup (lots of typical gear resists shock, very few take more shock damage). Players will still prefer something like Blast of Fire (15-23) due to its common 10-30% damage bonuses over shock's 10-30% resisted damage values. Not to mention the ranged spells cost more mana and vigor. Perhaps this rebalance will help Fireball and Lightning Bolt better compete with bows.
