### PR TITLE
Fix fonts for player names

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -3419,7 +3419,6 @@ void D3DRenderNamesDraw3D(d3d_render_cache_system *pCacheSystem, d3d_render_pool
 			z = 0;
 			ptr = pName;
 
-      // XXX
 			while (c = *ptr++)
 			{
         int index = c - 32;
@@ -5145,9 +5144,6 @@ void D3DRenderLMapPostWallAdd(WallData *pWall, d3d_render_pool_new *pPool, unsig
 			pChunk->indices[1] = 2;
 			pChunk->indices[2] = 0;
 			pChunk->indices[3] = 3;
-
-//			for (i = 0; i < 4; i++)
-//				CACHE_ST_ADD(pRenderCache, 1, stBase[i].s, stBase[i].t);
 		}
 	}
 }
@@ -5170,7 +5166,6 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
    BYTE			bAlpha;
   
 	pFont->fontHeight = GetFontHeight(hFont);
-//	pFont->flags = flags;
 	pFont->flags = 0;
 	pFont->texScale = 1.0f;
    
@@ -7995,10 +7990,6 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 			continue;
 
 		D3DComputePlayerOverlayArea(pDib, pOverlay->hotspot, &objArea);
-//		objArea.x *= screenW;
-//		objArea.y *= screenH;
-//		objArea.cx /= screenW;
-//		objArea.cy /= screenH;
 
 		overlays = *(obj->overlays);
 
@@ -8059,21 +8050,6 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 		else
 		{
 			D3DObjectLightingCalc(room, pRNode, &bgra, 0);
-/*				lastDistance = D3DRenderObjectLightGetNearest(pRNode);
-
-			light = D3DRenderObjectGetLight(room->tree, pRNode);
-
-			if ((pRNode->obj.flags & OF_FLICKERING) || (pRNode->obj.flags & OF_FLASHING))
-				light = GetLightPaletteIndex(D3DRENDER_LIGHT_DISTANCE, light, FINENESS,
-							-pRNode->obj.lightAdjust);
-			else
-				light = GetLightPaletteIndex(D3DRENDER_LIGHT_DISTANCE, light, FINENESS,
-							0);
-
-			light = light * COLOR_AMBIENT / 64;
-
-			bgra.r = bgra.g = bgra.b = min(255, light + lastDistance);
-			bgra.a = 255;*/
 		}
 
 		if (GetDrawingEffectIndex(pRNode->obj.flags) == (OF_TRANSLUCENT25 >> 20))
@@ -8091,8 +8067,6 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 		pChunk->xyz[0].z = pChunk->xyz[3].z = objArea.y;
 		pChunk->xyz[2].x = pChunk->xyz[3].x = pChunk->xyz[0].x + objArea.cx;
 		pChunk->xyz[2].z = pChunk->xyz[1].z = pChunk->xyz[0].z + objArea.cy;
-
-//		D3DObjectLightingCalc(room, pRNode, &bgra);
 
 		for (count = 0; count < 4; count++)
 		{
@@ -8137,15 +8111,6 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 		pChunk->st1[2].t += (gFrame & 3) / 256.0f;
 		pChunk->st1[3].s += (gFrame & 3) / 256.0f;
 		pChunk->st1[3].t -= (gFrame & 3) / 256.0f;
-
-/*		pChunk->st1[0].s = 0.0f;
-		pChunk->st1[0].t = 0.0f;
-		pChunk->st1[1].s = 0.0f;
-		pChunk->st1[1].t = 1.0f;
-		pChunk->st1[2].s = 1.0f;
-		pChunk->st1[2].t = 1.0f;
-		pChunk->st1[3].s = 1.0f;
-		pChunk->st1[3].t = 0.0f;*/
 
 		pChunk->indices[0] = 1;
 		pChunk->indices[1] = 2;

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -1379,7 +1379,6 @@ void D3DRenderLMapsPostDraw(BSPnode *tree, Draw3DParams *params)
 			/* then do walls on the separator */
 			if (side != 0)
 			{
-				//WallList list;
 				WallData	*pWall;
 				int			flags, wallFlags;
 
@@ -1519,7 +1518,6 @@ void D3DRenderLMapsDynamicPostDraw(BSPnode *tree, Draw3DParams *params)
 			/* then do walls on the separator */
 			if (side != 0)
 			{
-				//WallList list;
 				WallData	*pWall;
 				int			flags, wallFlags;
 
@@ -1896,25 +1894,12 @@ void D3DGeometryBuildNew(room_type *room, d3d_render_pool_new *pPool)
 			break;
 
 			case BSPleaftype:
-				if (pNode->u.leaf.sector == &room->sectors[0])
-				{
-/*					if ((pNode->bbox.x0 < 0) ||
-						(pNode->bbox.x1 > room->width))
-						break;*/
-//					if (pNode->u.leaf.sector->server_id == 0)
-//						break;
-/*						if (bDone)
-							break;
-						else
-							bDone = TRUE;*/
-				}
-
 				D3DRenderPacketFloorAdd(pNode, &gWorldPoolStatic, FALSE);
 				D3DRenderPacketCeilingAdd(pNode, &gWorldPoolStatic, FALSE);
-			break;
+        break;
 
 			default:
-			break;
+        break;
 		}
 	}
 
@@ -2237,7 +2222,6 @@ void D3DRenderPacketFloorAdd(BSPnode *pNode, d3d_render_pool_new *pPool, Bool bD
 	pChunk = D3DRenderChunkNew(pPacket);
 	assert(pChunk);
 
-//	pChunk->numIndices = (pNode->u.leaf.poly.npts - 2) * 3;
 	pChunk->numVertices = pNode->u.leaf.poly.npts;
 	pChunk->numIndices = pChunk->numVertices;
 	pChunk->numPrimitives = pChunk->numVertices - 2;
@@ -2331,7 +2315,6 @@ void D3DRenderPacketCeilingAdd(BSPnode *pNode, d3d_render_pool_new *pPool, Bool 
 	pChunk = D3DRenderChunkNew(pPacket);
 	assert(pChunk);
 
-//	pChunk->numIndices = (pNode->u.leaf.poly.npts - 2) * 3;
 	pChunk->numVertices = pNode->u.leaf.poly.npts;
 	pChunk->numIndices = pChunk->numVertices;
 	pChunk->numPrimitives = pChunk->numVertices - 2;
@@ -2481,7 +2464,6 @@ void D3DRenderPacketWallAdd(WallData *pWall, d3d_render_pool_new *pPool, unsigne
 
 	if (NULL == pDib)
 		return;
-//		pDib = current_room.sectors[0].floor;
 
 	D3DRenderWallExtract(pWall, pDib, &flags, xyz, st, bgra, type, side);
 
@@ -2845,7 +2827,6 @@ void D3DRenderFloorMaskAdd(BSPnode *pNode, d3d_render_pool_new *pPool, Bool bDyn
 	pChunk = D3DRenderChunkNew(pPacket);
 	assert(pChunk);
 
-//	pChunk->numIndices = (pNode->u.leaf.poly.npts - 2) * 3;
 	pChunk->numVertices = pNode->u.leaf.poly.npts;
 	pChunk->numIndices = pChunk->numVertices;
 	pChunk->numPrimitives = pChunk->numVertices - 2;
@@ -2908,7 +2889,6 @@ void D3DRenderCeilingMaskAdd(BSPnode *pNode, d3d_render_pool_new *pPool, Bool bD
 	pChunk = D3DRenderChunkNew(pPacket);
 	assert(pChunk);
 
-//	pChunk->numIndices = (pNode->u.leaf.poly.npts - 2) * 3;
 	pChunk->numVertices = pNode->u.leaf.poly.npts;
 	pChunk->numIndices = pChunk->numVertices;
 	pChunk->numPrimitives = pChunk->numVertices - 2;
@@ -3328,8 +3308,7 @@ void D3DRenderNamesDraw3D(d3d_render_cache_system *pCacheSystem, d3d_render_pool
 		vector.x = pRNode->motion.x - player.x;
 		vector.y = pRNode->motion.y - player.y;
 
-		distance = (vector.x * vector.x) + (vector.y * vector.y);
-		distance = (float)sqrt((double)distance);
+		distance = sqrtf((vector.x * vector.x) + (vector.y * vector.y));
 		if (distance <= 0)
 			distance = 1;
 
@@ -3388,10 +3367,6 @@ void D3DRenderNamesDraw3D(d3d_render_cache_system *pCacheSystem, d3d_render_pool
 			}
 		}
 
-		//			z = ((float)pDib->height / (float)pDib->shrink * 16.0f) - (float)pDib->yoffset * 4.0f;
-
-//			z += ((float)pRNode->boundingHeightAdjust * 4.0f);// / 1.66f;
-
 		MatrixRotateY(&rot, (float)angleHeading * 360.0f / 4096.0f * PI / 180.0f);
 		MatrixTranspose(&rot, &rot);
 		MatrixTranslate(&mat, (float)pRNode->motion.x, (float)max(bottom,
@@ -3442,33 +3417,34 @@ void D3DRenderNamesDraw3D(d3d_render_cache_system *pCacheSystem, d3d_render_pool
 		{
 			x = 0.0f;
 			z = 0;
-//			z = ((float)pDib->height / (float)pDib->shrink * 16.0f) - (float)pDib->yoffset * 4.0f;
-
-//			z += ((float)pRNode->boundingHeightAdjust * 4.0f);// / 1.66f;
-
 			ptr = pName;
 
+      // XXX
 			while (c = *ptr++)
 			{
-				x += (pFont->texST[c - 32][1].s - pFont->texST[c - 32][0].s) *
-					pFont->texWidth / pFont->texScale * (distance / FINENESS);
+        int index = c - 32;
+        float charWidth = (pFont->texST[index][1].s - pFont->texST[index][0].s) *
+          pFont->texWidth / pFont->texScale;
+				x += charWidth;
 			}
-
+      x *= (distance / FINENESS);
+      
 			ptr = pName;
 
 			while (c = *ptr++)
 			{
 				int	i;
+        int index = c - 32;
 
 				// flip t values since bmps are upside down
-				st[0].s = pFont->texST[c - 32][0].s;
-				st[0].t = pFont->texST[c - 32][1].t;
-				st[1].s = pFont->texST[c - 32][0].s;
-				st[1].t = pFont->texST[c - 32][0].t;
-				st[2].s = pFont->texST[c - 32][1].s;
-				st[2].t = pFont->texST[c - 32][0].t;
-				st[3].s = pFont->texST[c - 32][1].s;
-				st[3].t = pFont->texST[c - 32][1].t;
+				st[0].s = pFont->texST[index][0].s;
+				st[0].t = pFont->texST[index][1].t;
+				st[1].s = pFont->texST[index][0].s;
+				st[1].t = pFont->texST[index][0].t;
+				st[2].s = pFont->texST[index][1].s;
+				st[2].t = pFont->texST[index][0].t;
+				st[3].s = pFont->texST[index][1].s;
+				st[3].t = pFont->texST[index][1].t;
 
 				width = (st[2].s - st[0].s) * pFont->texWidth * 2.0f / pFont->texScale *
 					(distance / FINENESS);
@@ -3492,7 +3468,6 @@ void D3DRenderNamesDraw3D(d3d_render_cache_system *pCacheSystem, d3d_render_pool
 
 				if (offset)
 				{
-					//MatrixScale(&scale, 1.01f);
 					MatrixTranslate(&trans, -30.0f * distance / MAX_NAME_DISTANCE,
 						-30.0f * distance / MAX_NAME_DISTANCE, 0);
 					MatrixMultiply(&pChunk->xForm, &trans, &xForm);
@@ -4417,8 +4392,8 @@ void D3DRenderLMapsBuild(void)
 	{
 		for (width = 0; width < 32; width++)
 		{
-			float	scale = (float)sqrt((double)((height - 16) * (height - 16) +
-											(width - 16) * (width - 16)));
+			float	scale = sqrtf((height - 16) * (height - 16) +
+											(width - 16) * (width - 16));
 			scale = 16.0f - scale;
 			scale = max(scale, 0);
 			scale /= 16.0f;
@@ -4448,8 +4423,8 @@ void D3DRenderLMapsBuild(void)
 	{
 		for (width = 0; width < 32; width++)
 		{
-			float	scale = (float)sqrt((double)((height - 16) * (height - 16) +
-											(width - 16) * (width - 16)));
+			float	scale = sqrtf((height - 16) * (height - 16) +
+											(width - 16) * (width - 16));
 
 			scale = 16.0f - scale;
 			scale = max(scale, 0);
@@ -4480,8 +4455,8 @@ void D3DRenderLMapsBuild(void)
 	{
 		for (width = 0; width < 128; width++)
 		{
-			float	scale = (float)sqrt((double)((height - 64) * (height - 64) +
-											(width - 64) * (width - 64)));
+			float	scale = sqrtf((height - 64) * (height - 64) +
+											(width - 64) * (width - 64));
 
 			scale = 64.0f - scale;
 			scale = max(scale, 0);
@@ -4515,8 +4490,8 @@ void D3DRenderLMapsBuild(void)
 	{
 		for (width = 0; width < 32; width++)
 		{
-			float	scale = (float)sqrt((double)((height - 16) * (height - 16) +
-											(width - 16) * (width - 16)));
+			float	scale = sqrtf((height - 16) * (height - 16) +
+											(width - 16) * (width - 16));
 			float	scaleAlpha;
 
 			scale = 16.0f - scale;
@@ -5194,7 +5169,7 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 		pFont->texWidth = pFont->texHeight = 512;
 	else
 		pFont->texWidth = pFont->texHeight = 256;
-   
+
 	IDirect3DDevice9_GetDeviceCaps(gpD3DDevice, &d3dCaps);
   
 	if (pFont->texWidth > (long) d3dCaps.MaxTextureWidth)
@@ -5223,19 +5198,10 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
    hbmBitmap = CreateDIBSection(hDC, &bmi, DIB_RGB_COLORS, (VOID**)&pBitmapBits, NULL, 0 );
    SetMapMode(hDC, MM_TEXT);
   
-/*	nHeight = -MulDiv(pFont->fontHeight, (int)(GetDeviceCaps(hDC, LOGPIXELSY)
- * pFont->texScale), 72);
- dwBold = (pFont->flags & D3DFONT_BOLD) ? FW_BOLD : FW_NORMAL;
- dwItalic = (pFont->flags & D3DFONT_ITALIC) ? TRUE : FALSE;
- hFont = CreateFont(nHeight, 0, 0, 0, dwBold, dwItalic,
- FALSE, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS,
- CLIP_DEFAULT_PRECIS, ANTIALIASED_QUALITY,
- VARIABLE_PITCH, pFont->strFontName);*/
-  
-	assert(hFont);
+   assert(hFont);
    
-	SelectObject(hDC, hbmBitmap);
-	SelectObject(hDC, hFont);
+   SelectObject(hDC, hbmBitmap);
+   SelectObject(hDC, hFont);
    
    // Set text properties
    SetTextColor(hDC, RGB(255,255,255));
@@ -5245,20 +5211,20 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
    for(c = 32; c < 127; c++ )
    {
       BOOL	temp;
-      int left_offset, right_offset;
+      int left_offset;
+      int index = c-32;
       
       str[0] = c;
       GetTextExtentPoint32(hDC, str, 1, &size);
       
-      if (!GetCharABCWidths(hDC, c, c, &pFont->abc[c-32])) {
-         pFont->abc[c-32].abcA = 0;
-         pFont->abc[c-32].abcB = size.cx;
-         pFont->abc[c-32].abcC = 0;
+      if (!GetCharABCWidths(hDC, c, c, &pFont->abc[index])) {
+         pFont->abc[index].abcA = 0;
+         pFont->abc[index].abcB = size.cx;
+         pFont->abc[index].abcC = 0;
       }
-      
-      left_offset = abs(pFont->abc[c-32].abcA);
-      right_offset = abs(pFont->abc[c-32].abcC);
-      size.cx = abs(pFont->abc[c-32].abcA) + pFont->abc[c-32].abcB + abs(pFont->abc[c-32].abcC);
+
+      left_offset = abs(pFont->abc[index].abcA);
+      size.cx = abs(pFont->abc[index].abcA) + pFont->abc[index].abcB + abs(pFont->abc[index].abcC);
       
       if (x + size.cx + 1 > pFont->texWidth)
       {
@@ -5268,10 +5234,10 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
       
       temp = ExtTextOut(hDC, x + left_offset, y+0, ETO_OPAQUE, NULL, str, 1, NULL);
       
-      pFont->texST[c-32][0].s = ((FLOAT)(x+0)) / pFont->texWidth;
-      pFont->texST[c-32][0].t = ((FLOAT)(y+0)) / pFont->texHeight;
-      pFont->texST[c-32][1].s = ((FLOAT)(x+0 + size.cx)) / pFont->texWidth;
-      pFont->texST[c-32][1].t = ((FLOAT)(y+0 + size.cy)) / pFont->texHeight;
+      pFont->texST[index][0].s = ((FLOAT)(x+0)) / pFont->texWidth;
+      pFont->texST[index][0].t = ((FLOAT)(y+0)) / pFont->texHeight;
+      pFont->texST[index][1].s = ((FLOAT)(x+0 + size.cx)) / pFont->texWidth;
+      pFont->texST[index][1].t = ((FLOAT)(y+0 + size.cy)) / pFont->texHeight;
       
       x += size.cx+1;
    }

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -3425,6 +3425,9 @@ void D3DRenderNamesDraw3D(d3d_render_cache_system *pCacheSystem, d3d_render_pool
         int index = c - 32;
         float charWidth = (pFont->texST[index][1].s - pFont->texST[index][0].s) *
           pFont->texWidth / pFont->texScale;
+
+        // Take out space for kerning
+        charWidth -= (pFont->abc[index].abcA + pFont->abc[index].abcC);
 				x += charWidth;
 			}
       x *= (distance / FINENESS);
@@ -3478,28 +3481,33 @@ void D3DRenderNamesDraw3D(d3d_render_cache_system *pCacheSystem, d3d_render_pool
 				pPacket->pMaterialFctn = &D3DMaterialObjectPacket;
 				pChunk->pMaterialFctn = &D3DMaterialObjectChunk;
 
-				pChunk->xyz[0].x = x;
+        float leftx = x;
+        // Kerning: add in leading for character
+        leftx -= 2.0 * pFont->abc[index].abcA * (distance / FINENESS);
+        float rightx = leftx - width;
+        
+				pChunk->xyz[0].x = leftx;
 				pChunk->xyz[0].y = 0;
 				pChunk->xyz[0].z = z;
 
 				pChunk->st0[0].s = st[0].s;
 				pChunk->st0[0].t = st[0].t;
 
-				pChunk->xyz[1].x = x;
+				pChunk->xyz[1].x = leftx;
 				pChunk->xyz[1].y = 0;
 				pChunk->xyz[1].z = z + height;
 
 				pChunk->st0[1].s = st[1].s;
 				pChunk->st0[1].t = st[1].t;
 
-				pChunk->xyz[2].x = x - width;
+				pChunk->xyz[2].x = rightx;
 				pChunk->xyz[2].y = 0;
 				pChunk->xyz[2].z = z + height;
 
 				pChunk->st0[2].s = st[2].s;
 				pChunk->st0[2].t = st[2].t;
 
-				pChunk->xyz[3].x = x - width;
+				pChunk->xyz[3].x = rightx;
 				pChunk->xyz[3].y = 0;
 				pChunk->xyz[3].z = z;
 
@@ -3542,7 +3550,10 @@ void D3DRenderNamesDraw3D(d3d_render_cache_system *pCacheSystem, d3d_render_pool
 					pChunk->xLat1 = 0;
 				}
 
+        // Deal with kerning when moving to next character: character width
+        // doesn't include overhangs
 				x -= width;
+        x -= 2.0 * (pFont->abc[index].abcA + pFont->abc[index].abcC) * (distance / FINENESS);
 			}
 		}
 	}

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -121,6 +121,7 @@ typedef struct d_light_cache
 	d_light	dLights[MAX_DLIGHTS];
 } d_light_cache;
 
+static const int numChars = 128 - 32;
 typedef struct font_3d
 {
 	TCHAR				strFontName[80];
@@ -130,9 +131,11 @@ typedef struct font_3d
 	long				texWidth;
 	long				texHeight;
 	float				texScale;
-	custom_st			texST[128 - 32][2];
+	custom_st			texST[numChars][2];
   // Deal with underhanging and overhanging characters
-  ABC         abc[128 - 32];
+  ABC         abc[numChars];
+  int          numKerningPairs;
+  KERNINGPAIR *kerningPairs;
 } font_3d;
 
 extern LPDIRECT3D9				gpD3D;

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -125,7 +125,6 @@ typedef struct font_3d
 {
 	TCHAR				strFontName[80];
 	long				fontHeight;
-	long				flags;
 
 	LPDIRECT3DTEXTURE9	pTexture;
 	long				texWidth;

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -124,16 +124,16 @@ typedef struct d_light_cache
 static const int numChars = 128 - 32;
 typedef struct font_3d
 {
-	TCHAR				strFontName[80];
-	long				fontHeight;
+	TCHAR        strFontName[80];
+	long         fontHeight;
 
 	LPDIRECT3DTEXTURE9	pTexture;
-	long				texWidth;
-	long				texHeight;
-	float				texScale;
-	custom_st			texST[numChars][2];
+	long				 texWidth;
+	long				 texHeight;
+	float				 texScale;
+	custom_st	   texST[numChars][2];
   // Deal with underhanging and overhanging characters
-  ABC         abc[numChars];
+  ABC          abc[numChars];
   int          numKerningPairs;
   KERNINGPAIR *kerningPairs;
 } font_3d;

--- a/clientd3d/draw3d.c
+++ b/clientd3d/draw3d.c
@@ -184,7 +184,7 @@ void GraphicsResetFont(void)
    SelectObject(gBitsDC, hFont);
 
    if (gD3DEnabled)
-	D3DRenderFontInit(&gFont, hFont);
+     D3DRenderFontInit(&gFont, hFont);
 }
 
 /************************************************************************/

--- a/clientd3d/font.c
+++ b/clientd3d/font.c
@@ -48,61 +48,6 @@ LOGFONT *GetLogfont(int fontNum)
    return &logfonts[fontNum];
 }
 
-Bool GetLogFont(WORD fontnum, LOGFONT *pLogFont)
-{
-   char str[MAX_FONTNAME], name[10], *ptr;
-   char *separators = ",";
-   int temp;
-   LOGFONT lf;
-   Bool success;
-
-   sprintf(name, "Font%d", fontnum);
-   GetPrivateProfileString(font_section, name, fontinfo[fontnum], str, MAX_FONTNAME, ini_file);
-
-   success = True;
-   if ((ptr = strtok(str, separators)) == NULL || sscanf(ptr, "%d", &lf.lfHeight) != 1)
-      success = False;
-   if ((ptr = strtok(NULL, separators)) == NULL || sscanf(ptr, "%d", &lf.lfWidth) != 1)
-      success = False;
-   if ((ptr = strtok(NULL, separators)) == NULL || sscanf(ptr, "%d", &lf.lfEscapement) != 1)
-      success = False;
-   if ((ptr = strtok(NULL, separators)) == NULL || sscanf(ptr, "%d", &lf.lfOrientation) != 1)
-      success = False;
-   if ((ptr = strtok(NULL, separators)) == NULL || sscanf(ptr, "%d", &lf.lfWeight) != 1)
-      success = False;
-   if ((ptr = strtok(NULL, separators)) == NULL || sscanf(ptr, "%d", &temp) != 1)
-      success = False;
-   else lf.lfItalic = temp; /* 1 byte value */
-   if ((ptr = strtok(NULL, separators)) == NULL || sscanf(ptr, "%d", &temp) != 1)
-      success = False;
-   else lf.lfUnderline = temp;
-   if ((ptr = strtok(NULL, separators)) == NULL || sscanf(ptr, "%d", &temp) != 1)
-      success = False;
-   else lf.lfStrikeOut = temp;
-   if ((ptr = strtok(NULL, separators)) == NULL || sscanf(ptr, "%d", &temp) != 1)
-      success = False;
-   else lf.lfCharSet = temp;
-   if ((ptr = strtok(NULL, separators)) == NULL || sscanf(ptr, "%d", &temp) != 1)
-      success = False;
-   else lf.lfOutPrecision = temp;
-   if ((ptr = strtok(NULL, separators)) == NULL || sscanf(ptr, "%d", &temp) != 1)
-      success = False;
-   else lf.lfClipPrecision = temp;
-   if ((ptr = strtok(NULL, separators)) == NULL || sscanf(ptr, "%d", &temp) != 1)
-      success = False;
-   else lf.lfQuality = temp;
-   if ((ptr = strtok(NULL, separators)) == NULL || sscanf(ptr, "%d", &temp) != 1)
-      success = False;
-   else lf.lfPitchAndFamily = temp;
-   if ((ptr = strtok(NULL, separators)) == NULL)	 
-      success = False; 
-   else strcpy(lf.lfFaceName, ptr);
-   
-   if (success)
-      memcpy(pLogFont,&lf,sizeof(LOGFONT));
-   return success;
-}
-
 /************************************************************************/
 /*
  * FontsCreate:  Create all fonts for use in the game.
@@ -261,6 +206,14 @@ void FontsRestoreDefaults(void)
    MainChangeFont();
 
    ModuleEvent(EVENT_FONTCHANGED, -1, NULL);
+}
+/************************************************************************/
+HFONT FontsGetScaledFont(HFONT hFont, float scale)
+{
+  LOGFONT lf;
+  GetObject(hFont, sizeof(LOGFONT), &lf);
+  lf.lfHeight *= scale;
+  return CreateFontIndirect(&lf);
 }
 
 

--- a/clientd3d/font.h
+++ b/clientd3d/font.h
@@ -35,10 +35,12 @@ void FontsDestroy(void);
 M59EXPORT HFONT GetFont(WORD font);
 void FontsSave(void);
 void FontsRestoreDefaults(void);
-Bool GetLogFont(WORD fontnum, LOGFONT *pLogFont);
 
 void UserSelectFont(WORD font);
 M59EXPORT int GetFontHeight(HFONT hFont);
 LOGFONT *GetLogfont(int fontNum);
+
+// Return a new font that's the given font scaled by the given factor.
+HFONT FontsGetScaledFont(HFONT hFont, float scale);
 
 #endif /* #ifndef _FONT_H */


### PR DESCRIPTION
I made 3 changes:

- Handle leading and trailing spaces in font characters
- Triple resolution of 3D font
- Apply kerning

Before:
![before](https://user-images.githubusercontent.com/2266354/197798022-eb916a50-8602-40fb-93fe-acb792f89cb7.jpg)

After:
![image](https://user-images.githubusercontent.com/2266354/197798122-9b5d6fd9-89f2-438b-8d0a-c4262241cd48.png)
