### PR TITLE
Fix Dead Tree Description for Superclass Override

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/ent.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/ent.kod
@@ -230,7 +230,7 @@ messages:
                     #playername=Send(killer,@GetTrueName),#mob=TRUE,
                     #BodyTranslation=piColor_Translation,
                     #LegsTranslation=piColor_Translation,
-                    #monstername=ent_dead_name_rsc,
+                    #monstername=vrName,
                     #PlayerBodyOverlay=vrDead_leaves);
    }
 

--- a/kod/object/active/holder/nomoveon/battler/monster/evilent.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/evilent.kod
@@ -240,7 +240,7 @@ messages:
                     #playername=Send(killer,@GetTrueName),#mob=TRUE,
                     #BodyTranslation=piColor_Translation,
                     #LegsTranslation=piColor_Translation,                    
-                    #monstername=EvilEnt_dead_name_rsc,
+                    #monstername=vrName,
                     #PlayerBodyOverlay=vrDead_leaves);
    }
 


### PR DESCRIPTION
Without this change, based on kod/object/passive/body.kod, the dead description of a tree would be...

"This is a dead, decompossing dead remains of diseased tree..."