### PR TITLE
Removed Karma requirement from VampWeaponAttribute

### DIFF
--- a/kod/object/passive/itematt/weapatt/wavamper.kod
+++ b/kod/object/passive/itematt/weapatt/wavamper.kod
@@ -58,7 +58,7 @@ messages:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
       
    ModifyDamage(damage = 0, target = $, wielder = $, lData= $)
-   "Wielder has a 1% chance of blinding target with any hit."
+   "Wielder has a 1% chance of stealing life from target with any hit."
    {
       local oSpell;
       if random(1,100) <= piEffect_percent

--- a/kod/object/passive/itematt/weapatt/wavamper.kod
+++ b/kod/object/passive/itematt/weapatt/wavamper.kod
@@ -79,11 +79,6 @@ messages:
 
    ItemReqUse(oItem=$,oPlayer=$)
   {
-      if send(oPlayer,@GetKarma) > -30
-      {
-	 send(oPlayer, @MsgSendUser, #message_rsc = Vamper_fail_use_karma);
-	 return FALSE;	    
-      }
       if send(oItem,@GetProf,#who=oPlayer) < 50      
       {
 	 send(oPlayer, @MsgSendUser, #message_rsc = Vamper_fail_use,


### PR DESCRIPTION
I did never understand why hold/blind/purge weapons have no karma requirements but vampiric weapons have.
Without it they would be great building weapons!
