### PR TITLE
Adds name change service to Caramo

### DIFF
--- a/blakserv/ccode.c
+++ b/blakserv/ccode.c
@@ -930,41 +930,43 @@ blak_int C_SetResource(int object_id,local_var_type *local_vars,
 	
 	str_val = RetrieveValue(object_id,local_vars,normal_parm_array[1].type,
 		normal_parm_array[1].value);
-
-    switch (str_val.v.tag)
-    {
-    case TAG_TEMP_STRING:
-        snod = GetTempString();
-        new_len = snod->len_data;
-        new_str = snod->data;
-        break;
-    case TAG_RESOURCE:
-        r = GetResourceByID(str_val.v.data);
-        if (r == NULL)
-        {
-            bprintf("C_SetResource can't set from bad resource %i\n", str_val.v.data);
-            return NIL;
-        }
-        new_len = strlen(r->resource_val);
-        new_str = r->resource_val;
-        break;
-    case TAG_STRING:
-        snod = GetStringByID(str_val.v.data);
-        if (snod == NULL)
-        {
-            bprintf("C_SetResource can't set from bad string %i\n", str_val.v.data);
-            return NIL;
-        }
-        new_len = snod->len_data;
-        new_str = snod->data;
-        break;
-    default:
-        bprintf("C_SetResource can't set from non temp string %i,%i\n", str_val.v.tag,
-                str_val.v.data);
-        return NIL;
-    }
-
-    r = GetResourceByID(drsc_val.v.data);
+	switch (str_val.v.tag)
+	{
+	case TAG_TEMP_STRING :
+		snod = GetTempString();
+		new_len = snod->len_data;
+		new_str = snod->data;
+		break;
+		
+	case TAG_RESOURCE :
+			r = GetResourceByID(str_val.v.data);
+			if (r == NULL)
+			{
+				bprintf("C_SetResource can't set from bad resource %i\n",
+					str_val.v.data);
+				return NIL;
+			}
+			new_len = strlen(r->resource_val);
+			new_str = r->resource_val;
+			break;
+	case TAG_STRING :
+		snod = GetStringByID(str_val.v.data);
+		if (snod == NULL)
+		{
+			bprintf( "C_SetResource can't set from bad string %i\n",
+				str_val.v.data);
+			return NIL;
+		}
+		new_len = snod->len_data;
+		new_str = snod->data;
+		break;
+	default :
+		bprintf("C_SetResource can't set from non temp string %i,%i\n",
+			str_val.v.tag,str_val.v.data);
+		return NIL;
+	}
+	
+	r = GetResourceByID(drsc_val.v.data);
 	if (r == NULL)
 	{
 		eprintf("C_SetResource got dyna rsc number that doesn't exist\n");

--- a/blakserv/ccode.c
+++ b/blakserv/ccode.c
@@ -930,43 +930,41 @@ blak_int C_SetResource(int object_id,local_var_type *local_vars,
 	
 	str_val = RetrieveValue(object_id,local_vars,normal_parm_array[1].type,
 		normal_parm_array[1].value);
-	switch (str_val.v.tag)
-	{
-	case TAG_TEMP_STRING :
-		snod = GetTempString();
-		new_len = snod->len_data;
-		new_str = snod->data;
-		break;
-		
-	case TAG_RESOURCE :
-			r = GetResourceByID(str_val.v.data);
-			if (r == NULL)
-			{
-				bprintf("C_SetResource can't set from bad resource %i\n",
-					str_val.v.data);
-				return NIL;
-			}
-			new_len = strlen(r->resource_val);
-			new_str = r->resource_val;
-			break;
-	case TAG_STRING :
-		snod = GetStringByID(str_val.v.data);
-		if (snod == NULL)
-		{
-			bprintf( "C_SetResource can't set from bad string %i\n",
-				str_val.v.data);
-			return NIL;
-		}
-		new_len = snod->len_data;
-		new_str = snod->data;
-		break;
-	default :
-		bprintf("C_SetResource can't set from non temp string %i,%i\n",
-			str_val.v.tag,str_val.v.data);
-		return NIL;
-	}
-	
-	r = GetResourceByID(drsc_val.v.data);
+
+    switch (str_val.v.tag)
+    {
+    case TAG_TEMP_STRING:
+        snod = GetTempString();
+        new_len = snod->len_data;
+        new_str = snod->data;
+        break;
+    case TAG_RESOURCE:
+        r = GetResourceByID(str_val.v.data);
+        if (r == NULL)
+        {
+            bprintf("C_SetResource can't set from bad resource %i\n", str_val.v.data);
+            return NIL;
+        }
+        new_len = strlen(r->resource_val);
+        new_str = r->resource_val;
+        break;
+    case TAG_STRING:
+        snod = GetStringByID(str_val.v.data);
+        if (snod == NULL)
+        {
+            bprintf("C_SetResource can't set from bad string %i\n", str_val.v.data);
+            return NIL;
+        }
+        new_len = snod->len_data;
+        new_str = snod->data;
+        break;
+    default:
+        bprintf("C_SetResource can't set from non temp string %i,%i\n", str_val.v.tag,
+                str_val.v.data);
+        return NIL;
+    }
+
+    r = GetResourceByID(drsc_val.v.data);
 	if (r == NULL)
 	{
 		eprintf("C_SetResource got dyna rsc number that doesn't exist\n");

--- a/blakserv/ccode.c
+++ b/blakserv/ccode.c
@@ -939,7 +939,6 @@ blak_int C_SetResource(int object_id,local_var_type *local_vars,
 		break;
 		
 	case TAG_RESOURCE :
-		{
 			r = GetResourceByID(str_val.v.data);
 			if (r == NULL)
 			{
@@ -950,7 +949,17 @@ blak_int C_SetResource(int object_id,local_var_type *local_vars,
 			new_len = strlen(r->resource_val);
 			new_str = r->resource_val;
 			break;
+	case TAG_STRING :
+		snod = GetStringByID(str_val.v.data);
+		if (snod == NULL)
+		{
+			bprintf( "C_SetResource can't set from bad string %i\n",
+				str_val.v.data);
+			return NIL;
 		}
+		new_len = snod->len_data;
+		new_str = snod->data;
+		break;
 	default :
 		bprintf("C_SetResource can't set from non temp string %i,%i\n",
 			str_val.v.tag,str_val.v.data);

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqclerk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqclerk.kod
@@ -265,6 +265,31 @@ resources:
    % This string must be < 20 chars long to fit in the subject line with a player name
    barloque_clerk_pardon_7 = " granted reprieve"
 
+   % Name changing.
+   barloque_clerk_trigger_change = "change"
+   barloque_clerk_trigger_name = "name"
+   barloque_clerk_change_name = \
+      "Yes, I can change your legal name by deed poll.  Simply fill out your "
+      "new name on this scroll and return it to me. If it is available and not "
+      "obscene, it shall be yours.  I must warn you, there is a fee of %i "
+      "shillings for providing this service."
+   barloque_clerk_cant_hold = \
+      "I can change your legal name by deed poll, but you have no room in "
+      "your inventory to hold the scroll you would need to fill out."
+   barloque_clerk_not_enough = \
+      "Come back when you have enough money for this service."
+   barloque_clerk_bad_name = \
+      "Sorry, that name is not valid."
+   barloque_clerk_name_changed = \
+      "Your name has been changed."
+
+   barloque_clerk_name_post_1 = "'s name has been changed"
+   barloque_clerk_name_post_2 = "Let it be known that "
+   barloque_clerk_name_post_3 = \
+      "'s name has been changed by deed poll to "
+   barloque_clerk_name_post_4 = \
+      ". So it has been spoken, so shall it be done. \n\n-- Caramo"
+
 classvars:
 
    vrName = barloque_clerk_name_rsc
@@ -314,7 +339,7 @@ messages:
 
    Constructor()
    {
-      plWantedItems = [ &BallotItem ];
+      Send(self,@SetWantedItems);
       psJunkString = CreateString();
       Send(SYS,@SetCaramo,#oCaramo=self);
 
@@ -325,7 +350,25 @@ messages:
       propagate;
    }
 
-   %%% Selling and accepting Ballots
+   Recreate()
+   "Delete outstanding scrolls"
+   {
+      Send(self,@SetWantedItems);
+
+      % Delete any outstanding scrolls
+      Send(&NameChangeScroll,@Delete);
+
+      return;
+   }
+
+   SetWantedItems()
+   {
+      plWantedItems = [ &NameChangeScroll, &BallotItem ];
+
+      return;
+   }
+
+   %%% Selling and accepting Ballots and Name Changes
 
    IsCustomerOkay(who=$)
    {
@@ -358,7 +401,91 @@ messages:
          return;
       }
       
+      if IsClass(obj,&NameChangeScroll)
+      {
+         Send(self,@TryChangePlayerName,#who=who,#oItem=obj);
+
+         return;
+      }
+
       propagate;
+   }
+
+   %%% Name change and recordkeeping
+
+   TryChangePlayerName(who=$,oItem=$)
+   "Attempts to change a player's name. If they can pay the fee, will check with "
+   "System to see if the name is valid. If it is, name will be changed."
+   {
+      local i, iAmount, oMoney;
+
+      if who = $ or oItem = $
+      {
+         return;
+      }
+
+      iAmount = Send(Send(SYS,@GetSettings),@GetNameChangeCost);
+
+      % Check if name is valid.
+      if NOT Send(SYS,@ValidateUserName,#oUser=who,#sName=Send(oItem,@GetInscription))
+      {
+         Send(self,@SayToOne,#target=who,#message_rsc=barloque_clerk_bad_name);
+
+         return;
+      }
+
+      % Get player purse
+      oMoney = Send(who,@GetMoneyObject);
+      
+      % Check to see if they have enough money
+      if Send(oMoney,@GetValue) >= iAmount
+      {
+         % Player has enough money, change their name and take the money.
+         Send(oMoney,@SubtractNumber,#number=iAmount);
+         Send(self,@SayToOne,#target=who,#message_rsc=barloque_clerk_name_changed);
+
+         % Record the name change in the Book of Jala.
+         Send(self,@RecordNameChangeBook,#parm1=Send(who,@GetTrueName),#parm2=Send(oItem,@GetInscription));
+
+         % System will handle changing the name.
+         Send(SYS,@ChangeUserName,#oUser=who,#sName=Send(oItem,@GetInscription));
+
+         % Delete scroll
+         Send(oItem,@Delete);
+      }
+      else
+      {
+         % Not enough money.
+         Send(self,@SayToOne,#target=who,#message_rsc=barloque_clerk_not_enough);
+      }
+
+      return;
+   }
+
+   RecordNameChangeBook(parm1=$, parm2=$)
+   "parm1=oldname,parm2=newname"
+   {
+      local sString, sString2, oBook;
+
+      ClearTempString();
+      AppendTempString(parm1);
+      AppendTempString(barloque_clerk_name_post_1);
+      sString = CreateString();
+      setString(sString,GetTempString());
+
+      ClearTempString();
+      AppendTempString(barloque_clerk_name_post_2);
+      AppendTempString(parm1);
+      AppendTempString(barloque_clerk_name_post_3);
+      AppendTempString(parm2);
+      AppendTempString(barloque_clerk_name_post_4);
+      sString2 = CreateString();
+      setString(sString2,GetTempString());
+
+      oBook = Send(poOwner,@GetBook);
+      Send(oBook,@PostNews,#what=self,#title=sString,#body=sString2);
+
+      return;
    }
 
    SetForSale()
@@ -922,6 +1049,39 @@ messages:
 
    CitizenSaid(who = $, string = $)
    {
+      local iAmount, oScroll;
+
+      % name change
+      if StringContain(string,barloque_clerk_trigger_change)
+            AND StringContain(string,barloque_clerk_trigger_name)
+      {
+         iAmount = Send(Send(SYS,@GetSettings),@GetNameChangeCost);
+         oScroll = Create(&NameChangeScroll);
+
+         if Send(who,@ReqNewHold,#what=oScroll)
+         {
+            Send(self,@SayToOne,#target=who,#message_rsc=barloque_clerk_change_name,#parm1=iAmount);
+
+            % Don't give out multiple scrolls.
+            if Send(who,@FindHolding,#class=&NameChangeScroll) = $
+            {
+               Send(who,@NewHold,#what=oScroll);
+            }
+            else
+            {
+               % Send a player tell to the effect of, "You already have one"
+               Send(oScroll,@Delete);
+            }
+         }
+         else
+         {
+            Send(self,@SayToOne,#target=who,#message_rsc=barloque_clerk_cant_hold);
+            Send(oScroll,@Delete);
+         }
+
+         return TRUE;
+      }
+
       % justicar report
       if (stringContain(string, barloque_clerk_report_phrase))
       {

--- a/kod/object/active/holder/room/barlqrm/barcourt.kod
+++ b/kod/object/active/holder/room/barlqrm/barcourt.kod
@@ -47,6 +47,9 @@ resources:
       "you no longer wish to be notified, say 'no advertise' to her instead.  "
       "Outlaws and murderers will not be notified of the vote, since they "
       "cannot properly participate."
+      "\n\n"
+      "Citizens can also ask for a legal name change by deed poll, for "
+      "a high cost.  Caramo will provide more information if asked."
 
 classvars:
 
@@ -107,6 +110,10 @@ messages:
       if poCaramo = $
       {
          poCaramo = Create(&BarloqueClerk);
+      }
+      else
+      {
+         Send(poCaramo,@Recreate);
       }
       
       Send(self,@NewHold,#what=poCaramo,

--- a/kod/object/item/passitem/inscript.kod
+++ b/kod/object/item/passitem/inscript.kod
@@ -24,7 +24,7 @@ resources:
 
    inscript_emote_write_third_rsc = "%s scribbles something on %s%s."
 
-   inscript_blank_rsc = " "
+   inscript_blank_rsc = ""
    inscript_q = "%q"
 
 classvars:
@@ -77,7 +77,7 @@ messages:
 
       oOwner=send(self,@GetOwner);
 
-      if IsClass(self,&BallotItem) or IsClass(self,&Book)
+      if IsClass(self,&BallotItem) or IsClass(self,&Book) or IsClass(self,&NameChangeScroll)
       {
          return FALSE;
       }

--- a/kod/object/item/passitem/inscript/makefile
+++ b/kod/object/item/passitem/inscript/makefile
@@ -5,6 +5,6 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\inscript.bof
-BOFS = book.bof ballot.bof
+BOFS = book.bof ballot.bof namechscroll.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/item/passitem/inscript/namechscroll.kod
+++ b/kod/object/item/passitem/inscript/namechscroll.kod
@@ -1,0 +1,138 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+NameChangeScroll is InscriptionItem
+
+constants:
+
+   include blakston.khd
+
+   DEED_POLL_DESTROY_TIME = 3600000
+
+resources:
+
+   deedpoll_name_rsc = "deed poll"
+   deedpoll_icon_rsc = scr02.bgf
+   deedpoll_desc_rsc = \
+      "This is an official document of the Office of the Justicar.\n"
+      "The Royal Justicar's office is responsible for organizing legal "
+      "name changes.  Fill out your requested name and return this scroll "
+      "to Caramo in the Office of the Justicar in North Barloque, and if "
+      "your proposed name is valid, it shall be yours.\n"
+      "\n"
+      "    =[C]=   Caramo, Assistant to the Royal Justicar"
+   deedpoll_cant_drop_rsc = \
+      "You find yourself unable to get rid of the deed poll."
+   deedpoll_destroyed_rsc = \
+      "Your deed poll suddenly crumbles into dust!"
+
+classvars:
+
+   vrName = deedpoll_name_rsc
+   vrIcon = deedpoll_icon_rsc
+   vrDesc = deedpoll_desc_rsc
+
+   viWeight = 2
+
+properties:
+
+   ptDestroy = $
+
+messages:
+
+   NewOwner(what=$)
+   {
+      if ptDestroy <> $
+      {
+         DeleteTimer(ptDestroy);
+         ptDestroy = $;
+      }
+
+      if IsClass(what,&Player)
+      {
+         ptDestroy = CreateTimer(self,@Destroy,DEED_POLL_DESTROY_TIME);
+      }
+
+      propagate;
+   }
+
+   Destroy()
+   {
+      ptDestroy = $;
+
+      if poOwner <> $
+         AND IsClass(poOwner,&User)
+      {
+         Send(poOwner,@MsgSendUser,#message_rsc=deedpoll_destroyed_rsc);
+      }
+
+      Send(self,@Delete);
+
+      return;
+   }
+
+   Delete()
+   {
+      if ptDestroy <> $
+      {
+         DeleteTimer(ptDestroy);
+         ptDestroy = $;
+      }
+
+      propagate;
+   }
+
+   ShowDesc()
+   {
+      AddPacket(4, deedpoll_desc_rsc);
+
+      return;
+   }
+
+   ReqNewOwner(what = $)
+   {
+      if poOwner = $
+         OR what = $
+      {
+         return TRUE;
+      }
+
+      if IsClass(what,&BarloqueClerk)
+      {
+         return TRUE;
+      }
+
+      if IsClass(poOwner,&User)
+      {
+         Send(poOwner,@MsgSendUser,#message_rsc=deedpoll_cant_drop_rsc);
+      }
+
+      return FALSE;
+   }
+
+   CanSwap()
+   {
+      % No more using these for swap mules
+      return FALSE;
+   }
+
+   DropOnDeath()
+   {
+      % No drop so that people can't load up on these and avoid real penalties
+      return FALSE;
+   }
+
+   CanBeStoredInVault()
+   {
+       return FALSE;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -125,6 +125,9 @@ properties:
    % Justicar
    piMinHPForJusticar = 100
 
+   % Cost for Caramo to change a player's name.
+   piNameChangeCost = 3000000
+
    % If enabled, unsafe penalties send the player to their hometown.
    % This is intended to prevent being players 'kept offline' by enemies.
    pbHometownPenaltiesEnable = FALSE
@@ -320,6 +323,12 @@ messages:
    GetMinHPForJusticar()
    {
       return piMinHPForJusticar;
+   }
+
+   % Returns the cost for player name changes through Caramo
+   GetNameChangeCost()
+   {
+      return piNameChangeCost;
    }
    
    % This returns whether players go to a room's blink spot or their hometown when they pen

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -3660,8 +3660,7 @@ messages:
 
    ReceiveClient(client_msg = $,number_stuff = $,session_id = $)
    {
-      local i,liClient_cmd,oUser,lCharinfo,sName,sDesc,oLookup,iGender,rOldName,bLegal,
-            lBadNameContain,lBadNameIs,sTemp;
+      local i, liClient_cmd, oUser, lCharinfo, sName, sDesc, iGender, bLegal;
 
       liClient_cmd = First(client_msg);
 
@@ -3681,108 +3680,13 @@ messages:
 
          % Validate name and description
          sName = Nth(client_msg,3);
-         if StringLength(sName) < MIN_CHAR_NAME_LEN OR 
-            StringLength(sName) > MAX_CHAR_NAME_LEN
-         {
-            Debug("Got char name length out of range for user ", oUser);
-            bLegal = FALSE;
-         }
 
-         if NOT StringConsistsOf(sName, 
-             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890_ '!@$^&*()+=:[]{};/?|<>")
-         {
-            Debug("Got char name with illegal characters for user ", oUser);
-            bLegal = FALSE;
-         }
+         bLegal = Send(self,@ValidateUserName,#oUser=oUser,#sName=sName);
 
          sDesc = Nth(client_msg,4);
          if StringLength(sDesc) > MAX_CHAR_DESCRIPTION_LEN
          {
             Debug("Got description length out of range for user ", oUser);
-            bLegal = FALSE;
-         }
-
-
-         oLookup = Send(SYS,@FindUserByString,#string=sName);
-         if oLookup <> $ AND oLookup <> oUser
-         {
-            bLegal = FALSE;
-         }
-
-         % No using monster or NPC names.
-         if Send(SYS,@FindMonsterByString,#string=sName) <> $
-            OR Send(SYS,@FindNPCByString,#string=sName) <> $
-            OR Send(SYS,@FindGuildByString,#string=sName) <> $
-         {
-            bLegal = FALSE;
-         }
-
-         % Check for people who put "a" or "an" in front of a monster name.
-         for i in plMonsterTemplates
-         {
-            if StringContain(sName,Send(i,@GetTrueName))
-            {
-               if psTemp = $
-               {
-                  psTemp = CreateString();
-               }
-
-               % Use the local temp string, substitute out the name, see if
-               %  we're left with "a" or "an"
-               SetString(psTemp,sName);
-               StringSubstitute(psTemp,Send(i,@GetTrueName),"");
-               if StringEqual(psTemp,"a")
-                  OR StringEqual(psTemp,"an")
-               {
-                  bLegal = FALSE;
-               }
-            }
-         }
-
-         % Don't do these lengthy checks if we're already looking bad.
-         if bLegal
-         {
-            % This is a list of bad things for the name to contain.
-            % Start with the dirty words.
-            lBadNameContain = plNaughtyWords;
-
-            % Confusing names
-            lBadNameContain = Cons("guardian angel", lBadNameContain);
-            lBadNameContain = Cons("guardianangel", lBadNameContain);
-
-            % This is a list of bad names in general.
-            lBadNameIs = [ % God's names.
-                           "Faren", "Shal'ille", "Qor", "Faren",
-                           "Kraanan", "Riija", "Jala",
-                           % Causes confusion.
-                           "You", system_hidden_admin
-                         ];
-
-            for i in lBadNameContain
-            {
-               if StringContain(sName,i)
-               {
-                  bLegal = FALSE;
-
-                  break;
-               }
-            }
-
-            for i in lBadNameIs
-            {
-               if StringEqual(sName, i)
-               {
-                  bLegal = FALSE;
-
-                  break;
-               }
-            }
-         }
-
-         % Pull the string from user.  This is the name we gmail to contact
-         %  our own guild.
-         if StringEqual(sName, "guild")
-         {
             bLegal = FALSE;
          }
 
@@ -3813,9 +3717,7 @@ messages:
          % such references expire through gameplay.
 
          Send(self,@RecreatedUser,#what=oUser);
-         rOldName = Send(oUser,@GetUserName);
          i = Send(oUser,@GetLastRestartTime);
-         DeleteTableEntry(phUsers,rOldName);
 
          if pbRecycleUsersEnabled
          {
@@ -3828,13 +3730,12 @@ messages:
          AddPacket(4,oUser);
          SendPacket(session_id);
 
-         if not isClass(oUser,&Guest)
+         if NOT isClass(oUser,&Guest)
          {
-            Debug("User suicide",oUser,"from",rOldName,"to",sName);
+            Debug("User suicide",oUser,"from",Send(oUser,@GetTrueName),"to",sName);
          }
 
-         SetResource(Send(oUser,@GetUserName),sName);
-         AddTableEntry(phUsers,Send(oUser,@GetUserName),oUser);
+         Send(self,@ChangeUserName,#oUser=oUser,#sName=sName);
 
          Send(oUser,@SetLastRestartTime,#time=i);
 
@@ -3852,6 +3753,131 @@ messages:
       }
 
       return;
+   }
+
+   ValidateUserName(oUser=$,sName=$)
+   {
+      local i, lBadNameContain, lBadNameIs, oLookup;
+
+      if oUser = $
+         OR sName = $
+      {
+         return FALSE;
+      }
+
+      if StringLength(sName) < MIN_CHAR_NAME_LEN
+         OR StringLength(sName) > MAX_CHAR_NAME_LEN
+      {
+         Debug("Got char name length out of range for user ", oUser);
+
+         return FALSE;
+      }
+
+      if NOT StringConsistsOf(sName, 
+          "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890_ '!@$^&*()+=:[]{};/?|<>")
+      {
+         Debug("Got char name with illegal characters for user ", oUser);
+
+         return FALSE;
+      }
+
+      oLookup = Send(SYS,@FindUserByString,#string=sName);
+      if oLookup <> $
+         AND oLookup <> oUser
+      {
+         return FALSE;
+      }
+
+      % No using monster or NPC names.
+      if Send(SYS,@FindMonsterByString,#string=sName) <> $
+         OR Send(SYS,@FindNPCByString,#string=sName) <> $
+         OR Send(SYS,@FindGuildByString,#string=sName) <> $
+      {
+         return FALSE;
+      }
+
+      % Check for people who put "a" or "an" in front of a monster name.
+      for i in plMonsterTemplates
+      {
+         if StringContain(sName,Send(i,@GetTrueName))
+         {
+            if psTemp = $
+            {
+               psTemp = CreateString();
+            }
+
+            % Use the local temp string, substitute out the name, see if
+            %  we're left with "a" or "an"
+            SetString(psTemp,sName);
+            StringSubstitute(psTemp,Send(i,@GetTrueName),"");
+            if StringEqual(psTemp,"a")
+               OR StringEqual(psTemp,"an")
+            {
+               return FALSE;
+            }
+         }
+      }
+
+      % This is a list of bad things for the name to contain.
+      % Start with the dirty words.
+      lBadNameContain = plNaughtyWords;
+
+      % Confusing names
+      lBadNameContain = Cons("guardian angel", lBadNameContain);
+      lBadNameContain = Cons("guardianangel", lBadNameContain);
+
+      % This is a list of bad names in general.
+      lBadNameIs = [ % God's names.
+                     "Faren", "Shal'ille", "Qor", "Faren",
+                     "Kraanan", "Riija", "Jala",
+                     % Causes confusion.
+                     "You", system_hidden_admin
+                   ];
+
+      for i in lBadNameContain
+      {
+         if StringContain(sName,i)
+         {
+            return FALSE;
+         }
+      }
+
+      for i in lBadNameIs
+      {
+         if StringEqual(sName, i)
+         {
+            return FALSE;
+         }
+      }
+
+      % Pull the string from user.  This is the name we gmail to contact
+      %  our own guild.
+      if StringEqual(sName, "guild")
+      {
+            return FALSE;
+      }
+
+      % Name should be valid.
+
+      return TRUE;
+   }
+
+   ChangeUserName(oUser=$,sName=$)
+   {
+      local rOldName;
+
+      if oUser = $
+         OR sName = $
+      {
+         return FALSE;
+      }
+
+      rOldName = Send(oUser,@GetUserName);
+      DeleteTableEntry(phUsers,rOldName);
+      SetResource(Send(oUser,@GetUserName),sName);
+      AddTableEntry(phUsers,Send(oUser,@GetUserName),oUser);
+
+      return TRUE;
    }
 
    GetHiddenAdminName()
@@ -4765,6 +4791,7 @@ messages:
       plItemTemplates = cons(create(&Letter),plItemTemplates);
       plItemTemplates = cons(create(&InscriptionItem),plItemTemplates);
       plItemTemplates = cons(create(&BallotItem),plItemTemplates);
+      plItemTemplates = cons(create(&NameChangeScroll),plItemTemplates);
       plItemTemplates = cons(create(&Rose),plItemTemplates);
       plItemTemplates = cons(create(&OreChunk),plItemTemplates);
       plItemTemplates = cons(create(&NeruditeOreChunk),plItemTemplates);


### PR DESCRIPTION
This PR adds the ability to change names through Caramo's office and was first implemented [here](https://github.com/OpenMeridian/Meridian59/pull/1045/files) by @skittles1 in the OpenMeridian project. This version differs from their implementation in a couple ways detailed below. **It is submitted now as a draft for review and feedback.**

# Overview
Once deployed, this PR makes it possible for any player to change their name in Caramo's office. Player's can request a scroll, fill out their new name, then return to the scroll to Caramo to process the name change at the predetermined price point. This process does not require a game administrator. The default price for this service is 3,000,000.

## Key Points
- Names are validated using the existing name validation code in `System`, which has been refactored for use outside of the initial character creation flow.
- A record of each name change is logged to the Book of Jala in the Justicar's office.
- At this time, players can change their name as often as they'd like and limited only by the size of their bank account.
- Unlike the OpenMeridian implementation, this PR requires players to have the required money in their inventory and not simply in their bank account. There ought to at least be an ounce of danger involved, in my opinion at least.

# Testing
1. Travel to the Office of the Justicar, `go 970`
2. Request a name change scroll by saying `change name` or `name change`
3. Acquire the necessary funds for the service -- 3,000,000 using `dm get money`
4. Edit the scroll with a new username
5. Offer the scroll to Caramo while holding 3,000,000 shillings
6. Verify that the scroll is now gone, you are lighter by 3,000,000 shillings, and your name has been changed

# Questions
- Should murderers and outlaws be able to change their name? They can currently.