### PR TITLE
feature: update blue and green text colors, add yellow text color option

### DIFF
--- a/clientd3d/srvrstr.c
+++ b/clientd3d/srvrstr.c
@@ -261,16 +261,12 @@ typedef struct {
 } FormatCode;
 
 static FormatCode code_table[] = {
-{ 'r', CODE_COLOR, PALETTERGB(128,   0,   0) }, // Maroon
-{ 'g', CODE_COLOR, PALETTERGB(  0, 100,   0) }, // Green 
-{ 'b', CODE_COLOR, PALETTERGB(  0,   0, 255) }, // Blue
+{ 'r', CODE_COLOR, PALETTERGB(128,   0,   0) }, // Maroon Red
+{ 'g', CODE_COLOR, PALETTERGB(  0, 255,   0) }, // Lime Green 
+{ 'b', CODE_COLOR, PALETTERGB(  0, 255, 255) }, // Cyan  Blue
 { 'k', CODE_COLOR, PALETTERGB(  0,   0,   0) }, // Black
 { 'w', CODE_COLOR, PALETTERGB(255, 255, 255) }, // White
-{ 'a', CODE_COLOR, PALETTERGB(  0, 255, 255) }, // Aqua
-{ 'l', CODE_COLOR, PALETTERGB(  0, 255,   0) }, // Lime
 { 'y', CODE_COLOR, PALETTERGB(255, 255,   0) }, // Yellow
-{ 'p', CODE_COLOR, PALETTERGB(255, 192, 203) }, // Pink
-{ 'o', CODE_COLOR, PALETTERGB(255, 172,  28) }, // Bright Orange
 { 'B', CODE_STYLE, STYLE_BOLD },
 { 'I', CODE_STYLE, STYLE_ITALIC },
 { 'U', CODE_STYLE, STYLE_UNDERLINE },

--- a/clientd3d/srvrstr.c
+++ b/clientd3d/srvrstr.c
@@ -263,7 +263,7 @@ typedef struct {
 static FormatCode code_table[] = {
 { 'r', CODE_COLOR, PALETTERGB(128,   0,   0) }, // Maroon Red
 { 'g', CODE_COLOR, PALETTERGB(  0, 255,   0) }, // Lime Green 
-{ 'b', CODE_COLOR, PALETTERGB(  0, 255, 255) }, // Cyan  Blue
+{ 'b', CODE_COLOR, PALETTERGB(  0, 255, 255) }, // Cyan Blue
 { 'k', CODE_COLOR, PALETTERGB(  0,   0,   0) }, // Black
 { 'w', CODE_COLOR, PALETTERGB(255, 255, 255) }, // White
 { 'y', CODE_COLOR, PALETTERGB(255, 255,   0) }, // Yellow

--- a/clientd3d/srvrstr.c
+++ b/clientd3d/srvrstr.c
@@ -261,11 +261,16 @@ typedef struct {
 } FormatCode;
 
 static FormatCode code_table[] = {
-{ 'r', CODE_COLOR, PALETTERGB(128,   0,   0) },
-{ 'g', CODE_COLOR, PALETTERGB(  0, 100,   0) },
-{ 'b', CODE_COLOR, PALETTERGB(  0,   0, 255) },
-{ 'k', CODE_COLOR, PALETTERGB(  0,   0,   0) },
-{ 'w', CODE_COLOR, PALETTERGB(255, 255, 255) },
+{ 'r', CODE_COLOR, PALETTERGB(128,   0,   0) }, // Maroon
+{ 'g', CODE_COLOR, PALETTERGB(  0, 100,   0) }, // Green 
+{ 'b', CODE_COLOR, PALETTERGB(  0,   0, 255) }, // Blue
+{ 'k', CODE_COLOR, PALETTERGB(  0,   0,   0) }, // Black
+{ 'w', CODE_COLOR, PALETTERGB(255, 255, 255) }, // White
+{ 'a', CODE_COLOR, PALETTERGB(  0, 255, 255) }, // Aqua
+{ 'l', CODE_COLOR, PALETTERGB(  0, 255,   0) }, // Lime
+{ 'y', CODE_COLOR, PALETTERGB(255, 255,   0) }, // Yellow
+{ 'p', CODE_COLOR, PALETTERGB(255, 192, 203) }, // Pink
+{ 'o', CODE_COLOR, PALETTERGB(255, 172,  28) }, // Bright Orange
 { 'B', CODE_STYLE, STYLE_BOLD },
 { 'I', CODE_STYLE, STYLE_ITALIC },
 { 'U', CODE_STYLE, STYLE_UNDERLINE },


### PR DESCRIPTION
Added 5 new text color codes for message use

Colors
Aqua, Lime, Yellow, Pink, Orange
Using the respective prefixes a l y p o

![new_colors](https://user-images.githubusercontent.com/4023541/231272811-83ed0c4a-8dc1-438e-aea8-1cea6e2ae4de.png)


I tested other RBG codes but these stood out the best, some either look too close to the system message purple, or have visibilities issues (too bright or too dark).