### PR TITLE
Allow non-damage walls in doors

### DIFF
--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3910,7 +3910,7 @@ messages:
       {
          each_obj = Send(self,@HolderExtractObject,#data=i);
          if (IsClass(each_obj,&ActiveWallElement)
-            or IsClass(each_obj,&Brambles)
+            or IsClass(each_obj,&Brambles))
             AND NOT IsClass(each_obj,&ActiveSporeCloud)
             AND NOT IsClass(each_obj,&Web)
          {

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3909,8 +3909,10 @@ messages:
       for i in plActive
       {
          each_obj = Send(self,@HolderExtractObject,#data=i);
-         if IsClass(each_obj,&ActiveWallElement)
+         if (IsClass(each_obj,&ActiveWallElement)
             or IsClass(each_obj,&Brambles)
+            AND NOT IsClass(each_obj,&ActiveSporeCloud)
+            AND NOT IsClass(each_obj,&Web)
          {
             if Send(who,@SquaredDistanceTo,#what=each_obj) <= (WALL_DELETE_RADIUS * WALL_DELETE_RADIUS)
             {
@@ -3924,7 +3926,6 @@ messages:
       {
          each_obj = Send(self,@HolderExtractObject,#data=i);
          if IsClass(each_obj,&PassiveWallofFire)
-            OR IsClass(each_obj,&SporeCloud)
             OR IsClass(each_obj,&PassiveWallofLightning)
          {
             if Send(who,@SquaredDistanceTo,#what=each_obj) <= (WALL_DELETE_RADIUS * WALL_DELETE_RADIUS)


### PR DESCRIPTION
Popular requests to re-enable webs and spores in doors have been
intense, to say the least, predicated on the basis that they do not deal
damage and can't be used to kill newbies in a cheesy fashion. They are
also very important for crowd control, and best used in doors
specifically.