### PR TITLE
Fixes a comparison bug in `player.kod`, which leads to a compilation error

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -7656,7 +7656,7 @@ messages:
          }
 
          % Give newbies a little bonus.
-         if piBase_Max_health = < Send(Send(SYS,@GetSettings),@GetPKillEnableHP)
+         if piBase_Max_health < Send(Send(SYS,@GetSettings),@GetPKillEnableHP)
          {
             gain = gain + 1;
          }


### PR DESCRIPTION
This commit fixes a comparison bug in #300. Plain and simple.