### PR TITLE
Disallowing Karahol to be re-cast prior to expiration

### DIFF
--- a/kod/object/passive/spell/persench/karahol.kod
+++ b/kod/object/passive/spell/persench/karahol.kod
@@ -98,16 +98,10 @@ messages:
 
    CanPayCosts(who = $, lTargets = $)
    {
-      if lTargets = $
-      {
-         lTargets = [who];
-      }
-      
       % check for enchantment already applied
-      if Send(first(lTargets),@IsEnchanted,#what=self)
+      if Send(who,@IsEnchanted,#what=self)
       {
-         Send(first(lTargets),@MsgSendUser,#message_rsc=KaraholsCurse_already_enchanted_rsc,
-              #parm1=Send(self,@GetIndef),#parm2=Send(self,@GetName));
+         Send(who,@MsgSendUser,#message_rsc=KaraholsCurse_already_enchanted_rsc);
 
          return FALSE;
       }

--- a/kod/object/passive/spell/persench/karahol.kod
+++ b/kod/object/passive/spell/persench/karahol.kod
@@ -96,6 +96,25 @@ messages:
       return iDuration;
    }
 
+   CanPayCosts(who = $, lTargets = $)
+   {
+      if lTargets = $
+      {
+         lTargets = [who];
+      }
+      
+      % check for enchantment already applied
+      if Send(first(lTargets),@IsEnchanted,#what=self)
+      {
+         Send(first(lTargets),@MsgSendUser,#message_rsc=KaraholsCurse_already_enchanted_rsc,
+              #parm1=Send(self,@GetIndef),#parm2=Send(self,@GetName));
+
+         return FALSE;
+      }
+
+      propagate;
+   }
+
    EndEnchantment(who=$, report=TRUE, state=0)
    {
       local oHoldSpell, iDuration;


### PR DESCRIPTION
Applying anonymity logic to Karahol; removing the ability for users to "hold" themselves immediately upon re-self cast.