### PR TITLE
fix: spelling errors and formatting goad.kod

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
@@ -31,7 +31,7 @@ resources:
    Goad_icon_rsc = GoadX.bgf
    Goad_desc_rsc = "As a mortal man Goad betrayed his Queen, sending her to her death.  To his dismay, she was only temporarily inconvenienced and now she has bound him here, to serve for all eternity.  His twisted form writhes in constant agony, relieved only briefly by the wash of ecstasy he feels when he oversees the death of another."
 
-   Goad_ad_need_champion1 = "Come my prettys, be not afriad . . . "
+   Goad_ad_need_champion1 = "Come my pretties, be not afraid . . . "
    Goad_ad_need_champion2 = "I can taste your desire  . . . give in to it, there is so much power to be gained."
    Goad_ad_need_champion3 = "It is such a small thing to kill another, won't you dance for me?"
    Goad_ad_need_champion4 = "I must have death!"
@@ -42,7 +42,7 @@ resources:
 
    Goad_no_need = "Be calm little one, your time to die will come."     
    Goad_need_champion = "By ancient law I must first have a Champion.  Give yourself to me."     
-   Goad_dont_need_challenger = "Later my sweet, later.  Enough blood flows through the viens of these fools, I can wait for yours."
+   Goad_dont_need_challenger = "Later my sweet, later.  Enough blood flows through the veins of these fools, I can wait for yours."
    Goad_fight_in_progress = "Yes!  As soon as I have feasted upon these fools you may follow them."
 
    Goad_already_combatant = "So generous . . . but, you are already mine."
@@ -78,7 +78,7 @@ resources:
 
    Goad_must_choose_style = "First things first . . . are we to have a duel or a bloodbath?"     
    Goad_cant_switch = "You can't change that now, worm."
-   Goad_new_combat_style = "Excellent.  I've been thristing for a good %s.  Now, who'll say the magic word, \"champion\"?"
+   Goad_new_combat_style = "Excellent.  I've been thirsting for a good %s.  Now, who'll say the magic word, \"champion\"?"
 
    Goad_style_one_on_one = "duel"
    Goad_style_last_man_standing = "bloodbath"
@@ -146,8 +146,8 @@ properties:
    pbLastMinute = FALSE       %% has the Watcher given the one minute warning?
 
    plUserStats = $         %% stores values for the players' HP, mana,
-               %% and vigor upon entring the battle area,
-               %% which are restored upon leaving the area.
+                           %% and vigor upon entering the battle area,
+                           %% which are restored upon leaving the area.
 
    pbWarned = FALSE      %%Goad warns once before killing slow combatants.
 
@@ -162,10 +162,10 @@ messages:
 
 
    NewOwner(what=$)
-   "If Goad is ever loaded someplace other than the arena of brax, "
-   "go back to brax."
+   "If Goad is ever loaded someplace other than the arena of Brax, "
+   "go back to Brax."
    {
-      %haveta give the room time to be created on a recreateall, so we post.
+      % We must give the room time to be created on a recreateall, so we post.
       post(self,@PostNewOwner);
       propagate;
    }
@@ -285,7 +285,7 @@ messages:
        return FALSE;
     }
 
-    AcceptingChallengers() %%How many can brax fit?
+    AcceptingChallengers() %% How many can Brax fit?
     {
        if length(plCombatants) < 2 AND piCombat_Style = STYLE_ONE_ON_ONE
        { return TRUE; }
@@ -456,7 +456,7 @@ messages:
       
       if (died = FALSE) and (send(self,@FightInSession) OR ptCommence <> $)
       {
-         debug("Someone tried to renege while fight was in session without dieing. Zuts alors I have missed one.");
+         debug("Someone tried to renege while fight was in session without dying.");
          return;
       }
 


### PR DESCRIPTION
Fixed spelling from Goad NPC and in comments.
Slightly adjusted formatting.

No significant changes.