### PR TITLE
changed shocking fury to be an executioner type of spell.

### DIFF
--- a/kod/object/passive/spell/atakspel/shokfury.kod
+++ b/kod/object/passive/spell/atakspel/shokfury.kod
@@ -21,7 +21,8 @@ resources:
    ShockingFury_icon_rsc = ishkfury.bgf
 
    ShockingFury_desc_rsc = \
-      "Releases Faren's fury as a large amount of electricity directed at a target at short range.  "
+      "Allows you to overcharge your magical energy into a devastating torrent of electrical destruction."
+      "While extremely powerful, this technique will leave you too drained to cast spells for a short while."
       "Requires blue mushrooms and elderberries to cast."
 
    ShockingFury_sound = fzap.wav
@@ -38,19 +39,19 @@ classvars:
 
    viSchool = SS_FAREN
    viSpell_level = 3
-   viMana = 8
+   viMana = 20
 
    vrSucceed_wav = ShockingFury_sound
 
    % In seconds, since it works off GetTime().
-   viPostCast_time = 2
+   viPostCast_time = 10
 
    viChance_To_Increase = 5
 
 properties:
 
-   piDamageMin = 12
-   piDamageMax = 20
+   piDamageMin = 25
+   piDamageMax = 30
    piRange = 5
 
 messages:


### PR DESCRIPTION
Significantly increased damage of shocking fury from 12-20 to 25-30, but increased its post cast delay from 2 seconds to 10 seconds and increased its mana cost to 20.

This gives an otherwise useless spell a spot to shine.
