### PR TITLE
Fix inconsistent security redbook fallback string

### DIFF
--- a/blakserv/game.c
+++ b/blakserv/game.c
@@ -774,7 +774,7 @@ void UpdateSecurityRedbook()
 char* GetSecurityRedbook()
 {
    if (!_redbookstring)
-      return "BLAKSTON: Unknown Redbook";
+      return "BLAKSTON: Greenwich Q Zjiria";
 
    return _redbookstring;
 }

--- a/clientd3d/server.c
+++ b/clientd3d/server.c
@@ -153,7 +153,7 @@ void UpdateSecurityRedbook(ID idRedbook)
 char* GetSecurityRedbook()
 {
    if (!_redbookstring)
-      return "BLAKSTON: Unknown Redbook";
+      return "BLAKSTON: Greenwich Q Zjiria";
 
    return _redbookstring;
 }


### PR DESCRIPTION
See GetSecurityRedbook() in game.c (server) and GetSecurityRedbook() in server.c (client)

This patch fixes a bug that makes your client-builds unusable as long as you don't set a proper string/resource ID to use for the security redbook thing in your server config. I actually don't know which server config value it is.

By default (unchanged blakserv build config) it is set to 0 (transmitted with each BP_ECHO_PING).
This value makes the client and server fall back to a static string, however it was not the same :(

As a result of this bug, your client crashes or shows strange behaviour if it was decoding more than 10 messages with this fallback-string. (Because the first 10 chars still match!)

This fixes this issue.
