### PR TITLE
Control z-depth by the position of each item in the 3D world

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -6854,7 +6854,7 @@ ZPoint calculateBin(const ZPoint& point, int binSize) {
 	return { point.x / binSize, point.y / binSize, point.z / binSize };
 }
 
-// Function to compare points (needed to use Point as a key in std::map)
+// Function to compare points (needed to use ZPoint as a key in std::map)
 bool operator<(const ZPoint& p1, const ZPoint& p2) {
 	return std::tie(p1.x, p1.y, p1.z) < std::tie(p2.x, p2.y, p2.z);
 }

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -6871,7 +6871,7 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 	// This is to mitigate z-fighting by incrementing z-depths for each unique object in the same position.
 	// The key is composed of the x and y coordinates of the object and the value is the current
 	// count of objects found at that location.
-	std::unordered_map<int64, BYTE> depth_adjustment_map;
+	std::unordered_map<int64, int> depth_adjustment_map;
 
 	// base objects
 	for (curObject = 0; curObject < nitems; curObject++)
@@ -7020,10 +7020,10 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 			// offset by the number of items already drawn at this location.
 
 			// Combine objects x and y position into a single int64 for the map key.
-			int64_t key = ((int64_t)pRNode->motion.x << 32) | (int32_t)(pRNode->motion.y & 0xFFFFFFFF);
+			int64 key = ((int64)pRNode->motion.x << 32) | (int)(pRNode->motion.y & 0xFFFFFFFF);
 
 			// Increment the counter at the appropriate bin and assign the appropriate zBias.
-			pChunk->zBias = ZBIAS_DEFAULT + depth_adjustment_map[key]++;
+			pChunk->zBias = ZBIAS_DEFAULT + (BYTE)depth_adjustment_map[key]++;
 		}
 
 		lastDistance = 0;

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -6,9 +6,7 @@
 //
 // Meridian is a registered trademark.
 #include "client.h"
-#include <tuple>
 #include <unordered_map>
-#include <vector>
 
 #define	TEX_CACHE_MAX_OBJECT	8000000
 #define	TEX_CACHE_MAX_WORLD		8000000

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -6,6 +6,9 @@
 //
 // Meridian is a registered trademark.
 #include "client.h"
+#include <tuple>
+#include <map>
+#include <vector>
 
 #define	TEX_CACHE_MAX_OBJECT	8000000
 #define	TEX_CACHE_MAX_WORLD		8000000
@@ -6842,6 +6845,20 @@ d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDI
 	return pPacket;
 }
 
+struct ZPoint {
+	int x, y, z;
+};
+
+// Function to calculate the bin for a given point and bin size
+ZPoint calculateBin(const ZPoint& point, int binSize) {
+	return { point.x / binSize, point.y / binSize, point.z / binSize };
+}
+
+// Function to compare points (needed to use Point as a key in std::map)
+bool operator<(const ZPoint& p1, const ZPoint& p2) {
+	return std::tie(p1.x, p1.y, p1.z) < std::tie(p2.x, p2.y, p2.z);
+}
+
 void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 							 Draw3DParams *params, int flags)
 {
@@ -6866,8 +6883,8 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 
 	anglePitch = PlayerGetHeightOffset();
 
-	// For each object rendered we increase the z-depth to prevent z-fighting.
-	int z_depth_inc = 0;
+	// Track objects in similar positions in the 3d world.
+	std::map<ZPoint, std::vector<ZPoint>> objection_position_bins;
 
 	// base objects
 	for (curObject = 0; curObject < nitems; curObject++)
@@ -7012,8 +7029,15 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 		// Nodes with a bound height adjust are part of other players' upper bodies.
 		if (pRNode->boundingHeightAdjust == 0)
 		{
+			// For objects in a similar position we increase the z depth
+			// to prevent z fighting at that location.
+			float binSize = 5.0f;
+			const ZPoint position {pRNode->motion.x, pRNode->motion.y, pRNode->motion.z};
+			const ZPoint bin = calculateBin(position, binSize);
+			objection_position_bins[bin].push_back(position);
+
 			// Typical items such as reagents, keys, etc.
-			pChunk->zBias = ZBIAS_DEFAULT + (z_depth_inc++);
+			pChunk->zBias = ZBIAS_DEFAULT + (BYTE)(objection_position_bins[bin].size() & 0xFF);
 		}
 
 		lastDistance = 0;


### PR DESCRIPTION
When a relatively large number of items are rendered in the 3d scene some items (for example the urn in Tos by the GY) would render with an incorrect depth. We now control z-depths by the location of items in the 3d world rather than increasing z depths for each item in the scene.

<img width="1075" alt="image" src="https://github.com/Meridian59/Meridian59/assets/7548210/62eeb18f-6876-4ecc-94a2-a29053c28696">
