### PR TITLE
feature: sortable inventory

### DIFF
--- a/blakserv/sprocket.c
+++ b/blakserv/sprocket.c
@@ -35,6 +35,7 @@ client_def_table_type client_def_table[] =
 	{ BP_REQ_TURN,             { {4, TAG_OBJECT}, {2, TAG_INT}, {0, DONE_PARM} } },
 	{ BP_REQ_GET,              { {4, TAG_OBJECT}, {0, DONE_PARM} } },
 	{ BP_REQ_DROP,             { {4, TAG_OBJECT}, {0, DONE_PARM} } },
+	{ BP_REQ_INVENTORY_MOVE,   { {4, TAG_OBJECT}, {4, TAG_OBJECT}, {0, DONE_PARM} } },
 	{ BP_REQ_PUT,              { {4, TAG_OBJECT}, {4, TAG_OBJECT}, {0, DONE_PARM} } },
 	{ BP_REQ_LOOK,             { {4, TAG_OBJECT}, {0, DONE_PARM} } },
 	{ BP_SEND_MAIL,            { {2, LIST_OBJ_PARM}, {0, TAG_STRING}, {0, DONE_PARM} } },

--- a/blakserv/sprocket.c
+++ b/blakserv/sprocket.c
@@ -35,7 +35,7 @@ client_def_table_type client_def_table[] =
 	{ BP_REQ_TURN,             { {4, TAG_OBJECT}, {2, TAG_INT}, {0, DONE_PARM} } },
 	{ BP_REQ_GET,              { {4, TAG_OBJECT}, {0, DONE_PARM} } },
 	{ BP_REQ_DROP,             { {4, TAG_OBJECT}, {0, DONE_PARM} } },
-	{ BP_REQ_INVENTORY_MOVE,   { {4, TAG_OBJECT}, {4, TAG_OBJECT}, {0, DONE_PARM} } },
+	{ BP_REQ_INVENTORY_MOVE,   { {2, TAG_INT}, {2, TAG_INT}, {0, DONE_PARM} } },
 	{ BP_REQ_PUT,              { {4, TAG_OBJECT}, {4, TAG_OBJECT}, {0, DONE_PARM} } },
 	{ BP_REQ_LOOK,             { {4, TAG_OBJECT}, {0, DONE_PARM} } },
 	{ BP_SEND_MAIL,            { {2, LIST_OBJ_PARM}, {0, TAG_STRING}, {0, DONE_PARM} } },

--- a/clientd3d/client.def
+++ b/clientd3d/client.def
@@ -145,6 +145,8 @@ EXPORTS
 	list_length
 	list_move_to_front
 	list_add_sorted_item
+	list_get_position
+	list_move_item
 
 ; ID lists
 	IDListAdd

--- a/clientd3d/list.h
+++ b/clientd3d/list.h
@@ -44,5 +44,8 @@ M59EXPORT list_type list_destroy(list_type l);
 M59EXPORT int       list_length(list_type l);
 M59EXPORT list_type list_move_to_front(list_type l, void *data, CompareProc compare);
 M59EXPORT list_type list_add_sorted_item(list_type l, void *newdata, SortProc compare);
+M59EXPORT int       list_get_position(list_type l, void *data, CompareProc compare);
+M59EXPORT list_type list_move_item(list_type l, void *data1, void *data2, CompareProc compare);
+
 
 #endif /* #ifndef _LIST_H */

--- a/clientd3d/protocol.c
+++ b/clientd3d/protocol.c
@@ -36,6 +36,7 @@ static client_message game_msg_table[] = {
 { BP_REQ_TURN,             { PARAM_ID, PARAM_WORD, PARAM_END }, },
 { BP_REQ_GET,              { PARAM_ID, PARAM_END }, },
 { BP_REQ_INVENTORY,        { PARAM_END }, },
+{ BP_REQ_INVENTORY_MOVE,   { PARAM_ID, PARAM_ID, PARAM_END }, },
 { BP_REQ_DROP,             { PARAM_OBJECT, PARAM_END }, },
 { BP_REQ_PUT,              { PARAM_OBJECT, PARAM_ID, PARAM_END }, },
 { BP_SAY_TO,               { PARAM_SAY_INFO, PARAM_STRING, PARAM_END }, },

--- a/clientd3d/protocol.c
+++ b/clientd3d/protocol.c
@@ -36,7 +36,7 @@ static client_message game_msg_table[] = {
 { BP_REQ_TURN,             { PARAM_ID, PARAM_WORD, PARAM_END }, },
 { BP_REQ_GET,              { PARAM_ID, PARAM_END }, },
 { BP_REQ_INVENTORY,        { PARAM_END }, },
-{ BP_REQ_INVENTORY_MOVE,   { PARAM_ID, PARAM_ID, PARAM_END }, },
+{ BP_REQ_INVENTORY_MOVE,   { PARAM_WORD, PARAM_WORD, PARAM_END }, },
 { BP_REQ_DROP,             { PARAM_OBJECT, PARAM_END }, },
 { BP_REQ_PUT,              { PARAM_OBJECT, PARAM_ID, PARAM_END }, },
 { BP_SAY_TO,               { PARAM_SAY_INFO, PARAM_STRING, PARAM_END }, },

--- a/clientd3d/protocol.h
+++ b/clientd3d/protocol.h
@@ -78,6 +78,7 @@ ToServer(BP_REQ_MOVE, NULL, FinenessClientToKod(y) + KOD_FINENESS, \
 #define RequestPickup(id)            ToServer(BP_REQ_GET, NULL, id)
 #define RequestInventory()           ToServer(BP_REQ_INVENTORY, NULL)
 #define RequestDrop(obj)             ToServer(BP_REQ_DROP, NULL, obj)
+#define RequestInventoryMove(id1, id2) ToServer(BP_REQ_INVENTORY_MOVE, NULL, id1, id2)
 #define RequestPut(id1, id2)         ToServer(BP_REQ_PUT, NULL, id1, id2)
 #define SendSay(info, msg)           ToServer(BP_SAY_TO, NULL, info, msg)
 #define SendSayGroup(objs, msg)      ToServer(BP_SAY_GROUP, NULL, objs, msg)

--- a/include/proto.h
+++ b/include/proto.h
@@ -133,6 +133,7 @@ enum {
    BP_REQ_BUY               = 124,
    BP_REQ_BUY_ITEMS         = 125,
    BP_CHANGE_DESCRIPTION    = 126,
+   BP_REQ_INVENTORY_MOVE    = 127,
 
    BP_PLAYER                = 130,
    BP_STAT                  = 131,

--- a/kod/include/protocol.khd
+++ b/kod/include/protocol.khd
@@ -78,6 +78,7 @@
    BP_REQ_BUY               = 124
    BP_REQ_BUY_ITEMS         = 125
    BP_CHANGE_DESCRIPTION    = 126
+   BP_REQ_INVENTORY_MOVE    = 127
 
    BP_PLAYER                = 130
    BP_STAT                  = 131

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -858,7 +858,7 @@ messages:
       local liClient_cmd, oWhat, oWhere, oRoom, iRow, iCol, iSay_type,
             sStr_said, sStr_mailed, lDest_mail, iAttack_type, iGroup, lItems,
             lUsers, oApply_on, iNid, sTitle, iAngle, sBody, iNum, iSpeed,
-            lTargets, bSpam, oPayload, oTarget;
+            lTargets, bSpam, iPayload, iTarget;
 
       bSpam = FALSE;
 
@@ -982,9 +982,9 @@ messages:
       
       if liClient_cmd = BP_REQ_INVENTORY_MOVE
       {
-         oPayload = Nth(client_msg,2);
-         oTarget = Nth(client_msg,3);
-         Send(self,@UserMoveInventoryItem,#payload=oPayload,#target=oTarget);
+         iPayload = Nth(client_msg,2);
+         iTarget = Nth(client_msg,3);
+         Send(self,@UserMoveInventoryItem,#payload=iPayload,#target=iTarget);
 
          return;
       }
@@ -3761,9 +3761,6 @@ messages:
    UserMoveInventoryItem(payload=$,target=$)
    % User moved an item in their inventory, now update plPassive list
    {
-      local iPayload, iTarget;
-
-      % Sanity checks
       if payload = $
          OR target = $
          OR payload = target
@@ -3772,17 +3769,8 @@ messages:
          return;
       }
 
-      % Find the list positions for the two objects that the player wants to move
-      iPayload = FindListElem(plPassive,payload); 
-      iTarget = FindListElem(plPassive,target);
-
-      if iTarget > iPayload
-         {
-            iTarget = iTarget + 1;
-         }
-
-      % Check that the payload object isn't found in plPassive.
-      if iPayload = $ OR iTarget = $
+      % Check that the payload or target objects aren't found in plPassive.
+      if payload = $ OR target = $
          {
             Debug("ALERT! ",Send(self,@GetTrueName),self,"tried to move "
                   "an object or an object to a target in their inventory that does not exist!");
@@ -3791,7 +3779,7 @@ messages:
          }
 
       % If all checks pass, move the item
-      MoveListElem(plPassive, iPayload, iTarget);
+      MoveListElem(plPassive, payload, target);
 
       return; 
    }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3758,10 +3758,8 @@ messages:
       return;
    }
 
-   % Server has received a client request to move an item from the first item's position
-   %   in the inventory list to a second item's position.  This function executes the move
-   %   in the plPassive inventory list assuming all checks clear.
    UserMoveInventoryItem(payload_index=1,target_index=1)
+   "Move the item from payload_index to just before target_index in the user's inventory\n"
    {
       local plPassive_max_index;
 
@@ -3775,7 +3773,7 @@ messages:
          return;
       }
 
-      % Check to make sure payload_index and target_index are within plPassive
+      % Check to make sure payload_index and target_index are valid requests
       plPassive_max_index = Length(plPassive) + 1;
 
       if payload_index > plPassive_max_index

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -984,7 +984,7 @@ messages:
       {
          iPayload = Nth(client_msg,2);
          iTarget = Nth(client_msg,3);
-         Send(self,@UserMoveInventoryItem,#payload=iPayload,#target=iTarget);
+         Send(self,@UserMoveInventoryItem,#payload_index=iPayload,#target_index=iTarget);
 
          return;
       }
@@ -3758,29 +3758,38 @@ messages:
       return;
    }
 
-   UserMoveInventoryItem(payload=$,target=$)
-   % User moved an item in their inventory, now update plPassive list
+   % Server has received a client request to move an item from the first item's position
+   %   in the inventory list to a second item's position.  This function executes the move
+   %   in the plPassive inventory list assuming all checks clear.
+   UserMoveInventoryItem(payload_index=1,target_index=1)
    {
-      if payload = $
-         OR target = $
-         OR payload = target
+      local plPassive_max_index;
+
+      if payload_index = $
+         OR target_index = $
+         OR payload_index = target_index
          OR plPassive = $
       {
+         Debug("ALERT! ",Send(self,@GetTrueName),self,"tried to move "
+                  "an object or an object to a target in their inventory that does not exist!");
          return;
       }
 
-      % Check that the payload or target objects aren't found in plPassive.
-      if payload = $ OR target = $
-         {
-            Debug("ALERT! ",Send(self,@GetTrueName),self,"tried to move "
-                  "an object or an object to a target in their inventory that does not exist!");
+      % Check to make sure payload_index and target_index are within plPassive
+      plPassive_max_index = Length(plPassive) + 1;
 
-            return;
-         }
+      if payload_index > plPassive_max_index
+         OR payload_index < 1
+         OR target_index > plPassive_max_index
+         OR target_index < 1
+      {
+         Debug("ALERT! ",Send(self,@GetTrueName),self," attempted an invalid inventory move! "
+                  "plPassive_max_index",plPassive_max_index,"payload_index",payload_index,"target_index",target_index);
+         return;
+      }
 
       % If all checks pass, move the item
-      MoveListElem(plPassive, payload, target);
-
+      MoveListElem(plPassive, payload_index, target_index);
       return; 
    }
 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -858,7 +858,7 @@ messages:
       local liClient_cmd, oWhat, oWhere, oRoom, iRow, iCol, iSay_type,
             sStr_said, sStr_mailed, lDest_mail, iAttack_type, iGroup, lItems,
             lUsers, oApply_on, iNid, sTitle, iAngle, sBody, iNum, iSpeed,
-            lTargets, bSpam;
+            lTargets, bSpam, oPayload, oTarget;
 
       bSpam = FALSE;
 
@@ -980,6 +980,15 @@ messages:
          return;
       }
       
+      if liClient_cmd = BP_REQ_INVENTORY_MOVE
+      {
+         oPayload = Nth(client_msg,2);
+         oTarget = Nth(client_msg,3);
+         Send(self,@UserMoveInventoryItem,#payload=oPayload,#target=oTarget);
+
+         return;
+      }
+
       if liClient_cmd = BP_REQ_PUT
       {
          oWhat = Nth(client_msg,2);
@@ -3747,6 +3756,44 @@ messages:
       }
       
       return;
+   }
+
+   UserMoveInventoryItem(payload=$,target=$)
+   % User moved an item in their inventory, now update plPassive list
+   {
+      local iPayload, iTarget;
+
+      % Sanity checks
+      if payload = $
+         OR target = $
+         OR payload = target
+         OR plPassive = $
+      {
+         return;
+      }
+
+      % Find the list positions for the two objects that the player wants to move
+      iPayload = FindListElem(plPassive,payload); 
+      iTarget = FindListElem(plPassive,target);
+
+      if iTarget > iPayload
+         {
+            iTarget = iTarget + 1;
+         }
+
+      % Check that the payload object isn't found in plPassive.
+      if iPayload = $ OR iTarget = $
+         {
+            Debug("ALERT! ",Send(self,@GetTrueName),self,"tried to move "
+                  "an object or an object to a target in their inventory that does not exist!");
+
+            return;
+         }
+
+      % If all checks pass, move the item
+      MoveListElem(plPassive, iPayload, iTarget);
+
+      return; 
    }
 
    UserPut(what = $,where = $,number = $)

--- a/module/merintr/inventry.c
+++ b/module/merintr/inventry.c
@@ -1102,10 +1102,35 @@ Bool InventoryMoveCurrentItem(int x, int y)
    if (item->obj->id == drop_position->obj->id)
       return False;
 
+   /* Before we send the move request to the server, we need to convert
+   *   the move index arguments from 0-based to 1-based (Blakod).
+   *   We also need to reverse the list indeces because the client
+   *   and Blakod inventory lists are reversed.
+   */
+
+   int pos_payload, pos_target;
+   pos_payload = list_get_position(items, (void *)item->obj->id, InventoryCompareIdItem);
+   pos_target = list_get_position(items, (void *)drop_position->obj->id, InventoryCompareIdItem);
+
+   int length;
+   length = list_length(items);
+
+   // subtract client pos from list length to reverse the list indeces
+   pos_payload = length - pos_payload;
+   pos_target = length - pos_target;
+
+   /* add 1 to targetpos if target pos > payload pos because 
+   *   the destination argument is the index of the item you
+   *   want the moved item to go before.
+   */
+
+   if (pos_target > pos_payload)
+      pos_target +=1;
+
    items = list_move_item(items, (void *)item->obj->id, (void *)drop_position->obj->id, InventoryCompareIdItem);
    InventoryRedraw();
 
-   RequestInventoryMove(item->obj->id, drop_position->obj->id);
+   RequestInventoryMove(pos_payload, pos_target);
 
    return True;
 }

--- a/module/merintr/inventry.c
+++ b/module/merintr/inventry.c
@@ -1078,13 +1078,13 @@ Bool InventoryDropCurrentItem(room_contents_node *container)
 /************************************************************************/
 /*
  * InventoryMoveCurrentItem:  Move the selected item with the inventory cursor 
- *   to the given (x, y) coordinates, if any.  Return True iff item moved.
+ *   to the item at the given (x, y) coordinates, if any. Returns True iff item moved.
  *   Coordinates (0,0) are at the top left corner of the inventory window,
  *   increasing as you go to the right and down.
  */
 Bool InventoryMoveCurrentItem(int x, int y)
 {
-   InvItem *item, *drop_position;
+   InvItem *item;
 
    item = InventoryGetCurrentItem();
    if (item == NULL)
@@ -1095,6 +1095,8 @@ Bool InventoryMoveCurrentItem(int x, int y)
    row = top_row + y / INVENTORY_BOX_HEIGHT;
    col = x / INVENTORY_BOX_WIDTH;
 
+   InvItem *drop_position;
+
    drop_position = (InvItem *) list_nth_item(items, row * cols + col);
    if (drop_position == NULL)
       return False;
@@ -1104,8 +1106,8 @@ Bool InventoryMoveCurrentItem(int x, int y)
 
    /* Before we send the move request to the server, we need to convert
    *   the move index arguments from 0-based to 1-based (Blakod).
-   *   We also need to reverse the list indeces because the client
-   *   and Blakod inventory lists are reversed.
+   *   We also need to reverse the list indices because the client
+   *   inventory list is reversed compared to the server Blakod list.
    */
 
    int pos_payload, pos_target;
@@ -1115,7 +1117,7 @@ Bool InventoryMoveCurrentItem(int x, int y)
    int length;
    length = list_length(items);
 
-   // subtract client pos from list length to reverse the list indeces
+   // subtract client pos from list length to reverse the list indices
    pos_payload = length - pos_payload;
    pos_target = length - pos_target;
 
@@ -1125,7 +1127,7 @@ Bool InventoryMoveCurrentItem(int x, int y)
    */
 
    if (pos_target > pos_payload)
-      pos_target +=1;
+      pos_target += 1;
 
    items = list_move_item(items, (void *)item->obj->id, (void *)drop_position->obj->id, InventoryCompareIdItem);
    InventoryRedraw();

--- a/module/merintr/inventry.c
+++ b/module/merintr/inventry.c
@@ -1084,20 +1084,15 @@ Bool InventoryDropCurrentItem(room_contents_node *container)
  */
 Bool InventoryMoveCurrentItem(int x, int y)
 {
-   InvItem *item;
-
-   item = InventoryGetCurrentItem();
+   InvItem *item = InventoryGetCurrentItem();
    if (item == NULL)
       return False;
 
    // Find row and col in absolute coordinates
-   int row, col;
-   row = top_row + y / INVENTORY_BOX_HEIGHT;
-   col = x / INVENTORY_BOX_WIDTH;
+   int row = top_row + y / INVENTORY_BOX_HEIGHT;
+   int col = x / INVENTORY_BOX_WIDTH;
 
-   InvItem *drop_position;
-
-   drop_position = (InvItem *) list_nth_item(items, row * cols + col);
+   InvItem *drop_position = (InvItem *) list_nth_item(items, row * cols + col);
    if (drop_position == NULL)
       return False;
 
@@ -1110,12 +1105,9 @@ Bool InventoryMoveCurrentItem(int x, int y)
    *   inventory list is reversed compared to the server Blakod list.
    */
 
-   int pos_payload, pos_target;
-   pos_payload = list_get_position(items, (void *)item->obj->id, InventoryCompareIdItem);
-   pos_target = list_get_position(items, (void *)drop_position->obj->id, InventoryCompareIdItem);
-
-   int length;
-   length = list_length(items);
+   int pos_payload = list_get_position(items, (void *)item->obj->id, InventoryCompareIdItem);
+   int pos_target = list_get_position(items, (void *)drop_position->obj->id, InventoryCompareIdItem);
+   int length = list_length(items);
 
    // subtract client pos from list length to reverse the list indices
    pos_payload = length - pos_payload;
@@ -1125,7 +1117,6 @@ Bool InventoryMoveCurrentItem(int x, int y)
    *   the destination argument is the index of the item you
    *   want the moved item to go before.
    */
-
    if (pos_target > pos_payload)
       pos_target += 1;
 

--- a/module/merintr/inventry.c
+++ b/module/merintr/inventry.c
@@ -672,23 +672,23 @@ void InventoryLButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT keyFl
 /************************************************************************/
 /*
  * InventoryLButtonUp:  User released left mouse button on inventory box.
- * Call InventoryMoveCurrentItem if the mouse is within the inventory.
  */
 void InventoryLButtonUp(HWND hwnd, int x, int y, UINT keyFlags)
 {
    int temp_x, temp_y;
    room_contents_node *r;
    POINT mouse;
-   AREA a;
+   AREA inventory_area;
 
-   InventoryGetArea(&a);
+   InventoryGetArea(&inventory_area);
    GetCursorPos(&mouse);
    ScreenToClient(cinfo->hMain, &mouse);
 
    if (!InventoryReleaseCapture())
       return;
 
-   if (IsInArea(&a, mouse.x, mouse.y))
+   // If button was released in inventory area, move selected item to new location in inventory list
+   if (IsInArea(&inventory_area, mouse.x, mouse.y))
       {
          InventoryMoveCurrentItem(x, y);
          return;
@@ -1077,9 +1077,10 @@ Bool InventoryDropCurrentItem(room_contents_node *container)
 }
 /************************************************************************/
 /*
- * InventoryMoveCurrentItem:  Move the item with the inventory cursor, if any.
- *   Return True iff item moved.  Coordinates (0,0) are at the top left corner
- *   of the inventory window, increasing as you go to the right and down.
+ * InventoryMoveCurrentItem:  Move the selected item with the inventory cursor 
+ *   to the given (x, y) coordinates, if any.  Return True iff item moved.
+ *   Coordinates (0,0) are at the top left corner of the inventory window,
+ *   increasing as you go to the right and down.
  */
 Bool InventoryMoveCurrentItem(int x, int y)
 {


### PR DESCRIPTION
Note: cleaned up version of draft PR #462  - had to resubmit because of a complex rebase

Adds

- User can move items with the mouse to sort them as desired
- Backend ability to re-order items in your inventory using MoveListElem from PR #484 
- Paves way for future inventory configuration options (maybe add preconfigured sort commands - group by reagents or alphabetical etc.)

Disclaimer / Notes

- Starting point was skittles1's PR below
- https://github.com/OpenMeridian/Meridian59/pull/964
- Thank to Hektic for helping me resolve some Git issues, and Zaphod for the optimized server side sort function.

Testing / QA

- I haven't seen any issues with this in limited testing
- Code looks sane
- Difficult to test alone in a comprehensive manner compared to production use