### PR TITLE
Eliminated hidden damage factors

### DIFF
--- a/kod/object/passive/skill/stroke/fire.kod
+++ b/kod/object/passive/skill/stroke/fire.kod
@@ -49,7 +49,7 @@ classvars:
    viSkillExertion = 2
    vbCheck_exertion = FALSE
 
-   viDamage_factor = 90
+   viDamage_factor = 100
 
 properties:
 

--- a/kod/object/passive/skill/stroke/slash.kod
+++ b/kod/object/passive/skill/stroke/slash.kod
@@ -40,7 +40,7 @@ classvars:
    viskillExertion = 2
    vbCheck_exertion = FALSE
 
-   viDamage_factor = 80
+   viDamage_factor = 100
 
 properties:
 


### PR DESCRIPTION
Rooting deep, deep into the code, I found that all fire skill based
damage is only 90% effective, and all slash skill based damage is only
80% effective. I believe this is a relic of a stroke system that was
never finished - there is also thrust, which has a low hit factor and a
high damage factor, and unarmed (punch), along with kicks and
other unused skills.

In any case, these two hidden factors make it very difficult to balance
weapons. They're in a completely different part of the code, and it
doesn't make sense that melee weapons do less than bows. This might be a
big reason why melee weapons are underpowered - they have been receiving
a hidden 20% damage cut this entire time. By setting these both to 100,
we will make equal the 'numbers you see in the code' and the 'actual numbers',
making better understanding and balancing possible.

This will add roughly 1 damage to fire based skills, and 2 damage to slash skills.
