### PR TITLE
Allows guild allies to enter guild hall

### DIFF
--- a/kod/object/active/holder/room/ghall.kod
+++ b/kod/object/active/holder/room/ghall.kod
@@ -1050,7 +1050,8 @@ messages:
 
       oGuild = Send(who,@GetGuild);
 
-      if oGuild = poGuild_owner
+      if (oGuild = poGuild_owner
+         OR Send(poGuild_owner,@IsAlly,#otherguild=oGuild))
          AND Send(oGuild,@GetRank,#who=who) >= RANK_SIR
       {
          return TRUE;


### PR DESCRIPTION
This commit re-enables previously removed logic and now allows allied guild members above the rank of Initiate to enter a guild hall. The code change was made back in 2013 in #163 at a time when I'm sure the community was a bit different, but there's been conversation about bringing it back.

My personal opinion is that the community ought to be able to police themselves on this one.