### PR TITLE
Umbrella revisions

### DIFF
--- a/kod/object/passive/spell/umbrella.kod
+++ b/kod/object/passive/spell/umbrella.kod
@@ -60,6 +60,8 @@ classvars:
    viChance_To_Increase = 35
    viCast_Time = 10000
 
+   viManaDrain = 1 % Drain is amount used every UMBRELLA_CHECK_TIME milliseconds
+
 properties:
    
 messages:
@@ -121,15 +123,16 @@ messages:
       iDuration = bound(iDuration,50,240);
       iDuration = iDuration * 1000;
 
-      % Put spell maintenance info in casters enchantment list.
+      % Kick off a periodic timer for handling players that enter and leave the umbrella
       Send(who,@StartEnchantment,#what=self,#time=UMBRELLA_CHECK_TIME,
-           #state=[iElapsed,lEnchanted,iSpellpower,iDuration]);      
+         #state=[iElapsed,lEnchanted,iSpellpower,iDuration],#lastcall=FALSE);      
+      Send(who,@SetTranceFlag);
 
       propagate;
    }
 
    BreakTrance(who = $, state = $, event = 1)
-   "Clears trance, removes enchantment(s), and sends notifications to any previously enchanted players"
+   "Clears trance, removes enchantment and notifies any players affected"
    {
       local oUser,lEnchanted,iSpellpower;
 
@@ -180,8 +183,7 @@ messages:
       return;
    }
 
-   EndEnchantment( who = $, state = $ )
-   "Called only for caster. Do spell test and/or end spell."
+   StartPeriodicEnchantment(who = $,where = $,state = 0)
    {
       local lEnchanted, iElapsed, oUser, iSpellpower, iDuration, oRoom, lActive;
 
@@ -194,13 +196,7 @@ messages:
 
       if iElapsed >= iDuration  %% end spell
       {
-         Send(who,@ClearTranceFlag);
-         for oUser in lEnchanted
-         {
-            Send(oUser,@MsgSendUser,#message_rsc=umbrella_off);
-            Send(self,@LeaveUmbrella,#who=oUser,#iSpellpower=iSpellpower);
-         }
-         return;
+         Send(self,@EndEnchantment,#who=who,#state=state);
       }
       else
       {
@@ -232,9 +228,39 @@ messages:
          }
       }
 
-      Send(who,@StartEnchantment,#what=self,#time=UMBRELLA_CHECK_TIME,
-           #state=[iElapsed,lEnchanted,iSpellpower,iDuration],#Report=FALSE);
+      % If we've reached the final check time, then we need to do a last call to end
+      % the periodic timer and put an end to the enchantment.
+      if (iDuration - iElapsed) <= UMBRELLA_CHECK_TIME
+         OR Send(who,@GetMana) < viManaDrain * 2
+      {
+         Send(who,@StartEnchantment,#what=self,#time=UMBRELLA_CHECK_TIME,
+            #state=[iElapsed,lEnchanted,iSpellpower,iDuration],#addicon=FALSE,#lastcall=TRUE,#Report=FALSE);
+      }
+      else 
+      {
+         Send(who,@StartEnchantment,#what=self,#time=UMBRELLA_CHECK_TIME,
+            #state=[iElapsed,lEnchanted,iSpellpower,iDuration],#addicon=FALSE,#lastcall=FALSE,#Report=FALSE);
+      }
 
+      Send(who,@LoseMana,#amount=viManaDrain);
+
+      return;
+   }
+
+   EndEnchantment(who = $,state = $)
+   "Called only for caster. Do spell test and/or end spell."
+   {
+      local lEnchanted, iElapsed, oUser, iSpellpower, iDuration, oRoom, lActive;
+
+      lEnchanted = Nth(state,2);
+      iSpellpower = Nth(state,3);
+
+      Send(who,@ClearTranceFlag);
+      for oUser in lEnchanted
+      {
+         Send(oUser,@MsgSendUser,#message_rsc=umbrella_off);
+         Send(self,@LeaveUmbrella,#who=oUser,#iSpellpower=iSpellpower);
+      }
       return;
    }
 

--- a/kod/object/passive/spell/umbrella.kod
+++ b/kod/object/passive/spell/umbrella.kod
@@ -38,6 +38,7 @@ resources:
    Umbrella_on = "You are encompassed by a dome of magical energy."
    Umbrella_off = "The dome of magical energy dissipates."
    Umbrella_outside = "You have passed outside the dome of magical energy."
+   Umbrella_wince_trance = "You wince as the dome of magical energy absorbs the blow!"
    Umbrella_break_trance = "Loss of concentration causes the dome of magical energy to implode!"
 
    Umbrella_deflected = "%s%s's guardian angel deflects the brunt of the blast back at you!"
@@ -127,16 +128,24 @@ messages:
       propagate;
    }
 
-   BreakTrance(who = $, state = $)
+   BreakTrance(who = $, state = $, event = 1)
    "Clears trance, removes enchantment(s), and sends notifications to any previously enchanted players"
    {
       local oUser,lEnchanted,iSpellpower;
 
+      iSpellpower = Nth(state,3);
+      
+      % The caster has up to a 50% chance to maintain trance even when damage is taken
+      if event = EVENT_DAMAGE
+         AND (Random(1,99) <= iSpellpower/2)
+      {
+         Send(oUser,@MsgSendUser,#message_rsc=Umbrella_wince_trance);
+         return;
+      }
+
       Send(who,@ClearTranceFlag);
       
-      iSpellpower = Nth(state,3);
       lEnchanted = Nth(state,2);
-      
       for oUser in lEnchanted
       {
          Send(oUser,@MsgSendUser,#message_rsc=Umbrella_break_trance);

--- a/kod/object/passive/spell/umbrella.kod
+++ b/kod/object/passive/spell/umbrella.kod
@@ -28,7 +28,9 @@ resources:
    Umbrella_icon_rsc = iumbrela.bgf
    Umbrella_desc_rsc = \
       "Creates a dome of magical energy that protects all "
-      "players near the caster for several minutes.  Requires emeralds to cast."
+      "players near the caster for several minutes.  The spell "
+      "dissipates if caster breaks concentration by running or "
+      "combat.  Requires emeralds to cast."
 
    Umbrella_already_enchanted = "You already have %s%s."
 
@@ -123,6 +125,25 @@ messages:
            #state=[iElapsed,lEnchanted,iSpellpower,iDuration]);      
 
       propagate;
+   }
+
+   BreakTrance(who = $, state = $)
+   "Clears trance, removes enchantment(s), and sends notifications to any previously enchanted players"
+   {
+      local oUser,lEnchanted,iSpellpower;
+
+      Send(who,@ClearTranceFlag);
+      
+      iSpellpower = Nth(state,3);
+      lEnchanted = Nth(state,2);
+      
+      for oUser in lEnchanted
+      {
+         Send(oUser,@MsgSendUser,#message_rsc=Umbrella_break_trance);
+         Send(oUser,@RemoveEnchantment,#what=self);
+      }
+
+      return;
    }
 
    EnterUmbrella( who = $,iSpellpower = $ )
@@ -230,6 +251,7 @@ messages:
    %%% Defense modifier stuff.
 
    ModifyDefensePower(who = $,what = $,defense_power = 0)
+   "Adds 500 to the battler's ability to avoid being hit"
    {
       return defense_power + 500;
    }
@@ -254,8 +276,9 @@ messages:
    %%% Resistance stuff:
 
    GetResistanceStrength(iSpellpower=$)
+   "Increase resistance strength by 50 + half of spellpower"
    {
-      return iSpellpower/5;
+      return 50 + iSpellpower/2;
    }
 
    AddResistances(who=$,value=$)


### PR DESCRIPTION
This PR follows on the heels of #455 and revises umbrella in the following ways:

* Umbrella is now a trance spell and the caster must maintain focus to keep the umbrella up. Running, attacking, or taking damage will all cause umbrella to dissipate.
* As a trance spell, Umbrella comes at a cost of 1 mana per second. When the caster's mana is completely drained, the umbrella will dissipate.
* Umbrella protects any other player near the caster, even attackers. They are notified when they enter and leave the protection of the spell.
* The higher the caster's spell power, the higher the likelihood that they maintain their trance when hit. At maximum spell power, this offers a 50% chance of holding the trance. A new message has been added for this event.
* It offers a much higher resistance to attack spells than before (`spellpower/5` to `50 + spellpower/2`) but is balanced by the fact that the caster must hold trance.
* Umbrella now uses a periodic enchantment timer, not a basic enchantment timer. I believe it's the more appropriate enchantment timer for this spell and as a result, the PE icon no longer flickers.

**Trance Breaking**
A few of us talked about the current state, which feels too easily disrupted by any type of damage. Rather than swinging too wildly in the opposite direction, I chose to build in odds based on spell power. While the existing defense modifier helps avoid a lot of ranged attacks (bows in particular), one hit would spell the end of the umbrella. I felt that the odds made it more interesting for higher level players and less likely to be abused by mules, but am open to suggestions.

**Flickering PE Icon**
Umbrella is built upon a 1-second timer that checks for players entering or leaving the umbrella each cycle. But because of how `StartEnchantment` was being called, it was removing and redrawing the PE icon. In my testing it was most obvious late in the spell. I re-implemented it using the periodic enchantment timer, which won't call an end to the enchantment until `lastcall=true`.

**Defense and Resistance Modifiers**
Umbrella adds defense and resistance modifiers to the caster and anyone within range. These effects can be seen added to and removed from players entering and leaving the umbrella. The strength of these modifiers has been returned to their former values, which offer a great deal of defense but also put the caster at risk. It was suggested that we start here and see how it's used before making any tweaks there. When testing, it's important to check that the resistance and defense modifiers come and go as expected on the caster and everyone else in range.