### PR TITLE
Fixed Might & Aim issue

### DIFF
--- a/kod/object/passive/skill/stroke.kod
+++ b/kod/object/passive/skill/stroke.kod
@@ -336,7 +336,7 @@ messages:
    {
       local iDamage, might;
 
-      iDamage = 0;
+      iDamage = damage;
       % KLUDGEISH: this information should probably be in player.
       % Get weapon proficiency bonuses.
       if weapon_used <> $

--- a/kod/object/passive/skill/stroke/fire.kod
+++ b/kod/object/passive/skill/stroke/fire.kod
@@ -173,7 +173,7 @@ messages:
    {
       local iDamage, iAim;
 
-      iDamage = 0;
+      iDamage = damage;
       % Get weapon proficiency bonuses.
       if weapon_used <> $
       {


### PR DESCRIPTION
Might and Aim have not been adding damage correctly. They
have both been skipping a good half of base damage when giving their
percentage bonus.

This is why Might and Aim have been useless all these years. They haven't
been including the 5 base damage from a player's Mastery.
Therefore the stats' bonuses have been reduced by half or more.

This fix will increase Might's bonus to melee at 65 Might by +2 damage.
It will also increase Aim's bonus to bows at 60 Aim (highest achievable) by 1.75,
50 aim by 1.25, 40 aim by 1, and 25 aim and less by zero.

The full achievable Aim bonus using nerudite arrows, a battle bow, and 99% archery
will now roughly be:
0 damage at 25 aim
1 damage at 35 aim
2 damage at 45 aim
2-3 damage at 50 aim
2-4 damage at 55 aim
3-4 damage at 60 aim.

The new values should actually be noticeable, finally, and give a new reason
to actually put points into Aim. Might's bonuses will be similar to that list,
but of course, many characters already take high Might and Super Strength
is an easy +20.
