### PR TITLE
Error log cleanup

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3484,6 +3484,15 @@ messages:
    TextureSendUser(id = $,new_texture = $,flags = 0)
    "Sent by room when one of its textures changes."
    {
+      if (id = $
+         OR new_texture = $
+         OR flags = $)
+         AND Send(self,@GetOwner) <> $
+      {
+         % We must find out in which room this error is occurring
+         Debug("Had a texture error in ",Send(Send(self,@GetOwner),@GetName));
+      }
+
       if pbLogged_on
       {
          AddPacket(1,BP_CHANGE_TEXTURE,2,id,2,new_texture,1,flags);


### PR DESCRIPTION
* [memmap/user.bof (3491)] AddBlakodToPacket looking for value, got NIL

This is an error relating to TextureSendUser. I believe somewhere a room
has improperly changed its textures. We must find out where. A few rooms
do this, like Icky cave's dispel or Ancient place's brax elevator. It
may also be a borked rented room.

**So far, this pull request's only change is to add a debug to TextureSendUser
to gather information about where this is happening.**

---------

* [memmap/player.bof (11047)] DeleteTimer can't find timer <number>

This error is related to faction service timers somehow being lost. 103
also has this problem! A few of these seem to accumulate over time. We
have been able to fix a majority of them with a brute force function
that checks all players' faction timers, but 2-3 still remained. It's
one of the problems we've been working on the longest. It almost feels
like there is a fundamental breakdown in the handling of timers over
many years. Somehow, somewhere, a small number of references go bad.

---------

* [Server] SendBlakodMessage CLASS PrincessTroop (11135) OBJECT 830066
can't find a handler for MESSAGE AttributeTimer (12354)

Messages like this one are the result of an incorrect reference for a
timer, and I believe they are a child of this problem:

Dec  02 2018 16:00:01 | GetObjectByID can't retrieve deleted OBJECT
842179 which was CLASS Axe
Dec  02 2018 16:00:01 | RenumberTimerObjectReferences death by garbage
collection, message AttributeTimer
Dec  02 2018 16:00:01 | GetObjectByID can't retrieve deleted OBJECT
835025 which was CLASS RemoveCursePotion
Dec  02 2018 16:00:01 | RenumberTimerObjectReferences death by garbage
collection, message GoBad

As I mentioned above, I believe these all stem from the extremely rare
timer 'reference corruption' plus the extreme age of Server 101.

---------

* Dec  02 2018 13:00:04 | GetObjectByID can't retrieve invalid object
840120
Dec  02 2018 13:00:04 | SaveEachTimer can't get object 840120

This error is similarly related. A small number of objects or timers
seem to just get... lost. This generates continual errors, especially
around saves.