### PR TITLE
For each object rendered we increase the z-depth to prevent z-fighting

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -6841,6 +6841,9 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 
 	anglePitch = PlayerGetHeightOffset();
 
+	// For each object rendered we increase the z-depth to prevent z-fighting.
+	int z_depth_inc = 0;
+
 	// base objects
 	for (curObject = 0; curObject < nitems; curObject++)
 	{
@@ -6979,7 +6982,7 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 		pChunk->numPrimitives = pChunk->numVertices - 2;
 		pChunk->xLat0 = xLat0;
 		pChunk->xLat1 = xLat1;
-		pChunk->zBias = ZBIAS_BASE;
+		pChunk->zBias = ZBIAS_OVEROVER+(z_depth_inc++);
 
 		lastDistance = 0;
 

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -6983,7 +6983,7 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 		pChunk->xLat0 = xLat0;
 		pChunk->xLat1 = xLat1;
 		pChunk->zBias = ZBIAS_DEFAULT+(z_depth_inc++);
-			
+
 		lastDistance = 0;
 
 		if (GetDrawingEffect(pRNode->obj.flags) == OF_BLACK)

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -6982,8 +6982,8 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 		pChunk->numPrimitives = pChunk->numVertices - 2;
 		pChunk->xLat0 = xLat0;
 		pChunk->xLat1 = xLat1;
-		pChunk->zBias = ZBIAS_OVEROVER+(z_depth_inc++);
-
+		pChunk->zBias = ZBIAS_DEFAULT+(z_depth_inc++);
+			
 		lastDistance = 0;
 
 		if (GetDrawingEffect(pRNode->obj.flags) == OF_BLACK)

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -6983,15 +6983,12 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 		pChunk->xLat0 = xLat0;
 		pChunk->xLat1 = xLat1;
 
-		if (pRNode->boundingHeightAdjust != 0)
-		{
-			// Nodes with a bound height adjust are part of other players upper body.
-			pChunk->zBias = ZBIAS_BASE;
-		}
-		else
+		pChunk->zBias = ZBIAS_BASE;
+		// Nodes with a bound height adjust are part of other players' upper bodies.
+		if (pRNode->boundingHeightAdjust == 0)
 		{
 			// Typical items such as reagents, keys, etc.
-			pChunk->zBias = ZBIAS_DEFAULT+(z_depth_inc++);
+			pChunk->zBias = ZBIAS_DEFAULT + (z_depth_inc++);
 		}
 
 		lastDistance = 0;

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -6991,8 +6991,7 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 		else
 		{
 			// Typical items such as reagents, keys, etc.
-			pChunk->zBias = ZBIAS_BASE +(z_depth_inc++);
-			z_depth_inc += 1;
+			pChunk->zBias = ZBIAS_DEFAULT+(z_depth_inc++);
 		}
 
 		lastDistance = 0;

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -6982,7 +6982,18 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 		pChunk->numPrimitives = pChunk->numVertices - 2;
 		pChunk->xLat0 = xLat0;
 		pChunk->xLat1 = xLat1;
-		pChunk->zBias = ZBIAS_DEFAULT+(z_depth_inc++);
+
+		if (pRNode->boundingHeightAdjust != 0)
+		{
+			// Nodes with a bound height adjust are part of other players upper body.
+			pChunk->zBias = ZBIAS_BASE;
+		}
+		else
+		{
+			// Typical items such as reagents, keys, etc.
+			pChunk->zBias = ZBIAS_BASE +(z_depth_inc++);
+			z_depth_inc += 1;
+		}
 
 		lastDistance = 0;
 


### PR DESCRIPTION
Rendered objects in the hardware renderer suffers from z-fighting, to prevent this we increase the z-depth for each object drawn.

You could easily spot the z-fighting taking place, such as below:

<img width="562" alt="image" src="https://github.com/Meridian59/Meridian59/assets/7548210/dbbc1a09-791c-4aae-bb6f-ec6ea757f3e6">

With this small update we can see many objects without such visual artifacts:

<img width="608" alt="image" src="https://github.com/Meridian59/Meridian59/assets/7548210/3fba5bb7-df6f-465b-9e6d-9b2236fcb9af">

