### PR TITLE
Allow simultaneous read access to game resources

### DIFF
--- a/clientd3d/memmap.c
+++ b/clientd3d/memmap.c
@@ -18,7 +18,7 @@
  */
 Bool CliMappedFileOpenRead(char *filename, file_node *f)
 {
-   f->fh = CreateFile(filename,GENERIC_READ,0,NULL,
+   f->fh = CreateFile(filename,GENERIC_READ,FILE_SHARE_READ,NULL,
 		      OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,NULL);
    if (f->fh == INVALID_HANDLE_VALUE)
    {


### PR DESCRIPTION
When using more than one client to play the game you will likely see black square assets in place of the correct images.
With this small change we now enable subsequent open operations on a file or device to request read access.
This issue was due to the share mode preventing other processes from opening files.

<img width="463" alt="image" src="https://github.com/Meridian59/Meridian59/assets/7548210/23eeb0d7-c20c-4b27-8c42-c81f0e0442f3">

<img width="464" alt="image" src="https://github.com/Meridian59/Meridian59/assets/7548210/71e76034-3166-4785-94f9-3e458aca543d">

<img width="100" alt="image" src="https://github.com/Meridian59/Meridian59/assets/7548210/f8fb173d-c596-4f40-9d0b-45e5b9344128">

https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea