### PR TITLE
Fixing club and keybind, fixing warnings

### DIFF
--- a/bbgun/bmparea.c
+++ b/bbgun/bmparea.c
@@ -63,7 +63,7 @@ void DoDraw(HDC hDC1, HWND hWnd)
    int OverX, OverY;
    int i;
    BOOL highlight;
-   Bitmap *b, *anchor, *wanderer;
+   Bitmap *b, *anchor, *wanderer = NULL;
 
    ClearBitmap();
       

--- a/blakserv/adminfn.c
+++ b/blakserv/adminfn.c
@@ -711,7 +711,7 @@ void AdminTable(int len_command_table,admin_table_type command_table[],int sessi
 				char *command)
 {
 	int mode_type,i,index,num_parms,num,num_blak_parm;
-	char *parm_str,*prev_tok;
+	char *parm_str = NULL,*prev_tok = NULL;
 	admin_parm_type admin_parm[MAX_ADMIN_PARM];
 	parm_node blak_parm[MAX_ADMIN_BLAK_PARM];
 	val_type blak_val;

--- a/blakserv/blakserv.h
+++ b/blakserv/blakserv.h
@@ -117,6 +117,10 @@ enum
 #define PACKAGE_FILE "packages.txt"
 #define SPROCKET_FILE "sprocket.dll"
 
+#if !defined(BLAK_PLATFORM_WINDOWS) && !defined(BLAK_PLATFORM_LINUX)
+#error You must specify BLAK_PLATFORM_WINDOWS or BLAK_PLATFORM_LINUX
+#endif
+
 #ifdef BLAK_PLATFORM_WINDOWS
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX

--- a/blakserv/game.c
+++ b/blakserv/game.c
@@ -294,7 +294,7 @@ void GameSyncProcessSessionBuffer(session_node *s)
 void GameSyncInputChar(session_node *s,char ch)
 {
    int sync_len;
-   unsigned char *sync_buf;
+   unsigned char *sync_buf = NULL;
 
    switch (s->game->game_state)
    {

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -2398,12 +2398,12 @@ void D3DRenderPacketCeilingAdd(BSPnode *pNode, d3d_render_pool_new *pPool, Bool 
 void D3DRenderPacketWallAdd(WallData *pWall, d3d_render_pool_new *pPool, unsigned int type, int side,
 							   Bool bDynamic)
 {
-	Sidedef			*pSideDef;
+	Sidedef			*pSideDef = NULL;
 	custom_xyz		xyz[4];
 	custom_st		st[4];
 	custom_bgra		bgra[MAX_NPTS];
 	unsigned int	flags = 0;
-	PDIB			pDib;
+	PDIB			pDib = NULL;
 	int				vertex;
 
 	d3d_render_packet_new	*pPacket;
@@ -2534,12 +2534,12 @@ void D3DRenderPacketWallAdd(WallData *pWall, d3d_render_pool_new *pPool, unsigne
 void D3DRenderPacketWallMaskAdd(WallData *pWall, d3d_render_pool_new *pPool, unsigned int type,
 								int side, Bool bDynamic)
 {
-	Sidedef			*pSideDef;
+	Sidedef			*pSideDef = NULL;
 	custom_xyz		xyz[4];
 	custom_st		st[4];
 	custom_bgra		bgra[MAX_NPTS];
 	unsigned int	flags;
-	PDIB			pDib;
+	PDIB			pDib = NULL;
 	int				vertex;
 	Bool			bNoVTile = FALSE;
 	Bool			bNoLookThrough = FALSE;
@@ -4904,8 +4904,8 @@ void D3DRenderLMapPostWallAdd(WallData *pWall, d3d_render_pool_new *pPool, unsig
 	custom_st		stBase[4];
 	custom_bgra		bgra[4];
 	unsigned int	flags;
-	PDIB			pDib;
-	Sidedef			*pSideDef;
+	PDIB			pDib = NULL;
+	Sidedef			*pSideDef = NULL;
 	int				numLights;
 
 	d3d_render_packet_new	*pPacket;
@@ -5378,7 +5378,7 @@ int D3DRenderWallExtract(WallData *pWall, PDIB pDib, unsigned int *flags, custom
 {
 	int				top, bottom;
 	int				xOffset, yOffset;
-	Sidedef			*pSideDef;
+	Sidedef			*pSideDef = NULL;
 	int				drawTopDown;
 	int				paletteIndex;
 	BYTE			light;

--- a/clientd3d/drawbsp.c
+++ b/clientd3d/drawbsp.c
@@ -3960,7 +3960,7 @@ static void doDrawBackground(ViewCone *c)
    long mincol,maxcol;
    long row,col;
    long width,height;
-   BYTE *bkgnd_bmap, *bkgnd_ptr;
+   BYTE *bkgnd_bmap = NULL, *bkgnd_ptr = NULL;
    long length;
    long xoffset;
    list_type l;

--- a/club/makefile
+++ b/club/makefile
@@ -4,7 +4,7 @@ DYNAMIC=1
 
 SOURCEDIR = $(TOPDIR)\club
 
-CLUBLIBS = user32.lib gdi32.lib archive.lib comctl32.lib wininet.lib zlib.lib advapi32.lib
+CLUBLIBS = user32.lib gdi32.lib archive_static.lib comctl32.lib wininet.lib zlib.lib advapi32.lib
 
 all: makedirs $(OUTDIR)\club.exe
 

--- a/club/makefile
+++ b/club/makefile
@@ -4,7 +4,7 @@ DYNAMIC=1
 
 SOURCEDIR = $(TOPDIR)\club
 
-CLUBLIBS = user32.lib gdi32.lib archive_static.lib comctl32.lib wininet.lib zlib.lib advapi32.lib
+CLUBLIBS = user32.lib gdi32.lib archive.lib comctl32.lib wininet.lib zlib.lib advapi32.lib
 
 all: makedirs $(OUTDIR)\club.exe
 

--- a/common.mak
+++ b/common.mak
@@ -61,17 +61,18 @@ KODINCLUDEDIR = $(KODDIR)\include
 PALETTEFILE = $(TOPDIR)\blakston.pal
 
 # compiler specs -- uses multi-threaded DLL C runtime library
-# /TP builds C files in C++ mode ("Compile As" - "C++")
+# See this link for information on each setting: https://msdn.microsoft.com/en-us/library/fwkeyyhe.aspx
+# /TP builds C files in C++ mode
 # /WX treats warnings as errors
-# /GR- turns off RTTI ("Enable Run-Time Type Information" - "disable")
-# /EHsc- turns off exceptions ("Enable C++ Exceptions" - disabled?)
+# /GR- turns off Run-Time Type Information
+# /EHsc- turns off exceptions
 # /wd4996  disables warning (GetVersionExA has been deprecated)
-# -arch:IA32 disables SSE instructions (not supported on ancient Athlon CPUs) ("Enable Enhanced Instruction Set" - "disable")
+# -arch:IA32 disables SSE instructions (not supported on ancient Athlon CPUs)
 
 # Configuration specific flags:
-# -Zi turns on debug information ("Debug Information Format" - "Edit & Continue")
-# /Ox enables full optimization ("Optimization" - "Full Optimization")
-# -W# specifies which warning level ("Warning Level")
+# -Zi turns on debug information compatible with "Edit & Continue"
+# /Ox enables full optimization
+# -W# specifies which warning level
 
 CCOMMONFLAGS = -nologo -DBLAK_PLATFORM_WINDOWS -DWIN32 \
              -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE \

--- a/common.mak
+++ b/common.mak
@@ -61,16 +61,21 @@ KODINCLUDEDIR = $(KODDIR)\include
 PALETTEFILE = $(TOPDIR)\blakston.pal
 
 # compiler specs -- uses multi-threaded DLL C runtime library
-# /TP builds C files in C++ mode
+# /TP builds C files in C++ mode ("Compile As" - "C++")
 # /WX treats warnings as errors
-# /GR- turns off RTTI
-# /EHsc- turns off exceptions
+# /GR- turns off RTTI ("Enable Run-Time Type Information" - "disable")
+# /EHsc- turns off exceptions ("Enable C++ Exceptions" - disabled?)
 # /wd4996  disables warning (GetVersionExA has been deprecated)
-# -arch:IA32 disables SSE instructions (not supported on ancient Athlon CPUs)
+# -arch:IA32 disables SSE instructions (not supported on ancient Athlon CPUs) ("Enable Enhanced Instruction Set" - "disable")
+
+# Configuration specific flags:
+# -Zi turns on debug information ("Debug Information Format" - "Edit & Continue")
+# /Ox enables full optimization ("Optimization" - "Full Optimization")
+# -W# specifies which warning level ("Warning Level")
 
 CCOMMONFLAGS = -nologo -DBLAK_PLATFORM_WINDOWS -DWIN32 \
              -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE \
-             -D_WINSOCK_DEPRECATED_NO_WARNINGS /wd4996 \
+             -D_WINSOCK_DEPRECATED_NO_WARNINGS -DNO_WARN_MBCS_MFC_DEPRECATION /wd4996 \
 				 -TP -WX -GR- -EHsc- -arch:IA32
 
 CNORMALFLAGS = $(CCOMMONFLAGS) -W2 /Ox

--- a/keybind/StdAfx.h
+++ b/keybind/StdAfx.h
@@ -17,6 +17,7 @@
 #pragma once
 #endif // _MSC_VER > 1000
 
+// https://msdn.microsoft.com/en-us/library/aa383745(VS.85).aspx
 #define _WIN32_WINNT NTDDI_WINXP
 
 #define VC_EXTRALEAN		// Exclude rarely-used stuff from Windows headers

--- a/keybind/StdAfx.h
+++ b/keybind/StdAfx.h
@@ -17,6 +17,8 @@
 #pragma once
 #endif // _MSC_VER > 1000
 
+#define _WIN32_WINNT NTDDI_WINXP
+
 #define VC_EXTRALEAN		// Exclude rarely-used stuff from Windows headers
 
 #include <afxwin.h>         // MFC core and standard components

--- a/keybind/makefile
+++ b/keybind/makefile
@@ -7,7 +7,6 @@ SOURCEDIR = $(KEYBINDDIR)
 
 CFLAGS = $(CFLAGS) /EHsc
 LINKFLAGS = $(LINKFLAGS) $(LINKWINDOWSFLAGS)
-LIBS = $(LIBS) nafxcw.lib
 
 OBJS = \
 	$(OUTDIR)\Assignkey.obj \

--- a/makebgf/makebgf.c
+++ b/makebgf/makebgf.c
@@ -279,8 +279,8 @@ void Usage(void)
 /**************************************************************************/
 int main(int argc, char **argv)
 {
-   int arg, len;
-   char *output_filename;
+   int arg, len = 0;
+   char *output_filename = NULL;
    int output_file_found = 0;
    Options options;
 

--- a/module/mailnews/mailfile.c
+++ b/module/mailnews/mailfile.c
@@ -126,7 +126,7 @@ void MailNewMessage(int server_index, char *sender, int num_recipients,
 {
    int index, num_msgs, msgnum;
    char new_msg[MAXMAIL + 200 + MAX_SUBJECT + MAXUSERNAME * MAX_RECIPIENTS];
-   char *subject, *ptr, *subject_str;
+   char *subject = NULL, *ptr, *subject_str;
    int i, num;
    char filename[FILENAME_MAX + MAX_PATH];
    char date[MAXDATE];
@@ -312,7 +312,7 @@ Bool MailParseMessage(int msgnum, MailInfo *info)
    int num_fields = 5;  // Don't increase this without changing szLoadString (only 5 at a time)
    int field_ids[] = {IDS_SUBJECT_ENGLISH, IDS_SUBJECT_GERMAN,
                       IDS_FROM, IDS_TO, IDS_DATE};
-   char *fields[5], *ptr;
+   char *fields[5], *ptr = NULL;
    int i, index;
 
    if ((index = MailFindIndex(msgnum)) == -1)
@@ -408,7 +408,7 @@ Bool MailParseMessageHeader(int msgnum, char *filename, MailHeader *header)
    int field_ids[] = {IDS_SUBJECT_ENGLISH, IDS_SUBJECT_GERMAN,
                       IDS_FROM, IDS_TO, IDS_DATE};
    int i;
-   char *fields[5], *ptr;
+   char *fields[5], *ptr = NULL;
    char line[MAX_LINE];
 
    if ((infile = fopen(filename, "r")) == NULL)

--- a/module/merintr/spells.c
+++ b/module/merintr/spells.c
@@ -273,7 +273,7 @@ spell *FindSpellByID(ID id)
 spell *FindSpellByName(char *name)
 {
    list_type l;
-   spell *sp, *best_spell;
+   spell *sp = NULL, *best_spell = NULL;
    int match, max_match;
    Bool tied;            // True if a different spell matches as well as best_spell
    char *ptr, *spell_name;
@@ -328,7 +328,7 @@ spell *FindSpellByName(char *name)
 /********************************************************************/
 void UserCastSpell(void)
 {
-   spell *sp, *temp;
+   spell *sp = NULL, *temp = NULL;
    list_type sel_list, l;
 
    if (GetPlayer()->viewID && (GetPlayer()->viewID != GetPlayer()->id))
@@ -549,7 +549,7 @@ void MenuSpellChosen(int id)
    int len, num=0, index=0, i;
    char item_name[MAXRSCSTRING + 1];
    spell *sp;
-   HMENU submenu;
+   HMENU submenu = NULL;
 
    if (spell_menu == NULL)
       return;

--- a/module/merintr/statbtn.c
+++ b/module/merintr/statbtn.c
@@ -174,7 +174,7 @@ void StatsMoveButtons(void)
 	//	Buttons are now stretched to fit width of area.
 	for( i = 0; i < NUM_BUTTONS; i++ )
 	{
-		StatButton* button;
+		StatButton* button = NULL;
 		//	ajw Hard-coded changed order of buttons appearance.
 		switch( i )
 		{

--- a/util/rscmerge.c
+++ b/util/rscmerge.c
@@ -151,7 +151,7 @@ bool LoadRscFiles(int num_files, char **filenames)
 int main(int argc, char **argv)
 {
    int arg, len;
-   char *output_filename;
+   char *output_filename = NULL;
    int output_file_found = 0;
    
    if (argc < 3)


### PR DESCRIPTION
This fixes club & m59bind executables (so long as you have a Pro version
of Visual Studio), and also fixes a number of compiler warnings that
happen with warning level 2.
