### PR TITLE
Fix 3 aggro limit - check if player attacked monster.

### DIFF
--- a/kod/object/passive/brain.kod
+++ b/kod/object/passive/brain.kod
@@ -905,6 +905,7 @@ messages:
          % If they already have a lot of people chasing them then run away,
          % unless they attacked us.
          if NOT (event = TS_FIGHT_ME_VICTIM)
+            OR Send(Send(SYS,@GetSettings),@AlwaysCheckMonsterChasers)
          {
             iHatred = iHatred - (Send(what,@GetMonsterChasers)
                                        * piChaser_factor)/100;

--- a/kod/object/passive/brain.kod
+++ b/kod/object/passive/brain.kod
@@ -891,21 +891,31 @@ messages:
       {
         iHatred = iHatred + 20;
       }
-           
-      %% up to 20 points for level.
-      if isClass(what,&monster)
-      { iHatred = (iHatred + bound(send(what,@GetLevel),1,100)/5); }
-      else
-      { 	 
-      	 iHatred = (iHatred + (bound(send(what,@GetMaxHealth)-20,0,150)*piPlayer_factor)/100); 
-        
-        %% if they already have a lot of people chasing them, run away
-        iHatred = iHatred - (send(what,@GetMonsterChasers)*piChaser_factor)/100;
-      }   %% give newbies a break
-      if (behavior & AI_FIGHT_HYPERAGGRESSIVE)
-      { 
-        iHatred = iHatred + piHyperAggressive_factor;
+
+      % Up to 20 points for level.
+      if IsClass(what,&monster)
+      {
+         iHatred = (iHatred + Bound(Send(what,@GetLevel),1,100)/5);
       }
+      else
+      {
+         iHatred = (iHatred + (Bound(Send(what,@GetMaxHealth)-20,0,150)
+                        * piPlayer_factor)/100);
+
+         % If they already have a lot of people chasing them then run away,
+         % unless they attacked us.
+         if NOT (event = TS_FIGHT_ME_VICTIM)
+         {
+            iHatred = iHatred - (Send(what,@GetMonsterChasers)
+                                       * piChaser_factor)/100;
+         }
+      }
+
+      if (behavior & AI_FIGHT_HYPERAGGRESSIVE)
+      {
+         iHatred = iHatred + piHyperAggressive_factor;
+      }
+
       return iHatred;
    }
 

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -136,6 +136,11 @@ properties:
    % If disabled, outlaws & murderers will not be afforded the 1/3-hp damage cap protection.
    pbDamageCapProtectionMurderersEnable = FALSE
 
+   % If enabled, mobs will always check how many other mobs are aggroed on
+   % a player in hatred calculations. This is off by default, enabling it
+   % will allow players to attack monsters without them fighting back.
+   pbAlwaysCheckMonsterChasers = FALSE
+
 messages:
 
    Constructor(server_num = $)
@@ -332,6 +337,11 @@ messages:
    {
       return piLogoffPenaltyGhostTime;
    }
+
+   AlwaysCheckMonsterChasers()
+   {
+      return pbAlwaysCheckMonsterChasers;
+   }
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-


### PR DESCRIPTION
The 3 aggro limit is caused by not having monsters check if they're being attacked before cancelling hatred due to the amount of monsters already chasing the attacker.

This change adds a check for TS_FIGHT_ME_VICTIM before hatred is reduced, so that if a player attacks a monster, it will aggro no matter what (i.e. no more monsters sitting around letting themselves be killed).

Fixed up the spacing around the area I edited a little.