### PR TITLE
fix: bold and italicize mob kill messages

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -187,7 +187,7 @@ resources:
 
    player_tougher_wav_rsc = tougher.wav
    player_missed_something_wave_rsc = swordmis.wav
-   player_killed_something = "You killed %s%s."
+   player_killed_something = "~B~IYou killed %s%s."
    player_killed_player = \
       "You have killed another player and have been branded a murderer."
    player_wanted_now = "You are now wanted for the murder of %s%s."


### PR DESCRIPTION
### Bold and Italicize Kill Messages

**Change level**
Very minor change.

**The Change**
Bolded and italicized player "kill" messages.
This now matches the improve and tougher messages.

**Why**
The purple system text is more difficult to see than the red and new cyan colors.  
The health level messages from monsters are bolded and red, while the kill message is normal purple.

A kill message is an important message related to player progression so it should match the format of the improve and tougher messages.

Example screenshot
![kill_message_m59](https://github.com/Meridian59/Meridian59/assets/4023541/02c8baa3-727b-481e-a6ec-58e93571dbe9)
Before on the left
New format on the right.