### PR TITLE
Persists command-driven safety changes to game data

### DIFF
--- a/module/merintr/command.c
+++ b/module/merintr/command.c
@@ -552,6 +552,7 @@ void CommandActivate(char *args)
 void CommandSafetyOn(char *args)
 {
    SendSafety(1);
+   pinfo.aggressive = cinfo->config->aggressive = FALSE;
 }
 /************************************************************************/
 /*
@@ -560,6 +561,7 @@ void CommandSafetyOn(char *args)
 void CommandSafetyOff(char *args)
 {
    SendSafety(0);
+   pinfo.aggressive = cinfo->config->aggressive = TRUE;
 }
 /************************************************************************/
 /*


### PR DESCRIPTION
This commits addresses an issue brought up in #479 where the use of `safetyon` and `safetyoff` displays unintended toggling of the player's safety flag.

Currently, when a player uses these commands they're player flags are updated but their config is not. You can see these by using these commands and looking at your Preferences. Furthermore, there are reproducible steps where unequipping an item can drop your safety and that's not good.

This makes sure that once the player's safety is set, it's persisted to their player and config data.

#### Steps to reproduce from #479

1. Have no weapon equipped
2. Have "Can attack innocent players" ticbox checked under Game->Preferences [safety is off]
3. Equip a weapon
4. type safetyon command in the text box [safety is now on]
5. unequip the weapon [BUG: safety will now turn off] <-- this should not happen

Worth noting is that while testing with several debug statements in place, it looked as though a user command was being sent when unequipping the weapon (the scenario outlined here), causing the safety change, but no user commands are sent on subsequent equip/unequips of an item. I wasn't sure if this was indicative of a different duplicate client message bug or a result of not saving this to the player/config data.

Closes #479 