### PR TITLE
Allows gauntlets to be swapped with... gauntlets

### DIFF
--- a/kod/object/item/passitem/attmod/gauntlet.kod
+++ b/kod/object/item/passitem/attmod/gauntlet.kod
@@ -86,6 +86,23 @@ properties:
 
 messages:
 
+   ReqUseSomething(what = $)
+   {
+      if IsClass(what,&Gauntlet)
+      {
+         if Send(poOwner,@TryUnuseItem,#what=self)
+         {
+            propagate;
+         }
+         else
+         {
+            return FALSE;
+         }
+      }
+
+      propagate;
+   }
+
    NewUsed(what = $)
    {
       local i, oFound, iPriority;


### PR DESCRIPTION
This PR makes it so that one pair of gauntlets can be replaced by another, without having to unuse the first. This came up in player feedback and is already possible for Weapon and Armor items. It's also possible with items like Shirts, which are a closer comparison -- Shirts are `DefenseModifier` items and Gauntlets are `AttackModifier` items.

When testing, I looked at the Player attack and defense modifiers before and after to verify that this change doesn't have some weird effect on those. The footage below shows this -- Gauntlet's `4360` first equipped, then swapped with Gauntlets `4361` -- and the swap in action.

https://user-images.githubusercontent.com/467443/227801850-99b04eb8-31b0-4635-b4b2-6b46d427ba7d.mp4