### PR TITLE
Raza portal vigor fix

### DIFF
--- a/kod/object/active/portal/newbport.kod
+++ b/kod/object/active/portal/newbport.kod
@@ -92,7 +92,7 @@ messages:
 
          % Nearly everyone will be leaving Raza at around 200 vigor after
          % hitting 25, so top them off before sending them on their way.
-         Send(what, @EatSomething, #nutrition=200);
+         Send(what, @AddExertion, #amount=-2000000);
 
          % teleporting them out of region will clean inventory, etc.
          Post(what,@AddRealWorldObjects);

--- a/kod/object/active/portal/newbport.kod
+++ b/kod/object/active/portal/newbport.kod
@@ -90,7 +90,9 @@ messages:
             Send(what,@AdminGotoSafety);
          }
 
-         Send(what,@AddExertion,#amount=(send(what,@GetVigor) - 80) * 10000);
+         % Nearly everyone will be leaving Raza at around 200 vigor after
+         % hitting 25, so top them off before sending them on their way.
+         Send(what, @EatSomething, #nutrition=200);
 
          % teleporting them out of region will clean inventory, etc.
          Post(what,@AddRealWorldObjects);


### PR DESCRIPTION
Currently, exiting Raza sets the player's current vigor to 100 regardless of what it's currently at.  Since players generally leave Raza right after hitting 25 HP, and since gaining a hit point sets your vigor to 200, this is sort of an outdated/weird penalty more than anything else.  This change will bump their current vigor up to 200 (assuming it isn't at or around already) when they exit the Raza portal instead of setting it to 100.,