### PR TITLE
Changing karma of Narthyl Worm to -70 from 0

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/nrthlwrm.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/nrthlwrm.kod
@@ -53,7 +53,7 @@ classvars:
    viAttributes = 0
    viLevel = 120
    viDifficulty = 7
-   viKarma = 0
+   viKarma = -70
    viDefault_behavior = AI_FIGHT_AGGRESSIVE | AI_FIGHT_HYPERAGGRESSIVE
 
    vrSound_miss = NarthylWorm_sound_miss


### PR DESCRIPTION
There is absolutely no reason why this demon living in Brax next to -90 karma mobs should have neutral karma, wrecking any Sha's karma who builds there. Pure annoyance.
