### PR TITLE
Make rented room duration maximum editable by admins

### DIFF
--- a/kod/util/rntmaint.kod
+++ b/kod/util/rntmaint.kod
@@ -14,10 +14,6 @@ constants:
    
    include blakston.khd
 
-   % This is the max number of days that a player can rent a room at a time.
-   % Equal to about 20 offline days.
-   DAYS_MAX = 240
-
 resources:
 
    RoomMaintenance_room_already = "You already have a room here."
@@ -31,8 +27,9 @@ resources:
 properties:
 
    plHoldingDuringRecreate = $
-
    plRoomsRented = $
+   % Max number of days a room can be rented for at one time. ~20 offline days.
+   piRentableDaysMax = 240
 
 messages: 
 
@@ -188,9 +185,9 @@ messages:
       iDays = iAmount / iCost;
 
       % Make sure we don't go over max.
-      if send(oRoom,@GetDaysLeft) + iDays > DAYS_MAX
+      if send(oRoom,@GetDaysLeft) + iDays > piRentableDaysMax
       {
-         iDays = DAYS_MAX - send(oRoom,@GetDaysLeft);
+         iDays = piRentableDaysMax - send(oRoom,@GetDaysLeft);
          % Returning 0 gives up the special error message.
          if iDays <= 0
          {


### PR DESCRIPTION
This PR would close #382, which asks that the maximum length at which rooms can be rented be moved from a constant to a property that can be managed by an administrator with a deeper understanding of the state of the server.

To test this, I logged in as an administrator, found the `RentableRoomMaintenance` instance and updated `piRentableDaysMax` from `240` to `365`. I then executed a system save and confirmed that the property value was still `365`.

cc @qorkod