### PR TITLE
Prevent graphical lighting and other artefacts when vision is restored from blind

### DIFF
--- a/clientd3d/bspload.c
+++ b/clientd3d/bspload.c
@@ -60,7 +60,7 @@ Bool BSPRooFileLoad(char *fname, room_type *room)
    int node_pos, wall_pos, sidedef_pos, sector_pos, offset_adjust;
    file_node f;
 
-   if (!MappedFileOpenCopy(fname, &f))
+   if (!CliMappedFileOpenRead(fname, &f))
       return False;
 
    // Check magic number and version

--- a/clientd3d/memmap.c
+++ b/clientd3d/memmap.c
@@ -47,40 +47,6 @@ Bool CliMappedFileOpenRead(char *filename, file_node *f)
 }
 /***************************************************************************/
 /*
- * MappedFileOpenCopy:  Open filename as a memory-mapped file for write-on-copy, 
- *   and map a view of the entire file.  Returns True on success, and fills in f.
- */
-Bool MappedFileOpenCopy(char *filename, file_node *f)
-{
-   f->fh = CreateFile(filename,GENERIC_READ | GENERIC_WRITE,0,NULL,
-		      OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,NULL);
-   if (f->fh == INVALID_HANDLE_VALUE)
-   {
-      return False;
-   }
-
-   f->length = GetFileSize(f->fh, NULL);
-
-   f->mapfh = CreateFileMapping(f->fh,NULL,PAGE_WRITECOPY,0,f->length,NULL);
-   if (f->mapfh == NULL)
-   {
-      CloseHandle(f->fh);
-      return False;
-   }
-
-   f->mem = (char *) MapViewOfFile(f->mapfh,FILE_MAP_COPY,0,0,0);
-   if (f->mem == NULL)
-   {
-      CloseHandle(f->mapfh);
-      CloseHandle(f->fh);
-      return False;
-   }
-
-   f->ptr = f->mem;
-   return True;
-}
-/***************************************************************************/
-/*
  * MappedFileRead:  Copy num bytes from the memory-mapped file to buf.
  *   Increments the file pointer.  
  *   Returns num on success, or -1 on failure.

--- a/clientd3d/memmap.h
+++ b/clientd3d/memmap.h
@@ -25,7 +25,6 @@ typedef struct
 // Rename to avoid naming conflicts
 int  CliMappedFileRead(file_node *f, void *buf, int num);
 Bool CliMappedFileOpenRead(char *filename, file_node *f);
-Bool MappedFileOpenCopy(char *filename, file_node *f);
 Bool MappedFileGoto(file_node *f, int pos);
 Bool MappedFileClose(file_node *f);
 


### PR DESCRIPTION
When restoring vision from the blind effect the game world view would often appear to display issues with lighting and other artefacts.

This issue could also cause more severe impact when testing under more extreme conditions - such as creating popup error messages in the client - such messages could appear when running with multiple clients.

Here we make a small switch to obtain simultaneous read rather than write access to a rooms roo file which prevents these issue.

Kudos to m59's Mayhem for helping to identify and resolve this issue :pray: 

<img width="888" alt="image" src="https://github.com/Meridian59/Meridian59/assets/7548210/ddfabf84-df0b-4726-9f3a-e6813e0fe4db">

<img width="911" alt="image" src="https://github.com/Meridian59/Meridian59/assets/7548210/4904987f-9664-4d36-9dd7-106598471bb7">
