### PR TITLE
Remove wrap.lib

### DIFF
--- a/club/makefile
+++ b/club/makefile
@@ -3,7 +3,7 @@ TOPDIR=..
 
 SOURCEDIR = $(TOPDIR)\club
 
-CLUBLIBS = user32.lib gdi32.lib wrap.lib comctl32.lib wininet.lib
+CLUBLIBS = user32.lib gdi32.lib archive.lib comctl32.lib wininet.lib
 
 all: makedirs $(OUTDIR)\club.exe
 


### PR DESCRIPTION
Since we are no longer using wrap I do not know why it is still in here and archive.lib is not. Generates errors when trying to compile the source if wrap.lib is in.