### PR TITLE
Invigorate after HP.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -145,6 +145,7 @@ resources:
       "Feel free to take the %s%s by your feet as payment for returning the "
       "token."
    player_improve_maxhealth = "~I~BYou suddenly feel a little tougher."
+   player_improve_health_invigorate = "~I~BYou are invigorated by your success."
    player_spits = "You spit on the corpse of your unworthy foe."
    player_regain_angel = \
       "Due to your weakness, your protective guardian angel returns."
@@ -7702,6 +7703,10 @@ messages:
 
                Send(self,@MsgSendUser,#message_rsc=player_improve_maxhealth);
                Send(self,@WaveSendUser, #what=self, #wave_rsc=player_tougher_wav_rsc);
+               Send(self,@MsgSendUser,#message_rsc=player_improve_health_invigorate);
+               piHealth = piMax_Health;
+               Send(self,@DrawHealth);
+               Send(self,@EatSomething,#nutrition=200)
 
                piGain_chance = -(piBase_Max_health/2);
                


### PR DESCRIPTION
This is a change that went into 103, after an HP is basically fills vigor and sets HP's to their (new) max. It's based on the idea that building is a massive grind and it's a little pep-in-your-step to be rewarded with full vigor and max hp.


Mayhem requested I submit it to official servers.