### PR TITLE
Decrease position update interval

### DIFF
--- a/clientd3d/move.c
+++ b/clientd3d/move.c
@@ -54,7 +54,7 @@
 
 #define MAX_STEP_HEIGHT (HeightKodToClient(24)) // Max vertical step size (FINENESS units)
 
-#define MOVE_INTERVAL  1000            // Inform server at most once per this many milliseconds
+#define MOVE_INTERVAL 500              // Inform server at most once per this many milliseconds
 #define MOVE_THRESHOLD (FINENESS / 4)  // Inform server only of moves at least this large
 #define MOVE_THRESHOLD2 (MOVE_THRESHOLD * MOVE_THRESHOLD)
 #define TIME_THRESHOLD 1000


### PR DESCRIPTION
This change halves the interval the client sends position updates to the server, hence it generally increases the accuracy of your position on the server and is especially nice for melee combat. This will bring improvements for almost any case and won't make anything worse for the others in which IP packet loss and triggered TCP retransmit causes issues (high latency itself isn't a problem).

In fact I'm using this update rate in my new client and haven't found anything bad about it.

I know there is another pullrequest facing this, but it's stuck since month and this little change here can do a lot I think.

Please let me know if there is any other isue (like message limits) on the server with this, I did not ran into any trouble.
