### PR TITLE
Made broadcast mana penalty a setting that can be changed at runtime 

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -3227,7 +3227,7 @@ messages:
 
       if NOT Send(Send(SYS,@GetParliament),@BetaPotionsEnabled)
       {
-         iCost = Bound(piMax_mana/2+1,11,$);
+         iCost = piMana * Send(Send(SYS,@GetSettings),@GetBroadcastManaCost) / 100;
          if piMana < iCost
          {
             Send(self,@MsgSendUser,#message_rsc=player_cant_broadcast);

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -140,6 +140,12 @@ properties:
    % a player in hatred calculations. This is off by default, enabling it
    % will allow players to attack monsters without them fighting back.
    pbAlwaysCheckMonsterChasers = FALSE
+   
+   % Broadcast mana penalty in percent.  While the cost to broadcast can be
+   % useful to prevent flame wars and spamming, it also reduces player's
+   % ability to ask questions and socialize.  (Puts a damper on trivia
+   % contests too!)  This value can be changed to tweak the penalty in realtime
+   piBroadcastManaCost = 25
 
 messages:
 
@@ -343,5 +349,9 @@ messages:
       return pbAlwaysCheckMonsterChasers;
    }
 
+   GetBroadcastManaCost()
+   {
+      return piBroadcastManaCost;
+   }
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
While the cost to broadcast can be useful to prevent flame wars and spamming, it also reduces player ability to ask questions and socialize.  (Puts a damper on trivia contests too!)  This value can be changed to tweak the penalty in real time by an admin