### PR TITLE
Adding support for flag states during recreateall

### DIFF
--- a/kod/object/active/flag.kod
+++ b/kod/object/active/flag.kod
@@ -695,8 +695,7 @@ messages:
       return poClaimer;
    }
 
-   SetFaction(faction=FACTION_NEUTRAL)
-   "for admin use"
+   SetFaction(faction=FACTION_NEUTRAL,claim=TRUE)
    {
       piFaction = faction;
       if poOwner <> $
@@ -709,7 +708,11 @@ messages:
          }
       }
 
+      % If setting the faction as part of a bulk process (i.e. recreate),
+      % pass `claim=FALSE` and be sure to manually recalculate the flags 
+      % and save the flag states, as `FlagClaimed` does.
       if (send(SYS,@GetTerritoryGame) <> $)
+         AND claim
       {
          send(send(SYS,@GetTerritoryGame),@FlagClaimed,#flag=self);
       }

--- a/kod/util/factgame/territry.kod
+++ b/kod/util/factgame/territry.kod
@@ -397,7 +397,6 @@ messages:
    }
 
    ReloadFlagStates(lFlagStates=$)
-   "Used during recreates to save flag states."
    {
       local i, iRID, oRoom, oFlag;
 

--- a/kod/util/factgame/territry.kod
+++ b/kod/util/factgame/territry.kod
@@ -397,6 +397,7 @@ messages:
    }
 
    ReloadFlagStates(lFlagStates=$)
+   "Used during recreates to save flag states."
    {
       local i, iRID, oRoom, oFlag;
 

--- a/kod/util/factgame/territry.kod
+++ b/kod/util/factgame/territry.kod
@@ -396,25 +396,18 @@ messages:
       return;
    }
 
-   ReloadFlagStates(lFlagStates=$)
-   "Used during recreates to save flag states."
+   ReloadSavedFlagStates()
    {
       local i, iRID, oRoom, oFlag;
 
-      if lFlagStates = $
+      if plFlagStates = $
       {
-         lFlagStates = plFlagStates;
+         DEBUG("ReloadSavedFlagStates:: nothing saved, nothing reloaded");
       }
 
-      if lFlagStates = $
-         OR NOT IsList(lFlagStates)
+      if length(plFlagStates) <> length(plFlagRIDs)
       {
-         DEBUG("ReloadFlagStates:: nothing saved, nothing reloaded");
-      }
-
-      if length(lFlagStates) <> length(plFlagRIDs)
-      {
-         DEBUG("ReloadFlagStates:: error in saved flag states - length mismatch");
+         DEBUG("ReloadSavedFlagStates:: error in saved flag states - length mismatch");
       }
 
       i = length(plFlagRIDs);
@@ -425,16 +418,16 @@ messages:
          oRoom = send(SYS,@FindRoomByNum,#num=iRID);
          if oRoom = $
          {
-            DEBUG("ReloadFlagStates:: got nil room for RID=",iRID);
+            DEBUG("ReloadSavedFlagStates:: got nil room for RID=",iRID);
             continue;
          }
          oFlag = send(oRoom,@FindHoldingActive,#class=&Flagpole);
          if oFlag = $
          {
-            DEBUG("ReloadFlagStates:: got nil flag in",send(oRoom,@GetName));
+            DEBUG("ReloadSavedFlagStates:: got nil flag in",send(oRoom,@GetName));
             continue;
          }
-         send(oFlag,@SetFaction,#faction=nth(lFlagStates,(i+1)));
+         send(oFlag,@SetFaction,#faction=nth(plFlagStates,(i+1)));
       }
 
       return;
@@ -481,7 +474,7 @@ messages:
          DEBUG("ReloadSavedFlagStates:: encountered errors during save; not replacing older save.");
       }
 
-      return plFlagStates;
+      return;
    }
 
    FlagClaimed(flag=$)
@@ -886,11 +879,6 @@ messages:
    GetMinUsers()
    {
       return piMinUsers;
-   }
-
-   GetFlagStates()
-   {
-      return plFlagStates;
    }
 
    GetMinAllies()

--- a/kod/util/factgame/territry.kod
+++ b/kod/util/factgame/territry.kod
@@ -175,8 +175,6 @@ messages:
          else
          {
             send(self,@CountFlags);
-            % do this after, so that bonus town recalcs saved
-            send(self,@SaveFlagStates);
          }
 
          send(self,@RecountFlagItems);
@@ -186,7 +184,10 @@ messages:
       if piGameMode = GAME_PART
       {
          send(self,@UpdateFlagsPartialGame);
+         
       }
+
+      send(self,@SaveFlagStates);
 
       return;
    }
@@ -229,6 +230,10 @@ messages:
          return;
       }
 
+      % todo: Combine these loops because the new SetFaction accepts 
+      % `claim=FALSE` and won't trigger the callback. Counting of flags
+      % and saving of flag states will be handled by `Recreate`.
+      % 
       % Setting the faction on a flagpole causes a callback to us to
       % count all of the flags' factions.  But we might not be done
       % placing the other flags yet.  So we do this in two passes:
@@ -256,23 +261,23 @@ messages:
 
             if (lRIDs = plTosRIDs) or (lRIDs = plMarionRIDs)
             {
-               send(oFlag,@SetFaction,#faction=FACTION_DUKE);
+               send(oFlag,@SetFaction,#faction=FACTION_DUKE,#claim=FALSE);
             }
 
             if (lRIDs = plCorNothRIDs) or (lRIDs = plBarloqueRIDs)
             {
-               send(oFlag,@SetFaction,#faction=FACTION_PRINCESS);
+               send(oFlag,@SetFaction,#faction=FACTION_PRINCESS,#claim=FALSE);
             }
 
             if (lRIDs = plJasperRIDs)
             {
                if (random(0,1) = 0)
                {
-                  send(oFlag,@SetFaction,#faction=FACTION_PRINCESS);
+                  send(oFlag,@SetFaction,#faction=FACTION_PRINCESS,#claim=FALSE);
                }
                else
                {
-                  send(oFlag,@SetFaction,#faction=FACTION_DUKE);
+                  send(oFlag,@SetFaction,#faction=FACTION_DUKE,#claim=FALSE);
                }
             }
 
@@ -292,6 +297,10 @@ messages:
          return;
       }
 
+      % todo: Combine these loops because the new SetFaction accepts 
+      % `claim=FALSE` and won't trigger the callback. Counting of flags
+      % and saving of flag states will be handled by `Recreate`.
+      %
       % Setting the faction on a flagpole causes a callback to us to
       % count all of the flags' factions.  But we might not be done
       % placing the other flags yet.  So we do this in two passes:
@@ -315,7 +324,7 @@ messages:
          iLocation = FindListElem(plTosRIDs,iRID);
          if iLocation
          {
-            send(oFlag,@SetFaction,#faction=FACTION_DUKE);
+            send(oFlag,@SetFaction,#faction=FACTION_DUKE,#claim=FALSE);
             if iLocation = 1
             {
                % town flag
@@ -326,7 +335,7 @@ messages:
          iLocation = FindListElem(plBarloqueRIDs,iRID);
          if iLocation
          {
-            send(oFlag,@SetFaction,#faction=FACTION_PRINCESS);
+            send(oFlag,@SetFaction,#faction=FACTION_PRINCESS,#claim=FALSE);
             if iLocation = 1
             {
                % town flag
@@ -337,7 +346,7 @@ messages:
          iLocation = FindListElem(plJasperRIDs,iRID);
          if iLocation
          {
-            send(oFlag,@SetFaction,#faction=FACTION_REBEL);
+            send(oFlag,@SetFaction,#faction=FACTION_REBEL,#claim=FALSE);
             if iLocation = 1
             {
                % town flag
@@ -348,7 +357,7 @@ messages:
          iLocation = FindListElem(plMarionRIDs,iRID);
          if iLocation
          {
-            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL);
+            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL,#claim=FALSE);
             if iLocation = 1
             {
                % town flag
@@ -359,7 +368,7 @@ messages:
          iLocation = FindListElem(plCorNothRIDs,iRID);
          if iLocation
          {
-            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL);
+            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL,#claim=FALSE);
             if iLocation = 1
             {
                % town flag
@@ -367,7 +376,7 @@ messages:
             }
          }
       }
-
+      
       return;
    }
 
@@ -427,7 +436,7 @@ messages:
             DEBUG("ReloadSavedFlagStates:: got nil flag in",send(oRoom,@GetName));
             continue;
          }
-         send(oFlag,@SetFaction,#faction=nth(plFlagStates,(i+1)));
+         send(oFlag,@SetFaction,#faction=nth(plFlagStates,(i+1)),#claim=FALSE);
       }
 
       return;
@@ -566,7 +575,7 @@ messages:
                oFlagpole = send(oRoom,@FindHoldingActive,#class=&FlagPole);
                if send(oFlagPole,@GetFaction) <> (iFaction-1)
                {
-                  send(oFlagPole,@SetFaction,#faction=(iFaction-1));
+                  send(oFlagPole,@SetFaction,#faction=(iFaction-1),#claim=FALSE);
                   if report
                   {
                      send(self,@SendBonusTownMessage,#faction=(iFaction-1),#town=lRIDs);
@@ -799,7 +808,7 @@ messages:
             if iRID = first(lRIDs) { continue; }
             oRoom = send(SYS,@FindRoomByNum,#num=iRID);
             oFlag = send(oRoom,@FindHoldingActive,#class=&Flagpole);
-            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL);
+            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL,#claim=FALSE);
          }
       }
 
@@ -813,7 +822,7 @@ messages:
                if iRID = first(lRIDs) { continue; }
                oRoom = send(SYS,@FindRoomByNum,#num=iRID);
                oFlag = send(oRoom,@FindHoldingActive,#class=&Flagpole);
-               send(oFlag,@SetFaction,#faction=FACTION_DUKE);
+               send(oFlag,@SetFaction,#faction=FACTION_DUKE,#claim=FALSE);
                iDukeFlags = iDukeFlags - 1;
             }
          }
@@ -829,7 +838,7 @@ messages:
                if iRID = first(lRIDs) { continue; }
                oRoom = send(SYS,@FindRoomByNum,#num=iRID);
                oFlag = send(oRoom,@FindHoldingActive,#class=&Flagpole);
-               send(oFlag,@SetFaction,#faction=FACTION_PRINCESS);
+               send(oFlag,@SetFaction,#faction=FACTION_PRINCESS,#claim=FALSE);
                iPrincessFlags = iPrincessFlags - 1;
             }
          }

--- a/kod/util/factgame/territry.kod
+++ b/kod/util/factgame/territry.kod
@@ -396,18 +396,25 @@ messages:
       return;
    }
 
-   ReloadSavedFlagStates()
+   ReloadFlagStates(lFlagStates=$)
+   "Used during recreates to save flag states."
    {
       local i, iRID, oRoom, oFlag;
 
-      if plFlagStates = $
+      if lFlagStates = $
       {
-         DEBUG("ReloadSavedFlagStates:: nothing saved, nothing reloaded");
+         lFlagStates = plFlagStates;
       }
 
-      if length(plFlagStates) <> length(plFlagRIDs)
+      if lFlagStates = $
+         OR NOT IsList(lFlagStates)
       {
-         DEBUG("ReloadSavedFlagStates:: error in saved flag states - length mismatch");
+         DEBUG("ReloadFlagStates:: nothing saved, nothing reloaded");
+      }
+
+      if length(lFlagStates) <> length(plFlagRIDs)
+      {
+         DEBUG("ReloadFlagStates:: error in saved flag states - length mismatch");
       }
 
       i = length(plFlagRIDs);
@@ -418,16 +425,16 @@ messages:
          oRoom = send(SYS,@FindRoomByNum,#num=iRID);
          if oRoom = $
          {
-            DEBUG("ReloadSavedFlagStates:: got nil room for RID=",iRID);
+            DEBUG("ReloadFlagStates:: got nil room for RID=",iRID);
             continue;
          }
          oFlag = send(oRoom,@FindHoldingActive,#class=&Flagpole);
          if oFlag = $
          {
-            DEBUG("ReloadSavedFlagStates:: got nil flag in",send(oRoom,@GetName));
+            DEBUG("ReloadFlagStates:: got nil flag in",send(oRoom,@GetName));
             continue;
          }
-         send(oFlag,@SetFaction,#faction=nth(plFlagStates,(i+1)));
+         send(oFlag,@SetFaction,#faction=nth(lFlagStates,(i+1)));
       }
 
       return;
@@ -474,7 +481,7 @@ messages:
          DEBUG("ReloadSavedFlagStates:: encountered errors during save; not replacing older save.");
       }
 
-      return;
+      return plFlagStates;
    }
 
    FlagClaimed(flag=$)
@@ -879,6 +886,11 @@ messages:
    GetMinUsers()
    {
       return piMinUsers;
+   }
+
+   GetFlagStates()
+   {
+      return plFlagStates;
    }
 
    GetMinAllies()

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -4382,9 +4382,21 @@ messages:
 
    RecreateParliament()
    {
+      local plSavedFlagStates;
+
       if poParliament <> $
       {
+         plSavedFlagStates = Send(self,@ListCopy,#source=Send(Send(self,@GetTerritoryGame),@GetFlagStates));
+        
          Send(poParliament,@Recreate);
+         
+         if plSavedFlagStates <> $
+         {
+            Send(Send(self,@GetTerritoryGame),@ReloadFlagStates,#lFlagStates=plSavedFlagStates);
+            Send(Send(self,@GetTerritoryGame),@SaveFlagStates);
+            Send(Send(self,@GetTerritoryGame),@CountFlags);
+            plSavedFlagStates = $;
+         }
       }
       else
       {

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -4382,21 +4382,9 @@ messages:
 
    RecreateParliament()
    {
-      local plSavedFlagStates;
-
       if poParliament <> $
       {
-         plSavedFlagStates = Send(self,@ListCopy,#source=Send(Send(self,@GetTerritoryGame),@GetFlagStates));
-        
          Send(poParliament,@Recreate);
-         
-         if plSavedFlagStates <> $
-         {
-            Send(Send(self,@GetTerritoryGame),@ReloadFlagStates,#lFlagStates=plSavedFlagStates);
-            Send(Send(self,@GetTerritoryGame),@SaveFlagStates);
-            Send(Send(self,@GetTerritoryGame),@CountFlags);
-            plSavedFlagStates = $;
-         }
       }
       else
       {


### PR DESCRIPTION
This commit adds the restoring of territory flag states when recreating the parliament game. It was initially influenced by the work in [this commit](https://github.com/skittles1/Meridian59/commit/ed19967b2655d8ea938a0bc310ef94f0e314307e), but takes a different approach.

The ability to recreate the flag states during a recreate was essentially in place already. However, `SetFaction`, which was being called during the recreate process, was overwriting the flag states with the default ones. The result was that the first saved flag would be reloaded, but the rest would not.

My solution -- detailed more [below](https://github.com/Meridian59/Meridian59/pull/450#issuecomment-1484154619) -- adds a flag to `SetFaction` that makes recalculating flag counts and saving state optional and something reserved for cases where only an individual flag's faction is set. In other cases where flags are being processed in bulk, like during (re)creation, we disable this and handle it after the flags have been processed.

This PR is loosely related to #449 and solves 1/2 of #29. 