### PR TITLE
Fixes for Second Wind

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1182,17 +1182,8 @@ messages:
    %%% Vigor
 
    NewVigor()
-   "Ensures vigor stays in bounds, including attempts at second wind skill"
-   "Vigor display will be driven from here."
+   "Ensures vigor stays in bounds. Vigor display will be driven from here."
    {
-      % If vigor is changing and player has second wind, but isn't enchanted by it,
-      % then attempt second wind.
-      if Send(self,@GetSkillAbility,#Skill_num=SKID_SECOND_WIND) > 0
-         AND NOT Send(self,@IsEnchanted,#byClass=&SecondWind)
-      {
-         Send(Send(SYS,@FindSkillByNum,#num=SKID_SECOND_WIND),@TrySkill,#who=self);
-      }
-
       piVigor = bound(piVigor,1,viMax_vigor);
       Send(self,@DrawVigor);
 
@@ -1259,6 +1250,14 @@ messages:
          }
 
          Send(self,@NewVigor);
+      }
+
+      % If Second Wind is available and inactive, and (adjusted) exertion is present, attempt SW
+      if Send(self,@GetSkillAbility,#Skill_num=SKID_SECOND_WIND) > 0
+         AND iExertionAdded > 0
+         AND NOT Send(self,@IsEnchanted,#byClass=&SecondWind)
+      {
+         Send(Send(SYS,@FindSkillByNum,#num=SKID_SECOND_WIND),@DoSkill,#who=self);
       }
 
       return;

--- a/kod/object/passive/skill/secwind.kod
+++ b/kod/object/passive/skill/secwind.kod
@@ -76,14 +76,13 @@ messages:
       return iWaitTime;
    }
 
-   TrySkill(who=$)
+   DoSkill(who=$)
    "Do the skill only if player meets the requirements."
    {
       % If player has second wind, has fallen below the vigor 
       % threshold, and is not already enchanted
       if Send(self,@GetAbility,#who=who) > 0
          AND Send(who,@GetVigor) < viThreshold
-         AND NOT Send(who,@IsEnchanted,#byClass=&SecondWind)
       {
          % Apply the effects of second wind
          Send(self,@AddEnchantmentEffects,#who=who);
@@ -97,6 +96,8 @@ messages:
    
          % Send sound
          Send(who,@WaveSendUser,#wave_rsc=SecondWind_sound);
+
+         propagate;
       }
 
       return;
@@ -116,31 +117,6 @@ messages:
       
       % Update player vigor
       Send(who,@AddExertion,#amount=10000*iVigor);
-
-      return;
-   }
-
-   EndEnchantment(who=$, report=TRUE)
-   {
-      if report
-      {
-         Send(who,@MsgSendUser,#message_rsc=SecondWind_finished);
-      }
-
-      Post(self,@EndEnchantmentEffects,#who=who);
-
-      return;
-   }
-   
-   EndEnchantmentEffects(who=$)
-   "Resets vigor rest threshold once the enchantment ends."
-   {
-      local iAmount;
-
-      % Resets the player's vigor rest threshold based on second wind %
-      iAmount = 80 + ((Send(self,@GetAbility,#who=who) + 1) / 5);
-   
-      Send(who,@SetVigorRestThreshold,#amount=iAmount);
 
       return;
    }
@@ -167,7 +143,38 @@ messages:
       propagate;
    }
 
+   %
+   % While technically a skill, Second Wind acts like a personal 
+   % enchantment and the following handlers provide support for this.
+   %
+
+   EndEnchantment(who=$,state=$,report=TRUE)
+   "Included to support mimicing of personal enchantment spells."
+   {
+      local iAmount;
+
+      % Resets the player's vigor rest threshold based on second wind %
+      iAmount = 80 + ((Send(self,@GetAbility,#who=who) + 1) / 5);
+      Post(who,@SetVigorRestThreshold,#amount=iAmount);
+
+      if report
+      {
+         Send(who,@MsgSendUser,#message_rsc=SecondWind_finished);
+      }
+
+      return;
+   }
+
+   RemoveEnchantmentEffects(who=$,state=$,report=$)
+   "Included to support mimicing of personal enchantment spells."
+   {
+      Send(self,@EndEnchantment,#who=who,#report=report,#state=state);
+
+      return;
+   }
+
    ShowEnchantmentIcon(type=$)
+   "Included to support mimicing of personal enchantment spells."
    {
       return viShow_enchantment_icon & 0x02;
    }


### PR DESCRIPTION
This PR resolves some outstanding issues with recent Second Wind changes and includes some refactoring:

1. It hooks Second Wind into Skill advancement, so that SW advancement is in line with overall `Skill` advancement. Under the current conditions, SW improvements are unlikely.

2. It implements `RemoveEnchantmentEffects` -- a handler for personal enchantments -- that was seen throwing missing handlers errors. This is a minor issue and was the result of our testing using the admin command, `RemoveAllEnchantments`.

3. It refactors SW code from `NewVigor()` into `AddExertion()`, as it seemed more appropriate to handle SW when adding exertion, not setting a new vigor value.

4. It refactors `EndEnchantmentEffects` into `EndEnchantment` for the sake of readability.

### Testing
There's quite a bit to consider when testing this.

* Second Wind should not trigger when _gaining_ vigor (i.e. eating or resting)
* Second Wind, when active, should disallow any vigor gains
* Second Wind cannot be purged
* Second Wind, being treated as an enchantment now, can be removed by `RemoveAllEnchantments`
* Second Wind's % determines the players resting threshold. When SW is active, the resting threshold should be 10, but will otherwise be 80 (1%) - 100 (99%)
* Second Wind is tough to improve. I recommend turning up the server advancement rate for testing.
* Player instances keep track of an exertion amount. Triggering SW will dramatically reduce a players exertion. A player's exertion level determines whether or not their vigor is reduced. What this means for Second Wind is that there's a brief period after triggering SW where the exertion level have been reduced to a point where the player can move for a distance without vigor being reduced.

### Helpful commands (for LOCAL testing)
`create account admin test test`
`create admin 3`
`dm mortal`
`dm get spells`
`dm get food`
`send o <player#> adminsetskill num int 405 ability int 1` (give yourself Second Wind at 1%)
`send c user GainMana amount int 999` (give yourself 999 mana)
`set object 1 piAdvancementRate INT 600` (increase advancement rate in Settings to see imps)

At this point I start casting blink and breaking focus to quickly lower my vigor. When it drops below 25, Second Wind should trigger. With an advancement rate of 600, you should see an improvement. When it's active, spend your vigor again and verify SW does not trigger again under 25. Try eating food and resting to ensure you can't regain vigor by any means.

At this point you can do one of two things: wait for SW to dissipate or use send the player object a `RemoveAllEnchantments` message to wipe SW away. Both of these methods should be tested and you should verify that no errors pop up in the log. Verify that your rest threshold returns to the correct value (SW % dictates this value; at 1% your rest threshold should be 80). Verify that you can eat once it dissipates.
