### PR TITLE
Helmet & Ivy Circlet rebalancing

### DIFF
--- a/kod/object/item/passitem/defmod/helmet/ivycircl.kod
+++ b/kod/object/item/passitem/defmod/helmet/ivycircl.kod
@@ -63,8 +63,7 @@ messages:
    GetResistanceModifiers()
    {
       return [ [-ATCK_SPELL_FIRE,-10],
-               [-ATCK_SPELL_SHOCK,20],
-               [-ATCK_SPELL_UNHOLY,20]
+               [-ATCK_SPELL_UNHOLY,-20]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/helmet/simphelm.kod
+++ b/kod/object/item/passitem/defmod/helmet/simphelm.kod
@@ -27,8 +27,8 @@ classvars:
    vrDesc = SimpleHelm_desc_rsc
    vrIcon = SimpleHelm_icon_rsc
 
-   viHits_init_min = 200
-   viHits_init_max = 225
+   viHits_init_min = 550
+   viHits_init_max = 650
 
    viValue_average = 100
    viWeight = 50
@@ -42,7 +42,7 @@ classvars:
    viInventory_group = 2
    viBroken_group = 4
 
-   viDefense_base = 20
+   viDefense_base = 50
    viDamage_base = 1
 
 properties:
@@ -66,7 +66,11 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_BLUDGEON,-10]
+      return [ [ATCK_WEAP_THRUST,5],
+               [ATCK_WEAP_PIERCE,5],
+               [ATCK_WEAP_BLUDGEON,5],
+               [ATCK_WEAP_SLASH,5],
+               [-ATCK_SPELL_SHOCK,-10]
              ];
    }
 


### PR DESCRIPTION
Plain helmets actually make the player 10% _more_ vulnerable to
bludgeoning damage, and give almost nothing in return. This doesn't seem
right to me. They are literally actively bad to wear. Maybe it was a typo?

In an effort to make helmets useful (since they are
competing with ivy circlets and mana circlets, both incredibly useful) I
gave helmets more durability, a bit more defense rating, and a small 5%
value in the four weapon resistances. They are split up individually,
and not set by ATCK_WEAP_ALL, so that they stack with any other armor
resists the player might have (for example, herald shield's 10% piercing
resistance).

Gave Helmet -10% against shock damage as a consideration for Faren
attacks, and, because, well, you've got your head covered in metal.

Also noticed Ivy Circlet had unholy resistance when it should have had unholy
weakness per its mirror item, the Orc Shield. Flipped the unholy resist
value to -20% vs unholy to match Orc Shield's -20% vs holy. These are
the only objects in the game which give players holy or unholy resists or
weaknesses. If both of them give -20%, they create a reason to use
Qor and Shal enchants on weapons, where currently no reason exists
(Kraanan enchant is strictly superior otherwise).

Ivy Circlet had 20% shock resistance, causing problems with Faren
balance. I removed the shock resistance. This one's been a source of
mage frustration for years. Ivy resistance even stacked with robes of
the disciple shock resistance to give 35% shock resist for free, meaning
Faren's flagship element has been pretty laughable for a long time simply
on account of typical gear a large number of players are using as standard
practice. Maybe this will help.
