### PR TITLE
Autoloot for Numbered Items

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -195,6 +195,10 @@ resources:
 
    monster_default_attack = "attack"
 
+   autolooted_all = "You loot the corpse clean."
+   autolooted_some = "You loot some of the items from your fallen kill."
+   autolooted_none = "You find nothing easily lootable on your slain enemy."
+
 classvars:
 
    vrKocName = monster_koc_name
@@ -4945,7 +4949,7 @@ messages:
    CreateTreasure(who=$,corpse=$)
    {
       local i, iNumberItems, oTreasure, oTreasure_type, tokengen, iSafetyCntr,
-            lTreasureItems;
+            lTreasureItems, iNumberOfItemsDropped, iNumberOfItemsLooted;
 
       % Apparitions, etc, provide no treasure
       if pbIllusion
@@ -5031,6 +5035,9 @@ messages:
          lTreasureItems = cons(i,lTreasureItems);
       }
       
+      iNumberOfItemsDropped = 0;
+      iNumberOfItemsLooted = 0;
+      
       % Now drop all the treasure.
       for oTreasure in lTreasureItems
       {
@@ -5041,10 +5048,43 @@ messages:
          {
             Send(poOwner,@NewHold,#what=oTreasure,#new_row=piRow,
                  #new_col=piCol);
+            
+            iNumberOfItemsDropped = iNumberOfItemsDropped + 1;
+            
+            if IsClass(oTreasure,&NumberItem)
+               AND Send(SYS,@UtilGetRoom,#what=oTreasure) = Send(who,@GetOwner)
+               AND Send(oTreasure,@GetPos) <> $
+               AND IsClass(who,&User)
+               AND Send(who,@IsAutolooting)
+            {
+               iNumberOfItemsLooted = iNumberOfItemsLooted + 1;
+               Send(who,@UserGet,#what=oTreasure);
+            }
          }
          else
          {
             Send(oTreasure,@Delete);
+         }
+      }
+      
+      if iNumberOfItemsDropped <> 0
+         AND IsClass(who,&User)
+         AND Send(who,@IsAutolooting)
+      {
+            if iNumberOfItemsLooted = iNumberOfItemsDropped
+         {
+            Send(who,@MsgSendUser,#message_rsc=autolooted_all);
+         }
+
+         if iNumberOfItemsLooted > 0
+            AND iNumberOfItemsLooted < iNumberOfItemsDropped
+         {
+            Send(who,@MsgSendUser,#message_rsc=autolooted_some);
+         }
+
+         if iNumberOfItemsLooted = 0
+         {
+            Send(who,@MsgSendUser,#message_rsc=autolooted_none);
          }
       }
 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -293,6 +293,9 @@ resources:
 
    user_default_url = "http://www.Meridian59.com/"
    
+   autoloot_on_msg = "You decide to pick up treasure as it drops."
+   autoloot_off_msg = "You stop picking up treasure as it drops."
+   
    user_safety_on_wav_rsc = safety_on.wav
    user_safety_off_wav_rsc = safety_off.wav
 
@@ -347,6 +350,8 @@ properties:
    piMoveOldRow = 0
    piMoveOldCol = 0
    piMoveOldRoom = RID_TOS
+   
+   pbAutoloot = TRUE
 
    piCheaterLogs = 0
 
@@ -3915,6 +3920,25 @@ messages:
       {
          Send(self,@NotifyMonstersOfPresence);
       }
+      
+      if type = SAY_NORMAL
+      {
+         If StringContain(String,"autoloot on")
+            AND NOT Send(self,@IsAutolooting)
+         {
+            Send(self,@SetAutoloot,#value=TRUE);
+            Send(self,@MsgSendUser,#message_rsc=autoloot_on_msg);
+            return;
+         }
+
+If StringContain(String,"autoloot off")
+AND Send(self,@IsAutolooting)
+{
+Send(self,@SetAutoloot,#value=FALSE);
+Send(self,@MsgSendUser,#message_rsc=autoloot_off_msg);
+return;
+}
+}
 
       if NOT Send(poOwner,@RoomReqCommunication,#type=type,#string=string,
                   #who=self)
@@ -4331,12 +4355,12 @@ messages:
          string = psPlayerDescription;
       }
       
-      if StringContain(psPlayerDescription,"¶")
+      if StringContain(psPlayerDescription,"Â¶")
       {
          iCount = 0;
-         while StringContain(psPlayerDescription,"¶")
+         while StringContain(psPlayerDescription,"Â¶")
          {
-            StringSubstitute(psPlayerDescription,"¶","");
+            StringSubstitute(psPlayerDescription,"Â¶","");
             iCount = iCount + 1;
             if iCount > 10
             {
@@ -7820,6 +7844,17 @@ messages:
 	 i = i + 1;
       }
       return 0;
+   }
+
+   SetAutoloot(value=TRUE)
+   {
+      pbAutoloot = value;
+      return;
+   }
+   
+   IsAutolooting()
+   {
+      return pbAutoloot;
    }
 
 end


### PR DESCRIPTION
Quality of Life Improvement by M59Gar:

When treasure is generated, a UserGet is called for any dropped number
items, saving the player the hassle of constantly looting. It's a normal
Get attempt, so if the user can't hold the treasure or is too far away,
it will fail.

UserGet does notify the user upon failure due to range, capacity limits, and so on.
Autolooting gives a summary message telling the player whether they tried
to loot all, some, or none of the items from a kill.

This will pick up all numbered items like shillings, reagents, and arrows.

Users can say 'autoloot off' or 'autoloot on' to change their autolooting behavior.
Autoloot is default on.
