### PR TITLE
Fixes Mausoleum max monster count issue

### DIFF
--- a/kod/object/active/holder/room/monsroom/guest6.kod
+++ b/kod/object/active/holder/room/monsroom/guest6.kod
@@ -447,11 +447,6 @@ messages:
    {
       ptDoor = $;
 
-      if GetTime() > 59871006
-      {
-         piMonster_count_max = piMonster_count_max + 1;
-      }
-
       Send(self,@SomethingWaveRoom,#wave_rsc=guest6_door1_rsc,#what=poLever1);
       Send(self,@SetSector,#sector=SECTOR_DOOR,#animation=ANIMATE_CEILING_LIFT,
            #height=84,#speed=128);


### PR DESCRIPTION
This commit fixes #381 by removing a questionable bit of logic increasing the max monster count of the room by 1 each time the door slam timer is executed. The issue was resulting in an ever-increasing number of monsters in the room (in the hundreds).

Although this change now maintains the max monster count (20), the room's need to spawn 5 pit mummies means that max monster count will often be exceeded if close to 20 monsters are present elsewhere in the Mausoleum. For example, if you complete the pit and it resets while there are 18 monsters elsewhere, the pit will reset and there will be 23 monsters. The room should not exceed 25 monsters.

To test this locally I had to `SLAM_TIME = 2000` to `SLAM_TIME = 5000`, to give myself enough time to pull both levers and access the pit. I killed mummies outside the pit, completed the pit challenges several times, and monitored `piMonster_count_max` and `piMonster_count` throughout.