### PR TITLE
Added items and updated loot tables

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -1577,6 +1577,11 @@
    TID_DARK_ANGEL    = 51
    TID_MUMMY         = 52
    TID_THRASHER      = 53
+   TID_ICE_PERSON    = 54
+   TID_FROGMAN       = 55
+   TID_COW           = 56
+   TID_BABY_SPIDER   = 57
+   TID_SPIDER        = 58
 
    %%% English articles
 

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -4175,7 +4175,6 @@ messages:
          OR IsClass(what,&Book)
          OR IsClass(what,&Arsenic)
          OR IsClass(what,&SpiderEgg)
-         OR IsClass(what,&SpiderEggShell)
          OR IsClass(what,&Key) 
       {
          return TRUE;

--- a/kod/object/active/holder/nomoveon/battler/monster/cow.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/cow.kod
@@ -40,6 +40,10 @@ classvars:
    vrName = cow_name_rsc
    vrIcon = cow_icon_rsc
    vrDesc = cow_desc_rsc
+   vrDead_icon = cow_dead_icon_rsc
+   vrDead_name = cow_dead_name_rsc
+
+   viTreasure_type = TID_COW
 
    viMove_delay_min = 2000
    viMove_delay_max = 10000

--- a/kod/object/active/holder/nomoveon/battler/monster/frogman.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/frogman.kod
@@ -42,7 +42,7 @@ classvars:
    vrDead_icon = frogman_dead_icon_rsc
    vrDead_name = frogman_dead_name_rsc
 
-   viTreasure_type = TID_MEDIUM_HUMAN
+   viTreasure_type = TID_FROGMAN
 
    viSpeed = SPEED_AVERAGE
    viAttack_type = ATCK_WEAP_PIERCE

--- a/kod/object/active/holder/nomoveon/battler/monster/guard.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/guard.kod
@@ -32,13 +32,17 @@ classvars:
    vrName = guard_name_rsc
    vrIcon = guard_icon_rsc
    vrDesc = guard_desc_rsc
+   vrDead_icon = guard_dead_icon_rsc
+   vrDead_name = guard_dead_name_rsc
 
    viMove_delay_min = 2000
    viMove_delay_max = 10000
       
    viSpeed = SPEED_FAST
    viAttack_type = ATCK_WEAP_BITE
-   
+
+   viTreasure_type = TID_COW
+
    viLevel = 100
    viDifficulty = 5
    viKarma = 100

--- a/kod/object/active/holder/nomoveon/battler/monster/iceper.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/iceper.kod
@@ -13,6 +13,7 @@ Iceperson is Monster
 constants:
 
    include blakston.khd
+   SWORD_DROP_CHANCE = 15
 
 resources:
 
@@ -46,7 +47,7 @@ classvars:
    vrDead_icon = iceperson_dead_icon_rsc
    vrDead_name = iceperson_dead_name_rsc
 
-   viTreasure_type = TID_NONE
+   viTreasure_type = TID_ICE_PERSON
    viSpeed = SPEED_AVERAGE
    viAttack_type = ATCK_WEAP_THRUST
    viAttack_spell = ATCK_SPELL_COLD
@@ -162,7 +163,33 @@ messages:
    CanMorphTo()
    {
       return FALSE;
-   }      
+   }
+
+   CreateTreasure(who=$, corpse=$)
+   {
+      local oTreasure, iHits, iDropChance;
+      
+      % Not every ice person needs to drop a weapon every single time,
+      % but we're still doing the drop here instead of via the normal 
+      % treasure table so they never drop more than one.
+      if Random(0, 100) < SWORD_DROP_CHANCE
+      {
+         oTreasure = Create(&CustomWeapon, #corpse=corpse);
+         Send(oTreasure, @MakeIceSword);              
+         if Send(poOwner, @ReqNewHold, #what=oTreasure, #new_row=piRow, #new_col=piCol)
+            AND Send(poOwner, @ReqSomethingMoved, #what=oTreasure,
+            #new_row=piRow, #new_col=piCol)
+         {
+           Send(poOwner, @NewHold, #what=oTreasure, #new_row=piRow, #new_col=piCol);
+         }
+         else
+         {
+            Send(oTreasure, @Delete);
+         }
+      }
+
+      propagate;
+   }
 
 end
 

--- a/kod/object/active/holder/nomoveon/battler/monster/skel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/skel.kod
@@ -13,6 +13,7 @@ Skeleton is Monster
 constants:
 
    include blakston.khd
+   SWORD_DROP_CHANCE = 35
 
 resources:
 
@@ -172,23 +173,27 @@ messages:
 
    CreateTreasure(who=$,corpse=$)
    {
-      local oTreasure, iHits;
+      local oTreasure, iDropChance;
       
-      oTreasure = Create(&LongSword,#corpse=corpse);
-      iHits = Bound(Send(oTreasure,@GetHits)/Random(2,4),1,$);
-      Send(oTreasure,@SetHits,#number=iHits);
-              
-      if Send(poOwner,@ReqNewHold,#what=oTreasure,#new_row=piRow,#new_col=piCol)
-         AND Send(poOwner,@ReqSomethingMoved,#what=oTreasure,
-                  #new_row=piRow,#new_col=piCol)
+      % Not every skeleton needs to drop a weapon every single time,
+      % but we're still doing the drop here instead of via the normal 
+      % treasure table so they never drop more than one.
+      if Random(0, 100) < SWORD_DROP_CHANCE
       {
-         Send(poOwner,@NewHold,#what=oTreasure,#new_row=piRow,#new_col=piCol);
+         oTreasure = Create(&CustomWeapon, #corpse=corpse);
+         Send(oTreasure, @MakeRandomAncientSword);              
+         if Send(poOwner, @ReqNewHold, #what=oTreasure, #new_row=piRow, #new_col=piCol)
+            AND Send(poOwner, @ReqSomethingMoved, #what=oTreasure,
+            #new_row=piRow, #new_col=piCol)
+         {
+           Send(poOwner, @NewHold, #what=oTreasure, #new_row=piRow, #new_col=piCol);
+         }
+         else
+         {
+            Send(oTreasure, @Delete);
+         }
       }
-      else
-      {
-         Send(oTreasure,@Delete);
-      }
-      
+
       propagate;
    }
 

--- a/kod/object/active/holder/nomoveon/battler/monster/spdrbaby.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/spdrbaby.kod
@@ -39,7 +39,7 @@ classvars:
    vrDesc = spiderbaby_desc_rsc
    vrDead_icon = spiderbaby_dead_icon_rsc
    vrDead_name = spiderbaby_dead_name_rsc
-   viTreasure_type = TID_WIMPY
+   viTreasure_type = TID_BABY_SPIDER
    viDefault_behavior = AI_FIGHT_AGGRESSIVE
 
    viSpeed = SPEED_SLOW

--- a/kod/object/active/holder/nomoveon/battler/monster/spider.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/spider.kod
@@ -41,7 +41,7 @@ classvars:
    vrDead_icon = spider_dead_icon_rsc
    vrDead_name = spider_dead_name_rsc
 
-   viTreasure_type = TID_MEDIUM_TOUGH
+   viTreasure_type = TID_SPIDER
    viSpeed = SPEED_AVERAGE
    viAttack_type =  ATCK_WEAP_BITE
    viAttributes = MOB_SPASM

--- a/kod/object/item/passitem/makefile
+++ b/kod/object/item/passitem/makefile
@@ -7,7 +7,7 @@
 DEPEND = ..\passitem.bof
 BOFS = attmod.bof defmod.bof healer.bof key.bof \
 	numbitem.bof scepter.bof weapon.bof chalice.bof \
-	spdregg.bof spdreggX.bof \
+	spdregg.bof \
 	arsenic.bof necklace.bof ring.bof pforget.bof token.bof \
 	minigame.bof gift.bof pillufrm.bof instrum.bof sanctkey.bof \
 	totem.bof rose.bof orechunk.bof offering.bof letter.bof \

--- a/kod/object/item/passitem/numbitem/avarfthr.kod
+++ b/kod/object/item/passitem/numbitem/avarfthr.kod
@@ -1,0 +1,49 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+AvarFeather is NumberItem
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   AvarFeather_name_rsc = "avar feather"
+   AvarFeather_icon_rsc = avfeathr.bgf
+   AvarFeather_desc_rsc = \
+      "Pristine avar tailfeathers are considered to be a valuable trade "
+      "commodity, for both decorative and magical purposes."
+
+   AvarFeather_name_plural_rsc = "avar feathers"
+
+classvars:
+
+   vrName = AvarFeather_name_rsc
+   vrIcon = AvarFeather_icon_rsc
+   vrDesc = AvarFeather_desc_rsc
+
+   vrName_plural = AvarFeather_name_plural_rsc
+
+   viIndefinite = ARTICLE_AN
+
+   viValue_average = 80
+   viWeight = 1
+   viBulk = 3
+
+properties:
+
+   piNumber = 1
+   piItem_flags = 57
+
+messages:
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/numbitem/blbndust.kod
+++ b/kod/object/item/passitem/numbitem/blbndust.kod
@@ -1,0 +1,47 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+BlackenedBoneDust is NumberItem
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   BlackenedBoneDust_name_rsc = "pinch of blackened bone dust"
+   BlackenedBoneDust_icon_rsc = firesand.bgf
+   BlackenedBoneDust_desc_rsc = \
+      "While similar to ordinary bone dust, this variety has been tainted "
+      "by powerful dark magic and is exceptionally potent."
+
+   BlackenedBoneDust_name_plural_rsc = "pinches of blackened bone dust"
+
+classvars:
+
+   vrName = BlackenedBoneDust_name_rsc
+   vrIcon = BlackenedBoneDust_icon_rsc
+   vrDesc = BlackenedBoneDust_desc_rsc
+
+   vrName_plural = BlackenedBoneDust_name_plural_rsc
+
+   viValue_average = 200
+   viWeight = 2
+   viBulk = 2
+
+properties:
+
+   piNumber = 1
+   piItem_flags = 51
+
+messages:
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/numbitem/bonedust.kod
+++ b/kod/object/item/passitem/numbitem/bonedust.kod
@@ -1,0 +1,47 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+BoneDust is NumberItem
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   BoneDust_name_rsc = "pinch of bone dust"
+   BoneDust_icon_rsc = firesand.bgf
+   BoneDust_desc_rsc = \
+      "Ancient, dried skeleton bones that have been ground into a fine "
+      "powder are a potent reagent for weaving dark magic."
+
+   BoneDust_name_plural_rsc = "pinches of bone dust"
+
+classvars:
+
+   vrName = BoneDust_name_rsc
+   vrIcon = BoneDust_icon_rsc
+   vrDesc = BoneDust_desc_rsc
+
+   vrName_plural = BoneDust_name_plural_rsc
+
+   viValue_average = 60
+   viWeight = 2
+   viBulk = 2
+
+properties:
+
+   piNumber = 4
+   piItem_flags = 54
+
+messages:
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/numbitem/food/makefile
+++ b/kod/object/item/passitem/numbitem/food/makefile
@@ -8,6 +8,7 @@ DEPEND = ..\food.bof
 BOFS = inkycap.bof snack.bof watrskin.bof meatpie.bof apple.bof \
        bread.bof mug.bof spideye.bof drumstik.bof pork.bof \
        grapes.bof ftncooky.bof soup.bof goblet.bof gobletst.bof stew.bof \
-       gobletwn.bof kocmug.bof cheese.bof mint.bof turkyleg.bof chaosfood.bof
+       gobletwn.bof kocmug.bof cheese.bof mint.bof turkyleg.bof chaosfood.bof \
+       stnkycap.bof mushgray.bof mushgold.bof mystmeat.bof milk.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/item/passitem/numbitem/food/milk.kod
+++ b/kod/object/item/passitem/numbitem/food/milk.kod
@@ -1,0 +1,59 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Milk is Food
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   milk_name_rsc = "bottle of milk"
+   milk_icon_rsc = blubott4.bgf
+   milk_desc_rsc = \
+   "This bottle of cold, nutrient-rich milk was taken from the "
+   "famed pygmy cow.  Due to the scarcity of the modern-day pygmy "
+   "cow, this milk is considered by many to be a rare delicacy."
+
+   milk_name_plural_rsc = "bottles of milk"
+
+   milk_eat_wav = drink.wav
+
+classvars:
+
+   vrName = milk_name_rsc
+   vrIcon = milk_icon_rsc
+   vrDesc = milk_desc_rsc
+
+   vrName_plural = milk_name_plural_rsc
+
+   viBulk = 10
+   viWeight = 7
+   viValue_average = 40
+
+   vrEat_wav = milk_eat_wav
+
+properties:
+
+   viFilling = 16
+   viNutrition = 12
+   piNumber = 1
+   piItem_flags = 54
+
+messages:
+
+   IsBeverage()
+   {
+      return TRUE;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/numbitem/food/mushgold.kod
+++ b/kod/object/item/passitem/numbitem/food/mushgold.kod
@@ -1,0 +1,63 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+GoldenMushroom is Food
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   goldmushroom_name_rsc = "golden mushroom"
+   goldmushroom_icon_rsc = mushroom.bgf
+   goldmushroom_desc_rsc = \
+      "This mushroom's magical properties are unknown, however it is "
+      "exceedingly rare and might be worth a lot to the right person."
+
+   goldmushroom_name_plural_rsc = "golden mushrooms"
+
+   goldmushroom_use_rsc = "You can't help but wonder if eating such a "
+      "rare specimen was worth it, even if it was absolutely delicious."
+
+classvars:
+
+   vrName = goldmushroom_name_rsc
+   vrIcon = goldmushroom_icon_rsc
+   vrDesc = goldmushroom_desc_rsc
+
+   vrName_plural = goldmushroom_name_plural_rsc
+
+   viValue_average = 750
+   viWeight = 4
+   viBulk = 5
+   viItem_type = ITEMTYPE_FOOD | ITEMTYPE_SUNDRY | ITEMTYPE_REAGENT
+
+properties:
+
+   viNutrition = 45    % Almost inky-tier vigor-to-fill ratio, but these
+   viFilling = 25      % are better off sold for money
+   piNumber = 1
+   piItem_flags = 227
+
+messages:
+
+   SendTaste(what = $,apply_on = $)
+   {
+      if (IsClass(apply_on, &User))
+      {
+         Send(apply_on, @MsgSendUser, #message_rsc=goldmushroom_use_rsc);
+      }
+
+      return;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/numbitem/food/mushgray.kod
+++ b/kod/object/item/passitem/numbitem/food/mushgray.kod
@@ -1,0 +1,92 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+CorpseMushroom is Food
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   corpsemushroom_name_rsc = "corpse mushroom"
+   corpsemushroom_icon_rsc = mushroom.bgf
+   corpsemushroom_desc_rsc = \
+      "This rare mushroom is devoid of any color and only seems to grow on "
+      "corpses or in grave soil.  Surely there's a good reason for this, but "
+      "little is actually known about this unusual variety of highly-poisonous "
+      "mushroom."
+
+   corpsemushroom_name_plural_rsc = "corpse mushrooms"
+
+   corpsemushroom_use_rsc = "Your stomach burns like it's on fire as you "
+      "double over in mind-numbing agony!"
+
+classvars:
+
+   vrName = corpsemushroom_name_rsc
+   vrIcon = corpsemushroom_icon_rsc
+   vrDesc = corpsemushroom_desc_rsc
+
+   vrName_plural = corpsemushroom_name_plural_rsc
+
+   viWeight = 2
+   viBulk = 3
+
+   viValue_average = 100
+   viNutrition = 0       % Not good for you at all!
+   viFilling = 5
+   viDamage_min = 40     % Damage is capped at 50% max hp, thankfully
+   viDamage_max = 60
+   viLossRate = 30000    % 3 hp/sec - really nasty poison!
+   viDuration = 120000   % 120 seconds of agony
+
+   viItem_type = ITEMTYPE_FOOD | ITEMTYPE_SUNDRY | ITEMTYPE_REAGENT
+
+properties:
+
+   piNumber = 1
+   piItem_flags = 51
+
+messages:
+
+   SendTaste(what = $,apply_on = $)
+   {
+      local oPoison, iDamage;
+
+      % Eating one of these causes acute pain as well as a really nasty poison
+      oPoison = Send(SYS, @FindSpellByNum, #num=SID_POISON);
+
+      % Damage shouldn't exceed 50% of max health.  No insta-killing newbies
+      % who may not know any better!
+      iDamage = Bound(Random(viDamage_min, viDamage_max), 1, Send(apply_on, @GetMaxHealth) / 2);
+
+      if Send(apply_on, @AssessDamage, #what=self, #damage=iDamage, #report=FALSE) = $
+      {
+         % If it kills the user...
+         Send(Send(apply_on, @GetOwner), @SomethingKilled, #what=self, #victim=apply_on);
+         Send(apply_on, @Killed, #what=self);
+      }
+      else
+      {
+         Send(oPoison, @MakePoisoned, #who=apply_on, #lossrate=viLossRate, #duration=viDuration,
+            #report=FALSE);
+      }
+      if isClass(apply_on, &User) 
+      {
+         Send(apply_on, @EffectSendUserDuration, #effect=EFFECT_WAVER, #duration=viDuration);
+         Send(apply_on, @MsgSendUser, #message_rsc=corpsemushroom_use_rsc);
+      }
+
+      return;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/numbitem/food/mystmeat.kod
+++ b/kod/object/item/passitem/numbitem/food/mystmeat.kod
@@ -1,0 +1,78 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+MysteryMeat is Food
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   mysterymeat_name_rsc = "hunk of mystery meat"
+   mysterymeat_icon_rsc = pork.bgf
+   mysterymeat_desc_rsc = \
+      "No one knows exactly what sort of creature this slab of "
+      "meat came from.  It's simply a question of how hungry "
+      "you are."
+
+   mysterymeat_name_plural_rsc = "hunks of mystery meat"
+
+   mysterymeat_use_rsc = "Yuck, it tastes terrible!"
+
+   mysterymeat_disp_name = "unidentified animal"
+   mysterymeat_disp_icon = pig.bgf
+   mysterymeat_disp_desc = \
+     "You don't exactly know what sort of animal this tough, "
+     "rubbery meat came from, but if you're hungry enough, "
+     "anything can be food."
+   mysterymeat_got_one = "You tear off a tough chunk of mystery meat."
+
+classvars:
+
+   vrName = mysterymeat_name_rsc
+   vrIcon = mysterymeat_icon_rsc
+   vrDesc = mysterymeat_desc_rsc
+
+   vrDisp_name = mysterymeat_disp_name
+   vrDisp_icon = mysterymeat_disp_icon
+   vrDisp_desc = mysterymeat_disp_desc
+
+   vrName_plural = mysterymeat_name_plural_rsc
+
+   viBulk = 6
+   viWeight = 6
+
+   viValue_average = 10
+
+properties:
+
+   viFilling = 15
+   viNutrition = 10
+   piNumber = 3
+   piItem_flags = 83
+
+messages:
+
+   NewHoldMessage(who=$,disp=$)
+   "Called whenever a number item is created from a dispenser."
+   {
+      send(who,@msgsenduser,#message_rsc=mysterymeat_got_one);
+      return;
+   }
+
+   SendTaste(what = $,apply_on = $)
+   {
+      Send(apply_on, @MsgSendUser, #message_rsc=mysterymeat_use_rsc);
+	  return;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/numbitem/food/stnkycap.kod
+++ b/kod/object/item/passitem/numbitem/food/stnkycap.kod
@@ -1,0 +1,86 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+StinkyCap is Food
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   stinkycap_name_rsc = "Stinky-cap mushroom"
+   stinkycap_name_plural_rsc = "Stinky-cap mushrooms"
+   stinkycap_icon_rsc = mushroom.bgf
+   stinkycap_desc_rsc = \
+      "At first glance, these mushrooms appear common, but look at the green stem!  "
+      "These are actually...hey wait a minute.  The unusually foul smell emanating "
+      "from these mushrooms makes your stomach twist itself in knots."
+   stinkycap_use_rsc = "You immediately realize your mistake as you choke down the "
+      "vile, bitter-tasting mushroom."
+
+classvars:
+
+   vrName = stinkycap_name_rsc
+   vrName_plural = stinkycap_name_plural_rsc
+   vrIcon = stinkycap_icon_rsc
+   vrDesc = stinkycap_desc_rsc
+
+   viWeight = 2
+   viBulk = 3
+   viValue_average = 150
+   viItem_type = ITEMTYPE_FOOD | ITEMTYPE_SUNDRY | ITEMTYPE_REAGENT
+
+   viLossRate = 10000       % 1 hp/sec
+   viDuration = 30000       % 30 seconds of agony
+   viDementiaPower = 20     % strength of dementia effect
+   viPalsyPower = 20        % strength of palsy effect
+
+properties:
+
+   viFilling = 5
+   viNutrition = 0     % these are not good for you at all
+   piNumber = 1
+   piItem_flags = 124
+
+messages:
+
+   SendTaste(what = $,apply_on = $)
+   {
+      local oPoison, oDementia, oPalsy;
+
+      % Yeah, eating one of these is going to make you sick, sick, sick!
+      oPoison = Send(SYS, @FindSpellByNum, #num=SID_POISON);
+      oDementia = Send(SYS,@FindSpellByNum, #num=SID_DEMENTIA);
+      oPalsy = Send(SYS,@FindSpellByNum, #num=SID_PALSY);
+      
+      if NOT Send(apply_on, @IsEnchanted, #what=oDementia) 
+      {
+         Send(oDementia, @MakeSick, #who=apply_on, #iAmount=viDementiaPower, #iDuration=viDuration,
+            #report=FALSE);
+      }
+      if NOT Send(apply_on, @IsEnchanted, #what=oPalsy) 
+      {
+         Send(oPalsy, @MakeSick, #who=apply_on, #iAmount=viPalsyPower, #iDuration=viDuration,
+            #report=FALSE);
+      }
+      Send(oPoison, @MakePoisoned, #who=apply_on, #lossrate=viLossRate, #duration=viDuration,
+            #report=FALSE);
+
+      if isClass(apply_on, &User) 
+      {
+         Send(apply_on, @MsgSendUser, #message_rsc=stinkycap_use_rsc);
+      }
+      
+      return;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/numbitem/makefile
+++ b/kod/object/item/passitem/numbitem/makefile
@@ -10,6 +10,7 @@ BOFS = money.bof mushroom.bof mushb.bof mushp.bof mushr.bof \
 	dangfeth.bof farywing.bof diamond.bof emerald.bof sapphire.bof \
         ruby.bof entberry.bof firesand.bof dflyeye.bof kripclaw.bof \
         solagh.bof rnbwfern.bof uncserpm.bof webmass.bof shamblod.bof \
-        polserpm.bof yrxlsap.bof webmoss.bof
+        polserpm.bof yrxlsap.bof webmoss.bof avarfthr.bof bonedust.bof \
+        blbndust.bof trollbld.bof spdreggX.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/item/passitem/numbitem/spdreggX.kod
+++ b/kod/object/item/passitem/numbitem/spdreggX.kod
@@ -1,0 +1,42 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+SpiderEggShell is NumberItem
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   spidereggshell_name_rsc = "egg shell"
+   spidereggshell_icon_rsc = spdreggX.bgf
+   spidereggshell_desc_rsc = \
+   "This large broken shell has a tough, leathery texture."
+
+   spidereggshell_name_plural_rsc = "egg shells"
+
+classvars:
+
+   vrName = spidereggshell_name_rsc
+   vrIcon = spidereggshell_icon_rsc
+   vrDesc = spidereggshell_desc_rsc
+   vrName_plural = spidereggshell_name_plural_rsc
+
+   viValue_average = 25
+   viWeight = 3
+   viBulk = 5
+
+properties:
+   
+
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/numbitem/trollbld.kod
+++ b/kod/object/item/passitem/numbitem/trollbld.kod
@@ -1,0 +1,49 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+TrollBlood is NumberItem
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   TrollBlood_name_rsc = "bottle of troll blood"
+   TrollBlood_icon_rsc = goldbot4.bgf
+   TrollBlood_desc_rsc = \
+   "Thick, reddish-brown troll blood is believed to have powerful "
+   "regenerative properties, making it highly prized by alchemists "
+   "and mystics alike.  Whether or not this has any merit is open to "
+   "debate."
+
+   TrollBlood_name_plural_rsc = "bottles of troll blood"
+
+classvars:
+
+   vrName = TrollBlood_name_rsc
+   vrIcon = TrollBlood_icon_rsc
+   vrDesc = TrollBlood_desc_rsc
+
+   vrName_plural = TrollBlood_name_plural_rsc
+
+   viValue_average = 70
+   viWeight = 3
+   viBulk = 5
+
+properties:
+
+   piNumber = 3
+   piItem_flags = 77
+
+messages:
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/weapon/custweap.kod
+++ b/kod/object/item/passitem/weapon/custweap.kod
@@ -1,0 +1,394 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+CustomWeapon is Weapon
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   ancientsword_name_rsc = "ancient sword"
+   ancientsword_desc_low_rsc = \
+      "This sword was forged long ago by an unknown maker.  "
+      "Its blade is pitted, coated in rust, and dulled from many ages of "
+      "unrelenting combat.  It's unclear how much longer this weapon could possibly "
+      "last."
+   ancientsword_desc_med_rsc = \
+      "This sword was forged long ago by an unknown maker.  "
+      "Its blade is dented and scratched in several places, making it clear this "
+      "sword has seen many battles.  In its prime, this was likely a decent weapon."
+   ancientsword_desc_high_rsc = \
+      "This sword was forged long ago by an unknown maker.  "
+      "For its age, it's in remarkable shape with no noticeable flaws and it "
+      "balances perfectly in your hand.  Still polished to a shine after so long, "
+      "the blade is very sturdy and quite sharp."
+
+   icesword_name_rsc = "sword of pure ice"
+   icesword_desc_rsc = \
+      "Crafted entirely from solid ice, this brittle, crudely-fashioned sword is "
+      "lightweight, incredibly sharp, and of course cold to the touch.  Glistening "
+      "beads of water trickle down the length of the blade as it slowly starts "
+      "to melt."
+   icesword_melt_rsc = \
+      "The %s melts away, leaving nothing but a puddle of water behind."
+
+   customweapon_long_icon_rsc = sword.bgf
+   customweapon_long_window_overlay_rsc = povsword.bgf
+   customweapon_long_player_overlay = swordov.bgf
+
+   customweapon_short_icon_rsc  = shswd.bgf
+   customweapon_short_window_overlay_rsc = povshswd.bgf
+   customweapon_short_player_overlay = shswdov.bgf
+
+classvars:
+
+   % These are variable-quality thrusting weapons
+   viWeaponType = WEAPON_TYPE_THRUST
+
+   viGround_group = 1
+   viInventory_group = 3
+   viBroken_group = 2
+
+   viQualityHitsLowMin = 100
+   viQualityHitsLowMax = 150
+   viQualityHitsMedMin = 300
+   viQualityHitsMedMax = 350
+   viQualityHitsHighMin = 600
+   viQualityHitsHighMax = 650
+
+   viQualityValueLow = 75
+   viQualityValueMed = 600
+   viQualityValueHigh = 2500
+
+   viXlatHigh = 48    % Shiny platinum blade
+   viXlatMed = 43     % Dull gray blade
+   viXlatLow = 28     % Rusty/coppery blade
+   viXlatIce = 82     % Slight bluish hue
+
+properties:
+
+   % Many class-level properties need to be object-level for 
+   % this weapon so they can be modified upon randomization or
+   % edited by a DM
+
+   % A medium-quality fencing sword is the default item created
+   vrName = ancientsword_name_rsc
+   vrDesc = ancientsword_desc_med_rsc
+   vrIcon = customweapon_long_icon_rsc
+
+   vrWeapon_window_overlay = customweapon_long_window_overlay_rsc
+   vrWeapon_overlay = customweapon_long_player_overlay
+
+   viProficiency_Needed = SKID_PROFICIENCY_SWORD
+
+   viWeaponQuality = WEAPON_QUALITY_NORMAL
+   viValue_average = 600
+
+   viWeight = 80
+   viBulk = 60
+
+   % We need to be able to adjust these on randomization so that 
+   % the "has been mended before" text is displayed accurately
+   viHits_init_min = 300
+   viHits_init_max = 350
+
+   % Generally these will be just like any other weapon, although
+   % some exceptions may exist, such as ice swords not being mendable
+   % or enchantable
+   pbCanMend = TRUE
+   pbCanEnchant = TRUE
+   pbCanWeaken = TRUE
+   pbCanShatter = TRUE
+   pbCanSwap = TRUE
+
+   piAttack_type = ATCK_WEAP_NONMAGIC + ATCK_WEAP_SLASH
+   piItem_flags = 43
+
+   % For the ice person weapon variant, it melts over time
+   piDecayRate = 1     % This only matters if ptDecayTimer is active
+   ptDecayTimer = $
+
+messages:
+
+   SetAsLongsword()
+   {
+      % Sets this to be a long sword/fencing type weapon
+      viProficiency_Needed = SKID_PROFICIENCY_SWORD;
+      vrIcon = customweapon_long_icon_rsc;
+      vrWeapon_window_overlay = customweapon_long_window_overlay_rsc;
+      vrWeapon_overlay = customweapon_long_player_overlay;
+      viBulk = 60;
+
+      return;
+   }
+
+   SetAsShortsword()
+   {
+      % Sets this to be a short sword type weapon
+      viProficiency_Needed = SKID_PROFICIENCY_SHORT_SWORD;
+      vrIcon = customweapon_short_icon_rsc;
+      vrWeapon_window_overlay = customweapon_short_window_overlay_rsc;
+      vrWeapon_overlay = customweapon_short_player_overlay;
+      viBulk = 50;
+
+      return;
+   }
+
+   MakeRandomAncientSword()
+   {
+      local iRandomQuality;
+
+      iRandomQuality = Random(0, 1000);
+
+      % Extremely rare (1:1000)
+      if iRandomQuality = 59
+      {
+         Send(self, @MakePristineSword);
+      }
+      else
+      {
+         % Uncommon (35%)
+         if (iRandomQuality < 350)
+         {
+            Send(self, @MakeDentedSword);
+         }
+         % Common (65%)
+         else
+         {
+            Send(self, @MakeRustySword);
+         }
+      }
+
+      % Is it a short sword or a long sword?
+      if (Random(0, 100) < 50)
+      {
+         Send(self, @SetAsShortsword);
+      }
+      else
+      {
+         Send(self, @SetAsLongsword);
+      }
+
+      return iRandomQuality;
+   }
+
+   MakeRustySword()
+   {
+      % These are on par with short swords in terms of damage stats,
+      % but are lousy weapons overall
+
+      vrName = ancientsword_name_rsc;
+      vrDesc = ancientsword_desc_low_rsc;
+      viWeaponQuality = WEAPON_QUALITY_LOW;
+      viValue_average = viQualityValueLow;
+      viHits_init_min = viQualityHitsLowMin;
+      viHits_init_max = viQualityHitsLowMax;
+      viWeight = 90;               % Heavier, terrible weapon overall.
+      piItem_flags = viXlatLow;
+      piAttack_type = ATCK_WEAP_NONMAGIC + ATCK_WEAP_SLASH;
+      piAttack_spell = 0;
+
+      % These are in god-awful condition.
+      piHits_init = Random(viHits_init_min, viHits_init_max);
+      piHits = Bound(piHits_init * Random(20, 45) / 100, 1, $);
+
+      pbCanMend = TRUE;
+      pbCanEnchant = TRUE;
+      pbCanWeaken = TRUE;
+      pbCanShatter = TRUE;
+      pbCanSwap = TRUE;
+      Send(self, @ClearDecayTimer);
+
+      return;
+   }
+
+   MakeDentedSword()
+   {
+      % These are on par with long swords in terms of damage stats,
+      % and are average in every way.
+
+      vrName = ancientsword_name_rsc;
+      vrDesc = ancientsword_desc_med_rsc;
+      viWeaponQuality = WEAPON_QUALITY_NORMAL;
+      viValue_average = viQualityValueMed;
+      viHits_init_min = viQualityHitsMedMin;
+      viHits_init_max = viQualityHitsMedMax;
+      viWeight = 80;
+      piItem_flags = viXlatMed;
+      piAttack_type = ATCK_WEAP_NONMAGIC + ATCK_WEAP_SLASH;
+      piAttack_spell = 0;
+
+      % These can be in various states of wear.
+      piHits_init = Random(viHits_init_min, viHits_init_max);
+      piHits = Bound(piHits_init * Random(25, 85) / 100, 1, $);
+
+      pbCanMend = TRUE;
+      pbCanEnchant = TRUE;
+      pbCanWeaken = TRUE;
+      pbCanShatter = TRUE;
+      pbCanSwap = TRUE;
+      Send(self, @ClearDecayTimer);
+
+      return;
+   }
+
+   MakePristineSword()
+   {
+      % These are meant to be extremely rare, and are statwise on par
+      % with mystic swords, although they are nonmagical and enchantable.
+
+      vrName = ancientsword_name_rsc;
+      vrDesc = ancientsword_desc_high_rsc;
+      viWeaponQuality = WEAPON_QUALITY_HIGH;
+      viValue_average = viQualityValueHigh;
+      viHits_init_min = viQualityHitsHighMin;
+      viHits_init_max = viQualityHitsHighMax;
+      viWeight = 60;               % A bit lighter due to higher-quality materials.
+      piItem_flags = viXlatHigh;
+      piAttack_type = ATCK_WEAP_NONMAGIC + ATCK_WEAP_SLASH;
+      piAttack_spell = 0;
+
+      % The very rare variant is in near-perfect condition
+      piHits_init = Random(viHits_init_min, viHits_init_max);
+      piHits = Bound(piHits_init * Random(90, 95) / 100, 1, $);
+
+      pbCanMend = TRUE;
+      pbCanEnchant = TRUE;
+      pbCanWeaken = TRUE;
+      pbCanShatter = TRUE;
+      pbCanSwap = TRUE;
+      Send(self, @ClearDecayTimer);
+
+      return;
+   }
+
+   MakeIceSword()
+   {
+      vrName = icesword_name_rsc;
+      vrDesc = icesword_desc_rsc;
+      viWeaponQuality = WEAPON_QUALITY_NORMAL;
+      viValue_average = viQualityValueLow;   % Melting, so not worth much
+      viHits_init_min = viQualityHitsMedMin;
+      viHits_init_max = viQualityHitsMedMax;
+      viWeight = 10;                        % Ice is a lot lighter than steel
+      piItem_flags = viXlatIce;
+      piAttack_type = ATCK_WEAP_MAGIC + ATCK_WEAP_SLASH;
+      piAttack_spell = ATCK_SPELL_COLD;      % I mean, it's made out of ice...
+      piDecayRate = Random(1, 10);          % Some will melt faster than others
+      Send(self, @StartDecayTimer);
+
+      % Is it a short sword or a long sword?
+      if (Random(0, 100) < 50)
+      {
+         Send(self, @SetAsShortsword);
+      }
+      else
+      {
+         Send(self, @SetAsLongsword);
+      }
+
+      pbCanMend = FALSE;      % It decays over time like a torch, so no mend cheese!
+      pbCanEnchant = FALSE;   % Already quasi-enchanted with ice-type damage
+      pbCanWeaken = TRUE;
+      pbCanShatter = TRUE;
+      pbCanSwap = TRUE;
+
+      return;
+   }
+
+   CanMend()
+   {
+      return pbCanMend;
+   }
+
+   CanEnchant()
+   {
+      return pbCanEnchant;
+   }
+
+   CanWeaken()
+   {
+      return pbCanWeaken;
+   }
+
+   CanShatter()
+   {
+      return pbCanShatter;
+   }
+
+   CanSwap()
+   {
+      return pbCanSwap;
+   }
+
+   StartDecayTimer()
+   {
+      if ptDecayTimer <> $
+      {
+         DeleteTimer(ptDecayTimer);
+      }
+      ptDecayTimer = CreateTimer(self, @MeltWeapon, 60000);
+
+      return;
+   }
+
+   ClearDecayTimer()
+   {
+      if ptDecayTimer <> $
+      {
+         DeleteTimer(ptDecayTimer);
+         ptDecayTimer = $;
+      }
+
+      return;
+   }
+
+   MeltWeapon()
+   {
+      % Weapon loses durability every minute once the decay
+      % timer is started, lasting until it breaks or the timer
+      % is turned off
+      piHits = piHits - piDecayRate;
+
+      if (piHits <= 0)
+      {
+         if IsClass(poOwner, &User)
+         {
+            Send(poOwner, @MsgSendUser, #message_rsc=icesword_melt_rsc, #parm1=vrName);
+         }
+         ptDecayTimer = $;
+         Send(self, @Delete);
+      }
+      else
+      {
+         % This is here just in case a DM sets piDecayRate to a negative value.
+         % Doing so will cause the weapon to repair over time instead of decaying,
+         % so don't allow it to exceed its max hits value
+         if (piHits > piHits_init)
+         {
+            piHits = piHits_init;
+         }
+         ptDecayTimer = CreateTimer(self, @MeltWeapon, 60000);
+      }
+
+      return;
+   }
+
+   Delete()
+   {
+      Send(self, @ClearDecayTimer);
+
+      propagate;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/weapon/makefile
+++ b/kod/object/item/passitem/weapon/makefile
@@ -7,6 +7,6 @@
 DEPEND = ..\weapon.bof
 BOFS = shrtswrd.bof mystswrd.bof mace.bof bkdagger.bof spirhamm.bof\
         scimitar.bof longswrd.bof hammer.bof ranged.bof axe.bof goldswrd.bof \
-        riijaswd.bof neruswd.bof huntsw.bof unique.bof
+        riijaswd.bof neruswd.bof huntsw.bof unique.bof custweap.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/trestype/avart.kod
+++ b/kod/object/passive/trestype/avart.kod
@@ -28,18 +28,17 @@ messages:
    constructed()
    {
       plTreasure = [ [ &RainbowFern, 20],
-                     [ &Bread, 15],
+                     [ &AvarFeather, 15],
                      [ &KriipaClaw, 15],
-                     [ &Money, 14],
+                     [ &Money, 15],
+                     [ &Bread, 13],
                      [ &WebMoss, 8],
-                     [ &NeruditeSword, 7],
-                     [ &NeruditeArmor, 7],
-                     [ &IvyCirclet, 5],
-                     [ &CurePoisonPotion, 2],
-                     [ &CureDiseasePotion, 2],
-                     [ &RemoveCursePotion, 2],
-                     [ &PurifyPotion, 2],
-                     [ &Yrxlsap, 1]
+                     [ &TurkeyLeg, 5],
+                     [ &FireSand, 5],
+                     [ &Yrxlsap, 1],
+                     [ &IvyCirclet, 1],
+                     [ &NeruditeSword, 1],
+                     [ &NeruditeArmor, 1]
 		             ];
 
       propagate;

--- a/kod/object/passive/trestype/babyspdt.kod
+++ b/kod/object/passive/trestype/babyspdt.kod
@@ -8,7 +8,7 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-RatTreasure is TreasureType
+BabySpiderTreasure is TreasureType
 
 constants:
    
@@ -19,20 +19,20 @@ classvars:
 
 properties:
    
-   piTreasure_num = TID_RAT
+   piTreasure_num = TID_BABY_SPIDER
 
 messages:
    
    constructed()
    {
       plTreasure = [ [ &Herbs, 25 ],
-                     [ &Mushroom, 20],
+                     [ &Snack, 20],
+                     [ &Spideye, 20],
                      [ &Elderberry, 15 ],
-                     [ &Snack, 15],
-                     [ &Money, 10],
-                     [ &BlueMushroom, 5],
+                     [ &Mushroom, 15],
                      [ &RedMushroom, 5],
-                     [ &Cheese, 5 ] ];
+                     [ &BlueMushroom, 5]
+                   ];
 
       propagate;
    }

--- a/kod/object/passive/trestype/babyspdt.kod
+++ b/kod/object/passive/trestype/babyspdt.kod
@@ -25,13 +25,14 @@ messages:
    
    constructed()
    {
-      plTreasure = [ [ &Herbs, 25 ],
-                     [ &Snack, 20],
-                     [ &Spideye, 20],
+      plTreasure = [ [ &Herbs, 20 ],
+                     [ &Snack, 15 ],
+                     [ &Spideye, 15 ],
                      [ &Elderberry, 15 ],
-                     [ &Mushroom, 15],
-                     [ &RedMushroom, 5],
-                     [ &BlueMushroom, 5]
+                     [ &Mushroom, 15 ],
+                     [ &SpiderEggShell, 10 ],
+                     [ &RedMushroom, 5 ],
+                     [ &BlueMushroom, 5 ]
                    ];
 
       propagate;

--- a/kod/object/passive/trestype/cowtres.kod
+++ b/kod/object/passive/trestype/cowtres.kod
@@ -8,7 +8,7 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-RatTreasure is TreasureType
+CowTreasure is TreasureType
 
 constants:
    
@@ -19,22 +19,18 @@ classvars:
 
 properties:
    
-   piTreasure_num = TID_RAT
+   piTreasure_num = TID_COW
 
-messages:
+messages:  
    
    constructed()
    {
-      plTreasure = [ [ &Herbs, 25 ],
-                     [ &Mushroom, 20],
-                     [ &Elderberry, 15 ],
-                     [ &Snack, 15],
-                     [ &Money, 10],
-                     [ &BlueMushroom, 5],
-                     [ &RedMushroom, 5],
-                     [ &Cheese, 5 ] ];
+      plTreasure = [ [ &MeatPie, 50 ],
+                     [ &Milk, 35],
+                     [ &Cheese, 15 ]
+                   ];
 
-      propagate;
+		propagate;
    }
 
 end

--- a/kod/object/passive/trestype/frogtres.kod
+++ b/kod/object/passive/trestype/frogtres.kod
@@ -8,7 +8,7 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-RatTreasure is TreasureType
+FrogTreasure is TreasureType
 
 constants:
    
@@ -19,22 +19,26 @@ classvars:
 
 properties:
    
-   piTreasure_num = TID_RAT
+   piTreasure_num = TID_FROGMAN
+   piDiff_seed = 2
+   piItem_att_chance = 2
 
-messages:
+messages:  
    
    constructed()
    {
-      plTreasure = [ [ &Herbs, 25 ],
-                     [ &Mushroom, 20],
-                     [ &Elderberry, 15 ],
-                     [ &Snack, 15],
+      plTreasure = [ [ &Elderberry, 15],
+                     [ &MysteryMeat, 15],
+                     [ &Herbs, 10],
+                     [ &Mushroom, 10],
+                     [ &PurpleMushroom, 10],
                      [ &Money, 10],
-                     [ &BlueMushroom, 5],
-                     [ &RedMushroom, 5],
-                     [ &Cheese, 5 ] ];
+                     [ &Solagh, 10],
+                     [ &DragonflyEye, 10],
+                     [ &UncutSeraphym, 10]
+                   ];
 
-      propagate;
+		propagate;
    }
 
 end

--- a/kod/object/passive/trestype/highhumt.kod
+++ b/kod/object/passive/trestype/highhumt.kod
@@ -28,27 +28,27 @@ messages:
    
    constructed()
    {
-      plTreasure = [ [ &MeatPie, 10],
-                     [ &GoldShield, 8 ],
-                     [ &Gauntlet, 7 ],
-                     [ &Longsword, 7],
-                     [ &HealWand, 7 ],
-                     [ &Money, 7],
-                     [ &Sapphire, 6],
-                     [ &Diamond, 6],
-                     [ &BlueMushroom, 5 ],
-                     [ &RingofLethargy, 5],
-                     [ &AcidRing, 5],
-                     [ &FireRing, 4],
-                     [ &ColdRing, 4],
-                     [ &ShockRing, 4],
-                     [ &ScaleArmor, 4 ],
-                     [ &VampireWand, 3 ],
-                     [ &Scepter, 3 ],
+      plTreasure = [ [ &TrollBlood, 20 ],
+                     [ &BlueMushroom, 15 ],
+                     [ &Sapphire, 10 ],
+                     [ &Diamond, 10] ,
+                     [ &Money, 10 ],
+                     [ &MeatPie, 10 ],
+                     [ &PurpleMushroom, 3 ],
                      [ &DarkAngelFeather, 3 ],
                      [ &BlueDragonScale, 3 ],
-                     [ &FreeActionPotion, 3]
+                     [ &HealWand, 2 ],
+                     [ &VampireWand, 2 ],
+                     [ &Scepter, 2 ],
+                     [ &Gauntlet, 2 ],
+                     [ &Ruby, 2],
+                     [ &RingofLethargy, 2 ],
+                     [ &AcidRing, 1 ],
+                     [ &FireRing, 1 ],
+                     [ &ColdRing, 1 ],
+                     [ &ShockRing, 1 ]
                    ];
+
       propagate;
    }
 

--- a/kod/object/passive/trestype/icetres.kod
+++ b/kod/object/passive/trestype/icetres.kod
@@ -8,33 +8,33 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-SpiderEggShell is PassiveItem
+IceTreasure is TreasureType
 
 constants:
-
+   
    include blakston.khd
-
-resources:
-
-   spidereggshell_name_rsc = "egg shell"
-   spidereggshell_icon_rsc = spdreggX.bgf
-   spidereggshell_desc_rsc = \
-   "This large broken shell has a tough, leathery texture."
-
+   
 classvars:
 
-   vrName = spidereggshell_name_rsc
-   vrIcon = spidereggshell_icon_rsc
-   vrDesc = spidereggshell_desc_rsc
-
-   viBulk = 20
-   viWeight = 10
-
-   viValue_average = 25
 
 properties:
    
+   piTreasure_num = TID_ICE_PERSON
+   piDiff_seed = 5
+   piItem_att_chance = 2
 
+messages:  
+   
+   constructed()
+   {
+      plTreasure = [ [ &Waterskin, 59 ],
+                     [ &Sapphire, 20],
+                     [ &Diamond, 10 ],
+                     [ &UncutSeraphym, 10],
+                     [ &PolishedSeraphym, 1 ]
+                   ];
+		propagate;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/trestype/makefile
+++ b/kod/object/passive/trestype/makefile
@@ -12,6 +12,7 @@ BOFS = wimptres.bof notres.bof spquent.bof med-tght.bof wmp-medt.bof \
 	caveorct.bof orcwizt.bof orcpitt.bof avart.bof avarsht.bof \
 	avarcht.bof lupkingt.bof dflyt.bof licht.bof \
 	dethspdt.bof skel2t.bof skel3t.bof skel4t.bof narthylt.bof \
-	wrmlarvt.bof wrmquent.bof dangelt.bof newbietrs.bof thrasht.bof
+	wrmlarvt.bof wrmquent.bof dangelt.bof newbietrs.bof thrasht.bof \
+	icetres.bof frogtres.bof cowtres.bof babyspdt.bof spidtres.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/trestype/narthylt.kod
+++ b/kod/object/passive/trestype/narthylt.kod
@@ -28,19 +28,21 @@ messages:
    
    constructed()
    {
-      plTreasure = [ [ &BlueDragonScale, 15 ],
+      plTreasure = [ [ &MysteryMeat, 21 ],
+                     [ &BlueDragonScale, 15 ],
                      [ &DarkAngelFeather, 15 ],
-                     [ &NightVisionPotion, 10 ],
-                     [ &KaraholsCursePotion, 10 ],
-                     [ &CloakPotion, 10 ],
-                     [ &FireRing, 5 ],
-                     [ &ColdRing, 5 ],
-                     [ &ShockRing, 5 ],
+                     [ &Emerald, 10 ],
+                     [ &Sapphire, 10 ],
+                     [ &Diamond, 10 ],
+                     [ &Ruby, 5 ],
                      [ &BerserkerRing, 5 ],
-                     [ &ResistShockPotion, 5 ],
-                     [ &FeignDeathPotion, 5 ],
-                     [ &ResistMagicPotion, 5 ],
-                     [ &BaitPotion, 5 ]
+                     [ &InkyCap, 3 ],
+                     [ &AcidRing, 1 ],
+                     [ &FireRing, 1 ],
+                     [ &ColdRing, 1 ],
+                     [ &ShockRing, 1 ],
+                     [ &BaitPotion, 1 ],
+                     [ &NightVisionPotion, 1 ]
                    ];
 
       propagate;

--- a/kod/object/passive/trestype/skel2t.kod
+++ b/kod/object/passive/trestype/skel2t.kod
@@ -28,13 +28,17 @@ messages:
    
    Constructed()
    {
-      plTreasure = [ [ &MetalShield, 50 ],
-                     [ &Knightshield, 15 ],
+      plTreasure = [ [ &Snack, 20 ],
+	                 [ &StinkyCap, 15 ],
+	                 [ &Mushroom, 15 ],
                      [ &Money, 15 ],
-                     [ &Scimitar, 10 ],
+                     [ &BoneDust, 10 ],
+	                 [ &Emerald, 7 ],
+	                 [ &Sapphire, 7 ],
                      [ &NeruditeArrow, 5 ],
                      [ &InkyCap, 4 ],
-                     [ &DiscordScroll, 1 ]
+                     [ &DiscordScroll, 1 ],
+                     [ &SimpleHelm, 1 ]
                    ];
 
       propagate;

--- a/kod/object/passive/trestype/skel3t.kod
+++ b/kod/object/passive/trestype/skel3t.kod
@@ -28,18 +28,21 @@ messages:
    
    Constructed()
    {
-      plTreasure = [ [ &NeruditeArrow, 15 ],
-                     [ &ShortSword, 15 ],
+      plTreasure = [ [ &BoneDust, 20 ],
+                     [ &CorpseMushroom, 15 ],
+                     [ &NeruditeArrow, 15 ],
                      [ &InkyCap, 13 ],
                      [ &Money, 12 ],
-                     [ &Hammer, 10 ],
-                     [ &KnightShield, 8 ],
-                     [ &Scimitar, 8 ],
-                     [ &ScaleArmor, 5 ],
-                     [ &NodeburstPotion, 5 ],
-                     [ &LightScroll, 5 ],
-                     [ &EnfeebleWand, 2 ],
-                     [ &ForgetWand, 2 ]
+                     [ &Emerald, 5 ],
+                     [ &Sapphire, 5 ],
+					 [ &Diamond, 5 ],
+                     [ &LightScroll, 3 ],
+                     [ &Ruby, 2 ],
+                     [ &EnfeebleWand, 1 ],
+                     [ &ForgetWand, 1 ],
+                     [ &KnightShield, 1 ],
+                     [ &SimpleHelm, 1 ],
+                     [ &Gauntlet, 1 ]
                    ];
 
       propagate;

--- a/kod/object/passive/trestype/skel4t.kod
+++ b/kod/object/passive/trestype/skel4t.kod
@@ -31,22 +31,25 @@ messages:
    
    constructed()
    {
-      plTreasure = [ [ &Scimitar, 20 ],
+      plTreasure = [ [ &BoneDust, 15 ],
+                     [ &PurpleMushroom, 10 ],
                      [ &BlueDragonScale, 10 ],
-                     [ &SilverArrow, 10 ],
                      [ &DarkAngelFeather, 10 ],
-                     [ &Circlet, 9 ],
+                     [ &SilverArrow, 10 ],
+                     [ &CorpseMushroom, 10 ],
                      [ &Money, 7 ],
-                     [ &Gauntlet, 5 ],
-                     [ &SimpleHelm, 5 ],
+                     [ &BlackenedBoneDust, 5 ],
                      [ &InkyCap, 5 ],
-                     [ &KaraholsCursePotion, 5 ],
-                     [ &IdentifyWand, 5 ],
-                     [ &WindScroll, 2 ],
-                     [ &SummonPoisonFogScroll, 2 ],
-                     [ &KillingFieldScroll, 2 ],
-                     [ &LightScroll, 2 ],
-                     [ &DementWand, 1 ]
+                     [ &Sapphire, 5 ],
+                     [ &Diamond, 4 ],
+                     [ &Ruby, 2 ],
+                     [ &WindScroll, 1 ],
+                     [ &SummonPoisonFogScroll, 1 ],
+                     [ &KillingFieldScroll, 1 ],
+                     [ &GoldenMushroom, 1 ],
+                     [ &DementWand, 1 ],
+                     [ &IdentifyWand, 1 ],
+                     [ &Circlet, 1 ]
                   ];
 
       propagate;

--- a/kod/object/passive/trestype/spidtres.kod
+++ b/kod/object/passive/trestype/spidtres.kod
@@ -8,7 +8,7 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-SpiderQueenTreasure is TreasureType
+SpiderTreasure is TreasureType
 
 constants:
    
@@ -19,26 +19,28 @@ classvars:
 
 properties:
    
-   piTreasure_num = TID_SPIDER_QUEEN
-
-   %% good stuff, appears relatively rarely compared to other
-   %% supermonsters.
-   piDiff_seed = 5
-   piItem_att_chance = 5
+   piTreasure_num = TID_SPIDER
+   
+   %% monsters (like spiders) generate reasonably good stuff, but rarely
+   piDiff_seed = 4
+   piItem_att_chance = 1
 
 messages:
    
    constructed()
    {
-      plTreasure = [ [ &SpiderEgg, 20 ],
-                     [ &SpiderEggShell, 20 ],
+      plTreasure = [ [ &RedMushroom, 21 ],
+                     [ &Snack, 16],
                      [ &Spideye, 15],
-                     [ &BlueDragonScale, 10],
-                     [ &DarkAngelFeather, 10],
-                     [ &BerserkerRing, 10 ],
-                     [ &Ruby, 10 ],
-                     [ &GoldenMushroom, 5 ]
+                     [ &PurpleMushroom, 15],
+                     [ &Emerald, 10 ],
+                     [ &Sapphire, 10 ],
+                     [ &BlueMushroom, 8 ],
+                     [ &Diamond, 2 ],
+                     [ &Ruby, 2 ],
+                     [ &LightScroll, 1 ]
                    ];
+
       propagate;
    }
 

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -3489,6 +3489,12 @@ messages:
 
       Create(&ThrasherTreasure);
 
+      Create(&IceTreasure);
+      Create(&FrogTreasure);
+      Create(&CowTreasure);
+      Create(&BabySpiderTreasure);
+      Create(&SpiderTreasure);
+
       return;
    }
 
@@ -5002,6 +5008,17 @@ messages:
       plItemTemplates = cons(create(&ShrunkenHeadMask),plItemTemplates);
 
       plItemTemplates = cons(create(&ManaCrystal),plItemTemplates);
+
+      plItemTemplates = cons(create(&StinkyCap),plItemTemplates);
+      plItemTemplates = cons(create(&CorpseMushroom),plItemTemplates);
+      plItemTemplates = cons(create(&GoldenMushroom),plItemTemplates);
+      plItemTemplates = cons(create(&AvarFeather),plItemTemplates);
+      plItemTemplates = cons(create(&BoneDust),plItemTemplates);
+      plItemTemplates = cons(create(&BlackenedBoneDust),plItemTemplates);
+      plItemTemplates = cons(create(&MysteryMeat),plItemTemplates);
+      plItemTemplates = cons(create(&TrollBlood),plItemTemplates);
+      plItemTemplates = cons(create(&Milk),plItemTemplates);
+      plItemTemplates = cons(create(&CustomWeapon),plItemTemplates);
 
       return;
    }


### PR DESCRIPTION
Added items to add variety to monster loot drops:
- Stinky-cap mushroom (poison/diseased food, sellable as reagent)
- corpse mushroom (highly poisonous food, sellable as reagent)
- golden mushroom (sellable as reagent)
- bone dust (sellable as reagent)
- blackened bone dust (sellable as reagent)
- avar feather (sellable as reagent)
- troll blood (sellable as reagent)
- mystery meat (food)
- milk (food)
- ancient sword/sword of pure ice* (weapon)

* this weapon has variable properties, intended to produce a variety of weapon variants as for-flavor monster drops without clogging up the class pool with dozens of new weapons

Changed the following item from a non-stackable misc item to a numbitem/reagent type to use in loot tables, because it currently has zero use in game, and just because it just makes sense:
- egg shell

Updated loot tables for the following monsters to reduce item clutter in rooms, which would lead to eventual blinking/disappearing objects:  (in short, removed or greatly reduced the rates of normal weapons, armors, potions, etc and replaced them with other things, including the new flavor items)
- battered skeleton
- tusked skeleton
- daemon skeleton
- avar warrior
- troll
- narthyl worm

Skeletons (all types) now drop ancient swords (CustomWeapon class, 35% chance, down from 100% when they dropped normal long swords) of varying quality.  They're mostly low/medium quality, but have a very rare (1:1000) chance to drop a high quality variant with a shiny white blade.  This variant is Meridian's first true "rare drop" item.

Updated loot tables for the following monsters, mostly just for flavor:
- baby spider
- spider
- giant rat/snow rat (shared table)

Updated the following loot tables because they were lousy for being bosses:
- queen spider

Updated the following loot tables for being over the top compared to the difficulty level of the monster:
- frogman

Added loot tables to the following monsters, which had none until now:
- ice creature
- cow
- guard cow

Ice creatures have a 15% chance to drop a blade of pure ice (CustomWeapon class) that is medium quality, deals slash + cold damage.  It "melts" (loses durability) over time until it breaks/deletes itself.  This drop chance is separate from the normal loot tables, similar to how skeleton swords drop.

Finally, set the unused cowX image resource to cows and guard cows to give them a corpse, but I'll admit it's pretty low-quality in its current state.  It's just the normal cow image, facing forward.  May be better off as blank.bgf, but a corpse of some type is needed so the trestype class doesn't freak out.