### PR TITLE
Stops Jala casters from teleporting away from their room enchantments

### DIFF
--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -1907,10 +1907,7 @@ messages:
       }
 
       % Break trance if the user is in one
-      if IsClass(what,&User) AND Send(what,@CheckPlayerFlag,#flag=PFLAG_TRANCE)
-      {
-         Send(what,@BreakTrance,#event=EVENT_NEWOWNER);
-      }
+      % Send(what,@BreakTrance,#event=EVENT_NEWOWNER);
 
       % unenchant this one occupant
       for i in plEnchantments

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -1906,6 +1906,12 @@ messages:
          propagate;
       }
 
+      % Break trance if the user is in one
+      if IsClass(what,&User) AND Send(what,@CheckPlayerFlag,#flag=PFLAG_TRANCE)
+      {
+         Send(what,@BreakTrance,#event=EVENT_NEWOWNER);
+      }
+
       % unenchant this one occupant
       for i in plEnchantments
       {


### PR DESCRIPTION
This PR fixes #497 by intercepting users, in trances, who have left a room by teleportation. The two specific cases this has in mind are DM teleports and Rescue, which share teleport functionality. The issue prompting this is that Jala casters, wearing Jala necklaces, could Rescue out of a room and leave behind an indefinite room enchantment. In the same way, a DM could also cause this to happen if they cast a room enchantment under the same conditions and teleported away from the room. As result, users would crash or be ask to update their game.