### PR TITLE
feature: add bow condition messages

### DIFF
--- a/kod/object/item/passitem/weapon/ranged/bow.kod
+++ b/kod/object/item/passitem/weapon/ranged/bow.kod
@@ -33,6 +33,10 @@ resources:
    bow_bottom_faction = bwfbov.bgf
    bow_window_overlay_faction_rsc = povbowf.bgf
 
+   bow_condition_good = " is slightly worn but in generally good condition."
+   bow_condition_med = " is starting to crack and fray but is still effective."
+   bow_condition_broken = " is broken and in pieces."
+
 classvars:
 
    vrName = bow_name_rsc
@@ -61,6 +65,10 @@ classvars:
 
    % What's the basic color of the wood?
    viBaseXLAT = XLAT_TO_SKIN4
+
+   vrCondition_good = bow_condition_good 
+   vrCondition_med = bow_condition_med 
+   vrCondition_broken = bow_condition_broken
 
 properties:
 


### PR DESCRIPTION
**Background**

- The current bow.kod uses the standard weapon condition descriptions.
```
   weapon_condition_exc = " is in flawless condition."
   weapon_condition_exc_mended = " is in excellent condition, but has been repaired before."
   weapon_condition_good = " is slightly tarnished but in generally good condition."
   weapon_condition_med = " is notched and stained with blood but is still an effective weapon."
   weapon_condition_poor = " is well worn and may not last much longer."
   weapon_condition_broken = " has been shattered by a powerful blow."
```

**The Problem**

- These do not make sense for **bow** descriptions. A player reported it.
```
   weapon_condition_good = " is slightly tarnished but in generally good condition."
   weapon_condition_med = " is notched and stained with blood but is still an effective weapon."
   weapon_condition_broken = " has been shattered by a powerful blow."
```

**The Change**

-   Added new bow condition descriptions for good, medium, and broken.  
-   The other inherited condition states make sense and do not need any changes.

```
   bow_condition_good = " is slightly worn but in generally good condition."
   bow_condition_med = " is starting to crack and fray but is still effective."
   bow_condition_broken = " is broken and in pieces."
```