### PR TITLE
Eliminate PE focus times

### DIFF
--- a/kod/object/passive/spell/anon.kod
+++ b/kod/object/passive/spell/anon.kod
@@ -42,7 +42,7 @@ classvars:
    viMana = 15
    viSpellExertion = 10      
    viChance_To_Increase = 40
-   viCast_time = 5000
+   viCast_time = 0
    
    viFlash = FLASH_GOOD_SELF
    vrSucceed_wav = anonymity_sound

--- a/kod/object/passive/spell/focus.kod
+++ b/kod/object/passive/spell/focus.kod
@@ -43,7 +43,7 @@ classvars:
    viSchool = SS_FAREN
    viSpell_level = 3
 
-   viCast_time = 7000            %% 7 seconds
+   viCast_time = 0
    viChance_To_Increase = 15
 
 properties:

--- a/kod/object/passive/spell/persench/Eagleyes.kod
+++ b/kod/object/passive/spell/persench/Eagleyes.kod
@@ -57,7 +57,7 @@ classvars:
    viMana = 5
    viSpellExertion = 10
 
-   viCast_time = 2000
+   viCast_time = 0
    viChance_To_Increase = 20
 
 properties:

--- a/kod/object/passive/spell/persench/cloak.kod
+++ b/kod/object/passive/spell/persench/cloak.kod
@@ -45,7 +45,7 @@ classvars:
    viSpell_level = 1
    viMana = 5
 
-   viCast_time = 2000
+   viCast_time = 0
    viChance_To_Increase = 20
    vrSucceed_wav = Cloak_sound
 

--- a/kod/object/passive/spell/persench/deflect.kod
+++ b/kod/object/passive/spell/persench/deflect.kod
@@ -64,7 +64,7 @@ classvars:
    vrSpell_intro = Deflect_spell_intro
 
    viMana = 20
-   viCast_time = 3000
+   viCast_time = 0
    viSpell_level = 4
    viSchool = SS_KRAANAN
 

--- a/kod/object/passive/spell/persench/denial.kod
+++ b/kod/object/passive/spell/persench/denial.kod
@@ -46,7 +46,7 @@ classvars:
    viMana = 15
 
    viSpellExertion = 5
-   viCast_time = 1000
+   viCast_time = 0
 
    vbCanCastOnOthers = FALSE
 

--- a/kod/object/passive/spell/persench/detevil.kod
+++ b/kod/object/passive/spell/persench/detevil.kod
@@ -49,7 +49,7 @@ classvars:
    viMana = 10
    viSpellExertion = 5
 
-   viCast_time = 3000
+   viCast_time = 0
    viChance_To_Increase = 15
 
    vrSpell_intro = DetectEvil_spell_intro

--- a/kod/object/passive/spell/persench/detgood.kod
+++ b/kod/object/passive/spell/persench/detgood.kod
@@ -49,7 +49,7 @@ classvars:
    viMana = 10
    viSpellExertion = 5
 
-   viCast_time = 3000
+   viCast_time = 0
    viChance_To_Increase = 15
 
    vrSpell_intro = DetectGood_spell_intro

--- a/kod/object/passive/spell/persench/detinvis.kod
+++ b/kod/object/passive/spell/persench/detinvis.kod
@@ -42,7 +42,7 @@ classvars:
    viMana = 15
    viSpellExertion = 5
 
-   viCast_time = 3000
+   viCast_time = 0
    viChance_To_Increase = 15
 
 

--- a/kod/object/passive/spell/persench/freeact.kod
+++ b/kod/object/passive/spell/persench/freeact.kod
@@ -61,7 +61,7 @@ classvars:
    viMana = 10
    viSpellExertion = 5
 
-   viCast_time = 2000
+   viCast_time = 0
    viChance_To_Increase = 15
 
 properties:

--- a/kod/object/passive/spell/persench/gaze.kod
+++ b/kod/object/passive/spell/persench/gaze.kod
@@ -39,7 +39,7 @@ classvars:
    viSpell_num = SID_GAZE_OF_THE_BASILISK
    viSchool = SS_QOR
    viMana = 15          
-   viCast_Time = 5000   
+   viCast_Time = 0
    viSpell_Exetion = 15
    viSpell_level = 6
 

--- a/kod/object/passive/spell/persench/haste.kod
+++ b/kod/object/passive/spell/persench/haste.kod
@@ -48,7 +48,7 @@ classvars:
    viMana = 10
    viSpellExertion = 0
 
-   viCast_time = 2000
+   viCast_time = 0
    viChance_To_Increase = 15
 
    vrSpell_intro = Haste_spell_intro

--- a/kod/object/passive/spell/persench/respois.kod
+++ b/kod/object/passive/spell/persench/respois.kod
@@ -47,7 +47,7 @@ classvars:
    viMana = 10
    viSpellExertion = 5
 
-   viCast_time = 2000
+   viCast_time = 0
    viChance_To_Increase = 15
    vrSucceed_wav = resistpoison_sound
 

--- a/kod/object/passive/spell/persench/shadform.kod
+++ b/kod/object/passive/spell/persench/shadform.kod
@@ -42,7 +42,7 @@ classvars:
    viSchool = SS_RIIJA
    viMana = 5
    viSpellExertion = 5
-   viCast_time = 3000
+   viCast_time = 0
 
    vrSucceed_wav = shadowform_wave_rsc
    viChance_To_Increase = 30


### PR DESCRIPTION
Focus time is a clunky and unpopular mechanic that doesn't do its job
well. This commit eliminates focus times on all PEs.

Any specific rebalancing is left to another pull request.
