### PR TITLE
Negates the DefMod calls being made on wedding rings

### DIFF
--- a/kod/object/item/passitem/ring/ringwedd.kod
+++ b/kod/object/item/passitem/ring/ringwedd.kod
@@ -157,6 +157,18 @@ messages:
       return FALSE;
    }
 
+   % Negates the ring modifying defense power
+   ModifyDefensePower(who = $,what = $,defense_power = 0)
+   {
+      return defense_power;
+   }
+
+   % Negates the ring modifying defense damage
+   ModifyDefenseDamage(who = $,what = $,damage = $,atype = 0,aspell = 0)
+   {
+      return damage;
+   }
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
The implementation of #194 is causing issues due to the absence of handlers for ModifyDefensePower and ModifyDefenseDamage. This commit brings back those handlers and passes through the defense power and damage values in the DefMod calls on the wedding ring, rendering any sort of DefMod properties meaningless.