### PR TITLE
unset DRAWFX_INVISIBLE (=OF_INVISIBLE) bits in playerlist

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -795,7 +795,7 @@ messages:
          AddPacket(1,BP_PLAYER_ADD);
          AddPacket(4,what,4,rName);
          AddPacket(STRING_RESOURCE,rName);
-         AddPacket(4,Send(what,@GetObjectFlags));
+         AddPacket(4,Send(what,@GetObjectFlags) & ~DRAWFX_INVISIBLE);
          SendPacket(poSession);
 
          if IsClass(self,&Admin) AND IsClass(what,&Admin)
@@ -2505,7 +2505,7 @@ messages:
          rName = Send(i,@GetTrueName);
 
          AddPacket(4,i, 4,rName, STRING_RESOURCE,rName);
-         AddPacket(4,Send(i,@GetObjectFlags));
+         AddPacket(4,Send(i,@GetObjectFlags) & ~DRAWFX_INVISIBLE);
       }
       
       SendPacket(poSession);


### PR DESCRIPTION
This is a server-side fix for the black color of playernames in the wholist, which was never intended to be part of the "highlight murderes and outlaws change". In fact these players are just invisible because it's a black font color on black background.

This fix simply unsets the bits in the object flags before sending the data to the client.
Those bits, which indicate the object is shadowformed or invisible (shadowformbits are subset of invis bits).
