### PR TITLE
Fixed damage type typos in ALL monsters

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/BRAMBLE.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/BRAMBLE.kod
@@ -54,7 +54,7 @@ classvars:
    vrDead_name = brambles_dead_name_rsc
 
    viTreasure_type = TID_NONE
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
    viAttributes = MOB_NOMOVE | MOB_NOFIGHT | MOVEON_NOTIFY | MOB_NOQUEST
    viLevel = 25
    viDifficulty = 4 

--- a/kod/object/active/holder/nomoveon/battler/monster/BossBody.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/BossBody.kod
@@ -44,7 +44,7 @@ classvars:
    vrDead_name = OrcPitBossBody_dead_name_rsc
 
    viTreasure_type = TID_NONE
-   viAttack_types = ATCK_WEAP_WHIP
+   viAttack_type = ATCK_WEAP_WHIP
    viSpeed = SPEED_NONE
    viAttributes = MOB_NOMOVE 
    viDefault_behavior = AI_NOMOVE| AI_NOFIGHT

--- a/kod/object/active/holder/nomoveon/battler/monster/avar.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/avar.kod
@@ -63,7 +63,7 @@ classvars:
  
    viIndefinite = ARTICLE_AN
    viTreasure_type = TID_AVAR
-   viAttack_types = ATCK_WEAP_BLUDGEON
+   viAttack_type = ATCK_WEAP_BLUDGEON
    viSpeed = SPEED_AVERAGE
    viDefault_behavior = AI_MOVE_REGROUP | AI_FIGHT_AGGRESSIVE | AI_FIGHT_MONSTERS
    viLevel = 120

--- a/kod/object/active/holder/nomoveon/battler/monster/avchief.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/avchief.kod
@@ -77,7 +77,7 @@ classvars:
 
    viIndefinite = ARTICLE_AN
    viTreasure_type = TID_AVAR_CHIEF
-   viAttack_types = ATCK_WEAP_PIERCE
+   viAttack_type = ATCK_WEAP_PIERCE
    viSpeed = SPEED_FAST
    viDefault_behavior = AI_FIGHT_AGGRESSIVE | AI_MOVE_OPTIMAL_RANGE | AI_FIGHT_WIZARD_KILLER | AI_FIGHT_MONSTERS
    viLevel = 135

--- a/kod/object/active/holder/nomoveon/battler/monster/avshaman.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/avshaman.kod
@@ -77,7 +77,7 @@ classvars:
    
    viIndefinite = ARTICLE_AN
    viTreasure_type = TID_AVAR_SHAMAN
-   viAttack_types = ATCK_WEAP_PIERCE
+   viAttack_type = ATCK_WEAP_PIERCE
    viSpeed = SPEED_SLOW
    viDefault_behavior = AI_FIGHT_AGGRESSIVE | AI_MOVE_OPTIMAL_RANGE | AI_FIGHT_MONSTERS
    viLevel = 100
@@ -311,7 +311,7 @@ messages:
             {
                if iRandom < 90      
                {
-                  iSpell = SID_SHATTER;
+                  iSpell = SID_BRITTLE;
                   iManaCost = 10;
                }
                else

--- a/kod/object/active/holder/nomoveon/battler/monster/avshaman.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/avshaman.kod
@@ -78,6 +78,7 @@ classvars:
    viIndefinite = ARTICLE_AN
    viTreasure_type = TID_AVAR_SHAMAN
    viAttack_type = ATCK_WEAP_PIERCE
+   viAttack_type = ATCK_SPELL_QUAKE
    viSpeed = SPEED_SLOW
    viDefault_behavior = AI_FIGHT_AGGRESSIVE | AI_MOVE_OPTIMAL_RANGE | AI_FIGHT_MONSTERS
    viLevel = 100

--- a/kod/object/active/holder/nomoveon/battler/monster/avshaman.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/avshaman.kod
@@ -78,7 +78,7 @@ classvars:
    viIndefinite = ARTICLE_AN
    viTreasure_type = TID_AVAR_SHAMAN
    viAttack_type = ATCK_WEAP_PIERCE
-   viAttack_type = ATCK_SPELL_QUAKE
+   viAttack_spell = ATCK_SPELL_QUAKE
    viSpeed = SPEED_SLOW
    viDefault_behavior = AI_FIGHT_AGGRESSIVE | AI_MOVE_OPTIMAL_RANGE | AI_FIGHT_MONSTERS
    viLevel = 100

--- a/kod/object/active/holder/nomoveon/battler/monster/avshaman.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/avshaman.kod
@@ -312,7 +312,7 @@ messages:
             {
                if iRandom < 90      
                {
-                  iSpell = SID_BRITTLE;
+                  iSpell = SID_SHATTER;
                   iManaCost = 10;
                }
                else

--- a/kod/object/active/holder/nomoveon/battler/monster/centip.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/centip.kod
@@ -43,7 +43,7 @@ classvars:
    viTreasure_type = TID_WIMPY_MEDIUM
 
    viSpeed = SPEED_FAST
-   viAttack_types = ATCK_WEAP_BITE
+   viAttack_type = ATCK_WEAP_BITE
 
    viLevel = 30
    viDifficulty = 5

--- a/kod/object/active/holder/nomoveon/battler/monster/dangel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dangel.kod
@@ -66,8 +66,8 @@ classvars:
    viTreasure_type = TID_DARK_ANGEL
 
    viSpeed = SPEED_VERY_FAST
-   viAttack_types = ATCK_WEAP_MAGIC
-   viAttack_spells = ATCK_SPELL_FIRE
+   viAttack_type = ATCK_WEAP_MAGIC
+   viAttack_spell = ATCK_SPELL_FIRE
    viLevel = 200
    viDifficulty = 9
    viKarma = -100

--- a/kod/object/active/holder/nomoveon/battler/monster/dfly.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dfly.kod
@@ -65,7 +65,7 @@ classvars:
    viTreasure_type = TID_DRAGONFLY
 
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_PIERCE
+   viAttack_type = ATCK_WEAP_PIERCE
    viLevel = 120
    viDifficulty = 6
    viKarma = 40

--- a/kod/object/active/holder/nomoveon/battler/monster/dflypet.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dflypet.kod
@@ -66,7 +66,7 @@ classvars:
    viTreasure_type = TID_NONE
 
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_PIERCE
+   viAttack_type = ATCK_WEAP_PIERCE
    viLevel = 120
    viDifficulty = 6
    viKarma = 40

--- a/kod/object/active/holder/nomoveon/battler/monster/dflyq.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dflyq.kod
@@ -70,7 +70,7 @@ classvars:
    viTreasure_type = TID_DRAGONFLY
 
    viSpeed = SPEED_FAST
-   viAttack_types = ATCK_WEAP_PIERCE
+   viAttack_type = ATCK_WEAP_PIERCE
    viLevel = 145
    viDifficulty = 6
    viKarma = 40

--- a/kod/object/active/holder/nomoveon/battler/monster/duskrat.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/duskrat.kod
@@ -55,7 +55,7 @@ classvars:
    viTreasure_type = TID_RAT
 
    viSpeed = SPEED_VERY_FAST
-   viAttack_types = ATCK_WEAP_CLAW
+   viAttack_type = ATCK_WEAP_CLAW
    viAttributes = 0
    viLevel = 50
    viDifficulty = 6

--- a/kod/object/active/holder/nomoveon/battler/monster/ent.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/ent.kod
@@ -49,7 +49,7 @@ classvars:
    vrDead_name = ent_dead_name_rsc
 
    viTreasure_type = TID_ENT
-   viAttack_types = ATCK_WEAP_WHIP
+   viAttack_type = ATCK_WEAP_WHIP
    viSpeed = SPEED_NONE
    viAttributes = MOB_NOMOVE 
    viDefault_behavior = AI_NOMOVE | AI_FIGHT_KARMA_AGGRESSIVE

--- a/kod/object/active/holder/nomoveon/battler/monster/evfairy.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/evfairy.kod
@@ -49,8 +49,8 @@ classvars:
    viTreasure_type = TID_FAIRY
 
    viSpeed = SPEED_VERY_FAST
-   viAttack_types = 0
-   viAttack_spells = ATCK_SPELL_SHOCK
+   viAttack_type = 0
+   viAttack_spell = ATCK_SPELL_SHOCK
     
    viLevel = 60
    viDifficulty = 5

--- a/kod/object/active/holder/nomoveon/battler/monster/evilent.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/evilent.kod
@@ -47,7 +47,7 @@ classvars:
    vrDead_name = EvilEnt_dead_name_rsc
 
    viTreasure_type = TID_ENT
-   viAttack_types = ATCK_WEAP_WHIP
+   viAttack_type = ATCK_WEAP_WHIP
    viSpeed = SPEED_NONE
    viAttributes = MOB_NOMOVE 
    viDefault_behavior = AI_NOMOVE | AI_FIGHT_KARMA_AGGRESSIVE

--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -46,7 +46,7 @@ classvars:
    viTreasure_type = TID_NONE
 
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
    viAttributes = 0
    viLevel = 1
    viDifficulty = 9

--- a/kod/object/active/holder/nomoveon/battler/monster/fairy.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/fairy.kod
@@ -47,8 +47,8 @@ classvars:
    viTreasure_type = TID_FAIRY
 
    viSpeed = SPEED_VERY_FAST
-   viAttack_types = 0
-   viAttack_spells = ATCK_SPELL_SHOCK
+   viAttack_type = 0
+   viAttack_spell = ATCK_SPELL_SHOCK
    viDefault_behavior = AI_MOVE_REGROUP | AI_FIGHT_MONSTERS | AI_FIGHT_KARMA_AGGRESSIVE
    viWimpy = 10
 

--- a/kod/object/active/holder/nomoveon/battler/monster/flytrap.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/flytrap.kod
@@ -38,8 +38,8 @@ classvars:
    viTreasure_type = TID_LOW_HUMAN
 
    viSpeed = SPEED_VERY_SLOW
-   viAttack_types = 0
-   viAttack_spells = 0
+   viAttack_type = 0
+   viAttack_spell = 0
    viAttributes = 0
    viLevel = 60
    viDifficulty = 5

--- a/kod/object/active/holder/nomoveon/battler/monster/frogman.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/frogman.kod
@@ -45,7 +45,7 @@ classvars:
    viTreasure_type = TID_MEDIUM_HUMAN
 
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_PIERCE
+   viAttack_type = ATCK_WEAP_PIERCE
    viDefault_behavior = AI_FIGHT_KARMA_AGGRESSIVE
    viLevel = 70
    viDifficulty = 5

--- a/kod/object/active/holder/nomoveon/battler/monster/giarat.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/giarat.kod
@@ -43,7 +43,7 @@ classvars:
    viTreasure_type = TID_RAT
 
    viSpeed = SPEED_FAST
-   viAttack_types = ATCK_WEAP_CLAW
+   viAttack_type = ATCK_WEAP_CLAW
    viAttributes = 0
    viLevel = 30
    viDifficulty = 1

--- a/kod/object/active/holder/nomoveon/battler/monster/grdworm.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/grdworm.kod
@@ -59,7 +59,7 @@ classvars:
 
    viTreasure_type = TID_TOUGH
    viSpeed = SPEED_FAST
-   viAttack_types = ATCK_WEAP_ACID
+   viAttack_type = ATCK_SPELL_ACID
    viAttributes = 0
    viLevel = 100
    viDifficulty = 5

--- a/kod/object/active/holder/nomoveon/battler/monster/grdworm.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/grdworm.kod
@@ -59,7 +59,7 @@ classvars:
 
    viTreasure_type = TID_TOUGH
    viSpeed = SPEED_FAST
-   viAttack_type = ATCK_SPELL_ACID
+   viAttack_spell = ATCK_SPELL_ACID
    viAttributes = 0
    viLevel = 100
    viDifficulty = 5

--- a/kod/object/active/holder/nomoveon/battler/monster/grdworm/larva.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/grdworm/larva.kod
@@ -51,7 +51,7 @@ classvars:
 
    viTreasure_type = TID_WORM_LARVA
    viSpeed = SPEED_SLOW
-   viAttack_types = ATCK_WEAP_ACID
+   viAttack_spell = ATCK_SPELL_ACID
    viLevel = 35
    viDifficulty = 3
    viKarma = -10

--- a/kod/object/active/holder/nomoveon/battler/monster/grdworm/queen.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/grdworm/queen.kod
@@ -43,7 +43,7 @@ classvars:
 
    viTreasure_type = TID_WORM_QUEEN
    viSpeed = SPEED_SLOW
-   viAttack_types = ATCK_WEAP_ACID
+   viAttack_spell = ATCK_SPELL_ACID
    viLevel = 130
    viDifficulty = 7
    viKarma = -30

--- a/kod/object/active/holder/nomoveon/battler/monster/guard.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/guard.kod
@@ -37,7 +37,7 @@ classvars:
    viMove_delay_max = 10000
       
    viSpeed = SPEED_FAST
-   viAttack_types = ATCK_WEAP_BITE
+   viAttack_type = ATCK_WEAP_BITE
    
    viLevel = 100
    viDifficulty = 5

--- a/kod/object/active/holder/nomoveon/battler/monster/iceper.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/iceper.kod
@@ -48,7 +48,8 @@ classvars:
 
    viTreasure_type = TID_NONE
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_THRUST
+   viAttack_type = ATCK_WEAP_THRUST
+   viAttack_spell = ATCK_SPELL_COLD
    viAttributes = 0
    viLevel = 75
    viDifficulty = 5

--- a/kod/object/active/holder/nomoveon/battler/monster/kriipa.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/kriipa.kod
@@ -64,7 +64,7 @@ classvars:
    vrDead_name = Kriipa_dead_name_rsc
  
    viTreasure_type = TID_DRAGONFLY
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
    viSpeed = SPEED_FAST
    viDefault_behavior = AI_FIGHT_AGGRESSIVE | AI_FIGHT_HYPERAGGRESSIVE
    viLevel = 160

--- a/kod/object/active/holder/nomoveon/battler/monster/lich.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/lich.kod
@@ -102,7 +102,7 @@ classvars:
 
    viTreasure_type = TID_LICH
    viSpeed = SPEED_FAST
-   viAttack_types = ATCK_SPELL_UNHOLY
+   viAttack_spell = ATCK_SPELL_UNHOLY
    viLevel = 200
    viDifficulty = 9
    viKarma = -100

--- a/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
@@ -61,7 +61,7 @@ classvars:
 
    viTreasure_type = TID_LUPOGG_KING
    viSpeed = SPEED_SLOW
-   viAttack_types = ATCK_WEAP_CLAW
+   viAttack_type = ATCK_WEAP_CLAW
    viLevel = 200
    viDifficulty = 9
    viKarma = 0

--- a/kod/object/active/holder/nomoveon/battler/monster/lupogg.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/lupogg.kod
@@ -43,6 +43,7 @@ classvars:
    vrDead_name = lupogg_dead_name_rsc
 
    viTreasure_type = TID_VERY_TOUGH
+   viAttack_type = ATCK_WEAP_BITE
    viSpeed = 2
    viAttributes = 0
    viLevel = 105

--- a/kod/object/active/holder/nomoveon/battler/monster/lvstatue.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/lvstatue.kod
@@ -141,7 +141,7 @@ classvars:
 
    viTreasure_type = TID_MEDIUM_TOUGH
 
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
 
    vrSound_hit = LivingStatue_sound_attack
    vrSound_miss = LivingStatue_sound_attack

--- a/kod/object/active/holder/nomoveon/battler/monster/mollusk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/mollusk.kod
@@ -74,7 +74,7 @@ classvars:
 
    viTreasure_type = TID_TOUGH
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_BLUDGEON
+   viAttack_type = ATCK_WEAP_BLUDGEON
    viAttributes = 0
    viLevel = 150
    viDifficulty = 7

--- a/kod/object/active/holder/nomoveon/battler/monster/nrthlwrm.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/nrthlwrm.kod
@@ -49,7 +49,7 @@ classvars:
 
    viTreasure_type = TID_NARTHYL_WORM
    viSpeed = SPEED_SLOW
-   viAttack_types = ATCK_WEAP_PIERCE
+   viAttack_type = ATCK_WEAP_PIERCE
    viAttributes = 0
    viLevel = 120
    viDifficulty = 7

--- a/kod/object/active/holder/nomoveon/battler/monster/orc.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/orc.kod
@@ -46,7 +46,7 @@ classvars:
    viTreasure_type = TID_ORC
 
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
    viAttributes = 0
    viLevel = 45
    viDifficulty = 6

--- a/kod/object/active/holder/nomoveon/battler/monster/orcboss.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/orcboss.kod
@@ -55,7 +55,7 @@ classvars:
    viTreasure_type = TID_ORC_CHIEF
 
    viSpeed = SPEED_FAST
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
    viAttributes = 0
    viLevel = 115
    viDifficulty = 7

--- a/kod/object/active/holder/nomoveon/battler/monster/orccave.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/orccave.kod
@@ -44,7 +44,7 @@ classvars:
    viTreasure_type = TID_CAVE_ORC
 
    viSpeed = SPEED_FAST
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
    viAttributes = 0
    viLevel = 80
    viDifficulty = 7

--- a/kod/object/active/holder/nomoveon/battler/monster/orcwiza.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/orcwiza.kod
@@ -65,7 +65,7 @@ classvars:
    viTreasure_type = TID_ORC_WIZARD
 
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_BLUDGEON
+   viAttack_type = ATCK_WEAP_BLUDGEON
    viAttributes = 0
    viLevel = 80
    viDifficulty = 7

--- a/kod/object/active/holder/nomoveon/battler/monster/redant.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/redant.kod
@@ -43,7 +43,7 @@ classvars:
 
    viTreasure_type = TID_TOUGH
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_BITE
+   viAttack_type = ATCK_WEAP_BITE
    viAttributes = MOB_SPASM
    viLevel = 65
    viDifficulty = 8

--- a/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
@@ -51,7 +51,7 @@ classvars:
    viTreasure_type = TID_NONE
 
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
    viAttributes = 0
    viLevel = 45
    viDifficulty = 4

--- a/kod/object/active/holder/nomoveon/battler/monster/revenant.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/revenant.kod
@@ -51,7 +51,7 @@ classvars:
    vrDesc = revenant_desc_rsc
 
    viSpeed = SPEED_FAST
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
    viDefault_behavior = AI_FIGHT_AGGRESSIVE | AI_FIGHT_SINGLEMINDED | AI_MOVE_WALKTHROUGH_WALLS | AI_FIGHT_THROUGH_WALLS
 
 properties:

--- a/kod/object/active/holder/nomoveon/battler/monster/scorpion.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/scorpion.kod
@@ -43,7 +43,7 @@ classvars:
 
    viTreasure_type = TID_MEDIUM_TOUGH
    viSpeed = SPEED_FAST
-   viAttack_types = ATCK_WEAP_STING
+   viAttack_type = ATCK_WEAP_STING
 
    viLevel = 55
    viDifficulty = 8

--- a/kod/object/active/holder/nomoveon/battler/monster/shadowb.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/shadowb.kod
@@ -50,7 +50,7 @@ classvars:
    vrDead_name = Shadowbeast_dead_name_rsc
  
    viTreasure_type = TID_VERY_TOUGH
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
    viSpeed = SPEED_AVERAGE
    viDefault_behavior = AI_FIGHT_AGGRESSIVE
    viLevel = 200

--- a/kod/object/active/holder/nomoveon/battler/monster/skel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/skel.kod
@@ -43,7 +43,7 @@ classvars:
 
    viTreasure_type = TID_TOUGH
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_THRUST
+   viAttack_type = ATCK_WEAP_THRUST
    viAttributes = 0
    viLevel = 75
    viDifficulty = 5

--- a/kod/object/active/holder/nomoveon/battler/monster/skel/batrskel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/skel/batrskel.kod
@@ -47,7 +47,7 @@ classvars:
 
    viTreasure_type = TID_SKELETON2
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_THRUST
+   viAttack_type = ATCK_WEAP_THRUST
    viAttributes = 0
    viLevel = 60
    viDifficulty = 4

--- a/kod/object/active/holder/nomoveon/battler/monster/skel/daemskel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/skel/daemskel.kod
@@ -43,7 +43,7 @@ classvars:
 
    viTreasure_type = TID_SKELETON4
    viSpeed = SPEED_FAST
-   viAttack_types = ATCK_WEAP_THRUST
+   viAttack_type = ATCK_WEAP_THRUST
    viAttributes = 0
    viLevel = 130
    viDifficulty = 8

--- a/kod/object/active/holder/nomoveon/battler/monster/skel/tuskskel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/skel/tuskskel.kod
@@ -43,7 +43,7 @@ classvars:
 
    viTreasure_type = TID_SKELETON3
    viSpeed = SPEED_FAST
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
    viAttributes = 0
    viLevel = 100
    viDifficulty = 6

--- a/kod/object/active/holder/nomoveon/battler/monster/slime.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/slime.kod
@@ -43,7 +43,7 @@ classvars:
 
    viTreasure_type = TID_WIMPY_MEDIUM
    viSpeed = SPEED_SLOW
-   viAttack_spells = ATCK_SPELL_ACID
+   viAttack_spell = ATCK_SPELL_ACID
    viAttributes = 0
    viLevel = 35
    viDifficulty = 4

--- a/kod/object/active/holder/nomoveon/battler/monster/snowrat.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/snowrat.kod
@@ -43,7 +43,7 @@ classvars:
    viTreasure_type = TID_RAT
 
    viSpeed = SPEED_FAST
-   viAttack_types = ATCK_WEAP_CLAW
+   viAttack_type = ATCK_WEAP_CLAW
    viAttributes = 0
    viLevel = 60
    viDifficulty = 4

--- a/kod/object/active/holder/nomoveon/battler/monster/spdrbaby.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/spdrbaby.kod
@@ -43,7 +43,7 @@ classvars:
    viDefault_behavior = AI_FIGHT_AGGRESSIVE
 
    viSpeed = SPEED_SLOW
-   viAttack_types = ATCK_WEAP_BITE
+   viAttack_type = ATCK_WEAP_BITE
    viAttributes = MOB_SPASM
    viLevel = 25
    viDifficulty = 4

--- a/kod/object/active/holder/nomoveon/battler/monster/spdrquen.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/spdrquen.kod
@@ -49,7 +49,7 @@ classvars:
 
    viTreasure_type = TID_SPIDER_QUEEN
    viSpeed = SPEED_NONE
-   viAttack_types = ATCK_WEAP_BITE
+   viAttack_type = ATCK_WEAP_BITE
    viAttributes = MOB_NOMOVE
    viLevel = 165
    viDifficulty = 9

--- a/kod/object/active/holder/nomoveon/battler/monster/troop.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/troop.kod
@@ -159,7 +159,7 @@ classvars:
    viTreasure_type = TID_NONE
 
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
    viAttributes = 0
    viDefault_behavior = AI_FIGHT_NEWBIESAFE | AI_MOVE_REGROUP
 

--- a/kod/object/active/holder/nomoveon/battler/monster/troop/duketr.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/troop/duketr.kod
@@ -31,7 +31,7 @@ classvars:
    vrDead_name = DukeTroop_dead_name_rsc
 
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
    viAttributes = 0
    viDefault_behavior = AI_FIGHT_NEWBIESAFE | AI_MOVE_REGROUP
 

--- a/kod/object/active/holder/nomoveon/battler/monster/troop/necrotr.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/troop/necrotr.kod
@@ -37,7 +37,7 @@ classvars:
    vrDead_name = NecromancerTroop_dead_name_rsc
 
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
    viAttributes = 0
    viDefault_behavior = AI_FIGHT_NEWBIESAFE | AI_MOVE_REGROUP
 

--- a/kod/object/active/holder/nomoveon/battler/monster/troop/printr.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/troop/printr.kod
@@ -31,7 +31,7 @@ classvars:
    vrDead_name = PrincessTroop_dead_name_rsc
 
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
    viAttributes = 0
    viDefault_behavior = AI_FIGHT_NEWBIESAFE | AI_MOVE_REGROUP
 

--- a/kod/object/active/holder/nomoveon/battler/monster/troop/rebeltr.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/troop/rebeltr.kod
@@ -32,7 +32,7 @@ classvars:
    vrDead_name = RebelTroop_dead_name_rsc
 
    viSpeed = SPEED_AVERAGE
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
    viAttributes = 0
    viDefault_behavior = AI_FIGHT_NEWBIESAFE | AI_MOVE_REGROUP
 

--- a/kod/object/active/holder/nomoveon/battler/monster/xeochctl.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/xeochctl.kod
@@ -70,7 +70,7 @@ classvars:
    viTreasure_type = TID_NONE
    viDefault_behavior = AI_FIGHT_AGGRESSIVE | AI_FIGHT_SWITCHALOT \
                         | AI_MOVE_REGROUP | AI_MOVE_WALKTHROUGH_WALLS
-   viAttack_types = ATCK_WEAP_MAGIC
+   viAttack_type = ATCK_WEAP_MAGIC
    viLevel = 150
    viDifficulty = 8
    viSpeed = SPEED_AVERAGE

--- a/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeoair.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeoair.kod
@@ -36,7 +36,7 @@ resources:
    vrName = XeoAir_name_rsc
    vrKocName = XeoAir_koc_name_rsc
    
-   viAttack_types = ATCK_WEAP_MAGIC
+   viAttack_type = ATCK_WEAP_MAGIC
    viLevel = 150
    viDifficulty = 7
    viSpeed = SPEED_VERY_FAST

--- a/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeoearth.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeoearth.kod
@@ -36,7 +36,7 @@ resources:
    vrName = XeoEarth_name_rsc
    vrKocName = XeoEarth_koc_name_rsc
    
-   viAttack_types = ATCK_WEAP_MAGIC
+   viAttack_type = ATCK_WEAP_MAGIC
    viLevel = 200
    viDifficulty = 9
    viSpeed = SPEED_AVERAGE

--- a/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeofire.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeofire.kod
@@ -36,7 +36,7 @@ resources:
    vrName = XeoFire_name_rsc
    vrKocName = XeoFire_koc_name_rsc
    
-   viAttack_types = ATCK_WEAP_MAGIC
+   viAttack_type = ATCK_WEAP_MAGIC
    viLevel = 170
    viDifficulty = 7
    viSpeed = SPEED_FAST

--- a/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeowater.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeowater.kod
@@ -36,7 +36,7 @@ resources:
    vrName = XeoWater_name_rsc
    vrKocName = XeoWater_koc_name_rsc
    
-   viAttack_types = ATCK_WEAP_MAGIC
+   viAttack_type = ATCK_WEAP_MAGIC
    viLevel = 190
    viDifficulty = 8
    viSpeed = SPEED_FAST

--- a/kod/object/active/holder/nomoveon/battler/monster/yeti.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/yeti.kod
@@ -48,7 +48,7 @@ classvars:
 
    viTreasure_type = TID_VERY_TOUGH
    viSpeed = SPEED_SLOW
-   viAttack_types = ATCK_WEAP_CLAW
+   viAttack_type = ATCK_WEAP_CLAW
    viAttributes = 0
    viLevel = 170
    viDifficulty = 9

--- a/kod/object/active/holder/nomoveon/battler/monster/zombie.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/zombie.kod
@@ -44,7 +44,7 @@ classvars:
    vrDead_name = zombie_dead_name_rsc
 
    viSpeed = SPEED_VERY_SLOW
-   viAttack_types = ATCK_WEAP_SLASH
+   viAttack_type = ATCK_WEAP_SLASH
    viDefault_behavior = AI_FIGHT_KARMA_AGGRESSIVE | AI_MOVE_FLEE_FRIGHTENERS
 
    viDifficulty = 4


### PR DESCRIPTION
originaly by M59Gar

Because of a minor typing error the Monsters in Meridian all do only generic damage. They should do other damage types mostly like you can see in the code so this will fix this so Monster will do the damage type they should.

Also changed Avar Shamans to use brittle instead of shatter