### PR TITLE
Globe Post HP Req

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -295,6 +295,8 @@ resources:
 
    user_default_url = "http://www.Meridian59.com/"
 
+   not_enough_health_to_post_rsc = "Posting is restricted to players of %i health and above."
+
 classvars:
 
    viIndefinite = ARTICLE_NONE
@@ -5771,6 +5773,19 @@ messages:
       {
          Send(self, @MsgSendUser, #message_rsc=user_news_squelched);
          return;
+      }
+      
+      if NOT IsClass(self,&DM)
+      {
+         if Send(self,@GetBaseMaxHealth) < Send(Send(SYS,@GetSettings),@GetMinGlobePostHP)
+         {
+            if Send(self,@IsLoggedOn)
+            {
+               Send(self,@MsgSendUser,#message_rsc=not_enough_health_to_post_rsc,
+                       #parm1=Send(Send(SYS,@GetSettings),@GetMinGlobePostHP));
+            }
+            return;
+         }
       }
 
       oNews = Send(SYS,@FindNewsByNum,#num=nid);

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -136,6 +136,10 @@ properties:
    % If disabled, outlaws & murderers will not be afforded the 1/3-hp damage cap protection.
    pbDamageCapProtectionMurderersEnable = FALSE
 
+   % The minimum HP required to post on the globe
+   % Intended to reduce the amount of toxic anonymous posting
+   piMinGlobePostHp = 110
+
 messages:
 
    Constructor(server_num = $)
@@ -331,6 +335,11 @@ messages:
    GetLogoffPenaltyGhostTime()
    {
       return piLogoffPenaltyGhostTime;
+   }
+   
+   GetMinGlobePostHP()
+   {
+      return piMinGlobePostHp;
    }
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Implemented a setting that prevents posts by characters below a certain
HP threshold. This is intended to reduce toxic posts by anonymous characters.

The globe seems to be a major source of negative server morale. Nobody is using it
to communicate in a regular manner - I have never seen newbies posting questions
or people debating anything. We will not lose any legitimate use by restricting the posts
to players above a certain HP.

But hopefully, what will happen is an uptick in the types of conversations had on
the globe. A good 50%+ of the posts currently are anonymous mules spewing
insults and toxicity. If people are more or less forced to post only on built
characters, maybe the quality will improve.

Specifically, a large percentage of our lurkers log on just to chat and view the globe.
If the only thing they see month after month are anonymous trash posts full of
insults, there's really no chance to re-engage them. Maybe this will help.
