### PR TITLE
Parry Player Arrows

### DIFF
--- a/kod/object/passive/skill/stroke/fire.kod
+++ b/kod/object/passive/skill/stroke/fire.kod
@@ -61,12 +61,6 @@ messages:
 
    % General combat messages:
 
-   % Overriden from superclass.  Can't parry arrows.
-   CanParry()
-   {
-      return FALSE;
-   }
-
    % Finds ammo and uses it if not used.
    FindLikelyAmmo(who=$,report=FALSE)
    {


### PR DESCRIPTION
Allows players to parry arrows shot at them from other players.

I don't see any reason why in a fantasy game a person could not knock an arrow out of the air with a weapon. 

However this push is mostly a small step at melee weapons VS bow balance. Player can still not parry using a bow, so now a player gets a boost to their defense rating while using a melee weapon vs a player who can attack them at range.

Melee has a long way to go to even come close to being able to compete with bows but this to me feel like a simple way slightly improve the odds.

Note: I left in players not being able to parry chieftain attacks simply to reserve their difficulty. 
