### PR TITLE
Add Potion color to description

### DIFF
--- a/kod/object/item/passitem/spelitem/potion/anonp.kod
+++ b/kod/object/item/passitem/spelitem/potion/anonp.kod
@@ -18,9 +18,9 @@ resources:
 
    AnonymityPotion_name_rsc = "anonymity potion"
    %AnonymityPotion_icon_rsc = potion01.bgf
-   AnonymityPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   AnonymityPotion_desc_rsc = "This is a glass vial of gray-colored liquid.  "
                         "Its odor seems familiar, but you can't quite place a finger on it."
-   AnonymityPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   AnonymityPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy gray-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/baitp.kod
+++ b/kod/object/item/passitem/spelitem/potion/baitp.kod
@@ -18,9 +18,9 @@ resources:
 
    BaitPotion_name_rsc = "The Widow Qesino's Secret Sauce"
    %BaitPotion_icon_rsc = potion01.bgf
-   BaitPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   BaitPotion_desc_rsc = "This is a glass vial of purple-colored liquid.  "
                         "It smells mighty scrump-dilly-umptious!"
-   BaitPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   BaitPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy purple-colored liquid.  "
                         "It smells sort of sickly-sweet."
 
 

--- a/kod/object/item/passitem/spelitem/potion/cloakp.kod
+++ b/kod/object/item/passitem/spelitem/potion/cloakp.kod
@@ -18,9 +18,9 @@ resources:
 
    CloakPotion_name_rsc = "elixir of cloaking"
    %CloakPotion_icon_rsc = potion01.bgf
-   CloakPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   CloakPotion_desc_rsc = "This is a glass vial of gray-colored liquid.  "
                         "Its odor seems familiar, but you can't quite place a finger on it."
-   CloakPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   CloakPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy gray-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/curedisp.kod
+++ b/kod/object/item/passitem/spelitem/potion/curedisp.kod
@@ -18,9 +18,9 @@ resources:
 
    CureDiseasePotion_name_rsc = "cure disease potion"
    %CureDiseasePotion_icon_rsc = potion01.bgf
-   CureDiseasePotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   CureDiseasePotion_desc_rsc = "This is a glass vial of orange-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   CureDiseasePotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   CureDiseasePotion_bad_desc_rsc = "This is a glass vial of slightly cloudy orange-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
    CureDiseasePotion_drink = "You quaff the contents of the vial in a single gulp."

--- a/kod/object/item/passitem/spelitem/potion/curepsnp.kod
+++ b/kod/object/item/passitem/spelitem/potion/curepsnp.kod
@@ -18,9 +18,9 @@ resources:
 
    CurePoisonPotion_name_rsc = "cure poison potion"
    %CurePoisonPotion_icon_rsc = potion01.bgf
-   CurePoisonPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   CurePoisonPotion_desc_rsc = "This is a glass vial of pale blue-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   CurePoisonPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   CurePoisonPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy pale blue-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
    CurePoisonPotion_drink = "You quaff the contents of the vial in a single gulp."

--- a/kod/object/item/passitem/spelitem/potion/deflectp.kod
+++ b/kod/object/item/passitem/spelitem/potion/deflectp.kod
@@ -18,9 +18,9 @@ resources:
 
    DeflectPotion_name_rsc = "potion of deflection"
    %DeflectPotion_icon_rsc = potion01.bgf
-   DeflectPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   DeflectPotion_desc_rsc = "This is a glass vial of blue-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   DeflectPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   DeflectPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy blue-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/detevilp.kod
+++ b/kod/object/item/passitem/spelitem/potion/detevilp.kod
@@ -18,9 +18,9 @@ resources:
 
    DetectEvilPotion_name_rsc = "potion of evil detection"
    %DetectEvilPotion_icon_rsc = potion01.bgf
-   DetectEvilPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   DetectEvilPotion_desc_rsc = "This is a glass vial of orange-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   DetectEvilPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   DetectEvilPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy orange-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/detgoodp.kod
+++ b/kod/object/item/passitem/spelitem/potion/detgoodp.kod
@@ -18,9 +18,9 @@ resources:
 
    DetectGoodPotion_name_rsc = "potion of good detection"
    %DetectGoodPotion_icon_rsc = potion01.bgf
-   DetectGoodPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   DetectGoodPotion_desc_rsc = "This is a glass vial of orange-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   DetectGoodPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   DetectGoodPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy orange-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/detinvip.kod
+++ b/kod/object/item/passitem/spelitem/potion/detinvip.kod
@@ -18,9 +18,9 @@ resources:
 
    DetectInvisibilityPotion_name_rsc = "potion of invisibility detection"
    %DetectInvisibilityPotion_icon_rsc = potion01.bgf
-   DetectInvisibilityPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   DetectInvisibilityPotion_desc_rsc = "This is a glass vial of orange-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   DetectInvisibilityPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   DetectInvisibilityPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy orange-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/eageyep.kod
+++ b/kod/object/item/passitem/spelitem/potion/eageyep.kod
@@ -17,9 +17,9 @@ constants:
 resources:
 
    EagleEyesPotion_name_rsc = "bottled avian eyesight"
-   EagleEyesPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   EagleEyesPotion_desc_rsc = "This is a glass vial of orange-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   EagleEyesPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   EagleEyesPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy orange-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/feigndp.kod
+++ b/kod/object/item/passitem/spelitem/potion/feigndp.kod
@@ -18,9 +18,9 @@ resources:
 
    FeignDeathPotion_name_rsc = "possum potion"
    %FeignDeathPotion_icon_rsc = potion01.bgf
-   FeignDeathPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   FeignDeathPotion_desc_rsc = "This is a glass vial of gray-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   FeignDeathPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   FeignDeathPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy gray-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/freeactp.kod
+++ b/kod/object/item/passitem/spelitem/potion/freeactp.kod
@@ -18,9 +18,9 @@ resources:
 
    FreeActionPotion_name_rsc = "alembic of free action"
    %FreeActionPotion_icon_rsc = potion01.bgf
-   FreeActionPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   FreeActionPotion_desc_rsc = "This is a glass vial of pale blue-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   FreeActionPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   FreeActionPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy pale blue-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/hastep.kod
+++ b/kod/object/item/passitem/spelitem/potion/hastep.kod
@@ -18,9 +18,9 @@ resources:
 
    HastePotion_name_rsc = "potion of haste"
    %HastePotion_icon_rsc = potion01.bgf
-   HastePotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   HastePotion_desc_rsc = "This is a glass vial of sand-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   HastePotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   HastePotion_bad_desc_rsc = "This is a glass vial of slightly cloudy sand-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/karaholp.kod
+++ b/kod/object/item/passitem/spelitem/potion/karaholp.kod
@@ -18,7 +18,7 @@ resources:
 
    KaraholsCursePotion_name_rsc = "Karahol's accursed elixir"
    %KaraholsCursePotion_icon_rsc = potion01.bgf
-   KaraholsCursePotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   KaraholsCursePotion_desc_rsc = "This is a glass vial of dark-colored liquid.  "
                         "It smells like a cross between licorice and musk."
    KaraholsCursePotion_bad_desc_rsc = "This is a glass vial of dark, cloudy liquid.  "
                         "A slight whiff of it is enough to turn your stomach."

--- a/kod/object/item/passitem/spelitem/potion/mshieldp.kod
+++ b/kod/object/item/passitem/spelitem/potion/mshieldp.kod
@@ -18,9 +18,9 @@ resources:
 
    MagicShieldPotion_name_rsc = "potion of shielding"
    %MagicShieldPotion_icon_rsc = potion01.bgf
-   MagicShieldPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   MagicShieldPotion_desc_rsc = "This is a glass vial of pale blue-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   MagicShieldPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   MagicShieldPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy pale blue-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/nightvp.kod
+++ b/kod/object/item/passitem/spelitem/potion/nightvp.kod
@@ -18,9 +18,9 @@ resources:
 
    NightVisionPotion_name_rsc = "feline vitreous humour"
    %NightVisionPotion_icon_rsc = potion01.bgf
-   NightVisionPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   NightVisionPotion_desc_rsc = "This is a glass vial of orange-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   NightVisionPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   NightVisionPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy orange-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/nodebrsp.kod
+++ b/kod/object/item/passitem/spelitem/potion/nodebrsp.kod
@@ -18,12 +18,12 @@ resources:
 
    NodeBurstPotion_name_rsc = "pungent elixir"
    %NodeBurstPotion_icon_rsc = potion01.bgf
-   NodeBurstPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   NodeBurstPotion_desc_rsc = "This is a glass vial of red-colored liquid.  "
                         "It has an extremely pungent odor; one whiff is enough to leave your head spinning.  "
                         "Not surprisingly, it has a large warning label attached to it.  Apparently, this "
                         "strange elixir has the power to open all of your mana node links to the maximum, "
                         "supplying you with an instant burst of mana, but permanently severing one node link."
-   NodeBurstPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   NodeBurstPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy red-colored liquid.  "
                         "It has an extremely pungent, acrid odor; one whiff is almost enough to make you pass "
                         "out.  You would be well advised to heed the large warning label and avoid drinking "
                         "it."

--- a/kod/object/item/passitem/spelitem/potion/purifyp.kod
+++ b/kod/object/item/passitem/spelitem/potion/purifyp.kod
@@ -18,9 +18,9 @@ resources:
 
    PurifyPotion_name_rsc = "potion of purification"
    %PurifyPotion_icon_rsc = potion01.bgf
-   PurifyPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   PurifyPotion_desc_rsc = "This is a glass vial of pale blue-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   PurifyPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   PurifyPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy pale blue-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
    PurifyPotion_drink = "You quaff the contents of the vial in a single gulp."

--- a/kod/object/item/passitem/spelitem/potion/resacidp.kod
+++ b/kod/object/item/passitem/spelitem/potion/resacidp.kod
@@ -18,9 +18,9 @@ resources:
 
    ResistAcidPotion_name_rsc = "potion of acid resistance"
    %ResistAcidPotion_icon_rsc = potion01.bgf
-   ResistAcidPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   ResistAcidPotion_desc_rsc = "This is a glass vial of blue-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   ResistAcidPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   ResistAcidPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy blue-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/rescoldp.kod
+++ b/kod/object/item/passitem/spelitem/potion/rescoldp.kod
@@ -18,9 +18,9 @@ resources:
 
    ResistColdPotion_name_rsc = "potion of cold resistance"
    %ResistColdPotion_icon_rsc = potion01.bgf
-   ResistColdPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   ResistColdPotion_desc_rsc = "This is a glass vial of pale blue-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   ResistColdPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   ResistColdPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy pale blue-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/rescuep.kod
+++ b/kod/object/item/passitem/spelitem/potion/rescuep.kod
@@ -17,9 +17,9 @@ constants:
 resources:
 
    RescuePotion_name_rsc = "potion of deliverance"
-   RescuePotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   RescuePotion_desc_rsc = "This is a glass vial of gray-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   RescuePotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   RescuePotion_bad_desc_rsc = "This is a glass vial of slightly cloudy gray-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/resfirep.kod
+++ b/kod/object/item/passitem/spelitem/potion/resfirep.kod
@@ -18,9 +18,9 @@ resources:
 
    ResistFirePotion_name_rsc = "succulent salve"
    %ResistFirePotion_icon_rsc = potion01.bgf
-   ResistFirePotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   ResistFirePotion_desc_rsc = "This is a glass vial of pale blue-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   ResistFirePotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   ResistFirePotion_bad_desc_rsc = "This is a glass vial of slightly cloudy pale blue-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/resmagcp.kod
+++ b/kod/object/item/passitem/spelitem/potion/resmagcp.kod
@@ -18,9 +18,9 @@ resources:
 
    ResistMagicPotion_name_rsc = "elixir of magic resistance"
    %ResistMagicPotion_icon_rsc = potion01.bgf
-   ResistMagicPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   ResistMagicPotion_desc_rsc = "This is a glass vial of pale blue-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   ResistMagicPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   ResistMagicPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy pale blue-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/respoisp.kod
+++ b/kod/object/item/passitem/spelitem/potion/respoisp.kod
@@ -18,9 +18,9 @@ resources:
 
    ResistPoisonPotion_name_rsc = "potion of poison resistance"
    %ResistPoisonPotion_icon_rsc = potion01.bgf
-   ResistPoisonPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   ResistPoisonPotion_desc_rsc = "This is a glass vial of blue-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   ResistPoisonPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   ResistPoisonPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy blue-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/resshckp.kod
+++ b/kod/object/item/passitem/spelitem/potion/resshckp.kod
@@ -18,9 +18,9 @@ resources:
 
    ResistShockPotion_name_rsc = "potion of nonconductivity"
    %ResistShockPotion_icon_rsc = potion01.bgf
-   ResistShockPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   ResistShockPotion_desc_rsc = "This is a glass vial of blue-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   ResistShockPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   ResistShockPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy blue-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 

--- a/kod/object/item/passitem/spelitem/potion/rmcursep.kod
+++ b/kod/object/item/passitem/spelitem/potion/rmcursep.kod
@@ -18,9 +18,9 @@ resources:
 
    RemoveCursePotion_name_rsc = "remove curse potion"
    %RemoveCursePotion_icon_rsc = potion01.bgf
-   RemoveCursePotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   RemoveCursePotion_desc_rsc = "This is a glass vial of pale blue-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   RemoveCursePotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   RemoveCursePotion_bad_desc_rsc = "This is a glass vial of slightly cloudy pale blue-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
    RemoveCursePotion_drink = "You quaff the contents of the vial in a single gulp."

--- a/kod/object/item/passitem/spelitem/potion/shadowp.kod
+++ b/kod/object/item/passitem/spelitem/potion/shadowp.kod
@@ -18,7 +18,7 @@ resources:
 
    ShadowFormPotion_name_rsc = "shadow form potion"
    %ShadowFormPotion_icon_rsc = potion01.bgf
-   ShadowFormPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   ShadowFormPotion_desc_rsc = "This is a glass vial of dark-colored liquid.  "
                         "It smells like a cross between licorice and musk."
    ShadowFormPotion_bad_desc_rsc = "This is a glass vial of dark, cloudy liquid.  "
                         "A slight whiff of it is enough to turn your stomach."

--- a/kod/object/item/passitem/spelitem/potion/strengtp.kod
+++ b/kod/object/item/passitem/spelitem/potion/strengtp.kod
@@ -18,9 +18,9 @@ resources:
 
    StrengthPotion_name_rsc = "potion of super strength"
    %StrengthPotion_icon_rsc = potion01.bgf
-   StrengthPotion_desc_rsc = "This is a glass vial of colored liquid.  "
+   StrengthPotion_desc_rsc = "This is a glass vial of sand-colored liquid.  "
                         "It smells crisp, clean and refreshing."
-   StrengthPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
+   StrengthPotion_bad_desc_rsc = "This is a glass vial of slightly cloudy sand-colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
 
 


### PR DESCRIPTION
This PR updates the descriptions of Potions to include a color descriptor. This is in response to player feedback regarding accessibility and color blindness, which can make some of these potions difficult to visually discern from one another.

In most cases, I used a direct translation of `viColor`.

Mostly direct translations:
> This is a glass vial of blue-colored liquid.
> This is a glass vial of pale blue-colored liquid.
> This is a glass vial of gray-colored liquid.
> This is a glass vial of orange-colored liquid.
> This is a glass vial of red-colored liquid.
> This is a glass vial of purple-colored liquid.

And in other cases, I added my own translations that I felt were in the spirit of the game and make them identifiable:
> This is a glass vial of sand-colored liquid.
> This is a glass vial of dark-colored liquid.

I made these changes to the expired potion descriptions as well.

Example:
> This is a glass vial of slightly cloudy orange-colored liquid.

![image](https://user-images.githubusercontent.com/467443/230731567-a4864959-58fd-4a70-bdda-f6f7d6d391a4.png)

Thank you Nieba for the feedback leading to this.