### PR TITLE
Introduce Meridian day multiplier

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -35,6 +35,10 @@
    HOUR = 3600
    MINUTE = 60
 
+   % 1 offline day is equal to 12 Meridian days
+   % Use when calculating Meridian days using  
+   MERIDIAN_DAY_MULTIPLER = 12
+
    %%% Object type constants
 
    ACTIVE = 1

--- a/kod/util/rntmaint.kod
+++ b/kod/util/rntmaint.kod
@@ -28,8 +28,9 @@ properties:
 
    plHoldingDuringRecreate = $
    plRoomsRented = $
-   % Max number of days a room can be rented for at one time. ~20 offline days.
-   piRentableDaysMax = 240
+
+   % Max number of (offline) days a room can be rented for at one time
+   piRentableDaysMax = 20 * MERIDIAN_DAY_MULTIPLER
 
 messages: 
 


### PR DESCRIPTION
This commit is in response to [this comment](https://github.com/Meridian59/Meridian59/pull/397#issuecomment-1197227981) from @akirmse. It introduces a constant value that can be used when using an offline day count to calculate the number of Meridian days.

Thoughts: A cursory search of the codebase didn't reveal a whole lot of similar use cases -- days are the unit of measure. For example, the Assassin Game (amusingly named `assgame.kod`) is based on seconds, not days. I wonder: is this constant actually useful elsewhere or is your suggested `12 * 20` the better route?