### PR TITLE
Island room_no_combat defaults

### DIFF
--- a/kod/object/active/holder/room/bowhut.kod
+++ b/kod/object/active/holder/room/bowhut.kod
@@ -31,7 +31,6 @@ classvars:
    viTeleport_col = 4
 
    viTerrain_Type = TERRAIN_CITY | TERRAIN_SHOP
-   viPermanent_flags = ROOM_NO_COMBAT
 
 properties:
 

--- a/kod/object/active/holder/room/monsroom/kcforest/kc5.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/kc5.kod
@@ -30,8 +30,6 @@ classvars:
    viTeleport_col = 31
    viTerrain_type = TERRAIN_JUNGLE
 
-   viPermanent_flags = ROOM_NO_COMBAT
-
 properties:
 
    prRoom = room_OutdoorsKC5

--- a/kod/object/active/holder/room/monsroom/kcforest/kd4.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/kd4.kod
@@ -31,7 +31,6 @@ classvars:
    viTeleport_row = 55
    viTeleport_col = 44
    viTerrain_type = TERRAIN_JUNGLE
-   viPermanent_flags = ROOM_NO_COMBAT
 
 properties:
 


### PR DESCRIPTION
Every update an admin manually has to reset these rooms to enable
combat. This eliminates the non-combat defaults. This is an issue
because the island safe zones are literally adjacent to the three major
building spots and cause all sorts of problems with combat.
