### PR TITLE
Adds support for recreating shrines

### DIFF
--- a/kod/object/passive/shrine.kod
+++ b/kod/object/passive/shrine.kod
@@ -223,7 +223,7 @@ messages:
       return piAllegiance;
    }
 
-   SetAllegiance(allegiance = $)
+   SetAllegiance(allegiance=0)
    {
       piAllegiance = allegiance;
       return;

--- a/kod/object/passive/shrine.kod
+++ b/kod/object/passive/shrine.kod
@@ -223,6 +223,12 @@ messages:
       return piAllegiance;
    }
 
+   SetAllegiance(allegiance = $)
+   {
+      piAllegiance = allegiance;
+      return;
+   }
+
    GetPower()
    {
       return piShrine_power;

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -2750,7 +2750,8 @@ messages:
                n = n + 1;
             }
          }
-         else {
+         else 
+         {
             Debug("RecreateShrineAllegiances:: Length mismatch between shrines and shrine allegiances");
          }
       }

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -365,6 +365,7 @@ properties:
 
    plShrines = $
    plShrine_Powers = $
+   plShrine_Allegiances = $
 
    % Bonus spellpower set by admins for events.
    plBonusSpellpower = $
@@ -426,9 +427,8 @@ messages:
       Send(self,@RecreateAllBrains);
       Send(self,@RecreateLibrary);
       Send(self,@RecreateAllRooms);
-      % Creates the Faction games
       Send(self,@RecreateParliament);
-
+      Send(self,@RecreateShrineAllegiances);
       Send(self,@RecreateAssassinGame);
       Send(self,@RecreateQuestEngine);
       Send(self,@RecreateNodeAttack);
@@ -468,7 +468,6 @@ messages:
 
       Send(self,@RefigureAllAbilityTotals);
       Send(self,@RefigureAllAbilityTotals);
-      Send(self,@RecomputeShrineTotals);
       Send(self,@RecreateLearnAdvice);
 
       psTemp = CreateString();
@@ -524,6 +523,7 @@ messages:
       Send(self,@RecreateLibrary);
       Send(self,@RecreateAllRooms);
       Send(self,@RecreateAssassinGame);
+      Send(self,@RecreateShrineAllegiances);
       % The following two lines are handled in Parliament
       % Send(self,@RecreateTerritoryGame);
       % Send(self,@RecreateTokenGame);
@@ -624,7 +624,6 @@ messages:
       piRecreate_State = RECREATE_PHASE_FIVE;
 
       Send(self,@RecreateLearnAdvice);
-      Send(self,@RecomputeShrineTotals);
       Send(self,@RecreateMonsterTemplates);
       Send(self,@RecreateItemTemplates);
       Send(self,@RecreateMoneyTemplates);
@@ -2339,7 +2338,7 @@ messages:
    "CreateAllRoomsIfNew.\nUNSAFE to call from admin mode, as items"
    "in rooms lose state.  Use RecreateAll instead."
    {
-      local i, bFeast_Hall_Locked, oFeast_Hall;
+      local i, n, bFeast_Hall_Locked, oFeast_Hall;
 
       if plUsers_logged_on <> $
       {
@@ -2352,6 +2351,13 @@ messages:
       if oFeast_Hall <> $
       {
          bFeast_Hall_Locked = Send(oFeast_Hall, @IsLocked);
+      }
+
+      % Save shrine powers.
+      plShrine_Allegiances = $;
+      for n in plShrines
+      {
+         plShrine_Allegiances = Cons(Send(n,@GetAllegiance),plShrine_Allegiances);
       }
 
       if poParliament <> $
@@ -2716,6 +2722,30 @@ messages:
             Send(ShrineObj,@GotOffering,#what=what);
          }
       }
+
+      return;
+   }
+
+   RecreateShrineAllegiances()
+   {
+      % Shrines were recreated when rooms were recreated
+      % We now need to recreate their alliegences and power levels
+
+      local i, n;
+      if plShrine_Allegiances <> $
+      {
+         n = 5;
+
+         for i in plShrines
+         {
+            Send(i,@SetAllegiance,#allegiance=(Nth(plShrine_Allegiances,n)));
+            n = n - 1;
+         }
+      }
+      plShrine_Allegiances = $;
+
+      % Recalculate shrines
+      Send(self,@RecomputeShrineTotals);
 
       return;
    }

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -2338,7 +2338,7 @@ messages:
    "CreateAllRoomsIfNew.\nUNSAFE to call from admin mode, as items"
    "in rooms lose state.  Use RecreateAll instead."
    {
-      local i, n, bFeast_Hall_Locked, oFeast_Hall;
+      local i, n, shrine, bFeast_Hall_Locked, oFeast_Hall;
 
       if plUsers_logged_on <> $
       {
@@ -2355,9 +2355,16 @@ messages:
 
       % Preserve shrine powers
       plShrine_Allegiances = $;
-      for n in plShrines
+      
+      n = Length(plShrines);
+
+      % We build `plShrine_Allegiances` in reverse order to match the order
+      % of `plShrines`, used later when recreating the allegiances
+      while (n > 0)
       {
-         plShrine_Allegiances = Cons(Send(n,@GetAllegiance), plShrine_Allegiances);
+         shrine = Nth(plShrines,n);
+         plShrine_Allegiances = Cons(Send(shrine,@GetAllegiance),plShrine_Allegiances);
+         n = n - 1;
       }
 
       if poParliament <> $
@@ -2729,18 +2736,25 @@ messages:
    RecreateShrineAllegiances()
    "Resets shrine allegiances and power levels"
    {
-      local i, n;
+      local shrine, n;
 
       if plShrine_Allegiances <> $
       {
-         n = 5;
-
-         for i in plShrines
+         if Length(plShrine_Allegiances) = Length(plShrines)
          {
-            Send(i,@SetAllegiance,#allegiance=(Nth(plShrine_Allegiances,n)));
-            n = n - 1;
+            n = 1;
+
+            for shrine in plShrines
+            {
+               Send(shrine,@SetAllegiance,#allegiance=(Nth(plShrine_Allegiances,n)));
+               n = n + 1;
+            }
+         }
+         else {
+            Debug("RecreateShrineAllegiances:: Length mismatch between shrines and shrine allegiances");
          }
       }
+
       plShrine_Allegiances = $;
 
       Send(self,@RecomputeShrineTotals);

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -2353,11 +2353,11 @@ messages:
          bFeast_Hall_Locked = Send(oFeast_Hall, @IsLocked);
       }
 
-      % Save shrine powers.
+      % Preserve shrine powers
       plShrine_Allegiances = $;
       for n in plShrines
       {
-         plShrine_Allegiances = Cons(Send(n,@GetAllegiance),plShrine_Allegiances);
+         plShrine_Allegiances = Cons(Send(n,@GetAllegiance), plShrine_Allegiances);
       }
 
       if poParliament <> $
@@ -2727,11 +2727,10 @@ messages:
    }
 
    RecreateShrineAllegiances()
+   "Resets shrine allegiances and power levels"
    {
-      % Shrines were recreated when rooms were recreated
-      % We now need to recreate their alliegences and power levels
-
       local i, n;
+
       if plShrine_Allegiances <> $
       {
          n = 5;
@@ -2744,7 +2743,6 @@ messages:
       }
       plShrine_Allegiances = $;
 
-      % Recalculate shrines
       Send(self,@RecomputeShrineTotals);
 
       return;


### PR DESCRIPTION
This PR adds `RecreateAll` support for shrine allegiance and power level, as requested in #29. To test, I chose two random shrines and dedicated one to Kraanan and the other to Shal'ille, then verified that these dedications and bonuses were accurately recreated on `RecreateAll`. If there's something else I should consider, please let me know!

### Testing

1. Give yourself the necessary offerings

```
dm get misc
```

1. Check shrine bonuses:

```
send o 0 GetShrineBonus school int 1
send o 0 GetShrineBonus school int 2
send o 0 GetShrineBonus school int 3
send o 0 GetShrineBonus school int 4
send o 0 GetShrineBonus school int 5
send o 0 GetShrineBonus school int 6
```

| 1 | 2 | 3 | 4 | 5 | 6 |
|-|-|-|-|-|-|
| 0 | 0 | 0 | 0 | 0 | 0 |

1. Dedicate shrines

Note: I learned late in testing this that you can just teleport directly to objects using the admin panel (or related command). Do that instead of trying to find the right coordinates to move to the shrine like I did 🤦.

```
go rid_e5 (The Forest Shrine)
send object <room#> somethingmoved what object <player#> new_row int 11 new_col int 15 fine_row int 52 fine_col int 47
```

Drop Sweat of a Warrior King, dedicating this shrine to **Kraanan**

```
go rid_orc_cave5
send object <room#> somethingmoved what object <player#> new_row int 67 new_col int 42 fine_row int 32 fine_col int 32
```

Drop Tears of a Newborn, dedicating this shrine to **Shal'ille**

2. Verify state by running shrine bonus commands:

| 1 | 2 | 3 | 4 | 5 | 6 |
|-|-|-|-|-|-|
| 6 | 0 | 6 | 0 | 0 | 0 |

4. Recreate

```
send o 0 RecreateAll
```

6. Confirm state by running shrine bonus commands:

| 1 | 2 | 3 | 4 | 5 | 6 |
|-|-|-|-|-|-|
| 6 | 0 | 6 | 0 | 0 | 0 |


This is based on the work of @M59Gar and @skittles1 in the OpenMeridian project 🙇‍♂️