### PR TITLE
Fixes timer issue with create weapon

### DIFF
--- a/kod/object/passive/spell/creaweap.kod
+++ b/kod/object/passive/spell/creaweap.kod
@@ -118,6 +118,10 @@ messages:
 	      Send(who,@NewHold,#what=oWeapon);
 	      Send(who,@MsgSendUser,#message_rsc=createweapon_cast_rsc,
 	           #parm1=send(oWeapon,@GetCapIndef),#parm2=send(oWeapon,@GetName));
+
+         % Apply attribute only if the weapon has been added to the player's inventory
+         oItemAtt = send(SYS,@FindItemAttByNum,#Num=IA_MADE);
+         send(oItemAtt,@AddtoItem,#oitem=oWeapon,#timer_duration=send(self,@getduration,#iSpellpower=iSpellpower));
       }
       else
       {
@@ -125,10 +129,6 @@ messages:
 	      Send(who, @MsgSendUser, #message_rsc=createweapon_inv_full_rsc,#parm1=send(oWeapon,@GetCapIndef),#parm2=send(oWeapon,@GetName));
       }
       
-      oItemAtt = send(SYS,@FindItemAttByNum,#Num=IA_MADE);
-
-      send(oItemAtt,@AddtoItem,#oitem=oWeapon,#timer_duration=send(self,@getduration,#iSpellpower=iSpellpower));
-
       propagate;
    }
 
@@ -136,7 +136,7 @@ messages:
    {
       local iDuration;
 
-      iDuration = iSpellpower * 2;  %%In minutes
+      iDuration = iSpellpower * 2; %% In minutes
       iDuration = iDuration * 60 * 1000;
 
       return iDuration;


### PR DESCRIPTION
This PR fixes an issue with "create weapon" in which new timers were being created for weapons that had previously been deleted (on account of not enough inventory space). This was resulting in bad timers. 

**Related PRs:**
* #390 
* #286

# Testing
- As a player with create weapon and inventory space, when I cast create weapon, then I expect a random weapon to be generated and added to my inventory.
- As a player with create weapon and little to no available inventory space, when I cast create weapon, then I expect the created weapon to instantly vanish, along with a system message saying as much.

# Administration
- Monitor the server timers and notice that when a weapon is created, a new timer is added, but when a created weapon vanishes, the timer count does not increase.