### PR TITLE
Update light to use generic Faren sfx

### DIFF
--- a/kod/object/passive/spell/roomench/light.kod
+++ b/kod/object/passive/spell/roomench/light.kod
@@ -30,7 +30,7 @@ resources:
    light_new_entrant = "This place is illuminated by a magical glow."  %replace by icon
    light_spell_intro = "Faren Lv. 1:  Fills an area with magical illumination."
 
-   light_sound = flight.wav
+   light_sound = faren.wav
 
 classvars:
 


### PR DESCRIPTION
_A re-submission of #387 because I had to modify my local branches._

This updates Faren's Light sfx by updating its reference from `flight.wav`, a sfx that quite possibly doesn't exist, to`faren.wav`. It is in response to #224.

After installing and looking through the resources for the only two discs I could installed (Insurrection and Dark Auspices) I was unable to find `flight.wav` or equivalent sound under a different name. I created a potential new sfx that I'll share below, but ultimately chose to do what spells like Bramble and Lightning Wall do: use `faren.wav`. The generic Faren sfx might be one of the better choices considering how frequently a spell like Light might be cast (i.e. less noise, relatively speaking).

Here is the result:

https://user-images.githubusercontent.com/467443/175820684-450abfbc-93ce-4276-83cc-9aff6ed662f3.mp4

And here is the alternative I created:

https://user-images.githubusercontent.com/467443/175820748-fd50e7cb-4357-4a01-8f98-b1f93e50ea24.mp4

Note: this alternate version uses sfx from [freesound](https://freesound.org/), [licensed under the Attribution Noncommercial 4.0 License.](https://creativecommons.org/licenses/by-nc/4.0/)