### PR TITLE
Add blink success message to the user

### DIFF
--- a/kod/object/passive/spell/blink.kod
+++ b/kod/object/passive/spell/blink.kod
@@ -22,8 +22,9 @@ resources:
 	 "Requires nothing but a will to move."
 
    blink_spell_intro = "Riija Level 1: The Trickster's most basic spell teleports you to the local place of power."
-   blink_cast_rsc = "Upon opening your eyes, you find yourself realigned with your surroundings"
-   blink_cast_special = "You find yourself...elsewhere"
+   blink_cast_rsc = "You find yourself realigned with your surroundings."
+   blink_cast_special = "You find yourself...elsewhere."
+   blink_cast_special_sound = blink_cast_special.wav
 classvars:
 
    vrName = blink_name_rsc
@@ -70,6 +71,7 @@ messages:
          {
             post(oRoom,@Teleport,#what=who);
             send(who, @MsgSendUser, #message_rsc=blink_cast_special);
+            send(who, @WaveSendUser, #wave_rsc=blink_cast_special_sound);
             propagate;
          }
       }
@@ -81,6 +83,7 @@ messages:
          {
             post(oRoom,@teleport,#what=who);
             send(who, @MsgSendUser, #message_rsc=blink_cast_special);
+            send(who, @WaveSendUser, #wave_rsc=blink_cast_special_sound);
             propagate;
          }
       }

--- a/kod/object/passive/spell/blink.kod
+++ b/kod/object/passive/spell/blink.kod
@@ -24,7 +24,6 @@ resources:
    blink_spell_intro = "Riija Level 1: The Trickster's most basic spell teleports you to the local place of power."
    blink_cast_rsc = "You find yourself realigned with your surroundings."
    blink_cast_special = "You find yourself...elsewhere."
-   blink_cast_special_sound = blink_cast_special.wav
 classvars:
 
    vrName = blink_name_rsc
@@ -71,7 +70,7 @@ messages:
          {
             post(oRoom,@Teleport,#what=who);
             send(who, @MsgSendUser, #message_rsc=blink_cast_special);
-            send(who, @WaveSendUser, #wave_rsc=blink_cast_special_sound);
+
             propagate;
          }
       }
@@ -83,7 +82,7 @@ messages:
          {
             post(oRoom,@teleport,#what=who);
             send(who, @MsgSendUser, #message_rsc=blink_cast_special);
-            send(who, @WaveSendUser, #wave_rsc=blink_cast_special_sound);
+
             propagate;
          }
       }

--- a/kod/object/passive/spell/blink.kod
+++ b/kod/object/passive/spell/blink.kod
@@ -22,7 +22,7 @@ resources:
 	 "Requires nothing but a will to move."
 
    blink_spell_intro = "Riija Level 1: The Trickster's most basic spell teleports you to the local place of power."
-
+   blink_cast_rsc = "Upon opening your eyes, you find yourself realigned with your surroundings"
 classvars:
 
    vrName = blink_name_rsc
@@ -85,7 +85,7 @@ messages:
       }
 
       send(owner,@Teleport,#what=who);  
-
+      send(who, @MsgSendUser, #message_rsc=blink_cast_rsc);
       propagate;
    }
 

--- a/kod/object/passive/spell/blink.kod
+++ b/kod/object/passive/spell/blink.kod
@@ -23,6 +23,7 @@ resources:
 
    blink_spell_intro = "Riija Level 1: The Trickster's most basic spell teleports you to the local place of power."
    blink_cast_rsc = "Upon opening your eyes, you find yourself realigned with your surroundings"
+   blink_cast_special = "You find yourself...elsewhere"
 classvars:
 
    vrName = blink_name_rsc
@@ -68,7 +69,7 @@ messages:
          if oRoom <> $
          {
             post(oRoom,@Teleport,#what=who);
-
+            send(who, @MsgSendUser, #message_rsc=blink_cast_special);
             propagate;
          }
       }
@@ -79,7 +80,7 @@ messages:
          if oRoom <> $
          {
             post(oRoom,@teleport,#what=who);
-
+            send(who, @MsgSendUser, #message_rsc=blink_cast_special);
             propagate;
          }
       }


### PR DESCRIPTION
This PR adds two text messages sent to the user after succeeding in casting blink.  Currently no message is sent and the user's text window simply states the user is concentrating on the spell and the only indication of success is the animation.  This can lead to confusion in cases where you are casting blink often and happen to look away and miss the animation and sound effect.

There are two rooms where you blink and are teleported to a different room as a secret.  These situations now have their own separate success message.