### PR TITLE
feature: re-add dark green add pink orange text colors

### DIFF
--- a/clientd3d/srvrstr.c
+++ b/clientd3d/srvrstr.c
@@ -262,12 +262,15 @@ typedef struct {
 
 static FormatCode code_table[] = {
 { 'r', CODE_COLOR, PALETTERGB(128,   0,   0) }, // Maroon Red
-{ 'g', CODE_COLOR, PALETTERGB(  0, 255,   0) }, // Lime Green
+{ 'g', CODE_COLOR, PALETTERGB(  0, 100,   0) }, // Dark Green
+{ 'l', CODE_COLOR, PALETTERGB(  0, 255,   0) }, // Lime Green
 { 'b', CODE_COLOR, PALETTERGB(  0,   0, 255) }, // Blue
 { 'c', CODE_COLOR, PALETTERGB(  0, 255, 255) }, // Cyan Blue
 { 'k', CODE_COLOR, PALETTERGB(  0,   0,   0) }, // Black
 { 'w', CODE_COLOR, PALETTERGB(255, 255, 255) }, // White
 { 'y', CODE_COLOR, PALETTERGB(255, 255,   0) }, // Yellow
+{ 'o', CODE_COLOR, PALETTERGB(255, 172,  28) }, // Bright Orange
+{ 'p', CODE_COLOR, PALETTERGB(255, 192, 203) }, // Pink
 { 'B', CODE_STYLE, STYLE_BOLD },
 { 'I', CODE_STYLE, STYLE_ITALIC },
 { 'U', CODE_STYLE, STYLE_UNDERLINE },

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -193,7 +193,7 @@ resources:
    user_guildmate_logoff = "~IYour guildmate %s has just departed."
 
    user_safety_on = \
-      "### Your safety is now  ~B~gON~n   You can no longer strike innocents."
+      "### Your safety is now  ~B~lON~n   You can no longer strike innocents."
    user_safety_off = \
       "### Your safety is now  ~B~rOFF~n  Be careful, you are now able to "
       "hurt those around you."   


### PR DESCRIPTION
Changes
- Re-added classic dark green, but kept lime.
- Changed safety on message to use lime text color (instead of dark green)
- Added orange and pink.  The color changing for text messages appears popular with the players.

![image](https://github.com/Meridian59/Meridian59/assets/4023541/4d9f0ee3-a9b7-4a8d-90d6-e274e83ffc7e)