### PR TITLE
Correction to visible objects area height and width

### DIFF
--- a/clientd3d/draw3d.c
+++ b/clientd3d/draw3d.c
@@ -387,8 +387,8 @@ void UpdateRoom3D(room_type *room, Draw3DParams *params)
 
    // Size of offscreen bitmap.
    area.x = area.y = 0;
-   area.cx = min(params->width / 2, main_viewport_width);
-   area.cy = min(params->height / 2, main_viewport_height);
+   area.cx = main_viewport_width;
+   area.cy = main_viewport_height;
 
    // Force size to be even.
    area.cy = area.cy & ~1;
@@ -401,7 +401,7 @@ void UpdateRoom3D(room_type *room, Draw3DParams *params)
    num_visible_objects = 0;
 
    t1=timeGetTime();
-   DrawBSP(room, params, main_viewport_width, False);
+   DrawBSP(room, params, area.cx, False);
    t2=timeGetTime();
 
    // Draw corner treatment.


### PR DESCRIPTION
As `params->width` & `params->height` are now always equal to `main_viewport_width` and `main_viewport_height` the divide by 2 operation is incorrect. It turns out that as `DrawBSP` takes the `width` as a parameter but also uses `horizon` and therefore both values need to be correctly updated and so `area` should use the `main_viewport_width` and `main_viewport_height` values directly.

Previously we resolved issues with horizontal objects disappearing from view by avoiding using the use of `area.cx` when drawing the BSP switching to use `main_viewport_width` instead. This was only half of the fix as we should have updated `area.cx` and `area.cy` directly to always be that of `main_viewport_width` and `main_viewport_height`. This change implements this correction and should resolve outstanding visible object issues as before the refactor.