### PR TITLE
Implemented Parry Bonuses

### DIFF
--- a/kod/object/item/passitem/weapon.kod
+++ b/kod/object/item/passitem/weapon.kod
@@ -150,6 +150,7 @@ properties:
 
    piDamageBonus = 0
    piHitBonus = 0
+   piParryBonus = 0
 
    piUsed = UNUSED
 
@@ -483,10 +484,19 @@ messages:
    }
 
    % Return parry ability, include bonuses.
-   % TODO: Define standard bonuses for various weapon types.
+   % Note: all parry values are doubled in the player's defense equation.
    GetParryAbility(who=$)
    {
-      return send(who,@GetSkillAbility,#skill_num=SKID_PARRY);
+      local iParry;
+      
+      iParry = send(who,@GetSkillAbility,#skill_num=SKID_PARRY);
+      
+      if iParry = 0
+      {
+         return 0;
+      }
+
+      return iParry + piParryBonus;
    }
       
    % What is the weapon's name for use in the attack messages?

--- a/kod/object/item/passitem/weapon/goldswrd.kod
+++ b/kod/object/item/passitem/weapon/goldswrd.kod
@@ -51,6 +51,11 @@ classvars:
    viMin_damage = 2
    viMax_damage = 5
 
+   % Adds 150 defense
+   % No bonus outside of arena, or if player does not have parry.
+   % Gold sword is fantastic in the arena, but useless elsewhere.
+   viArenaParryBonus = 75
+
 properties:
 
    piAttack_type = ATCK_WEAP_NONMAGIC+ATCK_WEAP_THRUST
@@ -72,6 +77,25 @@ messages:
       return iDamage;
    }
 
+   GetParryAbility(who=$)
+   {
+      local oOwner, iParry;
+
+      iParry = send(who,@GetSkillAbility,#skill_num=SKID_PARRY);
+
+      if iParry = 0
+      {
+         return 0;
+      }
+      
+      oOwner = send(send(self,@GetOwner),@GetOwner);
+      if send(oOwner,@IsArena)
+      {
+         iParry = iParry + viArenaParryBonus;
+      }
+      
+      return iParry + piParryBonus;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/weapon/riijaswd.kod
+++ b/kod/object/item/passitem/weapon/riijaswd.kod
@@ -190,6 +190,18 @@ messages:
       return -10;
    }
 
+   % Riija sword cannot parry in the hands of someone other than the owner.
+   GetParryAbility(who=$)
+   {
+      if poOwner <> $
+         AND poQuester <> $
+         AND poOwner <> poQuester
+      {
+         return 0;
+      }
+
+      propagate;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/weapon/scimitar.kod
+++ b/kod/object/item/passitem/weapon/scimitar.kod
@@ -53,6 +53,21 @@ properties:
 
 messages:
 
+   % Scimitar is a great parrying weapon for those with natural talent.
+   GetParryAbility(who=$)
+   {
+      local iParry, iAgility;
+
+      iParry = send(who,@GetSkillAbility,#skill_num=SKID_PARRY);
+      iAgility = send(who,@GetAgility);
+      
+      if iParry = 0
+      {
+         return 0;
+      }
+
+      return iParry + (iAgility * 2) + piParryBonus;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/weapon/shrtswrd.kod
+++ b/kod/object/item/passitem/weapon/shrtswrd.kod
@@ -51,9 +51,18 @@ classvars:
 properties:
 
    piAttack_type = ATCK_WEAP_NONMAGIC+ATCK_WEAP_THRUST
+   
+   % Adds 100 defense
+   % Light weapon, decent for parrying.
+   % Ignores your actual parry skill, acts as if 50% parry.
+   piParryBonus = 50
 
 messages:
 
+   GetParryAbility(who=$)
+   {
+      return piParryBonus;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Parry bonuses for weapons were never implemented. They were left as a
TODO stub, only returning exactly the user's level of Parry skill. I
created a piParryBonus for weapons and set a few special parry functions
on the game's least-used weapons.
- Short swords now act as if player has 50% parry at all times, adding
  100 defense. Great for newbies, but horrible for built characters, who will
  actually parry worse. Maybe this will help the 'short sword fighting
  imping agony' many players suffer through. (Note - Parry bonus will not
  apply if held or blinded, as usual)
- Scimitar can add up to 200 defense based on the wielder's agility,
  perhaps giving it an advantage over fencing weapons. 200 is equal to the
  defense penalty of wearing a plate armor, and is reached at 50 natural
  agility.
- Riija swords won't parry for non-owners.
- Gold swords add 150 defense if in the arena. Seems fair for a weapon
  that doesn't have procs and can't be used in real combat.

Aside from these weapons, piParryBonus should allow admins to modify
event items' parry ability, and the value will of course exist for
future balancing. While common sense would say that fencing weapons
should have large parry bonuses, they're already the clear best weapons
in the game, so I decided not to touch general balance with this implementation.
