### PR TITLE
Protects Riija Sword when crossing Riija Temple bridge

### DIFF
--- a/kod/object/active/holder/room/temprii.kod
+++ b/kod/object/active/holder/room/temprii.kod
@@ -437,6 +437,7 @@ messages:
       if oItem <> $
          AND Send(oItem,@ReqLeaveOwner)
          AND Send(oItem,@DropOnDeath)
+         AND NOT IsClass(oItem,&RiijaSword)
          AND random(1,3) = 1
       {
          return TRUE;


### PR DESCRIPTION
This commit protects the Riija Sword from dropping when unsuccessfully crossing the invisible bridge to the Riija Template (`ke1`). It can still be lost in other ways and this is more a matter of convenience and to minimize the punishment dealt to players using the bridge. Currently, the Riija Sword drops at the bridge and must be retrieved by the player.

Referring to it explicitly felt like the right approach given that implementing `ReqLeaveOwner` or `DropOnDeath` would have had wide-ranging effects on the item outside of crossing the bridge.

### Testing
To confirm this change, I fell to my death 10 times with a Riija Sword in my inventory and did not lose it. I then added food to my inventory and fell again, that time losing one of my food stacks.
