### PR TITLE
Reagent Reductions

### DIFF
--- a/kod/object/passive/spell/anon.kod
+++ b/kod/object/passive/spell/anon.kod
@@ -25,7 +25,6 @@ resources:
    anonymity_desc_rsc = \
       "Makes you indistinct, and unrecognizable to all but those who you'd like to know its you.  "
       "Note that Shal'ille can not punish transgressors against you when you are anonymous.  "
-      "Requires rainbow ferns and firesand to cast."
    anonymity_sound = ranonym.wav
    
 classvars:
@@ -54,8 +53,6 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&RainbowFern,2],plReagents);
-      plReagents = Cons([&FireSand,1],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/artifice.kod
+++ b/kod/object/passive/spell/artifice.kod
@@ -52,8 +52,8 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&FireSand,3],plReagents);
-      plReagents = Cons([&UncutSeraphym,3],plReagents);
+      plReagents = Cons([&FireSand,1],plReagents);
+      plReagents = Cons([&UncutSeraphym,1],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/atakspel/blasfire.kod
+++ b/kod/object/passive/spell/atakspel/blasfire.kod
@@ -60,7 +60,7 @@ messages:
       % separate message so can change, then set from admin mode
 
       plReagents = $;
-      plReagents = Cons([&RedMushroom,2],plReagents);
+      plReagents = Cons([&RedMushroom,1],plReagents);
       plReagents = Cons([&Elderberry,1],plReagents);
  
       return;

--- a/kod/object/passive/spell/atakspel/boltspel/fireball.kod
+++ b/kod/object/passive/spell/atakspel/boltspel/fireball.kod
@@ -65,7 +65,7 @@ messages:
       % separate message so can change, then set from admin mode
 
       plReagents = $;
-      plReagents = Cons([&RedMushroom,2],plReagents);
+      plReagents = Cons([&RedMushroom,1],plReagents);
       plReagents = Cons([&OrcTooth,1],plReagents);
 
       return;

--- a/kod/object/passive/spell/atakspel/boltspel/lightnin.kod
+++ b/kod/object/passive/spell/atakspel/boltspel/lightnin.kod
@@ -65,7 +65,7 @@ messages:
       % separate message so can change, then set from admin mode
 
       plReagents = $;
-      plReagents = Cons([&BlueMushroom,2],plReagents);
+      plReagents = Cons([&BlueMushroom,1],plReagents);
       plReagents = Cons([&OrcTooth,1],plReagents);
 
       return;

--- a/kod/object/passive/spell/atakspel/exfrost.kod
+++ b/kod/object/passive/spell/atakspel/exfrost.kod
@@ -60,7 +60,7 @@ messages:
       % separate message so can change, then set from admin mode
 
       plReagents = $;
-      plReagents = cons([&RedMushroom,2],plReagents);
+      plReagents = cons([&RedMushroom,1],plReagents);
       plReagents = Cons([&Elderberry,1],plReagents);
 
       return;

--- a/kod/object/passive/spell/atakspel/shokfury.kod
+++ b/kod/object/passive/spell/atakspel/shokfury.kod
@@ -60,7 +60,7 @@ messages:
       % separate message so can change, then set from admin mode
 
       plReagents = $;
-      plReagents = Cons([&BlueMushroom,2],plReagents);
+      plReagents = Cons([&BlueMushroom,1],plReagents);
       plReagents = Cons([&Elderberry,1],plReagents);
 
       return;

--- a/kod/object/passive/spell/brthlife.kod
+++ b/kod/object/passive/spell/brthlife.kod
@@ -26,7 +26,6 @@ resources:
    breathoflife_desc_rsc = \
       "The great power of Shal'ille takes part of the caster's life force "
       "and gives it to another person.  "
-      "Requires herbs to cast."
 
    breathoflife_unnecessary_rsc = "%s%s cannot handle additional life force from this spell."
    breathoflife_toohurt_rsc = "You do not have enough health to transfer to another!"
@@ -63,7 +62,6 @@ messages:
       % separate message so can change, then set from admin mode
 
       plReagents = $;
-      plReagents = Cons([&Herbs,1],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/cpoison.kod
+++ b/kod/object/passive/spell/cpoison.kod
@@ -20,7 +20,7 @@ resources:
    curepoison_icon_rsc = icurpoi.bgf
    curepoison_desc_rsc = \
       "Pure, healing energy fights the effects of poison in the target.  "
-	   "Requires herbs and elderberries to cast."
+	   "Requires herbs to cast."
    
    curepoison_on = "The power of Shal'ille fights the effects of poison in your blood."
 
@@ -52,7 +52,6 @@ messages:
    {
       plReagents = $;
       plReagents = Cons([&Herbs,2],plReagents);
-      plReagents = Cons([&Elderberry,1],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/creafood.kod
+++ b/kod/object/passive/spell/creafood.kod
@@ -55,8 +55,8 @@ messages:
       % separate message so can change, then set from admin mode
 
       plReagents = $;
-      plReagents = Cons([&ElderBerry,2],plReagents);
-      plReagents = Cons([&Herbs,2],plReagents);
+      plReagents = Cons([&ElderBerry,1],plReagents);
+      plReagents = Cons([&Herbs,1],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/dispillu.kod
+++ b/kod/object/passive/spell/dispillu.kod
@@ -22,7 +22,7 @@ resources:
       "Attempts to dispel any illusions in your vicinity.  This powerful "
       "spell is the bane of the Riija school of magic, but at a significant "
       "cost in reagents.  "
-      "Requires dragonfly eyes, uncut seraphym, and solagh to cast."
+      "Requires solagh to cast."
 
    dispelillusion_castermsg_rsc = \
       "You cross your eyes momentarily to make the illusions in the area fade "
@@ -50,9 +50,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&DragonflyEye,1],plReagents);
-      plReagents = Cons([&UncutSeraphym,1],plReagents);
-      plReagents = Cons([&Solagh,2],plReagents);
+      plReagents = Cons([&Solagh,3],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/holysymb.kod
+++ b/kod/object/passive/spell/holysymb.kod
@@ -58,7 +58,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Elderberry,3],plReagents);
+      plReagents = Cons([&Elderberry,1],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/manabomb.kod
+++ b/kod/object/passive/spell/manabomb.kod
@@ -25,7 +25,6 @@ resources:
       "Initiates a white hot explosion which burns all of the "
       "caster's mana and consumes half of that amount from all "
       "others in the room.  "
-      "Requires sapphires to cast."
 
    manabomb_cast = "%s%s's mana violently detonates!"
    manabomb_hit_some = \
@@ -59,7 +58,6 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Sapphire,2],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/mend.kod
+++ b/kod/object/passive/spell/mend.kod
@@ -21,7 +21,6 @@ resources:
    mend_desc_rsc = \
       "Erases the wear of battle from a piece of equipment, restoring it to "
       "near new condition.  "
-      "Requires orc teeth and sapphire to cast."
 
    mend_not_weaponry = "You try to focus on %s%s, but nothing happens!"
    mend_beyond_hope = "%s%s is beyond salvage."
@@ -52,8 +51,6 @@ messages:
    {
       % Separate message so it can be changed, then set from admin mode.
       plReagents = $;
-      plReagents = Cons([&Sapphire,1],plReagents);
-      plReagents = Cons([&OrcTooth,1],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/mysttch.kod
+++ b/kod/object/passive/spell/mysttch.kod
@@ -28,7 +28,6 @@ resources:
    MysticTouch_desc_rsc = \
       "Draws upon the magic of Faren to transfer magical energy from caster to "
       "target.  "
-      "Requires mushrooms to cast."
    
    MysticTouch_cast_rsc = \
       "You feel the magical energies of another filling your body."
@@ -72,7 +71,6 @@ messages:
       % separate message so can change, then set from admin mode
 
       plReagents = $;
-      plReagents = Cons([&Mushroom,1],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/nodebrst.kod
+++ b/kod/object/passive/spell/nodebrst.kod
@@ -24,7 +24,6 @@ resources:
       "You tap all of your mana nodes to the maximum, giving you "
       "an instant burst of mana and health, but destroying your bonds.  "
       "May only be cast once per day.  "
-      "Requires fairy wings and entroot berries and is very tiring to cast."
 
    Nodeburst_fail = "You have no links to any mana nodes which you can burst."
    Nodeburst_success = \
@@ -60,8 +59,6 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&FairyWing,3],plReagents);
-      plReagents = Cons([&EntrootBerry,3],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/persench/Eagleyes.kod
+++ b/kod/object/passive/spell/persench/Eagleyes.kod
@@ -68,7 +68,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = cons([&Mushroom,3],plReagents);
+      plReagents = cons([&Mushroom,1],plReagents);
       plReagents = cons([&PurpleMushroom,1],plReagents);
 
       return;

--- a/kod/object/passive/spell/persench/bless.kod
+++ b/kod/object/passive/spell/persench/bless.kod
@@ -21,7 +21,7 @@ resources:
    bless_desc_rsc = \
       "Invokes Kraanan's blessing, increasing the accuracy "
       "and damage of attacks.  "
-      "Requires mushrooms and sapphires to cast."
+      "Requires mushrooms to cast."
    
    bless_already_enchanted_rsc = "You are already blessed."
    bless_on_rsc = "Kraanan fills you with the spirit of battle."
@@ -65,8 +65,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Mushroom,2],plReagents);
-      plReagents = Cons([&Sapphire,2],plReagents);
+      plReagents = Cons([&Mushroom,1],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/persench/cloak.kod
+++ b/kod/object/passive/spell/persench/cloak.kod
@@ -56,7 +56,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&EntrootBerry,2],plReagents);
+      plReagents = Cons([&EntrootBerry,1],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/persench/denial.kod
+++ b/kod/object/passive/spell/persench/denial.kod
@@ -76,7 +76,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&FireSand,2], plReagents);
+      plReagents = Cons([&FireSand,1], plReagents);
       plReagents = Cons([&Solagh,1],plReagents);
 
       return;

--- a/kod/object/passive/spell/persench/detevil.kod
+++ b/kod/object/passive/spell/persench/detevil.kod
@@ -21,7 +21,6 @@ resources:
    DetectEvil_desc_rsc = \
       "Allows you to see the vile defilers of her name.  Reveals all evil people and "
       "monsters that are more foul than you are pure.  "
-      "Requires a fairy wing to cast."
    
    DetectEvil_on_rsc = "You feel more attuned to the darkness of the hearts around you."
    DetectEvil_off_rsc = "Your eyesight returns to its former mundanity."
@@ -63,7 +62,6 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&FairyWing, 1],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/persench/detgood.kod
+++ b/kod/object/passive/spell/persench/detgood.kod
@@ -21,7 +21,6 @@ resources:
    DetectGood_desc_rsc = \
       "Allows you to see the disgustingly pure of heart.  This spell will reveal all good "
       "people and monsters that are more good than you are corrupted.  "
-      "Requires a fairy wing to cast."
    
    DetectGood_on_rsc = "You can now sense all things good, merely waiting to be defiled."
    DetectGood_off_rsc = "Your eyesight returns to its former mundanity."
@@ -63,7 +62,6 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&FairyWing, 1],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/persench/detinvis.kod
+++ b/kod/object/passive/spell/persench/detinvis.kod
@@ -52,7 +52,7 @@ messages:
 
    ResetReagents()
    {
-      plReagents = [ [&Solagh, 2] ];
+      plReagents = [ [&Solagh, 1] ];
 
       return;
    }

--- a/kod/object/passive/spell/persench/eavesdrp.kod
+++ b/kod/object/passive/spell/persench/eavesdrp.kod
@@ -61,7 +61,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&DragonflyEye,2],plReagents);
+      plReagents = Cons([&DragonflyEye,1],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/persench/haste.kod
+++ b/kod/object/passive/spell/persench/haste.kod
@@ -20,7 +20,6 @@ resources:
    Haste_icon_rsc = ihaste.bgf
    Haste_desc_rsc = \
       "Reduces the fatigue of running at full clip.  "
-      "Requires edible mushrooms to cast."
    
    Haste_on_rsc = "Your blood begins to tingle, cleansing your leg muscles of fatigue with every heartbeat."
    Haste_off_rsc = "Your feel the tide of energy in your blood recede, and running seems suddenly more taxing."
@@ -48,7 +47,7 @@ classvars:
    viMana = 10
    viSpellExertion = 0
 
-   viCast_time = 2000
+   viCast_time = 0
    viChance_To_Increase = 15
 
    vrSpell_intro = Haste_spell_intro
@@ -61,7 +60,6 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Snack,5],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/persench/mshield.kod
+++ b/kod/object/passive/spell/persench/mshield.kod
@@ -58,7 +58,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Mushroom,2],plReagents);
+      plReagents = Cons([&Mushroom,1],plReagents);
       plReagents = Cons([&RedMushroom,1],plReagents);
 
       return;

--- a/kod/object/passive/spell/persench/nightv.kod
+++ b/kod/object/passive/spell/persench/nightv.kod
@@ -20,7 +20,6 @@ resources:
    nightvision_icon_rsc = nitvsico.bgf
    nightvision_desc_rsc = \
       "Magically enhances the vision of the target.  "
-	   "Requires elderberry to cast."
    
    nightvision_already_enchanted_rsc = "You already have night vision."
 
@@ -55,7 +54,6 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&ElderBerry,3],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/persench/resist/resacid.kod
+++ b/kod/object/passive/spell/persench/resist/resacid.kod
@@ -65,7 +65,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Herbs,2],plReagents);
+      plReagents = Cons([&Herbs,1],plReagents);
       plReagents = Cons([&EntrootBerry,1],plReagents);
 
       return;

--- a/kod/object/passive/spell/persench/resist/rescold.kod
+++ b/kod/object/passive/spell/persench/resist/rescold.kod
@@ -60,7 +60,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Mushroom,3],plReagents);
+      plReagents = Cons([&Mushroom,1],plReagents);
       plReagents = Cons([&RedMushroom,1],plReagents);
 
       return;

--- a/kod/object/passive/spell/persench/resist/resfire.kod
+++ b/kod/object/passive/spell/persench/resist/resfire.kod
@@ -61,7 +61,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Mushroom,3],plReagents);
+      plReagents = Cons([&Mushroom,1],plReagents);
       plReagents = Cons([&RedMushroom,1],plReagents);
 
       return;

--- a/kod/object/passive/spell/persench/resist/resshock.kod
+++ b/kod/object/passive/spell/persench/resist/resshock.kod
@@ -60,7 +60,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Mushroom,3],plReagents);
+      plReagents = Cons([&Mushroom,1],plReagents);
       plReagents = Cons([&BlueMushroom,1],plReagents);
 
       return;

--- a/kod/object/passive/spell/persench/respois.kod
+++ b/kod/object/passive/spell/persench/respois.kod
@@ -20,7 +20,6 @@ resources:
    ResistPoison_icon_rsc = irespois.bgf
    ResistPoison_desc_rsc = \
       "Stabilizes your immune system, protecting you from some poisons.  "
-      "Requires herbs and red mushrooms."
    
    ResistPoison_on_rsc = "Your body tingles for a moment, and you feel a little "
                          "strange."
@@ -57,7 +56,7 @@ messages:
 
    ResetReagents()
    {
-      plReagents = [ [&Herbs, 2], [&RedMushroom,1] ];
+      plReagents = $;
 
       return;
    }

--- a/kod/object/passive/spell/persench/shadform.kod
+++ b/kod/object/passive/spell/persench/shadform.kod
@@ -21,7 +21,7 @@ resources:
    shadowform_desc_rsc = \
      "Transforms the target into a silhouette of their former self, "
 	  "perfect for skulking in darker locales and making them more difficult to hit.  "
-	  "Requires a handful of rainbow fern."
+	  "Requires a rainbow fern."
 
    shadowform_already_enchanted = "You already have shadow form."
    shadowform_already_affected = "The shadows refuse to hide what you wish."
@@ -55,7 +55,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&RainbowFern,3],plReagents);      
+      plReagents = Cons([&RainbowFern,1],plReagents);      
 
       return;
    }

--- a/kod/object/passive/spell/persench/strength.kod
+++ b/kod/object/passive/spell/persench/strength.kod
@@ -57,7 +57,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Mushroom,2],plReagents);
+      plReagents = Cons([&Mushroom,1],plReagents);
       plReagents = Cons([&OrcTooth,1],plReagents);
 
       return;

--- a/kod/object/passive/spell/relay.kod
+++ b/kod/object/passive/spell/relay.kod
@@ -25,8 +25,6 @@ resources:
    Relay_icon_rsc = irelay.bgf
    Relay_desc_rsc = \
       "The might of Kraanan allows you to give part of your vigor to another person.  "
-      "Requires an edible mushroom to cast."
-
    Relay_unnecessary_rsc = "%s%s cannot handle additional vigor from this spell."
    Relay_toolow_rsc = "You do not have enough vigor to transfer to another!"
    Relay_notonself_rsc = "You cannot cast Relay on yourself."
@@ -62,7 +60,6 @@ messages:
       % separate message so can change, then set from admin mode
 
       plReagents = $;
-      plReagents = Cons([&Snack,1],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/remcurse.kod
+++ b/kod/object/passive/spell/remcurse.kod
@@ -20,7 +20,6 @@ resources:
    RemoveCurse_icon_rsc = iremcurs.bgf
    RemoveCurse_desc_rsc = \
       "Breaks the magical bond binding you to a cursed item.  "
-      "Requires emeralds to cast."
    
    RemoveCurse_on = "Shal'ille tears the cursed item from your body."
    RemoveCurse_bad_target = \
@@ -52,7 +51,6 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Emerald,1],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/shroud.kod
+++ b/kod/object/passive/spell/shroud.kod
@@ -22,7 +22,7 @@ resources:
    shroud_name_rsc = "shroud"
    shroud_icon_rsc = ishroud.bgf
    shroud_desc_rsc = \
-	"Used to protect a warrior's tools against polluting magics.  Requires a large amount of inexpensive reagents."
+	"Used to protect a warrior's tools against polluting magics.  "
    shroud_lable_rsc = "Shrouder."
    
 
@@ -40,7 +40,7 @@ classvars:
    viSpell_level = 3
    viMana = 10
    viSpellExertion = 10
-   viCast_time = 30000
+   viCast_time = 0
 
    viChance_To_Increase = 25
 
@@ -51,9 +51,6 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Mushroom,3],plReagents);
-      plReagents = Cons([&Elderberry,3],plReagents);
-      plReagents = Cons([&Herbs,2],plReagents);
 
       return;
    }

--- a/kod/object/passive/spell/sweep.kod
+++ b/kod/object/passive/spell/sweep.kod
@@ -20,7 +20,6 @@ resources:
    Sweep_icon_rsc = isweep.bgf
    Sweep_desc_rsc = \
       "The wild winds of Faren sweep through the area gathering loose items for you.  "
-      "Requires mushrooms to cast."
 
    Sweep_room_cast = "%s%s magically sweeps some of the items in the area into %s hands."
 
@@ -61,7 +60,6 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Mushroom,2],plReagents);
 
       return;
    }


### PR DESCRIPTION
By popular request. NDS doubled and even tripled reagent costs when they re-opened the game, and many have been unhappy with the high costs ever since.
- Flagship spell reagents remain unchanged. (Invis, gort, earthquake, blind, and so on)
- Utility spells generally had their reagents eliminated entirely. Haste, Night Vision, Mend, Detect Good, etc. There's just no reason to force players to carry fairy wings or edible mushrooms for simple utilities. Most notable: Shroud now costs no reagents and is instant cast (the only actual mechanical change in this pull). It just doesn't make sense that such an important anti-griefing and non-pvp spell should take 30 seconds and a boatload of different reagents _per item_. Mana, vigor, and shrouding each day should be enough cost.
- Spells with alternate costs generally had their reagents eliminated. Breath of Life, Mystic Touch, Relay, Mana Bomb, Node burst, etc. The casters are paying for these spells in other ways.
- Personal enchantments got the bulk of the reduction - any reagents that required 3-of or 2-of became 1-of instead. In a few cases, a type of reagent was eliminated entirely. Most notable: Bless is now only 1 mushroom instead of 2 mushrooms and 2 sapphires. It's a _level 2 spell_ that people building need to make use of _all the time._ There are almost no zones where both mushrooms and sapphires drop. The current cost is just silly.
