### PR TITLE
Fix missing main stat icons on login

### DIFF
--- a/module/merintr/mermain.c
+++ b/module/merintr/mermain.c
@@ -129,7 +129,7 @@ void InterfaceResizeModule(int xsize, int ysize, AREA *view)
  */
 void InterfaceRedrawModule(HDC hdc)
 {
-	UserAreaRedraw();
+  UserAreaRedraw();
   InterfaceDrawElements(hdc);
   StatsDrawBorder();
   StatsMainRedraw();

--- a/module/merintr/statmain.c
+++ b/module/merintr/statmain.c
@@ -86,6 +86,7 @@ void StatsMainReceive(list_type stats)
    }
 
    StatsMainMove();
+   StatsMainRedraw();
 }
 /************************************************************************/
 /*


### PR DESCRIPTION
Players main stat icons (such as mana, vigour and health) and graph background are missing and often not visible when first logging in to the game.

![missing-icons](https://user-images.githubusercontent.com/7548210/211877752-3f7b2339-1ff1-469a-991f-221867e7df48.png)

Moving to a new screen or resizing the window refreshes these icons.

![visible-icons](https://user-images.githubusercontent.com/7548210/211877797-8e0fab91-8f0f-4ba1-8a90-189a83735850.png)

To fix this issue we redraw the icons whenever stats are received from the server.