### PR TITLE
Add minor items to Raza's shops

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/hazartwn/hzapoth.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/hazartwn/hzapoth.kod
@@ -39,9 +39,16 @@ messages:
 
    SetForSale()
    {
-      plFor_sale = [ [ Create(&RedMushroom)],
-                     $,
-                     $];
+      plFor_sale = [ [ Create(&Mushroom),
+                       Create(&RedMushroom),
+                       Create(&BlueMushroom),
+                       Create(&Herbs),
+                       Create(&Elderberry),
+                       Create(&Emerald),
+                       Create(&Flask),
+                       Create(&Torch)
+                   ],
+                   $,$];
       return;
    }
 

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/hazartwn/hzbart.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/hazartwn/hzbart.kod
@@ -46,15 +46,17 @@ messages:
 
    SetForSale()
    {
-      plFor_sale=[[Create(&Bread,#number=4),
+      plFor_sale=[[Create(&Skirt,#color=XLAT_TO_ORANGE),
+				   Create(&PantsC,#translation=PT_GRAY_TO_KGRAY),
+				   Create(&PantsA,#color=XLAT_TO_BLACK),
+				   Create(&Shirt,#color=XLAT_TO_ORANGE),
+				   Create(&Shirt,#color=XLAT_TO_GREEN),
+				   Create(&Bread,#number=4),
                    Create(&Apple,#number=2),
                    Create(&MeatPie,#number=4),
-                   Create(&Mug,#number=1),
-				   Create(&Shirt,#color=XLAT_TO_GREEN),
-				   Create(&PantsA,#color=XLAT_TO_BLACK),
-				   Create(&PantsC,#translation=PT_HAIR_OLDHAIR3)
+                   Create(&Mug,#number=1)
                    ],
-                  $,$];
+                   $,$];
       return;
    }
 

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/hazartwn/hzbart.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/hazartwn/hzbart.kod
@@ -47,11 +47,11 @@ messages:
    SetForSale()
    {
       plFor_sale=[[Create(&Skirt,#color=XLAT_TO_ORANGE),
-				   Create(&PantsC,#translation=PT_GRAY_TO_KGRAY),
-				   Create(&PantsA,#color=XLAT_TO_BLACK),
-				   Create(&Shirt,#color=XLAT_TO_ORANGE),
-				   Create(&Shirt,#color=XLAT_TO_GREEN),
-				   Create(&Bread,#number=4),
+                   Create(&PantsC,#translation=PT_GRAY_TO_KGRAY),
+                   Create(&PantsA,#color=XLAT_TO_BLACK),
+                   Create(&Shirt,#color=XLAT_TO_ORANGE),
+                   Create(&Shirt,#color=XLAT_TO_GREEN),
+                   Create(&Bread,#number=4),
                    Create(&Apple,#number=2),
                    Create(&MeatPie,#number=4),
                    Create(&Mug,#number=1)

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/hazartwn/hzbart.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/hazartwn/hzbart.kod
@@ -49,7 +49,10 @@ messages:
       plFor_sale=[[Create(&Bread,#number=4),
                    Create(&Apple,#number=2),
                    Create(&MeatPie,#number=4),
-                   Create(&Mug,#number=1)
+                   Create(&Mug,#number=1),
+				   Create(&Shirt,#color=XLAT_TO_GREEN),
+				   Create(&PantsA,#color=XLAT_TO_BLACK),
+				   Create(&PantsC,#translation=PT_HAIR_OLDHAIR3)
                    ],
                   $,$];
       return;

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/hazartwn/hzsmith.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/hazartwn/hzsmith.kod
@@ -36,9 +36,13 @@ messages:
 
    SetForSale()
    {
-      plFor_sale = [ [ Create(&Mace),Create(&ShortSword),
-                     Create(&LongSword),Create(&MetalShield),
-                     Create(&ScaleArmor),Create(&LeatherArmor)],$,$];
+      plFor_sale = [ [ Create(&ChainArmor),
+                       Create(&LeatherArmor),
+                       Create(&MetalShield),
+                       Create(&ShortSword),
+                       Create(&Mace)
+                       ],
+                       $,$];
       return;
    }
 

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/hazartwn/hzsmith.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/hazartwn/hzsmith.kod
@@ -37,8 +37,8 @@ messages:
    SetForSale()
    {
       plFor_sale = [ [ Create(&Mace),Create(&ShortSword),
-                     Create(&LongSword),Create(&ScaleArmor),
-					 Create(&LeatherArmor)],$,$];
+                     Create(&LongSword),Create(&MetalShield),
+                     Create(&ScaleArmor),Create(&LeatherArmor)],$,$];
       return;
    }
 


### PR DESCRIPTION
This is intended to make the newbie experience in Raza a little less spartan by adding items to shops that should be more useful to them while in town.  Complete overview of everything added/changed:
- Raza Smith:  Added small round shield, chain armor.  Removed long sword, scale armor.  The former is a bit of a trap item they can't use properly yet, and the latter is overkill armor.
- Raza Apothecary:  Added mushrooms, blue mushrooms, herbs, elderberries, emeralds, flasks, and torches.  In particular I wanted to make sure most lowbie spell reagents (especially those for touch spells) were covered, and now they are except for a few qor spells (such as acid touch) because they use entroot berries.  The torches and flasks should also prove handy.
- Raza Bartender:  Added green shirt, orange shirt, gray tight pants, gray baggy pants, orange long skirt.  Not the most fashionable items, just a taste of how clothing works.