### PR TITLE
fix: prevent prism deletion on DestroyDisposable room function call

### DIFF
--- a/kod/object/item/passitem/prism.kod
+++ b/kod/object/item/passitem/prism.kod
@@ -512,7 +512,13 @@ messages:
 
       return;
    }
-   
+
+   %%% Disposability
+
+   DestroyDisposable()
+   {
+      return FALSE;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
TLDR; prisms sometimes disappear when placed on the floor, this is bad.  This PR fixes that.

Issue
* Prisms are extremely rare items that must be dropped on the floor to use
* They are used during major events such as breaking into a guildhall which may take extended amounts of time
* the DestroyDisposable function will destroy objects in a room including prisms if they are not bonded  (code from room.kod pasted below for reference)
* Given that prisms are one of the only (perhaps only) items that must be dropped on the floor to use, it doesn't make sense they would be at risk of dissapearing due to a room cleanup function
* There is anecdotal evidence of his happening according to chat in the 101 discord where a user said they lost their prism within 3 minutes

The Fix
* return FALSE on DestroyDisposable() for prism.kod


```if NOT pbUser_in_room
      {
         % If no one is here, then try to destroy everything.
         Send(self,@DestroyDisposable);

         return;
      }
      else
      {
         % Someone's in the room.  If there are more than 5 things in the room,
         %  delete the 20% that are the oldest.  Note:  this may be screwed up
         %  by permanent, non-deleting objects like trees and braziers.

         iLen = Length(plPassive);
         if iLen > 5
         {
            delete_index = 4*iLen/5;
            count = 0;
            for i in plPassive
            {
               count = count + 1;
               if count > delete_index
               {
                  Send(First(i),@DestroyDisposable);
               }
            }
         }
      }
```