### PR TITLE
Little fix for ET/Reflection animations 

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -489,7 +489,7 @@ messages:
 
       if Weapon <> $   %IsClass(Weapon,&Weapon)
       {
-         if IsClass(Weapon,&Longbow)
+         if IsClass(Weapon,&Bow)
          {
             piAnimation = PANM_BOW_FIRE;
 

--- a/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
@@ -517,7 +517,7 @@ messages:
 
          if Weapon <> $
          {
-            if IsClass(Weapon,&Longbow)
+            if IsClass(Weapon,&Bow)
             {
                piAnimation = PANM_BOW_FIRE;
 


### PR DESCRIPTION
Originaly by MorbusM59

Reflections and evil twins were only correctly using bow animations when the owner was using a long bow. This allows the copies to use the correct animation for all bows.