### PR TITLE
Fixed Deflect bugs

### DIFF
--- a/kod/object/passive/spell/persench/deflect.kod
+++ b/kod/object/passive/spell/persench/deflect.kod
@@ -115,8 +115,8 @@ messages:
          AND Send(oSpell,@GetNumSpellTargets) = 1
          AND IsClass(oSpell,&AttackSpell)
       {
-         chance = Send(caster,@GetEnchantedState,#what=self);
-         if Random(0,100) > chance
+         chance = Send(victim,@GetEnchantedState,#what=self);
+         if Random(0,100) < chance
          {
             Send(self,@SendMessageTryDeflectSuccess,#victim=victim,#caster=caster);
 


### PR DESCRIPTION
Deflect was calling the attacker's deflect state, when in fact it is the
victim that has the deflect enchantment. This resulted in a 'chance to
reflect' of zero or nil.

Deflect also had its success check backwards, so that a zero or nil
value always succeeded. This was causing deflect to reflect 100% of all
attack spells.

With both of these fixed, the spell now reflects 10% - 75% of all attack
spells based on spellpower as intended.

"Your deflect enchantment attempts to bounce Gar's spell back, but is
not strong enough."

I still believe this spell is ridiculously overpowered, offering virtual immunity
to attack magic and actually damaging the attacker with his own spell up to
75% of the time, but balancing will have to be left up to future changes.
