### PR TITLE
Ammo fix Nerudite/Silver Arrows

### DIFF
--- a/kod/object/item/passitem/weapon.kod
+++ b/kod/object/item/passitem/weapon.kod
@@ -308,7 +308,7 @@ messages:
       local iDamage, i, oWeapAtt;
 
       % First, get base damage.
-      iDamage = send(self,@GetBaseDamage);
+      iDamage = send(self,@GetBaseDamage,#who=poOwner,#target=target);
 
       % Then check weapon attributes
       %  Weapon Attributes in general should only + or - damage - no multipliers!

--- a/kod/object/item/passitem/weapon/goldswrd.kod
+++ b/kod/object/item/passitem/weapon/goldswrd.kod
@@ -57,14 +57,14 @@ properties:
 
 messages:
 
-   GetBaseDamage()
+   GetBaseDamage(who=$,target=$)
    {
-      local oOwner, iDamage;
+      local poOwner, iDamage;
 
       iDamage = random(viMin_damage,viMax_damage);
 
-      oOwner = send(send(self,@GetOwner),@getowner);
-      if send(oOwner,@IsArena)
+      poOwner = send(send(self,@GetOwner),@getowner);
+      if send(poOwner,@IsArena)
       {
          iDamage = iDamage + 7;
       }


### PR DESCRIPTION
Nerudite Arrows haven't been shattering because BaseDamage wasn't
passing who and target. Silver Arrows also weren't doing double damage
to undead.
