### PR TITLE
Remove lever area from monster check

### DIFF
--- a/kod/object/active/holder/room/monsroom/guest6.kod
+++ b/kod/object/active/holder/room/monsroom/guest6.kod
@@ -26,7 +26,7 @@ constants:
    MAX_GEN_ROW = 37
    MAX_GEN_COL = 8
 
-   MIN_FINAL_ROW = 27
+   MIN_FINAL_ROW = 28
    MIN_FINAL_COL = 1
    MAX_FINAL_ROW = 40
    MAX_FINAL_COL = 9


### PR DESCRIPTION
This commit closes #402 by reducing the range of the Raza Mausoleum's monster check by 1 grid row. Currently, the logic reaches into row 27, which is the grid square the right lever sits in (see image below). It should not be included and since it is, a monster present in that square will block the final room from finishing. With this PR, the check extends to row 26.

It was brought to my attention that a mummy had made its way behind the lever and as a result, the column in the final room wouldn't drop. I was able to reproduce this locally by teleporting a mummy to ROW 27, COL 4 and confirmed that when the final room was cleared, the column dropped and the room reset as expected.

The rows and columns currently checked for monsters:
![image](https://user-images.githubusercontent.com/467443/182048302-cb76ae7d-d5b9-477c-8257-ed709213405b.png)