### PR TITLE
Vault change

### DIFF
--- a/kod/object/passive/storage.kod
+++ b/kod/object/passive/storage.kod
@@ -13,6 +13,8 @@ Storage is PassiveObject
 constants:
 
    include blakston.khd
+   
+   VAULT_ITEMS_MAX = 150
 
 resources:
    msg_not_enough_items_on_deposit = "%s%s does not have that many on deposit."
@@ -83,19 +85,19 @@ messages:
 
    CanDepositItems(lItems = $, who = $)
    {
-      local iBulk, i;
-      iBulk = 0;
+      local plItemsStored;
 
       if who = $     { debug("CanDepositItems passed with who=$!"); return FALSE; }
       if lItems = $  { debug("Cannot deposit a null set!"); return FALSE; }
-
-      iBulk = send(self,@GetCurrentBulkStored,#who=who);
-      for i in lItems
-      {	 
-	 iBulk = iBulk + send(i,@GetBulk);
+      
+      plItemsStored = Send(self,@GetItemsStored,#who=who);
+      if plItemsStored <> $
+         AND (Length(plItemsStored) + Length(lItems)) > VAULT_ITEMS_MAX
+         AND NOT (Length(lItems) = 1
+                  AND IsClass(First(lItems),&NumberItem))
+      {
+         return FALSE;
       }
-      if iBulk > piCapacity
-      { return FALSE; }
 
       return TRUE;
    }


### PR DESCRIPTION
The vault patch from 103 (https://github.com/Daenks/Meridian59_103/pull/175), but reduced the number of items to 150 instead
of their 600 which might be a little overkill. 150 might be to much too
but I leave that to the developers to decide.

The vaults allow you to carry 150 items (stacks of reagents/food count
as one item).
People are building and gathering loot but have to store it on multiple
mules, this would reduce the number of mules people are using.
