### PR TITLE
Activate main game window when inventory is restored as the active stat group

### DIFF
--- a/module/merintr/stats.c
+++ b/module/merintr/stats.c
@@ -231,17 +231,15 @@ void StatsClearArea(void)
 }
 /************************************************************************/
 /*
- * ActivateInventory: Activate the inventory stat group.
+ * ActivateInventory: Activate the inventory.
  */
 void ActivateInventory()
 {
 	DisplayInventory(cinfo->player->inventory);
 	DisplayInventoryAsStatGroup((BYTE)STATS_INVENTORY);
 
-	//InvalidateRect(GetHwndInv(), NULL, FALSE);
 	InventoryRedraw();
 	InventorySetFocus(true);
-
 
 	// The inventory is special and takes focus unlike the other stat groups.
 	// We now return focus to the main window.


### PR DESCRIPTION
Whenever the inventory is restored as the active stat group we now ensure that the main game view is the active window.

This includes change also includes an improvement to the interception point and cleaning the code for restoring the active stat group.