### PR TITLE
Removes handling of animate as a config option

### DIFF
--- a/clientd3d/animate.c
+++ b/clientd3d/animate.c
@@ -27,7 +27,7 @@
 
 #include "client.h"
 
-#define ANIMATE_INTERVAL 40       // ms between background animation updates
+#define ANIMATE_INTERVAL 8  // ms between background animation updates (8.3333 = 120fps)
 #define FLICKER_LEVEL (LIGHT_LEVELS/2)
 #define FLASH_LEVEL (LIGHT_LEVELS/2)
 #define TIME_FLASH 1000

--- a/clientd3d/animate.c
+++ b/clientd3d/animate.c
@@ -111,13 +111,10 @@ void AnimationTimerProc(HWND hwnd, UINT timer)
    ModuleEvent(EVENT_ANIMATE, dt);
 
    /* Send event to non-module child windows */
-   if (config.animate)
-   {
-      Lagbox_Animate(dt);
-   }
+   Lagbox_Animate(dt);
 
    /* Animate the first-person view elements */
-   if (config.animate && GetGameDataValid())
+   if (GetGameDataValid())
    {
       // Avoid short-circuiting OR
       need_redraw |= ObjectsMove(dt);
@@ -380,37 +377,6 @@ Bool AnimateSingle(Animate *a, int num_groups, int dt)
    return need_redraw;
 }
 
-/************************************************************************/
-/*
- * VerifyAnimation:  See if given animation should be performed, given whether
- *   animation is currently on.  If animation should be performed, return True
- *   (this may modify given animation structure if a modified animation should
- *   be performed).  If animation shouldn't be done at all, return False.
- */
-Bool VerifyAnimation(Animate *a)
-{
-   if (config.animate)
-      return True;
-
-   switch (a->animation)
-   {
-   case ANIMATE_NONE:
-      return True;
-      
-   case ANIMATE_CYCLE:
-      return False;
-      
-   case ANIMATE_ONCE:
-      // Skip right to end frame of animation
-      a->animation = ANIMATE_NONE;
-      a->group     = a->group_final;
-      return True;
-
-   default:
-      debug(("Unknown animation type %d in VerifyAnimation\n", a->animation));
-      return False;
-   }
-}
 /************************************************************************/
 /*
  * AnimateStop:  Stop given animation.

--- a/clientd3d/animate.c
+++ b/clientd3d/animate.c
@@ -27,7 +27,7 @@
 
 #include "client.h"
 
-#define ANIMATE_INTERVAL 165       // ms between background animation updates
+#define ANIMATE_INTERVAL 40       // ms between background animation updates
 #define FLICKER_LEVEL (LIGHT_LEVELS/2)
 #define FLASH_LEVEL (LIGHT_LEVELS/2)
 #define TIME_FLASH 1000

--- a/clientd3d/animate.c
+++ b/clientd3d/animate.c
@@ -72,11 +72,6 @@ void AnimationTimerAbort(void)
       animation_timer = 0;
    }
 }
-/************************************************************************/
-void AnimationSleep(void)
-{
-   Sleep(ANIMATE_INTERVAL);
-}
 
 DWORD GetFrameTime(void)
 {

--- a/clientd3d/animate.h
+++ b/clientd3d/animate.h
@@ -14,7 +14,6 @@
 
 void AnimationTimerAbort(void);
 void AnimationTimerStart(void);
-void AnimationSleep(void);
 M59EXPORT Bool AnimateObject(object_node *obj, int dt);
 void AnimationTimerProc(HWND hwnd, UINT timer);
 void AnimateStop(Animate *a);

--- a/clientd3d/animate.h
+++ b/clientd3d/animate.h
@@ -22,6 +22,4 @@ Bool AnimateSingle(Animate *a, int num_groups, int dt);
 
 DWORD GetFrameTime(void);
 
-Bool VerifyAnimation(Animate *a);
-
 #endif /* #ifndef _ANIMATE_H */

--- a/clientd3d/config.c
+++ b/clientd3d/config.c
@@ -40,7 +40,6 @@ static char INIPlayLoopSounds[]   = "PlayLoopSounds";
 static char INIPlayRandomSounds[]   = "PlayRandomSounds";
 static char INITimeout[]     = "Timeout";
 static char INIUserName[]    = "UserName";
-static char INIAnimate[]     = "Animate";
 static char INIArea[]        = "Area";
 static char INIDownload[]    = "Download";
 static char INIBrowser[]     = "Browser";

--- a/clientd3d/config.c
+++ b/clientd3d/config.c
@@ -192,12 +192,6 @@ void ConfigLoad(void)
    config.play_loop_sounds    = GetConfigInt(misc_section, INIPlayLoopSounds, True, ini_file);
    config.play_random_sounds    = GetConfigInt(misc_section, INIPlayRandomSounds, True, ini_file);
 
-   // Animation option removed 3/4/97 to fix movement bug
-#ifndef NODPRINTFS
-   config.animate       = GetConfigInt(misc_section, INIAnimate, True, ini_file);
-#else
-   config.animate       = True;
-#endif
    config.ini_version   = GetConfigInt(misc_section, INIVersion, 0, ini_file);
    config.default_browser = GetConfigInt(misc_section, INIDefaultBrowser, True, ini_file);
    GetPrivateProfileString(misc_section, INIUserName, "", 
@@ -315,7 +309,6 @@ void ConfigSave(void)
    WriteConfigInt(misc_section, INIPlayLoopSounds, config.play_loop_sounds, ini_file);
    WriteConfigInt(misc_section, INIPlayRandomSounds, config.play_random_sounds, ini_file);
    WriteConfigInt(misc_section, INITimeout, config.timeout, ini_file);
-   WriteConfigInt(misc_section, INIAnimate, config.animate, ini_file);
    WriteConfigInt(misc_section, INIVersion, config.ini_version, ini_file);
    WriteConfigInt(misc_section, INIDefaultBrowser, config.default_browser, ini_file);
    WritePrivateProfileString(misc_section, INIBrowser, config.browser, ini_file);

--- a/clientd3d/config.h
+++ b/clientd3d/config.h
@@ -51,7 +51,6 @@ typedef struct {
    char browser[MAX_PATH + 1];   /* Full path to user's browser program */
    Bool default_browser;         /* True when browser location was retrieved from registry */
 
-   Bool animate;                 /* Should we draw animations? */
    int  download_time;           /* Time of last successful download */
    Bool auto_connect;            /* Connect immediately upon starting program? */
    Bool debug;                   /* Display debugging window? */

--- a/clientd3d/draw3d.c
+++ b/clientd3d/draw3d.c
@@ -206,8 +206,6 @@ void DrawPreOverlayEffects(room_type* room, Draw3DParams* params)
 	{
 		SandDib(gBits, MAXX, MAXY, 200/*drops*/);
 		RedrawAll();
-		if (!config.animate)
-			effects.sand = 0;
 	}
 
 #if 0
@@ -215,16 +213,14 @@ void DrawPreOverlayEffects(room_type* room, Draw3DParams* params)
 	if (effects.raining && !pdibCeiling)
 	{
 		RainDib(gBits, MAXX, MAXY, 100/*drops*/, params->viewer_angle/*myheading*/, 0/*windheading*/, 10/*windstrength*/, TRUE/*torch*/);
-		if (config.animate)
-			RedrawAll();
+		RedrawAll();
 	}
 
 	// snow
 	if (effects.snowing && !pdibCeiling)
 	{
 		SnowDib(gBits, MAXX, MAXY, 100/*drops*/, params->viewer_angle/*myheading*/, 0/*windheading*/, 10/*windstrength*/, TRUE/*torch*/);
-		if (config.animate)
-			RedrawAll();
+		RedrawAll();
 	}
 #endif
 }
@@ -253,8 +249,6 @@ void DrawPostOverlayEffects(room_type* room, Draw3DParams* params)
 
       BlurDib(gBits, MAXX, MAXY, amount);
       RedrawAll();
-      if (!config.animate)
-	 effects.blur = 0;
    }
 
    // Wavering Vision.
@@ -264,8 +258,6 @@ void DrawPostOverlayEffects(room_type* room, Draw3DParams* params)
       offset++;
       WaverDib(gBits, MAXX, MAXY, offset);
       RedrawAll();
-      if (!config.animate)
-	 effects.waver = 0;
    }
 
    // Flash of XLAT.  Could be color, blindness, whatever.

--- a/clientd3d/draw3d.c
+++ b/clientd3d/draw3d.c
@@ -286,12 +286,6 @@ void DrawPostOverlayEffects(room_type* room, Draw3DParams* params)
       XlatDib(gBits, MAXX, MAXY, FindStandardXlat(XLAT_BLEND90WHITE));
    else if (effects.whiteout > 0)
       XlatDib(gBits, MAXX, MAXY, FindStandardXlat(XLAT_BLEND80WHITE));
-   if (!config.animate && effects.whiteout)
-   {
-      // Whiteout always shows up, but if not animating, it doesn't fade out, it blinks.
-      effects.whiteout = 0;
-      RedrawAll();
-   }
    
    // Pain (always drawn last).
    if (!config.pain)
@@ -312,13 +306,6 @@ void DrawPostOverlayEffects(room_type* room, Draw3DParams* params)
       XlatDib(gBits, MAXX, MAXY, FindStandardXlat(XLAT_BLEND20RED));
    else if (effects.pain)
       XlatDib(gBits, MAXX, MAXY, FindStandardXlat(XLAT_BLEND10RED));
-   
-   if (!config.animate && effects.pain)
-   {
-      // Pain always shows up, but if not animating, it doesn't fade out, it blinks.
-      effects.pain = 0;
-      RedrawAll();
-   }
 }
 
 /************************************************************************/

--- a/clientd3d/effect.c
+++ b/clientd3d/effect.c
@@ -69,8 +69,7 @@ Bool PerformEffect(WORD effect, char *ptr, int len)
 
    case EFFECT_SHAKE:
       Extract(&ptr, &duration, 4);
-      if (config.animate)
-	 effects.shake = duration;
+	   effects.shake = duration;
       break;
 
    case EFFECT_PARALYZE:
@@ -184,9 +183,6 @@ Bool PerformEffect(WORD effect, char *ptr, int len)
  */
 void EffectFlash(int duration)
 {
-   if (!config.animate)
-      return;
-
    effects.invert = duration;
 }
 /****************************************************************************/

--- a/clientd3d/game.c
+++ b/clientd3d/game.c
@@ -469,14 +469,6 @@ void ChangeObject(object_node *new_obj, BYTE translation, BYTE effect, Animate *
    object_node *obj;
    Bool in_room = False;
 
-   /* If animation off, discard animations */
-   if (!VerifyAnimation(new_obj->animate))
-   {
-      ObjectDestroyAndFree(new_obj);
-      list_destroy(overlays);
-      return;
-   }
-
    /* First look for object in room */
    r = GetRoomObjectById(new_obj->id);
    if (r != NULL)

--- a/clientd3d/map.c
+++ b/clientd3d/map.c
@@ -595,7 +595,7 @@ void MapZoom(int direction)
 
    now = timeGetTime();
    dt = now - last_time;
-   if (dt < MAP_ZOOM_DELAY && config.animate)
+   if (dt < MAP_ZOOM_DELAY)
       increment = increment * dt / MAP_ZOOM_DELAY;
    last_time = now;
 

--- a/clientd3d/meridian.ini
+++ b/clientd3d/meridian.ini
@@ -7,7 +7,6 @@ PlayLoopSounds=1
 PlayRandomSounds=1
 Timeout=0
 Area=1
-Animate=1
 INIVersion=3
 DefaultBrowser=1
 Browser="C:\Program Files\Internet Explorer\iexplore.exe"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                

--- a/clientd3d/move.c
+++ b/clientd3d/move.c
@@ -211,7 +211,7 @@ void UserMovePlayer(int action)
    if (dt <= 0)
       dt = 1;
    
-   if (dt < MOVE_DELAY && config.animate)
+   if (dt < MOVE_DELAY)
    {
       gravityAdjust = 1.0;
       move_distance = move_distance * dt / MOVE_DELAY;
@@ -420,21 +420,17 @@ void UserMovePlayer(int action)
    if (z == -1)
       z = player_obj->motion.z;
 
-   if (config.animate)
-   {
-      player_obj->motion.dest_z = z;
+   player_obj->motion.dest_z = z;
 
-      // Only set motion if not already moving that direction
-      if (z > player_obj->motion.z && player_obj->motion.v_z <= 0)
-      {
-	 player_obj->motion.v_z = CLIMB_VELOCITY_0;
-      }
-      else if (z < player_obj->motion.z && player_obj->motion.v_z >= 0)
-      {
-	 player_obj->motion.v_z = FALL_VELOCITY_0;
-      }
+   // Only set motion if not already moving that direction
+   if (z > player_obj->motion.z && player_obj->motion.v_z <= 0)
+   {
+      player_obj->motion.v_z = CLIMB_VELOCITY_0;
    }
-   else player_obj->motion.z = z;
+   else if (z < player_obj->motion.z && player_obj->motion.v_z >= 0)
+   {
+      player_obj->motion.v_z = FALL_VELOCITY_0;
+   }
 
    if (bounce)
       BounceUser(dt);
@@ -913,11 +909,11 @@ void UserTurnPlayer(int action)
    dt = now - last_turn_time;
    if (last_turn_time == 0 || dt <= 0)
       dt = 1;
-   if (dt < TURN_DELAY && config.animate)
+   if (dt < TURN_DELAY)
    {
       delta = delta * dt / TURN_DELAY;
    }
-   else if (dt > (4*TURN_DELAY) && config.animate)
+   else if (dt > (4*TURN_DELAY))
    {
       delta = (delta * (int)(GetFrameTime()) / TURN_DELAY) / 2;
    }
@@ -1060,11 +1056,11 @@ void PlayerChangeHeight(int dz)
    dt = now - last_time;
    if (last_time == 0 || dt <= 0)
       dt = 1;
-   if (dt < HEIGHT_DELAY && config.animate)
+   if (dt < HEIGHT_DELAY)
    {
       dz = dz * dt / HEIGHT_DELAY;
    }
-   else if (dt > (4*HEIGHT_DELAY) && config.animate)
+   else if (dt > (4*HEIGHT_DELAY))
    {
       dz = (dz * (int)(GetFrameTime()) / HEIGHT_DELAY) / 2;
    }

--- a/clientd3d/moveobj.c
+++ b/clientd3d/moveobj.c
@@ -99,7 +99,7 @@ void MoveObject2(ID object_id, int x, int y, BYTE speed, BOOL turnToFace)
 	}
 
 	// If animation off, don't interpolate motion
-	if (speed == 0 || !config.animate)
+	if (speed == 0)
 	{
 		r->motion.x = x;
 		r->motion.y = y;

--- a/clientd3d/overlay.c
+++ b/clientd3d/overlay.c
@@ -40,13 +40,6 @@ void SetPlayerOverlay(char hotspot, object_node *poverlay)
       return;
    }
 
-   // See if we should actually do animation
-   if (!VerifyAnimation(poverlay->animate))
-   {
-      ObjectDestroyAndFree(poverlay);
-      return;
-   }
-
    // Replace previous player overlay, if any
    if (player.poverlays[num].obj != NULL)
       ObjectDestroyAndFree(player.poverlays[num].obj);

--- a/clientd3d/project.c
+++ b/clientd3d/project.c
@@ -39,10 +39,6 @@ void ProjectileAdd(Projectile *p, ID source_obj, ID dest_obj, BYTE speed, WORD f
    int dx, dy, dz;
    room_contents_node *s, *d;
 
-   // If animation off, don't bother with projectiles
-   if (!config.animate)
-     return;
-
    debug(("Adding new projectile\n"));
 
    // Set source and destination coordinates based on object locations

--- a/clientd3d/roomanim.c
+++ b/clientd3d/roomanim.c
@@ -254,10 +254,6 @@ void WallChange(WORD wall_num, Animate *a, BYTE action)
 
    debug(("WallChange got wall %d\n", (int) wall_num));
 
-   // Adjust animation if user has it turned off
-   if (!config.animate)
-      VerifyAnimation(a);
-
    for (i=0; i < current_room.num_sidedefs; i++)
    {
       s = &current_room.sidedefs[i];
@@ -273,12 +269,12 @@ void WallChange(WORD wall_num, Animate *a, BYTE action)
       s->animate->u.bitmap.action = action;
 
       // If animation is a simple change of bitmap, do it now and throw it away
-      if (!config.animate || a->animation == ANIMATE_NONE)
+      if (a->animation == ANIMATE_NONE)
       {
-	 SidedefDoAnimation(&current_room, s, RAS_DONE);
-	 SafeFree(s->animate);
-	 s->animate = NULL;
-	 RedrawAll();
+         SidedefDoAnimation(&current_room, s, RAS_DONE);
+         SafeFree(s->animate);
+         s->animate = NULL;
+         RedrawAll();
       }
    }
 }
@@ -292,10 +288,6 @@ void SectorChange(WORD sector_num, Animate *a, BYTE action)
    Sector *s;
 
    debug(("SectorChange got sector %d\n", (int) sector_num));
-
-   // Adjust animation if user has it turned off
-   if (!config.animate)
-      VerifyAnimation(a);
 
    for (i=0; i < current_room.num_sectors; i++)
    {
@@ -313,12 +305,12 @@ void SectorChange(WORD sector_num, Animate *a, BYTE action)
       s->animate->u.bitmap.action = action;
 
       // If animation off, do it now and throw it away
-      if (!config.animate || a->animation == ANIMATE_NONE)
+      if (a->animation == ANIMATE_NONE)
       {
-	 SectorDoAnimation(&current_room, s, RAS_DONE);
-	 SafeFree(s->animate);
-	 s->animate = NULL;
-	 RedrawAll();
+         SectorDoAnimation(&current_room, s, RAS_DONE);
+         SafeFree(s->animate);
+         s->animate = NULL;
+         RedrawAll();
       }
    }
 }
@@ -434,11 +426,11 @@ void MoveSector(BYTE type, WORD sector_num, WORD height, BYTE speed)
 	  s->flags |= SF_HAS_ANIMATED;
 
       // Special case:  if speed = 0, perform lift immediately
-      if (speed == 0 || !config.animate)
+      if (speed == 0)
       {
-	 SectorAdjustHeight(&current_room, s, type, HeightKodToClient(height));
-	 RedrawAll();
-	 continue;
+         SectorAdjustHeight(&current_room, s, type, HeightKodToClient(height));
+         RedrawAll();
+         continue;
       }
 
       // Set up animation structure

--- a/clientd3d/statgame.c
+++ b/clientd3d/statgame.c
@@ -377,13 +377,6 @@ void GameIdle(void)
 
    // Are we the active foreground application?
    AnimationTimerAbort();
-
-   // If animation is off, or we're in the background, sleep to lower CPU load
-   if (!config.animate ||
-       GetWindowLong(GetActiveWindow(), GWL_HINSTANCE) != (LONG)hInst)
-   {
-      AnimationSleep();
-   }
 }
 /****************************************************************************/
 void GameEnterIdle(HWND hwnd, UINT source, HWND hwndSource)

--- a/module/merintr/merintr.c
+++ b/module/merintr/merintr.c
@@ -1732,16 +1732,14 @@ Bool WINAPI EventAnimate(int dt)
 {
    room_contents_node *r;
 
-   if (cinfo->config->animate)
-   {
-      AnimateInventory(dt);
-      AnimateEnchantments(dt);
+   AnimateInventory(dt);
+   AnimateEnchantments(dt);
 
-      // If self is invisible, redraw self view to make it shimmer
-      r = GetRoomObjectById(cinfo->player->id);
-      if (r != NULL && GetDrawingEffect(r->obj.flags) == OF_INVISIBLE)
-	 UserAreaRedraw();
-   }
+   // If self is invisible, redraw self view to make it shimmer
+   r = GetRoomObjectById(cinfo->player->id);
+   if (r != NULL && GetDrawingEffect(r->obj.flags) == OF_INVISIBLE)
+      UserAreaRedraw();
+   
    return True;
 }
 /****************************************************************************/


### PR DESCRIPTION
This PR:
- Removes code that slows down animations when the game is backgrounded
- Speeds up animations when dialogs are open to match non-dialog animations speeds
- Removes code for handling a config option related to animations that is no longer necessary.

Because the config option logic touches on lots of animations, I tested and validated the following:

* Guild hall doors animate as expected
* Blurry, wavering vision when drunk
* Animated sandstorm "dibs"
* POV shakes with earthquake cast
* Zooming the map in and out is smooth
* Firewalls animate
* Movement is slowed while walking through water
* Fireballs and lightning bolts animate towards their target
* Animations when going up or falling down vertically are present and consistent with production
* Animations are "smooth" and complete while app is not in the foreground
* Animations behind an in-game dialog are "smooth" and complete