### PR TITLE
Remove missing libs

### DIFF
--- a/clientd3d/makefile
+++ b/clientd3d/makefile
@@ -13,7 +13,7 @@ LIBS =  \
 	 user32.lib gdi32.lib comdlg32.lib shell32.lib \
 	 ws2_32.lib comctl32.lib advapi32.lib \
 	 winmm.lib archive.lib rscload.lib wininet.lib \
-	 ole32.lib mss32.lib mss32midi.lib waveplay.lib \
+	 ole32.lib waveplay.lib \
 	 d3d9.lib libpng.lib zdll.lib
 
 DEFFILE  = $(SOURCEDIR)\client.def


### PR DESCRIPTION
Remove mss32.lib and mss32midi.lib, trying to compile with these two libs added will generate error when trying to compile the source.