### PR TITLE
Add support for client UI language override with meridian.ini

### DIFF
--- a/clientd3d/client.c
+++ b/clientd3d/client.c
@@ -284,7 +284,20 @@ int PASCAL WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpszCmdPa
 
 	// Find location of configuration file
 	ConfigInit();
+	LoadSettings();
 
+	// Check for language override
+	// en = 0
+	// de = 1
+	if (config.language == 0)
+	{
+		SetThreadUILanguage(MAKELANGID(LANG_ENGLISH, SUBLANG_DEFAULT));
+	}
+	else if (config.language == 1)
+	{
+		SetThreadUILanguage(MAKELANGID(LANG_GERMAN, SUBLANG_DEFAULT));
+	}
+	
 	/* Register our custom classes */
 	RegisterWindowClasses();
 

--- a/clientd3d/config.c
+++ b/clientd3d/config.c
@@ -75,6 +75,7 @@ static char INILagbox[]      = "LatencyMeter";
 static char INIHaloColor[]   = "HaloColor";
 static char INIColorCodes[]  = "ColorCodes";
 static char INIMapAnnotations[] = "MapAnnotations";
+static char INILanguage[] = "Language";
 
 static char window_section[] = "Window";         /* Section in INI file for window info */
 static char INILeft[]        = "NormalLeft";
@@ -239,6 +240,7 @@ void ConfigLoad(void)
    config.halocolor    = GetConfigInt(interface_section, INIHaloColor, 0, ini_file);
    config.colorcodes   = GetConfigInt(interface_section, INIColorCodes, True, ini_file);
    config.map_annotations = GetConfigInt(interface_section, INIMapAnnotations, True, ini_file);
+   config.language = GetConfigInt(interface_section, INILanguage, -1, ini_file);
 
    config.guest        = GetConfigInt(misc_section, INIGuest, False, ini_file);
    config.server_low   = GetConfigInt(misc_section, INIServerLow, 0, ini_file);

--- a/clientd3d/config.h
+++ b/clientd3d/config.h
@@ -117,6 +117,8 @@ typedef struct {
 
    int sound_volume;           // 0 - 100
    int music_volume;           // 0 - 100
+
+   int language;
 } Config;
 
 void ConfigInit(void);

--- a/clientd3d/winmsg.c
+++ b/clientd3d/winmsg.c
@@ -124,9 +124,10 @@ BOOL MainInit(HWND hwnd, LPCREATESTRUCT lpCreateStruct)
 	hPal = InitializePalette();
 	InitStandardXlats(hPal);
 	
-	LoadSettings();
-	MenuDisplaySettings(hwnd);
+	WrapInit();
 	
+	MenuDisplaySettings(hwnd);
+
 	// Load rich edit control DLL and common controls
 	hRichEditLib = LoadLibrary("riched32.dll");
 	InitCommonControls();
@@ -159,6 +160,8 @@ void MainQuit(HWND hwnd)
 	
 	DeleteObject(hPal);
 
+   WrapShutdown();
+	
 	HookClose();
 	
 	FreeLibrary(hRichEditLib);

--- a/clientd3d/winmsg.c
+++ b/clientd3d/winmsg.c
@@ -124,10 +124,8 @@ BOOL MainInit(HWND hwnd, LPCREATESTRUCT lpCreateStruct)
 	hPal = InitializePalette();
 	InitStandardXlats(hPal);
 	
-	WrapInit();
-	
 	MenuDisplaySettings(hwnd);
-
+	
 	// Load rich edit control DLL and common controls
 	hRichEditLib = LoadLibrary("riched32.dll");
 	InitCommonControls();

--- a/clientd3d/winmsg.c
+++ b/clientd3d/winmsg.c
@@ -160,8 +160,6 @@ void MainQuit(HWND hwnd)
 	
 	DeleteObject(hPal);
 
-   WrapShutdown();
-	
 	HookClose();
 	
 	FreeLibrary(hRichEditLib);


### PR DESCRIPTION
Falls back to Windows set language detection if no or unknown language is found in meridian.ini.

PLEASE TEST WITH WINDOWS XP, I AM NOT SURE IF THE FUNCTION I USED FOR SETTING THE UI LANGUAGE WORKS BELOW WINDOWS VISTA!

0 = english
1 = german

[Interface]
Language=0