### PR TITLE
Fix Riija Bridge overzealous item dropping

### DIFF
--- a/kod/object/active/holder/room/temprii.kod
+++ b/kod/object/active/holder/room/temprii.kod
@@ -367,7 +367,8 @@ messages:
       dropped = FALSE;
       for i in send(what,@GetPlayerUsing)
       {
-         if send(i,@ReqLeaveOwner)
+         if Send(i,@ReqLeaveOwner)
+            AND Send(i,@DropOnDeath)
             AND random(1,3) = 1
          {
             send(self,@NewHold,#what=i,#new_row=send(what,@GetRow),#new_col=send(what,@GetCol));
@@ -381,8 +382,9 @@ messages:
       {
          for i in send(what,@GetHolderPassive)
          {
-            if send(i,@ReqLeaveOwner)
-            AND random(1,3) = 1
+            if Send(i,@ReqLeaveOwner)
+               AND Send(i,@DropOnDeath)
+               AND random(1,3) = 1
             {
                send(self,@NewHold,#what=i,#new_row=send(what,@GetRow),#new_col=send(what,@GetCol));
                

--- a/kod/object/active/holder/room/temprii.kod
+++ b/kod/object/active/holder/room/temprii.kod
@@ -367,9 +367,7 @@ messages:
       dropped = FALSE;
       for i in send(what,@GetPlayerUsing)
       {
-         if Send(i,@ReqLeaveOwner)
-            AND Send(i,@DropOnDeath)
-            AND random(1,3) = 1
+         if Send(self,@ShouldDropItem,#oItem=i)
          {
             send(self,@NewHold,#what=i,#new_row=send(what,@GetRow),#new_col=send(what,@GetCol));
             dropped = TRUE;
@@ -382,9 +380,7 @@ messages:
       {
          for i in send(what,@GetHolderPassive)
          {
-            if Send(i,@ReqLeaveOwner)
-               AND Send(i,@DropOnDeath)
-               AND random(1,3) = 1
+            if Send(self,@ShouldDropItem,#oItem=i)
             {
                send(self,@NewHold,#what=i,#new_row=send(what,@GetRow),#new_col=send(what,@GetCol));
                
@@ -434,6 +430,19 @@ messages:
       }
       
       return;
+   }
+
+   ShouldDropItem(oItem=$)
+   {
+      if oItem <> $
+         AND Send(oItem,@ReqLeaveOwner)
+         AND Send(oItem,@DropOnDeath)
+         AND random(1,3) = 1
+      {
+         return TRUE;
+      }
+
+      return FALSE;
    }
 
    TimerMessage1()


### PR DESCRIPTION
Riija Temple bridge is coded to sometimes drop an item when the player falls. However, it checks if an item is valid to drop with ReqLeaveOwner, which is only ever false for cursed items. Here I've added a check for DropOnDeath, which will exclude very important items like room keys and bonded equipment.