### PR TITLE
Changed starting mana and mana provided by each node.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5869,7 +5869,7 @@ messages:
 
    GetInitialMaxMana()
    {
-      return 15 + Send(self,@GetMysticism)/5;
+      return 54 + Send(self,@GetMysticism)/5;
    }
  
    StripNodeList(number=$)

--- a/kod/object/passive/mananode.kod
+++ b/kod/object/passive/mananode.kod
@@ -232,7 +232,7 @@ messages:
          return 0;
       }
 
-      return (((5 + Send(who,@GetMysticism)) / 10) + 3);
+      return ((5 + Send(who,@GetMysticism)) / 10);
    }
 
    ReqNewOwner(what = $)

--- a/kod/object/passive/mananode/feynode.kod
+++ b/kod/object/passive/mananode/feynode.kod
@@ -135,7 +135,7 @@ messages:
    GetManaAdjust(who=$)
    {
       % Twice the standard.
-      return (2*(((5 + Send(who,@GetMysticism)) / 10) + 3));
+      return (2*((5 + Send(who,@GetMysticism)) / 10));
    }
 
    SendAnimation()


### PR DESCRIPTION
I noticed that when new players start they have very little mana to cast the utility spells they may have chosen to start with and in order to really play around with the spells they need to leave Raza and grab a few nodes.  This essentially requires someone to take them on a node run and creates a lot of barriers for someone who has never played.

This change gives players a higher starting mana and reduces the mana given per node and ultimately the max mana stays the same.  The only downside is that it does reduce the importance of the nexus and vale node because a character missing two nodes will now have more mana than before.  A potential bonus to the reduced importance of individual nodes is that you can now add another node without greatly altering the end game.


Current   System
--
Myst | Base | Mana/Node | Max
:---:|:---:|:---:|:---:
1 | 15 | 3 | 54
5 | 16 | 4 | 68
10 | 17 | 4 | 69
15 | 18 | 5 | 83
20 | 19 | 5 | 84
25 | 20 | 6 | 98
30 | 21 | 6 | 99
35 | 22 | 7 | 113
40 | 23 | 7 | 114
45 | 24 | 8 | 128
50 | 25 | 8 | 129
55 | 25 | 9 | 142

Proposed System
--
Myst | Base | Mana/Node | Max
:---:|:---:|:---:|:---:
1 | 54 | 0 | 54
5 | 55 | 1 | 68
10 | 56 | 1 | 69
15 | 57 | 2 | 83
20 | 58 | 2 | 84
25 | 59 | 3 | 98
30 | 60 | 3 | 99
35 | 61 | 4 | 113
40 | 62 | 4 | 114
45 | 63 | 5 | 128
50 | 64 | 5 | 129
55 | 64 | 6 | 142



