### PR TITLE
Disables removal via purge/purify

### DIFF
--- a/kod/object/passive/skill/secwind.kod
+++ b/kod/object/passive/skill/secwind.kod
@@ -208,5 +208,12 @@ messages:
       return FALSE;
    }
 
+   CanBeRemovedByPlayer()
+   "Returns if a spell can be removed by normal Purge/Purify"
+   {
+      % Being a personal enchantment, stop SW from being removed by player(s)
+      return FALSE;
+   }
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This PR makes it so that the Second Wind buff/debuff can not be removed by players using purge/purify. #389 modified Second Wind to behave like a personal enchantment and as such, was affected by purge/purify. This PR adds an additional method (used elsewhere) that disallow removal by players.