### PR TITLE
Removing additional space in game mail subject for Gem Polishing quest failure

### DIFF
--- a/kod/util/questengine.kod
+++ b/kod/util/questengine.kod
@@ -540,7 +540,7 @@ resources:
    polishquest_assign = "Excuse me.  I’ve been honing my jewelling skills, and I was wondering if you have any "
          "uncut gems of any sort.  If you do, I’d be happy to polish them and give you one of the result."
    polishquest_success = "Ah, thank you.  Allow me to reward you."
-   polishquest_failure = "Subject:  Gem polishing\n"
+   polishquest_failure = "Subject: Gem polishing\n"
          "Never mind about the uncut gems, I found some from someone else.  Thanks, though."
 
    priestessinsignia_trigger = "insignia"


### PR DESCRIPTION
Tiny change to game mail subject for Gem Polishing quest failure.

<img width="150" alt="image" src="https://github.com/Meridian59/Meridian59/assets/7548210/7dab0c3e-c755-4845-9efe-464a5520c3e4">
