### PR TITLE
Movement update from 103 plus piTimeAttackedPlayer fix.

### DIFF
--- a/blakcomp/function.c
+++ b/blakcomp/function.c
@@ -59,6 +59,7 @@ function_type Functions[] = {
 {"LoadRoom",            CREATEROOMDATA,  AEXPRESSION,   ANONE},
 {"GetClass",            GETCLASS,        AEXPRESSION,   ANONE},
 {"GetTime",             GETTIME,         ANONE},
+{"GetTickCount",	GETTICKCOUNT,	 ANONE},
 {"CanMoveInRoom",       CANMOVEINROOM,   AEXPRESSION,   AEXPRESSION,AEXPRESSION,
     AEXPRESSION,AEXPRESSION,ANONE},
 {"CanMoveInRoomFine",CANMOVEINROOMFINE,AEXPRESSION,AEXPRESSION,AEXPRESSION,

--- a/blakdeco/blakdeco.c
+++ b/blakdeco/blakdeco.c
@@ -594,6 +594,7 @@ char * name_function(int fnum)
    case DELLISTELEM : return "DelListElem";
 
    case GETTIME : return "GetTime";
+   case GETTICKCOUNT : return "GetTickCount";
 
    case RANDOM  : return "Random";
    default : sprintf(s,"Unknown function %i",fnum); return s;

--- a/blakserv/adminfn.c
+++ b/blakserv/adminfn.c
@@ -2089,6 +2089,7 @@ void AdminShowCalls(int session_id,admin_parm_type parms[],
 		case DELLISTELEM : strcpy(c_name, "DelListElem"); break;
 		case FINDLISTELEM : strcpy(c_name, "FindListElem"); break;
 		case GETTIME : strcpy(c_name, "GetTime"); break;
+		case GETTICKCOUNT : strcpy(c_name, "GetTickCount"); break;
 		case ABS : strcpy(c_name, "Abs"); break;
 		case BOUND : strcpy(c_name, "Bound"); break;
 		case SQRT : strcpy(c_name, "Sqrt"); break;

--- a/blakserv/ccode.c
+++ b/blakserv/ccode.c
@@ -1907,6 +1907,27 @@ int C_GetTime(int object_id,local_var_type *local_vars,
 	return ret_val.int_val;
 }
 
+int C_GetTickCount(int object_id,local_var_type *local_vars,
+                   int num_normal_parms,parm_node normal_parm_array[],
+                   int num_name_parms,parm_node name_parm_array[])
+{
+    val_type ret_val;
+
+    ret_val.v.tag = TAG_INT;
+
+    /* We must subtract a number from the system time due to size
+       limitations within the blakod. Blakod uses 32 bit values,
+       -4 bits for type and -1 bit for sign. This leaves us with
+       27 bits for value, This only allows us to have 134M or so
+       as a positive value. Current system time is a bit larger
+       than that. So, we subtract off time to compensate.
+    */
+
+    ret_val.v.data = GetTickCount(); // W32API 10ms-16ms precision call
+
+    return ret_val.int_val;
+}
+
 int C_Random(int object_id,local_var_type *local_vars,
 			 int num_normal_parms,parm_node normal_parm_array[],
 			 int num_name_parms,parm_node name_parm_array[])

--- a/blakserv/ccode.h
+++ b/blakserv/ccode.h
@@ -189,6 +189,10 @@ int C_GetTime(int object_id,local_var_type *local_vars,
 	      int num_normal_parms,parm_node normal_parm_array[],
 	      int num_name_parms,parm_node name_parm_array[]);
 
+int C_GetTickCount(int object_id,local_var_type *local_vars,
+          int num_normal_parms,parm_node normal_parm_array[],
+          int num_name_parms,parm_node name_parm_array[]);
+		  
 int C_Random(int object_id,local_var_type *local_vars,
 	     int num_normal_parms,parm_node normal_parm_array[],
 	     int num_name_parms,parm_node name_parm_array[]);

--- a/blakserv/sendmsg.c
+++ b/blakserv/sendmsg.c
@@ -156,6 +156,7 @@ void InitBkodInterpret(void)
 	ccall_table[FINDLISTELEM] = C_FindListElem;
 	
 	ccall_table[GETTIME] = C_GetTime;
+	ccall_table[GETTICKCOUNT] = C_GetTickCount;
 	
 	ccall_table[CREATETABLE] = C_CreateTable;
 	ccall_table[ADDTABLEENTRY] = C_AddTableEntry;

--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -49,7 +49,7 @@ typedef unsigned char Bool;
 enum {False = 0, True = 1};
 
 #define MAJOR_REV 7   /* Major version of client program */
-#define MINOR_REV 16  /* Minor version of client program; must be in [0, 99] */
+#define MINOR_REV 17  /* Minor version of client program; must be in [0, 99] */
 
 #define MAXAMOUNT 9     /* Max # of digits in a server integer */
 #define MAXSTRINGLEN 255 /* Max length of a string loaded from string table */

--- a/clientd3d/move.c
+++ b/clientd3d/move.c
@@ -54,15 +54,13 @@
 
 #define MAX_STEP_HEIGHT (HeightKodToClient(24)) // Max vertical step size (FINENESS units)
 
-#define MOVE_INTERVAL  1000            // Inform server at most once per this many milliseconds
+#define MOVE_INTERVAL  250            // Inform server once per this many milliseconds
 #define MOVE_THRESHOLD (FINENESS / 4)  // Inform server only of moves at least this large
-#define MOVE_THRESHOLD2 (MOVE_THRESHOLD * MOVE_THRESHOLD)
-#define TIME_THRESHOLD 1000
 
-#define MIN_NOMOVEON (FINENESS / 4)      // Closest we can get to a nomoveon object
+#define MIN_NOMOVEON (FINENESS / 4)   // Closest we can get to a nomoveon object
 #define MIN_HOTPLATE_DIST (FINENESS ) // Closest we can get to a hotplate before notification
 
-#define TELEPORT_DELAY 5000              // # of milliseconds to wait for server to teleport us
+#define TELEPORT_DELAY 5000           // # of milliseconds to wait for server to teleport us
 
 #define MIN_SIDE_MOVE (MOVEUNITS / 4)
 
@@ -676,7 +674,7 @@ int MoveObjectAllowed(room_type *room, int old_x, int old_y, int *new_x, int *ne
                //if (last_move_action == A_FORWARDFAST || last_move_action == A_BACKWARDFAST)
                if (IsMoveFastAction(last_move_action))
                   speed *= 2;
-               RequestMove(*new_y, *new_x, speed, player.room_id);
+               MoveUpdateServer();
                moveReported = TRUE;
                idLastObjNotify = idObjNotify;
             }
@@ -820,9 +818,9 @@ void MoveUpdateServer(void)
 }
 /************************************************************************/
 /*
- * MoveUpdatePosition:  Update the server's knowledge of our position, if the user
- *   has moved a sufficient distance.  This procudure doesn't check if we've sent our
- *   position to the server recently.
+ * MoveUpdatePosition:  Update the server's knowledge of our position.
+ * This procudure does not care about elapsed interval, but  
+ * sends the update only when the position has changed at least a bit.
  */ 
 void MoveUpdatePosition(void)
 {
@@ -832,16 +830,23 @@ void MoveUpdatePosition(void)
    x = player.x;
    y = player.y;
 
+   // don't send update if we didn't move
    if ((server_x - x) * (server_x - x) + (server_y - y) * (server_y - y) > MOVE_THRESHOLD)
    {
+      // debug output
       debug(("MoveUpdatePosition: x (%d -> %d), y (%d -> %d)\n", server_x, x, server_y, y));
-//      speed = 10;
-	  speed = 18;
-//      if (last_move_action == A_FORWARDFAST || last_move_action == A_BACKWARDFAST)
-	  if (IsMoveFastAction(last_move_action))
-	 speed *= 2;
+   
+      // base walkspeed
+      speed = 18;
+   
+      // doubled on run
+      if (IsMoveFastAction(last_move_action))
+      speed *= 2;
 
+      // send update
       RequestMove(y, x, speed, player.room_id);
+   
+      // save last sent position and tick
       server_x = x;
       server_y = y;
       server_time = timeGetTime();

--- a/include/bkod.h
+++ b/include/bkod.h
@@ -160,6 +160,7 @@ enum
    FINDLISTELEM = 111,
 
    GETTIME = 120,
+   GETTICKCOUNT = 121,
 
    ABS = 131,
    BOUND = 132,

--- a/kod/object/active/holder/nomoveon/battler/monster/BRAMBLE.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/BRAMBLE.kod
@@ -323,15 +323,6 @@ messages:
 
       if iDistanceSquared <= (iLongRange * iLongRange)
       {
-         if IsClass(what,&User)
-         {
-            % This resets the move counter, since we had additional (legal) 
-            %  moves request from this object.
-            % We have to reset the moves counter, because it seems wall elements
-            %  generate more requests than they handle.
-            Send(what,@AdjustMoveCounter,#bReset=TRUE);
-         }
-
          if (iLongRange = piRange
              OR iDistanceSquared <= (piRange * piRange))
             AND Send(poOwner,@LineOfSight,#obj1=self,#obj2=what)

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -12270,7 +12270,8 @@ messages:
    {
       return Send(self,@IsUsingA,#class=&NecromancerAmulet);
    }
-
+   
+   % This fixes timer discrepancies caused by timer offset issue in ccode.c
    UpdateTimeValues()
    "Sets all time variables to the current time.  Useful for when changing "
    "server time."
@@ -12291,6 +12292,7 @@ messages:
       piGuildRejoinTimestamp = time;
       piLast_restart_time = time;
       piTimeLastStomachUpdate = time;
+      piTimeAttackedPlayer = time;
 
       return;
    }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -47,18 +47,11 @@ constants:
    USER_RUNNING_SPEED = 36
 
    % How many packets incoming per second do we allow?
-   INCOMING_PACKET_THROTTLE = 5
+   INCOMING_PACKET_THROTTLE = 20
 
    % What's the lower threshold for being able to run?  Below this, we can't
    %  run.
    VIGOR_RUN_THRESHOLD = 10
-
-   % What's the greatest time between moves that we'll consider to be "lag"
-   %  (in seconds).
-   MOVEMENT_DELTA_LAG_THRESHOLD = 5
-
-   % If piMovesCount goes over this, we have a suspected speedhacker.
-   MOVEMENT_COUNT_THRESHOLD = 2
 
    % Speedhack/cheating detection:
    % What's the maximum number of times we should log a violation?
@@ -341,13 +334,16 @@ properties:
    piLastPacketTime = 0
    piPacketsPerSecond = 0
 
+   % The ms tick we received last position update from user
    piLastMoveUpdateTime = 0
-   piMovesCounter = 0
-   piNumberOfMovesPerSecond = 0
-   piMoveOldRow = 0
-   piMoveOldCol = 0
-   piMoveOldRoom = RID_TOS
+   
+   % The ms tick we last drained vigor
+   piLastVigorDrainTime = 0
 
+   % Count the move requests we received in same tick
+   % mostly due to buffered up TCP segments.
+   piMovesInTick = 0
+ 
    piCheaterLogs = 0
 
 messages:
@@ -858,13 +854,11 @@ messages:
       local liClient_cmd, oWhat, oWhere, oRoom, iRow, iCol, iSay_type,
             sStr_said, sStr_mailed, lDest_mail, iAttack_type, iGroup, lItems,
             lUsers, oApply_on, iNid, sTitle, iAngle, sBody, iNum, iSpeed,
-            lTargets, bSpam;
-
-      bSpam = FALSE;
+            lTargets;
 
       % This checks to see if the user is trying to Send too many packets
       %  per second.  If they are, then we mark them as a spammer and
-      %  disallow certain commands.
+      %  don't process the message.
       if piLastPacketTime <> GetTime()
       {
          piLastPacketTime = GetTime();
@@ -876,14 +870,15 @@ messages:
          if piPacketsPerSecond > INCOMING_PACKET_THROTTLE
             AND NOT Send(self,@PlayerIsImmortal)
          {
-            bSpam = TRUE;
+            % Don't go on if marked as spammer
+            return;
          }
       }
 
       if type = 1
       {
          Send(self,@UserCommand,#client_msg=client_msg,
-              #number_stuff=number_stuff,#bSpam=bSpam);
+              #number_stuff=number_stuff);
 
          return;
       }
@@ -899,10 +894,6 @@ messages:
          iCol = Nth(client_msg,3);
          iSpeed = Nth(client_msg,4);
          oRoom = Nth(client_msg,5);
-
-         % XORed with some magic numbers to throw off teleport hacks.
-         %iRow = Send(SYS,@BitWiseXOR,#value=iRow,#value2=12692257);
-         %iCol = Send(SYS,@BitWiseXOR,#value=iCol,#value2=11627532);
 
          % Check if it's an outdated message, from a person going off side of
          %  room multiple times before they got their new room.
@@ -973,11 +964,6 @@ messages:
       
       if liClient_cmd = BP_REQ_DROP
       {
-         if bSpam AND NOT Send(self,@PlayerIsImmortal)
-         {
-            return;
-         }
-
          oWhat = Nth(client_msg,2);
          Send(self,@UserDrop,#what=oWhat,#number=number_stuff);
          
@@ -995,11 +981,6 @@ messages:
       
       if liClient_cmd = BP_SEND_OBJECT_CONTENTS
       {
-         if bSpam
-         {
-            return;
-         }
-
          oWhat = Nth(client_msg,2);
          Send(self,@UserObjectContents,#what=oWhat);
          
@@ -1026,11 +1007,6 @@ messages:
       
       if liClient_cmd = BP_REQ_LOOK
       {
-         if bSpam
-         {
-            return;
-         }
-
          oWhat = Nth(client_msg,2);
          Send(self,@UserLook,#what=oWhat);
          
@@ -1062,11 +1038,6 @@ messages:
       
       if liClient_cmd = BP_REQ_USE
       {
-         if bSpam
-         {
-            return;
-         }
-
          oWhat = Nth(client_msg,2);     
          Send(self,@UserUseItem,#what=oWhat);
          
@@ -1075,11 +1046,6 @@ messages:
       
       if liClient_cmd = BP_REQ_UNUSE
       {
-         if bSpam
-         {
-            return;
-         }
-
          oWhat = Nth(client_msg,2);
          Send(self,@UserUnuseItem,#what=oWhat);
 
@@ -1088,11 +1054,6 @@ messages:
       
       if liClient_cmd = BP_REQ_ATTACK
       {
-         if bSpam
-         {
-            return;
-         }
-
          iAttack_type = Nth(client_msg,2);
          oWhat = Nth(client_msg,3);
          Send(self,@UserAttack,#type=iAttack_type,#what=oWhat);
@@ -1110,11 +1071,6 @@ messages:
       
       if liClient_cmd = BP_REQ_OFFER
       {
-         if bSpam
-         {
-            return;
-         }
-
          oWhat = Nth(client_msg,2);
          lItems = Nth(client_msg,3);
          Send(self,@UserOffer,#what=oWhat,#item_list=lItems,
@@ -1148,14 +1104,6 @@ messages:
       
       if liClient_cmd = BP_REQ_GO
       {
-         % This also Sends a movement packet.  Decrement our move counter.
-         Send(self,@AdjustMoveCounter);
-      
-         if bSpam
-         {
-            return;
-         }
-
          Send(self,@UserGo);
          
          return;
@@ -1207,11 +1155,6 @@ messages:
       
       if liClient_cmd = BP_REQ_APPLY
       {
-         if bSpam
-         {
-            return;
-         }
-
          oWhat = Nth(client_msg,2);
          oApply_on = Nth(client_msg,3);
          Send(self,@UserApply,#what=oWhat,#apply_on=oApply_on);
@@ -1235,11 +1178,6 @@ messages:
       
       if liClient_cmd = BP_REQ_CAST
       {
-         if bSpam
-         {
-            return;
-         }
-
          oWhat = Nth(client_msg,2);  % Spell type
          lTargets = Nth(client_msg,3); % Targets of spell (if any)
          Send(self,@UserCast,#oSpell=oWhat,#lTargets=lTargets);
@@ -1276,11 +1214,6 @@ messages:
       
       if liClient_cmd = BP_ACTION
       {
-         if bSpam
-         {
-            return;
-         }
-
          iNum = Nth(client_msg, 2);
          Send(self,@UserAction,#action=iNum);
          
@@ -1312,11 +1245,6 @@ messages:
       
       if liClient_cmd = BP_CHANGE_DESCRIPTION
       {
-         if bSpam
-         {
-            return;
-         }
-
          % oWhat = who's editing.
          oWhat = Nth(client_msg,2);
          sBody = Nth(client_msg,3);
@@ -1356,11 +1284,6 @@ messages:
       
       if liClient_cmd = BP_REQ_ACTIVATE
       {
-         if bSpam
-         {
-            return;
-         }
-
          oWhat = Nth(client_msg,2);
          Send(self,@UserTryActivate,#what=oWhat);
          
@@ -1381,13 +1304,10 @@ messages:
          
          return;
       }
-
-      if NOT bSpam
-      {
-         Debug(Send(self,@GetTrueName),self,"sent unknown command from client",
-               liClient_cmd);
-      }
-      
+	  
+      Debug(Send(self,@GetTrueName),self,"sent unknown command from client",
+            liClient_cmd);    
+			
       return;
    }
 
@@ -1447,7 +1367,7 @@ messages:
       return Send(SYS,@GetSuccessRsc);
    }
 
-   UserCommand(client_msg=$, number_stuff=$, bSpam=FALSE)
+   UserCommand(client_msg=$, number_stuff=$)
    {
       local iClient_cmd, i, oMoney, cost, oGuild, oWhat;
 
@@ -1457,11 +1377,6 @@ messages:
 
       if iClient_cmd = UC_REST
       {
-         if bSpam
-         {
-            return;
-         }
-
          Send(self,@StartResting);
          
          return;
@@ -1469,11 +1384,6 @@ messages:
       
       if iClient_cmd = UC_STAND
       {
-         if bSpam
-         {
-            return;
-         }
-
          Send(self,@StopResting);
          
          return;
@@ -1553,11 +1463,6 @@ messages:
 
       if iClient_cmd = UC_REQ_GUILDINFO
       {
-         if bSpam
-         {
-            return;
-         }
-
          Send(self,@UserGuildSendInfo);
          
          return;
@@ -1565,11 +1470,6 @@ messages:
 
       if iClient_cmd = UC_INVITE
       {
-         if bSpam
-         {
-            return;
-         }
-
          Send(self,@UserGuildCommand,#command_num=GCID_INVITE,
               #oTarget=Nth(client_msg,2));
          
@@ -1601,11 +1501,6 @@ messages:
 
       if iClient_cmd = UC_VOTE
       {
-         if bSpam
-         {
-            return;
-         }
-
          Send(self,@UserGuildCommand,#command_num=GCID_VOTE,
               #oTarget=Nth(client_msg,2));
          
@@ -1702,11 +1597,6 @@ messages:
 
       if iClient_cmd = UC_MAKE_ALLIANCE
       {
-         if bSpam
-         {
-            return;
-         }
-
          Send(self,@UserGuildCommand,#command_num=GCID_FORGE_ALLIANCE,
               #oTarget=Nth(client_msg,2));
               
@@ -1715,11 +1605,6 @@ messages:
 
       if iClient_cmd = UC_END_ALLIANCE
       {
-         if bSpam
-         {
-            return;
-         }
-
          Send(self,@UserGuildCommand,#command_num=GCID_END_ALLIANCE,
               #oTarget=Nth(client_msg,2));
               
@@ -1728,11 +1613,6 @@ messages:
 
       if iClient_cmd = UC_MAKE_ENEMY
       {
-         if bSpam
-         {
-            return;
-         }
-
          Send(self,@UserGuildCommand,#command_num=GCID_DECLARE_ENEMY,
               #oTarget=Nth(client_msg,2));
               
@@ -1741,11 +1621,6 @@ messages:
 
       if iClient_cmd = UC_END_ENEMY
       {
-         if bSpam
-         {
-            return;
-         }
-
          Send(self,@UserGuildCommand,#command_num=GCID_PEACE,
               #oTarget=Nth(client_msg,2));
               
@@ -1841,11 +1716,6 @@ messages:
 
       if iClient_cmd = UC_CHANGE_URL
       {
-         if bSpam
-         {
-            return;
-         }
-
          oWhat = Nth(client_msg,2);
 
          if oWhat <> self
@@ -1902,11 +1772,6 @@ messages:
 
       if iClient_cmd = UC_APPEAL
       {
-         if bSpam
-         {
-            return;
-         }
-
          Send(self,@UserAppeal,#string=Nth(client_msg,2));
          
          return;
@@ -2213,8 +2078,7 @@ messages:
       Send(self,@LoadMailNews);
 
       % Count right now as the last time we moved.
-      piLastMoveUpdateTime = GetTime();
-      piMovesCounter = 0;
+      piLastMoveUpdateTime = GetTickCount();
 
       propagate;
    }
@@ -2859,126 +2723,208 @@ messages:
 
       return;
    }
-
-   AdjustMoveCounter(amount=-1, bReset=FALSE)
+   
+   GetMoveStepTolerance()
    {
-      if bReset
-      {
-         % Set it to max negative because wall spells don't properly remove
-         %  moves.
-         piMovesCounter = -MOVEMENT_DELTA_LAG_THRESHOLD;
-      }
-      
-      piMovesCounter = Bound((piMovesCounter + amount),
-                             -MOVEMENT_DELTA_LAG_THRESHOLD,$);
+      % Explanation:
+      % This tolerance is added to the maximum allowed stepsize
+      % TODO: measure and estimate RTT and adjust dynamically
 
-      return;
+      return Send(Send(SYS, @GetSettings), @GetMoveStepTolerance);
    }
+   
+   GetMoveAmountTolerance()
+   {
+      % Explanation:
+      % This is the amount of move requests that are allowed
+      % when processing several ones in one tick.
+      % This is required because of TCP retransmits,
+      % which can cause this to happen.
+      % But this is also exploitable by a speedhacker!
 
+      % Example:
+      % At an update interval of 250ms you probably want to
+      % keep this in between 2 and 12.
+      % At 8 the server will still accept a buffered-up movement
+      % processed at once, but legally created in steps within a 2s "lagspike".
+
+      % TODO: use estimated RTT to adjust dynamically.
+
+      return Send(Send(SYS, @GetSettings), @GetMoveMaxSimulReq);
+   }
+   
    UserMove(new_row = 1, new_col = 1,
             fine_row = FINENESS/2, fine_col = FINENESS/2, speed = 0)
    {
-      local iCurrentTime, iDelta, bFirstMove, iExertion, iHasteLevel,
-            iSquaredDistance, iNewRow, iNewCol, iNewRoom, iChanceTurn, iAngle;
+      local iCurrentTime, iDelta, iDeltaVigor, iExertion, iHasteLevel,
+      iChanceTurn, iAngle, iRow, iCol, iFineRow, iFineCol,
+      iDx, iDy, iMoveLength, iMaxMoveRun;
+    
+      % 1. Get current position values
+      iRow = Send(self,@GetRow);
+      iCol = Send(self,@GetCol);
+      iFineRow = Send(self,@GetFineRow);
+      iFineCol = Send(self,@GetFineCol);
+      iAngle = Send(self,@GetAngle);
 
-      % NEW Speedhack detection!
-      % How this works:
-      %   Speedhack works by sending a LOT of little moves very, very quickly.
-      %   Normal players only send 1 movement packet per second, but 
-      %   speedhackers send more.  Even at low levels, speedhackers will send
-      %   more packets per second.  So, we keep track of the number of packets
-      %   sent and the number of seconds that happen.  Every movement packet
-      %   sent increases our piMovesCounter by one.  Every second that passes
-      %   decreases it by one.  (In actuality, we subtact the time difference
-      %   from when movement packets were sent.)  We have to average this over
-      %   time, because lag can cause packets to be delayed and all show up in
-      %   one second.
-      %
-      %   We currently allow for players to have up to 3 more moves than 
-      %   allowed over the duration due to rounding errors, etc.
-
-      % Check the delta since the last time we moved.  Keep an upper bound on
-      %  the delta, since people could just be moving from rest.
-      iCurrentTime = GetTime();
-      iDelta = iCurrentTime - piLastMoveUpdateTime;
-
-      %  Make sure this person is not lagging; increment our counter since we
-      %  got a move packet, then adjust for last movement time.
-      %  Also make sure we don't go too far negative.
-      piMovesCounter = (piMovesCounter + 1) - iDelta;
-      piMovesCounter = bound(piMovesCounter,-MOVEMENT_DELTA_LAG_THRESHOLD,$);
-
-      % Check for cheating by sending more move packets than allowed.
-      % Don't log too many cheat detections, because it'll fill up our logs.
-      if piMovesCounter > MOVEMENT_COUNT_THRESHOLD
-         AND piCheaterLogs < MAX_LOGGED_THRESHOLD
+      % 2. Do not allow any moves if player is marked as not allowed to move
+      if Send(self,@CheckPlayerflag,#flag=PFLAG_NO_MOVE)
       {
-         piCheaterLogs = piCheaterLogs + 1;
-         Debug("ALERT!",Send(self,@GetTrueName),self," is moving too fast.  "
-               "Has moves count of ",piMovesCounter," Possible speedhacker.");
-         piMovesCounter = 0;
+         % reset position
+         Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
+              #new_row=iRow,
+              #new_col=iCol,
+              #fine_row=iFineRow,
+              #fine_col=iFineCol,
+              #new_angle=iAngle);
+
+         return;
       }
 
-      if speed > USER_WALKING_SPEED
+      % 3.1 Get current tick (ms resolution)
+      iCurrentTime = GetTickCount();
+      
+      % 3.2 Get time-deltas
+      iDelta = iCurrentTime - piLastMoveUpdateTime;
+      iDeltaVigor = iCurrentTime - piLastVigorDrainTime;
+
+      % 3.3 Bound time-deltas
+      % Prevents long teleports after stops and negative numbers
+      iDelta = bound(iDelta,0,Send(Send(SYS, @GetSettings), @GetMoveMaxLag));
+      iDeltaVigor = bound(iDeltaVigor,0,3000);
+
+      % 3.4 TCP workaround
+      % iDelta can be 0 (~16 within ms resolution for +- 1 tick) in case
+      % we're processing buffered up TCP segments with several requests at once.
+      % This can either happen because of IP packetloss and retransmits (legal)
+      % or because someone is sending multiple positions at once by purpose (illegal).
+      % So we must allow up to a certain amount of such buffered up requests,
+      % but limit it so no one can exploit it too much.
+      if iDelta <= 16
       {
+         % if within the limits of allowed multiple requests
+         if piMovesInTick < Send(self,@GetMoveAmountTolerance)
+         {
+            % fallback to default dt expected from client
+            iDelta = Send(Send(SYS, @GetSettings), @GetMoveDefaultInterval);
+
+            piMovesInTick = piMovesInTick + 1;
+         }
+         else
+         {
+            % this is too many buffered up requests
+            % reset position for this and any following in this tick
+            Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
+                 #new_row=iRow,
+                 #new_col=iCol,
+                 #fine_row=iFineRow,
+                 #fine_col=iFineCol,
+                 #new_angle=iAngle);
+
+            % make a logentry
+            if piCheaterLogs < MAX_LOGGED_THRESHOLD
+            {
+               piCheaterLogs = piCheaterLogs + 1;
+               Debug("ALERT!",Send(self,@GetTrueName),self,"exceeded multiple reqmove limit");
+            }
+
+            return;
+         }
+      }
+      else
+      {
+         % reset moves in tick counter
+         piMovesInTick = 1;
+      }
+
+      % 4.1 Get move-deltas
+      iDy = ((new_row * FINENESS) + fine_row) - ((iRow * FINENESS) + iFineRow);
+      iDx = ((new_col * FINENESS) + fine_col) - ((iCol * FINENESS) + iFineCol);
+
+      % 4.2 Get move-vector length.
+      % This is the squared move-vector length
+      iMoveLength = (iDy * iDy) + (iDx * iDx);
+
+      % 4.3 Calculate maximum allowed
+      % squared movesize for running in this dt
+      iMaxMoveRun = ((8 * USER_RUNNING_SPEED * iDelta) / 1000) + Send(self,@GetMoveStepTolerance);
+      iMaxMoveRun = (iMaxMoveRun * iMaxMoveRun);
+
+      % DEBUG output
+      %Debug(
+      % "iDelta:",iDelta,
+      % "iMaxMoveRun:",iMaxMoveRun,
+      % "iMoveLength:",iMoveLength,
+      % "iRow:",iRow,
+      % "iCol:",iCol,
+      % "iFineRow:",iFineRow,
+      % "iFineCol:",iFineCol,
+      % "new_row:",new_row,
+      % "new_col:",new_col,
+      % "fine_row:",fine_row,
+      % "fine_col:",fine_col);
+
+      % 5.1 This move is bigger than running allows (speedhack).
+      if (iMoveLength > iMaxMoveRun)
+      {
+         % reset position
+         Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
+              #new_row=iRow,
+              #new_col=iCol,
+              #fine_row=iFineRow,
+              #fine_col=iFineCol,
+              #new_angle=iAngle);
+
+         % make a logentry
+         if piCheaterLogs < MAX_LOGGED_THRESHOLD
+         {
+            piCheaterLogs = piCheaterLogs + 1;
+            Debug("ALERT!",Send(self,@GetTrueName),self,"was moving too fast");
+         }
+
+         return;
+      }
+
+      % 5.2 This move is bigger than walking allows.
+      % Right now: Still use the transmitted speed
+      if (speed > USER_WALKING_SPEED)
+      {
+         % disallow run with low vigor
          if Send(self,@GetVigor) < VIGOR_RUN_THRESHOLD
          {
-            % This person is cheating!  Stop them from moving, make a log note.
-            Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
-                 #new_row=Send(self,@GetRow),#new_col=Send(self,@GetCol),
-                 #fine_row=Send(self,@GetFineRow),
-                 #fine_col=Send(self,@GetFineCol),
-                 #new_angle=Send(self,@GetAngle));
+            % reset position
+			Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
+                   #new_row=iRow,
+                   #new_col=iCol,
+                   #fine_row=iFineRow,
+                   #fine_col=iFineCol,
+                   #new_angle=iAngle);   
 
+            % make a logentry			  
             if piCheaterLogs < MAX_LOGGED_THRESHOLD
             {
                piCheaterLogs = piCheaterLogs + 1;
                Debug("ALERT!",Send(self,@GetTrueName),self,"was running with "
                      "no vigor.");
             }
-         }
-
+            return;
+		 }
+         
+         % break trance
          if (piFlags & PFLAG_TRANCE)
          { 
             Send(self,@BreakTrance,#event=EVENT_RUN); 
          }
 
+         % stop dance
          if Send(self,@CheckPlayerFlag,#flag=PFLAG2_DANCING,#flagset=2)
          { 
             Send(self,@StopDancing);
          }
       }
 
-      if Send(self,@CheckPlayerflag,#flag=PFLAG_NO_MOVE)
-      {
-         Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
-              #new_row=Send(self,@GetRow),#new_col=Send(self,@GetCol),
-              #fine_row=Send(self,@GetFineRow),
-              #fine_col=Send(self,@GetFineCol),
-              #new_angle=Send(self,@GetAngle));
-
-         return;
-      }
-
-      % Code to annoy would be map memorizers and see-through-blinders.
-      if Send(self,@IsEnchanted,#byClass=&Blind)
-      {
-         iAngle = Send(self,@GetAngle);
-         iAngle = iAngle + Random(-256,256);
-         iChanceTurn = Random(1,100);
-
-         iAngle = iAngle mod MAX_ANGLE;
-
-         if iChanceTurn < 30
-         {
-            Send(poOwner,@SomethingTurned,#what=self,#new_angle=iAngle);
-         }
-      }
-
-      % Only drain vigor once per second, unless the moves counter indicates
-      %  we could be speedhacking.
-      if piLastMoveUpdateTime <> iCurrentTime
-         AND piMovesCounter < 0
+      %8. Drain vigor once per 1000ms
+      if iDeltaVigor >= 1000
       {
          % Reduce speed value to old value, 5/6ths current value, then
          %  square it.
@@ -2995,78 +2941,34 @@ messages:
          }
 
          Send(self,@AddExertion,#amount=iExertion);
+         
+         % save vigor drain tick
+         piLastVigorDrainTime = iCurrentTime;
       }
 
-      % Teleport detection!
-      % How this works:
-      %  We detect distances travelled.  If the distance seems too great and
-      %  the move counter delta isn't very high, then perhaps they are
-      %  teleporting.
-      if piCheaterLogs < MAX_LOGGED_THRESHOLD
-         AND NOT IsClass(self,&DM)
-      {
-         if piLastMoveUpdateTime = iCurrentTime
-         {
-            % Uh oh.  They've sent us more than one move per second.  Keep
-            %  track of 'em.
-            piNumberOfMovesPerSecond = piNumberOfMovesPerSecond + 1;
-         }
-         else
-         {
-            % Okay, first see if we the person violated our movement
-            %  limitations.
-            iNewRow = Send(self,@GetRow);
-            iNewCol = Send(self,@GetCol);
-            iNewRoom = Send(poOwner,@GetRoomNum);
-            iSquaredDistance = ((piMoveOldRow - iNewRow)
-                                 * (piMoveOldRow - iNewRow))
-                               + ((piMoveOldCol - iNewCol)
-                                 * (piMoveOldCol - iNewCol));
-
-            % See if they moved farther than they should have
-            % Only check if we're in the same room, and aren't in the blink
-            %  spot, (IE, just finished blinking).
-            if iNewRoom = piMoveOldRoom
-               AND (iNewRow <> Send(poOwner,@GetTeleportRow)
-                    AND iNewCol <> Send(poOwner,@GetTeleportCol))
-            {
-               % This is a large movement distance with a very low movement
-               %  delta, possibly cheat teleporting.
-               if iSquaredDistance >= 200
-                  AND iDelta < 3
-               {
-                  Debug("ALERT! ",Send(self,@GetTrueName),self," moved ",
-                        iSquaredDistance," with only ",iDelta," seconds since "
-                        "last movement update.");
-                  debug("Additional: ",Send(self,@GetTrueName)," went from (",
-                        piMoveOldRow,piMoveOldCol,") to (",iNewRow,iNewCol,
-                        ") in RID ",iNewRoom," Possible speedhacker.");
-                  piCheaterLogs = piCheaterLogs + 1;
-
-                  % A little extra penalty: Drain some vigor as we normally
-                  %  would.
-                  Send(self,@AddExertion,
-                       #amount=iSquaredDistance*EXERTION_PER_MOVE);
-               }
-            }
-
-            % Now, initialize values
-            piNumberOfMovesPerSecond = 1;
-            piMoveOldRow = Send(self,@GetRow);
-            piMoveOldCol = Send(self,@GetCol);
-            piMoveOldRoom = Send(poOwner,@GetRoomNum);
-         }
-      }
-
-      % Update this value for both speedhack detection AND movement detection.
-      piLastMoveUpdateTime = GetTime();
-
-      % bitflag check instead of function for speed.
+      % 9. Notify monsters about presence (bitflag check instead of function)
       if NOT (piFlags & PFLAG_MOVED_SINCE_ENTRY)
       {
          Send(self,@NotifyMonstersOfPresence);
       }
 
+      % 10. Mess-up orientation of blinded players.
+      if Send(self,@IsEnchanted,#byClass=&Blind)
+      {
+         iAngle = iAngle + Random(-256,256);
+         iChanceTurn = Random(1,100);
+         iAngle = iAngle mod MAX_ANGLE;
+
+         if iChanceTurn < 30
+         {
+            Send(poOwner,@SomethingTurned,#what=self,#new_angle=iAngle);
+         }
+      }	  
+      
+      % 11. Save this move tick for next execution
+      piLastMoveUpdateTime = iCurrentTime;
+   
+      % 12. Process the move
       Send(poOwner,@SomethingMoved,#what=self,
            #new_row=new_row,#new_col=new_col,
            #fine_row=fine_row,#fine_col=fine_col,
@@ -5944,8 +5846,7 @@ messages:
       Send(self,@CancelIfOffer);
 
       % Count right now as the last time we moved.
-      piLastMoveUpdateTime = GetTime();
-      piMovesCounter = 0;
+      piLastMoveUpdateTime = GetTickCount();
       
       % This is here because it has to be done before poOwner is changed.
 
@@ -7606,7 +7507,7 @@ messages:
       % Don't set piTimeNewsPosted to current time.  That'd potentially make
       %  people unable to post for a while.
       piTimeNewsPosted = 0;
-      piLastMoveUpdateTime = GetTime();
+      piLastMoveUpdateTime = GetTickCount();
 
       % Eliminate logoff penalty time.  Just easier this way.
       piLogoffPenaltyTime = 0;

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -1783,8 +1783,8 @@ messages:
       {
          if NOT pbUser_in_room
          {
-            Send(self,@FirstUserEntered,#what=what,#new_row=First(new_pos),
-                 #new_col=Nth(new_pos,2));
+            Send(self,@FirstUserEntered,#what=what,#new_row=Nth(new_pos,2),
+                 #new_col=Nth(new_pos,3));
          }
 
          % Now send music.

--- a/kod/object/active/hotplate.kod
+++ b/kod/object/active/hotplate.kod
@@ -68,13 +68,6 @@ messages:
       iRow = Send(self,@GetRow);
       iCol = Send(self,@GetCol);
 
-      if IsClass(what,&User)
-      {
-         % This decrements the move counter by 1, since we had an additional (legal) 
-         %  move request from this object.
-         Send(what,@AdjustMoveCounter,#bReset=TRUE);
-      }
-
       if new_row = iRow AND new_col = iCol
       {
          if what = self

--- a/kod/object/active/portal.kod
+++ b/kod/object/active/portal.kod
@@ -123,17 +123,19 @@ messages:
    TeleportSomething(what=$)
    "Called when something walks on top of us."
    {
+      % Test if the move is OK first (do_move=FALSE)
       if NOT Send(SYS,@UtilGoNearSquare,#what=what,
                   #where=Send(SYS,@FindRoomByNum,#num=piDest_room),
                   #new_row=piDest_row,#new_col=piDest_col,
                   #fine_row=piDest_fine_row,#fine_col=piDest_fine_col,
                   #new_angle=piDest_angle, #max_distance=viMaxDistance,
-                  #do_Move=FALSE)
+                  #do_move=FALSE)
       {
          debug("Portal",self,"unable to move",what);
       }
       else
       {
+         % Now actually do the move
          Send(SYS,@UtilGoNearSquare,#what=what,
               #where=Send(SYS,@FindRoomByNum,#num=piDest_room),
               #new_row=piDest_row,#new_col=piDest_col,

--- a/kod/object/active/wallelem.kod
+++ b/kod/object/active/wallelem.kod
@@ -249,15 +249,6 @@ messages:
 
       if iDistanceSquared <= (iLongRange * iLongRange)
       {
-         if IsClass(what,&User)
-         {
-            % This resets the move counter, since we had additional (legal) 
-            %  moves request from this object.
-            % We have to reset the moves counter, because it seems wall elements
-            %  generate more requests than they handle.
-            send(what,@AdjustMoveCounter,#bReset=TRUE);
-         }
-
          if (iLongRange = piRange
              OR iDistanceSquared <= (piRange * piRange))
             AND send(poOwner,@LineOfSight,#obj1=self,#obj2=what)

--- a/kod/util.kod
+++ b/kod/util.kod
@@ -25,7 +25,7 @@ messages:
    "Places <what> up to <max_distance> squares away from <new_row>,<new_col>."
    "If <new_angle> = $ and moving in a room, old angle is preserved."
    {
-      local distance,i,j,row,col,calc_max_dist,room_rows,room_cols;
+      local distance,i,j,row,col,room_rows,room_cols;
 
       if what = $ OR where = $ OR new_row = $ OR new_col = $
       {
@@ -41,20 +41,9 @@ messages:
          return FALSE;
       }
 
-      % calculate max distance that's still in room (could be tighter)
-      calc_max_dist = max_distance;
+      % get room boundaries
       room_rows = Send(where,@GetRoomRows);
       room_cols = Send(where,@GetRoomCols);
-
-      if calc_max_dist > room_rows
-      {
-         calc_max_dist = room_rows;
-      }
-
-      if calc_max_dist > room_cols
-      {
-         calc_max_dist = room_cols;
-      }
 
       distance = 0;
       while distance <= max_distance
@@ -124,6 +113,7 @@ messages:
    "otherwise the room move could go to adjacent rooms!! blah."
    "If <new_angle> = $, then no angle is passed to rooms (will leave old one if in room)."
    {
+      % MOVE in same room      
       if Send(what,@GetOwner) = where
       {
          if IsClass(what,&User)
@@ -143,6 +133,7 @@ messages:
             return TRUE;
          }
       }
+      % MOVE into other room
       else
       {
          if Send(where,@ReqNewHold,#what=what,#new_row=new_row,#new_col=new_col)
@@ -163,6 +154,10 @@ messages:
                   Send(where,@NewHold,#what=what,#new_row=new_row,#new_col=new_col,
                        #fine_row=fine_row,#fine_col=fine_col);
                }
+
+               % make sure the position is updated
+               Send(where,@SomethingMoved,#what=what,#new_row=new_row,#new_col=new_col,
+                    #fine_row=fine_row,#fine_col=fine_col);
             }
 
             return TRUE;

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -110,6 +110,22 @@ properties:
    % If true, tell DMs when a player crosses a "hot plate" object (in a guild hall).
    % Used for debugging the placement of hot plates.
    pbReportHotPlates = FALSE
+   
+   %
+   % Speedhack & Teleport protection
+   %
+
+   % Worst lagspike
+   piMoveMaxLag = 2000
+
+   % Limit for processing simultaneous move requests (due to TCP)
+   piMoveMaxSimulReq = 8
+
+   % The default interval the server expects from the client
+   piMoveDefaultInterval = 250
+
+   % A tolerance that is given on each move step
+   piMoveStepTolerance = 100
 
    %
    % Miscellaneous
@@ -291,7 +307,30 @@ messages:
       return pbReportHotPlates;
    }
 
+   %
+   % Speedhack & teleport protection
+   %
+   
+   GetMoveMaxLag()
+   {
+      return piMoveMaxLag;
+   }
 
+   GetMoveMaxSimulReq()
+   {
+      return piMoveMaxSimulReq;
+   }
+
+   GetMoveDefaultInterval()
+   {
+      return piMoveDefaultInterval;
+   }
+
+   GetMoveStepTolerance()
+   {
+      return piMoveStepTolerance;
+   }
+   
    %
    % Miscellaneous
    %


### PR DESCRIPTION
This pull request combines pulls #45, #69, #71, #92, #113 and #135 from the 103 repo to implement the 250ms movement update rate along with the speedhack and teleport protection that accompanies it. Client minor version incremented to 17. Also included is a fix for the continued issues from the time offset bug: piTimeAttackedPlayer is added to UpdateTimeValues() in player.kod, followed by running (as you probably already know) send c player UpdateTimeValues to set these to current game time. I think this variable has been added to the game since the last time offset fix, but was never added to that function.

Compiles and runs fine locally, no errors, all works as expected.