### PR TITLE
feature: improved safety on_off messages

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -193,9 +193,9 @@ resources:
    user_guildmate_logoff = "~IYour guildmate %s has just departed."
 
    user_safety_on = \
-      "### ~B`gSAFETY ON   `nYou can no longer strike innocents."
+      "### Your safety is now ~I~gON~n:  You can no longer strike innocents."
    user_safety_off = \
-      "### ~B`rSAFETY OFF  `nBe careful, you are now able to "
+      "### Your safety is now ~B~rOFF~n:  Be careful, you are now able to "
       "hurt those around you."   
 
    user_cant_go = "You are unable to go anywhere."
@@ -4327,12 +4327,12 @@ messages:
          string = psPlayerDescription;
       }
       
-      if StringContain(psPlayerDescription,"ï¿½")
+      if StringContain(psPlayerDescription,"¶")
       {
          iCount = 0;
-         while StringContain(psPlayerDescription,"ï¿½")
+         while StringContain(psPlayerDescription,"¶")
          {
-            StringSubstitute(psPlayerDescription,"ï¿½","");
+            StringSubstitute(psPlayerDescription,"¶","");
             iCount = iCount + 1;
             if iCount > 10
             {

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -193,9 +193,9 @@ resources:
    user_guildmate_logoff = "~IYour guildmate %s has just departed."
 
    user_safety_on = \
-      "### Your safety is now ~I~gON~n:  You can no longer strike innocents."
+      "### ~B`gSAFETY ON   `nYou can no longer strike innocents."
    user_safety_off = \
-      "### Your safety is now ~B~rOFF~n:  Be careful, you are now able to "
+      "### ~B`rSAFETY OFF  `nBe careful, you are now able to "
       "hurt those around you."   
 
    user_cant_go = "You are unable to go anywhere."
@@ -4327,12 +4327,12 @@ messages:
          string = psPlayerDescription;
       }
       
-      if StringContain(psPlayerDescription,"¶")
+      if StringContain(psPlayerDescription,"ï¿½")
       {
          iCount = 0;
-         while StringContain(psPlayerDescription,"¶")
+         while StringContain(psPlayerDescription,"ï¿½")
          {
-            StringSubstitute(psPlayerDescription,"¶","");
+            StringSubstitute(psPlayerDescription,"ï¿½","");
             iCount = iCount + 1;
             if iCount > 10
             {

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -193,9 +193,9 @@ resources:
    user_guildmate_logoff = "~IYour guildmate %s has just departed."
 
    user_safety_on = \
-      "### Your safety is now ~I~gON~n:  You can no longer strike innocents."
+      "### Your safety is now  ~B~gON~n   You can no longer strike innocents."
    user_safety_off = \
-      "### Your safety is now ~B~rOFF~n:  Be careful, you are now able to "
+      "### Your safety is now  ~B~rOFF~n  Be careful, you are now able to "
       "hurt those around you."   
 
    user_cant_go = "You are unable to go anywhere."
@@ -4327,12 +4327,12 @@ messages:
          string = psPlayerDescription;
       }
       
-      if StringContain(psPlayerDescription,"¶")
+      if StringContain(psPlayerDescription,"ï¿½")
       {
          iCount = 0;
-         while StringContain(psPlayerDescription,"¶")
+         while StringContain(psPlayerDescription,"ï¿½")
          {
-            StringSubstitute(psPlayerDescription,"¶","");
+            StringSubstitute(psPlayerDescription,"ï¿½","");
             iCount = iCount + 1;
             if iCount > 10
             {


### PR DESCRIPTION
The Problem / Opportunity

- Safety on off messages have a huge impact on the player experience
- The current on-off messages are not as visible as they could be
- Safety On message is currently in italics vs the Safety Off being bold.  It's easier to see if they are both bold.
- With PR#456 merged (brighter colors) we can use them to greater effect with safety on off messages

The Changes

- changed verbose start to very short, capitalized, colored messages "SAFETY ON" vs "your safety is now ON" 
- aligned the text so SAFETY ON and OFF are always in the same position

![safety_on_off](https://user-images.githubusercontent.com/4023541/231914488-22b0697b-886f-4b41-addf-67c02f23a3a9.png)

