### PR TITLE
Give new players a bit more time to solve the raza puzzle

### DIFF
--- a/kod/object/active/holder/room/monsroom/guest6.kod
+++ b/kod/object/active/holder/room/monsroom/guest6.kod
@@ -18,7 +18,7 @@ constants:
    SECTOR_NODE1 = 4
    SECTOR_NODE2 = 5
 
-   SLAM_TIME = 2000
+   SLAM_TIME = 5500
    FIGHT_TIME = 10000
 
    MIN_GEN_ROW = 29


### PR DESCRIPTION
Given the low player population, it is highly unlikely that 2 players will be in Raza to pull the 2 levers to open the door.  This adds a few seconds to allow 1 player to run from 1 lever to the other.