### PR TITLE
Changed format on combat messages.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -46,10 +46,10 @@ resources:
 
    battler_punch = "punch"
    battler_attack = "attack"
-   battler_blocked  = "is blocked by" 
-   battler_dodged  = "is dodged by"
-   battler_parried  = "is parried by"
-   battler_misses = "misses"
+   battler_blocked  = "is ~Bblocked~B by" 
+   battler_dodged  = "is ~Bdodged~B by"
+   battler_parried  = "is ~Bparried~B by"
+   battler_misses = "~Bmisses~B"
 
    battler_fail = "fails to damage"
    battler_nick = "nicks"


### PR DESCRIPTION
Update: Added damage numbers in brackets. Cleaned up the obsolete singular code. Streamlined the message a bit more. Added bold print to defense descriptors as well.

This is a slight change of format in combat messages in order to present the player with information in the easiest to grasp fashion.

Before the change, messages were using active voice only, resulting in a mix of combat messages that were extremely hard to analyze quickly and efficiently.

A standard combat log would read:
Your scimitar cuts Psychochild.
You avoid Psychochild's attack.
Psychochild parries your attack.
Psychochild maims you with his scimitar.

This means that a message starting with "You" could either refer to your attack or your opponents attack. It could also mean both a hit or a miss. The same was true for messages starting with your opponent's name. The only logical assumption was, that messages starting with "You", were beneficial, while messages starting with your opponent's name were not so good. This made it impossible to understand what was going on in battle with just a glance. 

Post change, missed attacks will be narrated in passive voice, creating cohesion between a message's look and it's meaning.

Attacks made by the enemy will now always start with the enemy's name:
Psychochild's scimitar MAIMS you for (25) damage.
Psychochild's attack MISSES you.

Likewise, your attacks will always start with the word "Your":
Your scimitar CUTS Psychochild for (1) damage.
Your attack is PARRIED by Psychochild.

To make information even easier to grasp, the damage levels of an attack and the defense descriptors will now be printed in bold (indicated here in caps). This will allow you to quickly figure out what is going on. It should be easy to distinguish hits from misses because of the bold damage number in brackets that comes with every hit message.
