### PR TITLE
Simplify list_move_item in client.

### DIFF
--- a/clientd3d/list.c
+++ b/clientd3d/list.c
@@ -12,6 +12,7 @@
  */
 
 #include "client.h"
+#include <vector>
 
 /************************************************************************/
 /* List abstraction: use void pointers to point to data field. 
@@ -348,90 +349,35 @@ list_type list_move_to_front(list_type l, void *data, CompareProc compare)
 }
 /************************************************************************/
 /*
- * list_move_item:  Given a list, a payload node, and a target node,
- *   removes the payload node (data1) and inserts it at the target node's
- *   (data2's) original index position. Returns a new list if the items
- *   are not in the same position. Otherwise returns the original list.
+ * list_move_item:  Given a list and source and dest indices, which must
+ *   be in range, move the item at the source index to just before the dest index.
  */
-list_type list_move_item(list_type l, void *data1, void *data2, CompareProc compare)
+list_type list_move_item(list_type l, int source_index, int dest_index)
 {
-   if (l == NULL)
-      return NULL;
-
-   int pos_payload = list_get_position(l, data1, compare);
-   int pos_target  = list_get_position(l, data2, compare);
-
-   // Check that payload (data1) and target (data2) are actually in the list
-   if (pos_payload == -1 || pos_target == -1)
+   // Anything to do?
+   if (source_index == dest_index)
       return l;
 
-   if (pos_payload == pos_target)
-      return l;
-
-   if (pos_target == 0) 
-      return list_move_to_front(l, data1, compare);
-
-   // If the payload node is removed from the list, we must adjust the *last pointer of the new HEAD node
-   list_type payload_data;
-   if (pos_payload == 0)
+   // Copy all list data into a vector
+   std::vector<void *> list_contents;
+   list_type node = l;
+   while (node != NULL)
    {
-      l->next->last = l->last;   // Set *last on the second list node to point to the end of the list
-      payload_data = l;          // Save payload data to insert later at the target index pos_target
-      l = l->next;               // Remove payload node from the start of the list
+     list_contents.push_back(node->data);
+     node = node->next;
    }
-
-   /* We must now check for all other pos_payload indexes (so far we have only checked index=0).
-   *   Use prev and temp list pointers to walk the list. */
-   list_type prev, temp;
-   prev = l;
-   temp = l->next;
-
-   int i;
-   for (i = 1; i <= pos_payload && temp != NULL; i++)  // Walk the list starting at the second node, index=1
-   { 
-      if (i == pos_payload)             // Payload node found, remove it from the list
-      {
-         payload_data = temp;           // save the value of the node we are removing
-         prev->next = temp->next;       // Remove the node from the list by linking the previous node to the next node
-         if (temp->next == NULL)        // Check if we are removing the last node
-            l->last = prev;             // If so, set *last pointer to point to the previous node
-      }
-      prev = temp;
-      temp = temp->next;
-   }
-
-   // If the payload (data1) was never found in the list, return the original list
-   if (payload_data == NULL)   
-      return l; 
-
-   /* We now have the value of the payload (data1) in payload_data, we have removed
-   *   the payload node from the list l, and we know the target (data2) original index
-   *   position pos_target.  We now need to re-insert the payload (data1) at the target
-   *   index (data2's original index position).  We do this by walking the list and 
-   *   re-inserting it at the target index of data2.*/
-
-   // First check if we need to add the payload as the last node in the list
-   if (list_length(l)-1 < pos_target)
+   
+   // Do the move on the vector
+   list_contents.insert(list_contents.begin() + dest_index, list_contents[source_index]);
+   int pos_to_erase = source_index + (source_index > dest_index ? 1 : 0);
+   list_contents.erase(list_contents.begin() + pos_to_erase);
+   
+   // Copy the vector back to the list
+   node = l;
+   for (auto data : list_contents)
    {
-      l->last->next = payload_data;    // Append payload (data1) to the end of the list
-      l->last = payload_data;          // Add *last to point to payload (data1)
-      payload_data->next = NULL;       // Make sure last node points to NULL
-      return l;
-   }
-
-   prev = l;
-   temp = l->next;
-
-   // Walk the list and insert the payload data at target index position
-   for (i = 1; i <= pos_target; i++)
-   {
-      if (i == pos_target)             // Target index found, insert payload (data1)
-      {
-         prev->next = payload_data;    // Insert payload (data1) by having previous node point to the payload_data node
-         payload_data->next = temp;    // have payload_data node point to the next node
-      }
-      prev = temp;
-      temp = temp->next;
+     node->data = data;
+     node = node->next;
    }
 
    return l;

--- a/clientd3d/list.h
+++ b/clientd3d/list.h
@@ -45,7 +45,7 @@ M59EXPORT int       list_length(list_type l);
 M59EXPORT list_type list_move_to_front(list_type l, void *data, CompareProc compare);
 M59EXPORT list_type list_add_sorted_item(list_type l, void *newdata, SortProc compare);
 M59EXPORT int       list_get_position(list_type l, void *data, CompareProc compare);
-M59EXPORT list_type list_move_item(list_type l, void *data1, void *data2, CompareProc compare);
+M59EXPORT list_type list_move_item(list_type l, int source_index, int dest_index);
 
 
 #endif /* #ifndef _LIST_H */

--- a/module/merintr/inventry.c
+++ b/module/merintr/inventry.c
@@ -1109,10 +1109,6 @@ Bool InventoryMoveCurrentItem(int x, int y)
    int pos_target = list_get_position(items, (void *)drop_position->obj->id, InventoryCompareIdItem);
    int length = list_length(items);
 
-   // subtract client pos from list length to reverse the list indices
-   pos_payload = length - pos_payload;
-   pos_target = length - pos_target;
-
    /* add 1 to targetpos if target pos > payload pos because 
    *   the destination argument is the index of the item you
    *   want the moved item to go before.
@@ -1120,8 +1116,12 @@ Bool InventoryMoveCurrentItem(int x, int y)
    if (pos_target > pos_payload)
       pos_target += 1;
 
-   items = list_move_item(items, (void *)item->obj->id, (void *)drop_position->obj->id, InventoryCompareIdItem);
+   items = list_move_item(items, pos_payload, pos_target);
    InventoryRedraw();
+
+   // Blakod indices are 1-based, and inventory list is reversed
+   pos_payload = length - pos_payload;
+   pos_target = length - pos_target + 1;
 
    RequestInventoryMove(pos_payload, pos_target);
 


### PR DESCRIPTION
Implements a more standard interface of move index X to index Y.  Changes the single existing caller (inventory item reordering).