### PR TITLE
Add admin cmd to clear unused accounts and compact IDs.

### DIFF
--- a/blakserv/account.c
+++ b/blakserv/account.c
@@ -541,3 +541,46 @@ void DeleteAccountAndAssociatedUsersByID(int account_id)
 	      account_id);
    }
 }
+
+// Iterate through accounts and remove unused ones.
+void DeleteAccountsIfUnused()
+{
+   account_node *a, *temp;
+
+   a = accounts;
+   while (a != NULL)
+   {
+      temp = a;
+      a = a->next;
+      DeleteAccountIfUnused(temp);
+   }
+}
+
+// Deletes an account and associated users if account has never been logged in.
+void DeleteAccountIfUnused(account_node *a)
+{
+   if (a->last_login_time == 0)
+      DeleteAccountAndAssociatedUsersByID(a->account_id);
+}
+
+// Compacts the accounts if any have been removed. Called by
+// AdminDeleteUnusedAccounts after deleting unused accounts.
+void CompactAccounts()
+{
+   account_node *a;
+   int new_number = 1;
+
+   a = accounts;
+
+   while (a != NULL)
+   {
+      if (a->account_id != new_number)
+      {
+         ChangeUserAccountID(a->account_id, new_number);
+         a->account_id = new_number;
+      }
+      ++new_number;
+      a = a->next;
+   }
+   SetNextAccountID(new_number);
+}

--- a/blakserv/account.h
+++ b/blakserv/account.h
@@ -50,6 +50,10 @@ void DoneLoadAccounts(void);
 void ForEachAccount(void (*callback_func)(account_node *a));
 void DeleteAccountAndAssociatedUsersByID(int account_id);
 
+void DeleteAccountsIfUnused();
+void DeleteAccountIfUnused(account_node *a);
+void CompactAccounts(void);
+
 Bool SuspendAccountAbsolute(account_node *a, int suspend_time);
 Bool SuspendAccountRelative(account_node *a, int hours);
 int GetActiveAccountCount();

--- a/blakserv/user.c
+++ b/blakserv/user.c
@@ -318,3 +318,15 @@ user_node * GetUserByName(char *username)
    return GetUserByObjectID(ret_val.v.data);
 }
 
+void ChangeUserAccountID(int account_id, int new_account_id)
+{
+   user_node *u;
+
+   u = users;
+   while (u != NULL)
+   {
+      if (u->account_id == account_id)
+         u->account_id = new_account_id;
+      u = u->next;
+   }
+}

--- a/blakserv/user.h
+++ b/blakserv/user.h
@@ -35,5 +35,6 @@ void ForEachUser(void (*callback_func)(user_node *u));
 void ForEachUserByAccountID(void (*callback_func)(user_node *u),int account_id);
 user_node * GetFirstUserByAccountID(int account_id);
 user_node * GetUserByName(char *username);
+void ChangeUserAccountID(int account_id, int new_account_id);
 
 #endif


### PR DESCRIPTION
Ported from https://github.com/OpenMeridian/Meridian59/pull/1213.

We recently added this on 103 as 14% of our accounts were never logged on. We though that this might be much more useful if run on 101/102 given how many accounts must be present after a decade.

The admin command "delete unused" will remove any unused accounts (i.e. any that have never been logged on before) and compact the account numbers to reclaim previously used ones.

Kicks off all users before carrying out the delete/compact to avoid any potential issues with sessions.

This took about 40 seconds to run with ~3500 accounts (deleting ~550).
