### PR TITLE
Fix second wind handler name

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1190,7 +1190,7 @@ messages:
       if Send(self,@GetSkillAbility,#Skill_num=SKID_SECOND_WIND) > 0
          AND NOT Send(self,@IsEnchanted,#byClass=&SecondWind)
       {
-         Send(Send(SYS,@FindSkillByNum,#num=SKID_SECOND_WIND),@TrySkill,#who=self);
+         Send(Send(SYS,@FindSkillByNum,#num=SKID_SECOND_WIND),@DoSkill,#who=self);
       }
 
       piVigor = bound(piVigor,1,viMax_vigor);

--- a/kod/object/passive/skill/secwind.kod
+++ b/kod/object/passive/skill/secwind.kod
@@ -76,7 +76,7 @@ messages:
       return iWaitTime;
    }
 
-   TrySkill(who=$)
+   DoSkill(who=$)
    "Do the skill only if player meets the requirements."
    {
       % If player has second wind, has fallen below the vigor 
@@ -99,7 +99,7 @@ messages:
          Send(who,@WaveSendUser,#wave_rsc=SecondWind_sound);
       }
 
-      return;
+      propagate;
    }
 
    AddEnchantmentEffects(who=$)


### PR DESCRIPTION
This PR fixes an issue where Second Wind appears to work as intended, but does not improve.

As a subclass of `Skill`, Second Wind should override and pass control back to `DoSkill`, where skill advancement is handled. When SW was refactored recently, `DoSkill` was renamed to `TrySkill` and in doing so, had it's advancement handling cut off. This PR renames the method, propagates control to `Skill` and updates the handler call in `Player` to use the new handler name.

To test, I created an admin player, then gave it all spells and second wind at 1%. I also played around with the server advancement rate while testing, first at 9999 to force an improvement and then at the default of 100 to see that improvements were only taking place some of the time. I triggered SW 10+ times at an advancement rate of 100 and verified that I was only improving some of the time.

### Some helpful test commands

#### Give self Second Wind (id 405) at 1%
`send o <player#> adminsetskill num int 405 ability int 1`

#### Give self mana - cast and break concentration blink to quickly reduce vigor
`send c user GainMana amount int 200`

#### Changing the advancement rate (Settings object)
`set object 1 piAdvancementRate INT 200`