### PR TITLE
Update second wind enchantment

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -87,9 +87,6 @@ constants:
    PANTS_MUL  = 0x0100
    
    BASE_NEED = 105
-
-   % If vigor gets this low, see if second wind skill kicks in.
-   SECONDWIND_THRESHOLD = 25
    
    % How steep is the curve for learning new levels of spells?
    %  A higher number means a greater slope (less points at low levels)
@@ -708,8 +705,6 @@ resources:
    player_logged_on_wav_rsc = player_login_or_out.wav
    player_logged_off_wav_rsc = player_logout2.wav
    
-   second_wind_finished = "You feel more relaxed as your second wind dissipates."
-
 classvars:
 
    viHand_space = 2
@@ -877,6 +872,7 @@ properties:
    
    piGender = GENDER_MALE
 
+   % Player vigor thresholds
    piVigor_rest_threshold = 80
 
    % The user's string description, typed when created (and editable in game).
@@ -937,9 +933,6 @@ properties:
 
    piLastDeathTime = 0
 
-   % This keeps the duration of our Second Wind skill's "downtime"
-   ptSecondWind = $
-
    % Measures how long we have to wait before we're rescued.
    ptRescue = $
 
@@ -998,14 +991,6 @@ messages:
       {
          DeleteTimer(ptAdvancement);
          ptAdvancement = $;
-      }
-      
-      if ptSecondWind <> $
-      {
-         DeleteTimer(ptSecondWind);
-         ptSecondWind = $;
-         Send(self,@ShowRemoveEnchantment,#what=Send(SYS,@FindSkillByNum,#num=SKID_SECOND_WIND),
-         	#type=ENCHANTMENT_PLAYER);
       }
 
       Send(self,@CancelRescue);
@@ -1197,72 +1182,20 @@ messages:
    %%% Vigor
 
    NewVigor()
-   "Ensures vigor stays in bounds.  Also checks for second wind skill"
-   "NOTE: Do not modify vigor below SECONDWIND_THRESHOLD if you do not want the skill to kick in."
+   "Ensures vigor stays in bounds, including attempts at second wind skill"
    "Vigor display will be driven from here."
    {
-      if piVigor < SECONDWIND_THRESHOLD
-         AND ptSecondWind = $
-         AND Send(self,@GetSkillAbility,#Skill_num=SKID_SECOND_WIND) > 0
-         AND Send(Send(SYS,@FindSkillByNum,#num=SKID_SECOND_WIND),@DoSkill,#who=self)
+      % If vigor is changing and player has second wind, but isn't enchanted by it,
+      % then attempt second wind.
+      if Send(self,@GetSkillAbility,#Skill_num=SKID_SECOND_WIND) > 0
+         AND NOT Send(self,@IsEnchanted,#byClass=&SecondWind)
       {
-         Send(self,@StartSecondWind);
+         Send(Send(SYS,@FindSkillByNum,#num=SKID_SECOND_WIND),@TrySkill,#who=self);
       }
-      
+
       piVigor = bound(piVigor,1,viMax_vigor);
       Send(self,@DrawVigor);
 
-      return;
-   }
-
-   StartSecondWind()
-   {
-      local oWind, iTime;
-
-      if Send(self,@GetSkillAbility,#Skill_num=SKID_SECOND_WIND) = 0
-      {
-         return FALSE;
-      }
-
-      oWind = Send(SYS,@FindSkillByNum,#num=SKID_SECOND_WIND);
-      iTime = Send(oWind,@GetWaitTime,#who=self);
-      ptSecondWind = CreateTimer(self,@EndSecondWindTimer,iTime);
-      Send(self,@SetVigorRestThreshold,#amount=10);
-      
-      return TRUE;
-   }
-
-   EndSecondWindTimer()
-   {
-      ptSecondWind = $;
-      Send(self,@EndSecondWind);
-      
-      return;
-   }
-
-   EndSecondWind()
-   {
-      local iAmount;
-
-      if ptSecondWind <> $
-      {
-         DeleteTimer(ptSecondWind);
-         ptSecondWind = $;
-      }
-      
-      % This prevents repeated triggering of the second wind skill.
-      if piVigor < SECONDWIND_THRESHOLD
-      {
-         piVigor = SECONDWIND_THRESHOLD;
-      }
-
-      iAmount = 80 + ((Send(self,@GetSkillAbility,#Skill_num=SKID_SECOND_WIND) + 1) / 5);
-      Send(self,@SetVigorRestThreshold,#amount=iAmount);
-      Send(self,@NewVigor);
-      Send(self,@MsgSendUser,#message_rsc=second_wind_finished);
-      Send(self,@ShowRemoveEnchantment,#what=Send(SYS,@FindSkillByNum,#num=SKID_SECOND_WIND),
-      		 #type=ENCHANTMENT_PLAYER);
-      
       return;
    }
 
@@ -1276,11 +1209,11 @@ messages:
       piVigor_rest_threshold = amount;
 
       % Don't go above rest threshold if we're still waiting for Second Wind.
-      if ptSecondWind <> $
+      if Send(self,@IsEnchanted,#byClass=&SecondWind)
       {
          piVigor_rest_threshold = 10;
       }
-      
+  
       piVigor_rest_threshold = Bound(piVigor_rest_threshold,10,100);
 
       Send(self,@DrawVigor);
@@ -1292,14 +1225,15 @@ messages:
    {
       local iExertionAdded, iPercentReduced, iVigorLost;
       
+      iExertionAdded = amount;
+
       % If we cannot gain vigor due to Second Wind, return out if trying
       %  to take away exertion
-      if ptSecondWind <> $ AND amount < 0
+      if Send(self,@IsEnchanted,#byClass=&SecondWind)
+         AND amount < 0
       {
          return;
       }
-
-      iExertionAdded = amount;
 
       if iExertionAdded > 0
       {
@@ -1326,7 +1260,7 @@ messages:
 
          Send(self,@NewVigor);
       }
-      
+
       return;
    }
 
@@ -1335,8 +1269,11 @@ messages:
    {        
       local iAmount;
 
-      % If we cannot gain vigor (probably due to Second Wind), return out if trying to take away exertion
-      if (ptSecondWind <> $) AND (amount < 0)
+      iAmount = amount;
+
+      % Return if extertion is being added but second wind skill is active
+      if Send(self,@IsEnchanted,#byClass=&SecondWind)
+         AND amount < 0
       {
          return;
       }
@@ -1346,7 +1283,6 @@ messages:
          return;
       }
       
-      iAmount = Amount;
       if Send(poOwner,@CheckRoomFlag,#flag=ROOM_SANCTUARY) AND amount < 0
       {
          iAmount = 2 * Amount;
@@ -1372,7 +1308,7 @@ messages:
       
       return;
    }
-      
+
    UpdateStomach()
    "Removes consumed food from stomach"
    {
@@ -3117,12 +3053,6 @@ messages:
          {
             Send(self,@ShowAddEnchantment,#what=each_obj,#type=ENCHANTMENT_PLAYER);
          }
-      }
-      
-      if ptSecondWind <> $
-      {
-	 Send(self,@ShowAddEnchantment,#what=Send(SYS,@FindSkillByNum,
-	    #num=SKID_SECOND_WIND),#type=ENCHANTMENT_PLAYER);
       }
 
       return;
@@ -10137,18 +10067,6 @@ messages:
       Send(self,@RemoveAllEnchantments);
       Send(self,@RecalcBulkAndWeight);
       Send(self,@ResetPlayerFlagList);
-
-      if ptSecondWind <> $
-      {
-         DeleteTimer(ptSecondWind);
-         ptSecondWind = $;
-         Send(self,@MsgSendUser,#message_rsc=second_wind_finished);
-         Send(self,@ShowRemoveEnchantment,#what=Send(SYS,@FindSkillByNum,#num=SKID_SECOND_WIND),
-         	#type=ENCHANTMENT_PLAYER);
-      }
-
-      iAmount = 80 + ((Send(self,@GetSkillAbility,#Skill_num=SKID_SECOND_WIND) + 1) / 5);
-      Send(self,@SetVigorRestThreshold,#amount=iAmount);
 
       % All attack modifiers should be a room enchantment, a personal enchantment
       %  or something they are wearing.  If one still exists, bug.  This is also

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1863,14 +1863,7 @@ messages:
       % Restart Health and Mana timers
       Send(self,@NewHealth);
       Send(self,@NewMana);
-      
-      % Add second wind icon if timer still active
-      if ptSecondWind <> $
-      {
-      Send(self,@ShowAddEnchantment,#what=Send(SYS,@FindSkillByNum,
-      	    #num=SKID_SECOND_WIND),#type=ENCHANTMENT_PLAYER);
-      }
-      
+
       Send(self,@SendUserAllWindowOverlays);
 
       if Send(SYS,@GetParliament)<>$

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -3126,6 +3126,12 @@ messages:
          }
       }
       
+      if ptSecondWind <> $
+      {
+	 Send(self,@ShowAddEnchantment,#what=Send(SYS,@FindSkillByNum,
+	    #num=SKID_SECOND_WIND),#type=ENCHANTMENT_PLAYER);
+      }
+
       return;
    }
 

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -707,6 +707,8 @@ resources:
 
    player_logged_on_wav_rsc = player_login_or_out.wav
    player_logged_off_wav_rsc = player_logout2.wav
+   
+   second_wind_finished = "You feel more relaxed as your second wind dissipates."
 
 classvars:
 
@@ -1002,6 +1004,8 @@ messages:
       {
          DeleteTimer(ptSecondWind);
          ptSecondWind = $;
+         Send(self,@ShowRemoveEnchantment,#what=Send(SYS,@FindSkillByNum,#num=SKID_SECOND_WIND),
+         	#type=ENCHANTMENT_PLAYER);
       }
 
       Send(self,@CancelRescue);
@@ -1255,6 +1259,9 @@ messages:
       iAmount = 80 + ((Send(self,@GetSkillAbility,#Skill_num=SKID_SECOND_WIND) + 1) / 5);
       Send(self,@SetVigorRestThreshold,#amount=iAmount);
       Send(self,@NewVigor);
+      Send(self,@MsgSendUser,#message_rsc=second_wind_finished);
+      Send(self,@ShowRemoveEnchantment,#what=Send(SYS,@FindSkillByNum,#num=SKID_SECOND_WIND),
+      		 #type=ENCHANTMENT_PLAYER);
       
       return;
    }
@@ -1856,6 +1863,13 @@ messages:
       % Restart Health and Mana timers
       Send(self,@NewHealth);
       Send(self,@NewMana);
+      
+      % Add second wind icon if timer still active
+      if ptSecondWind <> $
+      {
+      Send(self,@ShowAddEnchantment,#what=Send(SYS,@FindSkillByNum,
+      	    #num=SKID_SECOND_WIND),#type=ENCHANTMENT_PLAYER);
+      }
       
       Send(self,@SendUserAllWindowOverlays);
 
@@ -10129,6 +10143,9 @@ messages:
       {
          DeleteTimer(ptSecondWind);
          ptSecondWind = $;
+         Send(self,@MsgSendUser,#message_rsc=second_wind_finished);
+         Send(self,@ShowRemoveEnchantment,#what=Send(SYS,@FindSkillByNum,#num=SKID_SECOND_WIND),
+         	#type=ENCHANTMENT_PLAYER);
       }
 
       iAmount = 80 + ((Send(self,@GetSkillAbility,#Skill_num=SKID_SECOND_WIND) + 1) / 5);

--- a/kod/object/passive/skill/secwind.kod
+++ b/kod/object/passive/skill/secwind.kod
@@ -13,6 +13,7 @@ SecondWind is Skill
 constants:
 
    include blakston.khd
+   include protocol.khd
 
 resources:
 
@@ -48,6 +49,8 @@ classvars:
    vbCheck_exertion = FALSE
 
    vbAutomatic = TRUE
+   
+   viShow_enchantment_icon = 0x02
 
 properties:
 
@@ -87,6 +90,7 @@ messages:
       % Reverse sign so we're taking away exertion.
       iVigor = -iVigor;
       Send(who,@AddExertion,#amount=10000*iVigor);
+      Send(who,@ShowAddEnchantment,#what=self,#type=ENCHANTMENT_PLAYER);
 
       propagate;
    }
@@ -125,6 +129,10 @@ messages:
       propagate;
    }
 
+   ShowEnchantmentIcon(type = $)
+   {
+      return viShow_enchantment_icon & 0x02;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/skill/secwind.kod
+++ b/kod/object/passive/skill/secwind.kod
@@ -27,6 +27,7 @@ resources:
    SecondWind_skill_intro = "Weaponcraft Lv. 4: The ability to press on even when exhausted."
 
    SecondWind_success = "You catch your second wind!"
+   SecondWind_finished = "You feel more relaxed as your second wind dissipates."
    SecondWind_sound = wscndwnd.wav
 
 classvars:
@@ -44,6 +45,7 @@ classvars:
    viSchool = SKS_FENCING
    viSkill_Level = 4
    viChance_to_Increase = 50
+   viThreshold = 25
 
    viSkillExertion = 0
    vbCheck_exertion = FALSE
@@ -62,65 +64,101 @@ messages:
       return Send(who,@GetStamina);
    }
 
-   SkillFailed(who=$)
-   {
-      % Override base class behavior to do nothing.  Base class sends a
-      %  spammy message if we fail.
-      return;
-   }
-
-   DoSkill(who=$)
-   {
-      local iVigor;
-   
-      if who = $ 
-      {
-         debug("DoSkill called with bad who.");
-         return FALSE;
-      }
-      
-      if NOT (Send(self,@CanPayCosts,#who=who) AND Send(self,@PayCosts,#who=who))
-      {
-         return FALSE;
-      }
-      
-      send(who,@MsgSendUser,#message_rsc=SecondWind_success);
-      send(who,@WaveSendUser,#wave_rsc=SecondWind_sound);
-      iVigor = 40 + (Send(self,@GetRequisiteStat,#who=who)/2) + Send(who,@GetSkillAbility,#Skill_num=viSkill_num);
-      % Reverse sign so we're taking away exertion.
-      iVigor = -iVigor;
-      Send(who,@AddExertion,#amount=10000*iVigor);
-      Send(who,@ShowAddEnchantment,#what=self,#type=ENCHANTMENT_PLAYER);
-
-      propagate;
-   }
-
-   GetWaitTime(who=$)
+   GetDuration(who=$)
+   "Duration is anywhere from 5 to 10 minutes before Second Wind can be triggered again"
    {
       local iStamina, iWaitTime;
-   
-      if (who=$)
-      {
-         debug("GetWaitTime called with bad who.");
-         return FALSE;
-      }
-      
+
       iStamina = Send(self,@GetRequisiteStat,#who=who);
-      iWaitTime = ((100-iStamina) * Send(who,@GetSkillAbility,#Skill_num=viSkill_num)/100) + iStamina;
-      % 5 to 10 minutes wait time before you can leap into the action again.
+      iWaitTime = ((100-iStamina) * Send(self,@GetAbility,#who=who)/100) + iStamina;
       iWaitTime = (600 - (iWaitTime*3)) * 1000;
 
       return iWaitTime;
    }
 
-   % This is the initial chance to advance.
-   GetInitialChance(who = $)
+   TrySkill(who=$)
+   "Do the skill only if player meets the requirements."
+   {
+      % If player has second wind, has fallen below the vigor 
+      % threshold, and is not already enchanted
+      if Send(self,@GetAbility,#who=who) > 0
+         AND Send(who,@GetVigor) < viThreshold
+         AND NOT Send(who,@IsEnchanted,#byClass=&SecondWind)
+      {
+         % Apply the effects of second wind
+         Send(self,@AddEnchantmentEffects,#who=who);
+
+         % Start the enchantment timer and adds enchantment icon
+         Send(who,@StartEnchantment,#what=self,
+           #time=send(self,@GetDuration,#who=who));
+
+         % Send message
+         Send(who,@MsgSendUser,#message_rsc=SecondWind_success);
+   
+         % Send sound
+         Send(who,@WaveSendUser,#wave_rsc=SecondWind_sound);
+      }
+
+      return;
+   }
+
+   AddEnchantmentEffects(who=$)
+   "Adjusts vigor threshold and amount. Mimics a personal enchantment."
+   { 
+      local iVigor;
+      
+      % Lock the player's vigor rest threshold while enchanted
+      Send(who,@SetVigorRestThreshold,#amount=10);
+
+      % Calculate new vigor = 40 + Stamina/2 + skill %
+      iVigor = 40 + Send(self,@GetRequisiteStat,#who=who)/2 + Send(self,@GetAbility,#who=who);
+      iVigor = -iVigor; % Reverse sign so we're taking away exertion
+      
+      % Update player vigor
+      Send(who,@AddExertion,#amount=10000*iVigor);
+
+      propagate;
+   }
+
+   EndEnchantment(who=$, report=TRUE)
+   {
+      if report
+      {
+         Send(who,@MsgSendUser,#message_rsc=SecondWind_finished);
+      }
+
+      Post(self,@EndEnchantmentEffects,#who=who);
+
+      return;
+   }
+   
+   EndEnchantmentEffects(who=$)
+   "Resets vigor rest threshold once the enchantment ends."
+   {
+      local iAmount;
+
+      % Resets the player's vigor rest threshold based on second wind %
+      iAmount = 80 + ((Send(self,@GetAbility,#who=who) + 1) / 5);
+   
+      Send(who,@SetVigorRestThreshold,#amount=iAmount);
+
+      return;
+   }
+
+   SkillFailed(who=$)
+   "Overrides base class behavior to avoid spammy message if we fail."
+   {
+      return;
+   }
+
+   GetInitialChance(who=$)
+   "This is the initial chance to advance."
    {
       % No easy-cheezing it.  No advancement if you have an "easy" way to trigger
       %  the skill.  This includes tokens, cursed rings, or (token) deaths.
-      if send(who,@PossessesA,#class=&Token)
-         OR send(who,@PossessesA,#class=&RingOfLethargy)
-         OR send(send(who,@GetOwner),@GetRoomNum) = RID_UNDERWORLD
+      if Send(who,@PossessesA,#class=&Token)
+         OR Send(who,@PossessesA,#class=&RingOfLethargy)
+         OR Send(send(who,@GetOwner),@GetRoomNum) = RID_UNDERWORLD
       {
          % No initial chance to succeed; that is, you will always fail to advance.
          return 0;
@@ -129,9 +167,45 @@ messages:
       propagate;
    }
 
-   ShowEnchantmentIcon(type = $)
+   ShowEnchantmentIcon(type=$)
    {
       return viShow_enchantment_icon & 0x02;
+   }
+
+   IsPersonalEnchantment()
+   "Included to support mimicing of personal enchantment spells."
+   {
+      return TRUE;
+   }
+
+   SetSpellPlayerFlag(who=$)
+   "Included to support mimicing of personal enchantment spells."
+   {
+      return;
+   }
+
+   AffectsMaxMana()
+   "Included to support mimicing of personal enchantment spells."
+   {
+      return FALSE;
+   }
+
+   IsPeriodic()
+   "Included to support mimicing of personal enchantment spells."
+   {
+      return FALSE;
+   }
+
+   RestartEnchantmentEffect(who=$, state=$)
+   "Included to support mimicing of personal enchantment spells."
+   {
+      return;
+   }
+
+   IsHarmful()
+   "Included to support mimicing of personal enchantment spells."
+   {
+      return FALSE;
    }
 
 end


### PR DESCRIPTION
This PR builds on the work of @skittles1 and @Nagath in #296 and closes #296 if merged.

As it stands today, Second Wind does not trigger a visual indicator and #296 adds one with a few minor bugs this PR initially addressed. Per the suggestion of @Meridian59, I've pivoted this PR to refactor second wind to mimic personal enchantment spells. No changes to the core second wind functionality should be changed by this PR.

# Known Issues
- The original handling of second wind updates the player's rest threshold from 80 to >80 once second wind dissipates. I don't understand why and it seems like it could be a bug, because I don't see anything that says second wind should permanently affect a player's default rest threshold.

# Testing
## Overview
* Testing requires your player to to be in several states (i.e. vigor below threshold, vigor above, with and without second wind, etc). When testing, I used an admin player with the default stats (25) in mortal mode (`dm mortal`) with all spells and skills (`dm get spells` and `dm get skills`). I cast blink to quickly drain my vigor and trigger second wind.
* If you're comfortable in the code, consider overriding `iWaitTime` in `GetDuration()` to shorten the SW enchantment. Otherwise you'll be waiting 5-10 minutes for it to disippate.

## Tests

### Players without second wind

- As a playerwithout second wind, no exertion event (anything that negatively impacts vigor) should trigger an increase in vigor (e.g. second wind).

### Players with second wind, triggering

- As a player with second wind, any vigor change that results in vigor > 25 should not trigger second wind.
- As a player with second wind, any vigor change that results in vigor < 25 should trigger second wind, and result in a significant vigor boost (40 + stamina/2 + skill %), the appearance of a personal enchantment icon, an audible sound effect, and a system message.
- As a player with second wind, any vigor change that results in vigor < 25 should modify your rest threshold to 10.

### Players with second wind, enchanted

- As a player enchanted by second wind, consuming food or drink should not raise vigor.
- As a player enchanted by second wind, any activity that reduces vigor should continue to do so at it's normal rate.
- As a player enchanted by second wind, any reduction in vigor should not activate second wind enchantment again.
- As a player enchanted by second wind, my enchantment should continue after logging off and logging back in.
- As a player enchanted by second wind, my enchantment should continue after a system save.

### Players with second wind, dissipated

- As a player whose second wind enchantment has dissipated, my vigor should remain unchanged.
- As a player whose second wind enchantment has dissipated, my rest threshold should update to it's original value: (80 + (skill % + 1)/5)
- As a player whose second wind enchantment has dissipated, my enchantment icon should go away and a system message should alert me to the skill enchantment being removed.
- As a player whose second wind enchantment has dissipated, second wind should trigger again as soon as my vigor falls below 25.