### PR TITLE
feature: keep both blue and cyan blue client text msgs

### DIFF
--- a/clientd3d/srvrstr.c
+++ b/clientd3d/srvrstr.c
@@ -262,8 +262,9 @@ typedef struct {
 
 static FormatCode code_table[] = {
 { 'r', CODE_COLOR, PALETTERGB(128,   0,   0) }, // Maroon Red
-{ 'g', CODE_COLOR, PALETTERGB(  0, 255,   0) }, // Lime Green 
-{ 'b', CODE_COLOR, PALETTERGB(  0, 255, 255) }, // Cyan Blue
+{ 'g', CODE_COLOR, PALETTERGB(  0, 255,   0) }, // Lime Green
+{ 'b', CODE_COLOR, PALETTERGB(  0,   0, 255) }, // Blue
+{ 'c', CODE_COLOR, PALETTERGB(  0, 255, 255) }, // Cyan Blue
 { 'k', CODE_COLOR, PALETTERGB(  0,   0,   0) }, // Black
 { 'w', CODE_COLOR, PALETTERGB(255, 255, 255) }, // White
 { 'y', CODE_COLOR, PALETTERGB(255, 255,   0) }, // Yellow


### PR DESCRIPTION
### What
Keep classic Blue RBG (  0,  0, 255) as \`b
Keep Cyan but use `c

### Why
When I submitted PR #456 I did not realize that the blue color is referenced by monster combat messages and in other help messages (like the initial Raza text blurb when a player joins the game).

The Cyan color is highly visible but clashes a bit with other colors.  Since the monster messages also include red status messages and purple kill messages, it starts to become a bit overwhelming.

I suggest leaving in the classic blue for now, and adding the cyan blue as a communications color option (`c)


### The change
Dark blue as  \`b
Cyan blue as `c
![image](https://github.com/Meridian59/Meridian59/assets/4023541/4391fff9-5e12-47cc-8a62-dd4036a69113)
