### PR TITLE
Leather & Scale improvements

### DIFF
--- a/kod/object/item/passitem/defmod/armor/leather.kod
+++ b/kod/object/item/passitem/defmod/armor/leather.kod
@@ -46,7 +46,7 @@ classvars:
    vrIcon_male = Leatherarmor_male_icon_rsc
    vrIcon_female = Leatherarmor_female_icon_rsc
 
-   viDefense_base = 50
+   viDefense_base = 200
    viDamage_base = 0
 
 properties:
@@ -60,7 +60,7 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_ALL,5]
+      return [ [ATCK_WEAP_ALL,10]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/armor/scale.kod
+++ b/kod/object/item/passitem/defmod/armor/scale.kod
@@ -58,7 +58,9 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_BLUDGEON,10]
+      return [ [ATCK_WEAP_THRUST,20],
+               [ATCK_WEAP_BLUDGEON,10],
+               [ATCK_WEAP_SLASH,10]
              ];
    }
 


### PR DESCRIPTION
After six months of live experience, the improvements to leather and
chain have gone over well. Players are adapting to chain armor's
resistance to arrows by wearing it or switching to mystic attacks, and
the new combat opportunities have been rather fun. Haven't heard
complaints either, which is a singular experience.

General idea running around now is that scale armor should be upgraded,
too, and the role remaining now is that of anti-mystic armor. Leather
also had a good concept (no direct armor, no spellpower penalty, but
instead added defense and a little resistance), it just wasn't strong
enough.

This pull upgrades Leather Armor to 200 defense, equal to the defense
penalty of plate, and ups its weapon resistance from 5% to 10%, reaching
roughly 1-2 damage reduction. The plan is for this to be a 'caster
armor' for those mage builds that take low agility but want to reach
maximum defense by using block, dodge, and princess faction.

To create a "melee armor", Scale Armor has been given 20% thrust
resistance and 10% slash resistance in addition to its previous 10%
bludgeon resistance. With its base armor of 4, it will have roughly 3-8
damage reduction against mystics, compared to plate armor's 2-6. The 10%
bludgeon and slash resistance make scale comparable to plate on those
fronts without being superior. Scale has no arrow resistance.

Meanwhile, Plate continues to be the best general armor answer for all
situations. Interestingly enough, chain and scale together weigh the
same as plate, so if skilled players want to carry both instead of plate
and switch mid combat as the strategies shift, they can eke out some
small benefits.
