### PR TITLE
fix: adjust "_" in PUSHBUTTONs in char.rc

### DIFF
--- a/module/char/char.rc
+++ b/module/char/char.rc
@@ -56,7 +56,7 @@ BEGIN
     LTEXT           "Eigenschaftspunkte übrig:",-1,8,215,83,8
     CONTROL         "",1028,"BlakGraph",0x8,95,214,98,11
     PUSHBUTTON      "&<< Zurück",1008,219,214,41,12
-    PUSHBUTTON      "Weiter &>>",1009,263,214,41,12
+    PUSHBUTTON      "Weiter >&>",1009,263,214,41,12
     LTEXT           "Deine Stärke bestimmt den Schaden, den Du anrichtest und Deine Tragkraft.",-1,175,23,132,18
     LTEXT           "Kluge Charaktere können schneller ihre Fähigkeiten ausbauen und neue erlernen.",-1,175,42,134,17
     LTEXT           "Eine hohe Konstitution wirkt sich positiv auf die Lebenskraft und Ausdauer aus.",-1,175,61,136,17
@@ -95,7 +95,7 @@ BEGIN
     PUSHBUTTON      "<",1021,213,129,17,11,WS_GROUP
     PUSHBUTTON      ">",1026,230,129,17,11,NOT WS_TABSTOP
     PUSHBUTTON      "&<< Zurück",1008,213,146,38,14,WS_GROUP
-    PUSHBUTTON      "Weiter &>>",1009,259,146,36,14
+    PUSHBUTTON      "Weiter >&>",1009,259,146,36,14
 END
 
 142 DIALOGEX 0, 0, 316, 232
@@ -115,7 +115,7 @@ BEGIN
     LTEXT           "Fertigkeitspunkte übrig:",-1,13,215,74,8
     CONTROL         "",1028,"BlakGraph",0x8,94,214,98,11
     PUSHBUTTON      "&<< Zurück",1008,222,214,42,14
-    PUSHBUTTON      "Weiter &>>",1009,265,214,40,14,WS_DISABLED
+    PUSHBUTTON      "Weiter >&>",1009,265,214,40,14,WS_DISABLED
 END
 
 141 DIALOGEX 0, 0, 316, 232
@@ -136,7 +136,7 @@ BEGIN
     LTEXT           "Fertigkeitspunkte übrig:",-1,13,215,74,8
     CONTROL         "",1028,"BlakGraph",0x8,93,214,98,11
     PUSHBUTTON      "&<< Zurück",1008,220,214,40,12
-    PUSHBUTTON      "Weiter &>>",1009,263,214,41,12
+    PUSHBUTTON      "Weiter >&>",1009,263,214,41,12
 END
 
 129 DIALOG  0, 0, 215, 254
@@ -162,8 +162,8 @@ BEGIN
     EDITTEXT        1101,2,26,108,16,ES_AUTOHSCROLL
     LTEXT           "Hier kannst Du eine Beschreibung Deines Charakters eingeben. Du kannst sie noch ändern:",-1,2,52,292,8
     EDITTEXT        1000,2,64,302,138,ES_MULTILINE | ES_WANTRETURN | WS_VSCROLL
-    PUSHBUTTON      "<< Zurück",1008,220,214,38,14,WS_DISABLED
-    PUSHBUTTON      "Weiter >>",1009,270,214,36,14
+    PUSHBUTTON      "&<< Zurück",1008,220,214,38,14,WS_DISABLED
+    PUSHBUTTON      "Weiter >&>",1009,270,214,36,14
 END
 
 
@@ -262,8 +262,8 @@ BEGIN
     EDITTEXT        IDC_NAME,2,26,108,16,ES_AUTOHSCROLL
     LTEXT           "Enter a description of your character here:",IDC_STATIC,2,52,133,8
     EDITTEXT        IDC_DESCRIPTION,2,64,302,138,ES_MULTILINE | ES_WANTRETURN | WS_VSCROLL
-    PUSHBUTTON      "<< Prev",IDC_PREVIOUS_PAGE,231,214,34,12,WS_DISABLED
-    PUSHBUTTON      "Next >>",IDC_NEXT_PAGE,270,214,34,12
+    PUSHBUTTON      "&<< Prev",IDC_PREVIOUS_PAGE,231,214,34,12,WS_DISABLED
+    PUSHBUTTON      "Next >&>",IDC_NEXT_PAGE,270,214,34,12
 END
 
 IDD_CHARSPELLS DIALOGEX 0, 0, 316, 232
@@ -283,8 +283,8 @@ BEGIN
     LTEXT           "Shal'ille (good) and Qor (evil) spells cannot be chosen together.",IDC_STATIC,57,199,201,8
     LTEXT           "Spell/skill points left",IDC_STATIC,13,215,63,8
     CONTROL         "",IDC_POINTSLEFT,"BlakGraph",0x8,87,214,98,11
-    PUSHBUTTON      "<< Prev",IDC_PREVIOUS_PAGE,231,214,34,12
-    PUSHBUTTON      "Next >>",IDC_NEXT_PAGE,270,214,34,12
+    PUSHBUTTON      "&<< Prev",IDC_PREVIOUS_PAGE,231,214,34,12
+    PUSHBUTTON      "Next >&>",IDC_NEXT_PAGE,270,214,34,12
 END
 
 IDD_CHARSKILLS DIALOGEX 0, 0, 316, 232
@@ -303,8 +303,8 @@ BEGIN
     LISTBOX         IDC_SKILLIST2,195,31,105,161,LBS_SORT | LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
     LTEXT           "Spell/skill points left",IDC_STATIC,13,215,63,8
     CONTROL         "",IDC_POINTSLEFT,"BlakGraph",0x8,87,214,98,11
-    PUSHBUTTON      "<< Prev",IDC_PREVIOUS_PAGE,231,214,34,12
-    PUSHBUTTON      "Next >>",IDC_NEXT_PAGE,270,214,34,12,WS_DISABLED
+    PUSHBUTTON      "&<< Prev",IDC_PREVIOUS_PAGE,231,214,34,12
+    PUSHBUTTON      "Next >&>",IDC_NEXT_PAGE,270,214,34,12,WS_DISABLED
 END
 
 IDD_CHARAPPEARANCE DIALOG  0, 0, 316, 161
@@ -336,8 +336,8 @@ BEGIN
     LTEXT           "Mouth:",IDC_STATIC,172,129,23,8
     PUSHBUTTON      "<",IDC_MOUTH1,213,129,17,11,WS_GROUP
     PUSHBUTTON      ">",IDC_MOUTH2,230,129,17,11,NOT WS_TABSTOP
-    PUSHBUTTON      "<< Prev",IDC_PREVIOUS_PAGE,231,146,34,12,WS_GROUP
-    PUSHBUTTON      "Next >>",IDC_NEXT_PAGE,270,146,34,12
+    PUSHBUTTON      "&<< Prev",IDC_PREVIOUS_PAGE,231,146,34,12,WS_GROUP
+    PUSHBUTTON      "Next >&>",IDC_NEXT_PAGE,270,146,34,12
 END
 
 IDD_CHARSTATS DIALOGEX 0, 0, 316, 232
@@ -366,8 +366,8 @@ BEGIN
     LTEXT           "A flexible generalist",IDC_STATIC,87,190,161,8
     LTEXT           "Stat points left",IDC_STATIC,24,215,46,8
     CONTROL         "",IDC_POINTSLEFT,"BlakGraph",0x8,87,214,98,11
-    PUSHBUTTON      "<< Prev",IDC_PREVIOUS_PAGE,231,214,34,12
-    PUSHBUTTON      "Next >>",IDC_NEXT_PAGE,270,214,34,12
+    PUSHBUTTON      "&<< Prev",IDC_PREVIOUS_PAGE,231,214,34,12
+    PUSHBUTTON      "Next >&>",IDC_NEXT_PAGE,270,214,34,12
     LTEXT           "Might affects how much you can carry and the",IDC_STATIC,149,23,147,8
     LTEXT           "With a high intellect, you can learn more spells and",IDC_STATIC,149,42,160,8
     LTEXT           "skills faster than others. Used for advanced magics.",IDC_STATIC,149,50,162,8


### PR DESCRIPTION
## What / The Problem 
When creating a new character there are "<<" and ">>" PUSHBUTTONs to move between tabs.
There is an underscore on each side, but the underscore is always before the left symbol. Not sure if this a typo, or if they should always be on the inner section or outer section.  See attached image below.

## The Proposed Fix
Removed the underscore. Balance restored.

![image](https://github.com/Meridian59/Meridian59/assets/4023541/338267fb-0714-4018-8dc8-a6dfd35783b1)
