### PR TITLE
Made broadcast mana penalty a setting that can be changed at runtime

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -3216,7 +3216,7 @@ messages:
    "Called when the user wants to broadcast a string.  Return True/False, "
    "and use some mana too."
    {
-      local iCost;
+      local iCost, iBroadcastPenaltyPercent;
       
       if piFlags & PFLAG_SQUELCHED
       {
@@ -3227,7 +3227,15 @@ messages:
 
       if NOT Send(Send(SYS,@GetParliament),@BetaPotionsEnabled)
       {
-         iCost = Bound(piMax_mana/2+1,11,$);
+         iBroadcastPenaltyPercent = Send(Send(SYS,@GetSettings),@GetBroadcastManaCostPercent);
+
+         if iBroadcastPenaltyPercent = 0
+         {
+            return TRUE;
+         }
+            
+         iCost = Bound((piMax_Mana * iBroadcastPenaltyPercent / 100 + 1),1,$);
+
          if piMana < iCost
          {
             Send(self,@MsgSendUser,#message_rsc=player_cant_broadcast);

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -145,7 +145,7 @@ properties:
    % useful to prevent flame wars and spamming, it also reduces player's
    % ability to ask questions and socialize.  (Puts a damper on trivia
    % contests too!)  This value can be changed to tweak the penalty in realtime
-   piBroadcastManaCostPercent = 8
+   piBroadcastManaCostPercent = 50
 
 messages:
 

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -140,6 +140,12 @@ properties:
    % a player in hatred calculations. This is off by default, enabling it
    % will allow players to attack monsters without them fighting back.
    pbAlwaysCheckMonsterChasers = FALSE
+   
+   % Broadcast mana penalty in percent.  While the cost to broadcast can be
+   % useful to prevent flame wars and spamming, it also reduces player's
+   % ability to ask questions and socialize.  (Puts a damper on trivia
+   % contests too!)  This value can be changed to tweak the penalty in realtime
+   piBroadcastManaCostPercent = 8
 
 messages:
 
@@ -343,5 +349,9 @@ messages:
       return pbAlwaysCheckMonsterChasers;
    }
 
+   GetBroadcastManaCostPercent()
+   {
+      return piBroadcastManaCostPercent;
+   }
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
(Resolved issues with previous  pull request)

While the cost to broadcast can be useful to prevent flame wars and spamming, it also reduces player ability to ask questions and socialize. (Puts a damper on trivia contests too!) This value can be changed to tweak the penalty in real time by an admin