### PR TITLE
Very minor fixes and adjustments to items

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -303,6 +303,12 @@
    PT_ITEM_XLAT_BLUE_TO_SKIN2     = 0x9F
    PT_ITEM_XLAT_BLUE_TO_SKIN4     = 0xA0
 
+   % These will strip all color from the item, but note that
+   % the difference between each one is fairly subtle.
+   PT_GRAYSCALE_LIGHT             = 0x0036
+   PT_GRAYSCALE_MEDIUM            = 0x0032
+   PT_GRAYSCALE_DARK              = 0x0033
+
    % Metallic and other colors added for more flexibility
    % with coloring items using constants
    PT_MET_RED        = 0x004D       % metallic red #77

--- a/kod/object/item/passitem/numbitem/ammo/firearow.kod
+++ b/kod/object/item/passitem/numbitem/ammo/firearow.kod
@@ -21,8 +21,9 @@ resources:
 
    fire_arrow_name_rsc = "fire arrows"
    fire_arrow_icon_rsc = arrowfir.bgf
-   fire_arrow_desc_rsc = "These arrows do excellent damage, burning "
-      " brightly, they burn for extra damage."
+   fire_arrow_desc_rsc = \
+      "The enchanted, searing-hot heads of these arrows glow menacingly, "
+      "making them the clear choice for taking aim against flammable targets."
 
 classvars:
 

--- a/kod/object/item/passitem/numbitem/food/gobletwn.kod
+++ b/kod/object/item/passitem/numbitem/food/gobletwn.kod
@@ -44,7 +44,7 @@ properties:
    viFilling = 8
    viNutrition = 6
    piNumber = 1
-   piItem_flags = 50    % Pewter color to set it apart from goblet of ale
+   piItem_flags = PT_GRAYSCALE_MEDIUM    % Pewter color to set it apart from goblet of ale
 
 messages:
 

--- a/kod/object/item/passitem/numbitem/food/gobletwn.kod
+++ b/kod/object/item/passitem/numbitem/food/gobletwn.kod
@@ -44,6 +44,7 @@ properties:
    viFilling = 8
    viNutrition = 6
    piNumber = 1
+   piItem_flags = 50    % Pewter color to set it apart from goblet of ale
 
 messages:
 

--- a/kod/object/item/passitem/numbitem/food/kocmug.kod
+++ b/kod/object/item/passitem/numbitem/food/kocmug.kod
@@ -16,10 +16,10 @@ constants:
 
 resources:
 
-   kocatanmug_name_rsc = "copper pekonch mugs"
+   kocatanmug_name_rsc = "mug of Pekonch"
    kocatanmug_icon_rsc = mug2.bgf
    kocatanmug_desc_rsc = \
-      "Wine that is thick enough, you could stand a dagger up in it."
+      "This Ko'catani wine is so thick you could stand a dagger up in it."
    kocatanmug_name_plural_rsc = "mugs of Pekonch"
 
    kocatanmug_disp_name = "pitcher of pekonch"

--- a/kod/object/item/passitem/numbitem/food/mug.kod
+++ b/kod/object/item/passitem/numbitem/food/mug.kod
@@ -57,7 +57,7 @@ properties:
    viNutrition = 6
    piNumber = 1
 
-   piItem_flags = 57   % Slight golden hue to set it apart from mug of stout
+   piItem_flags = PT_BLEND25YELLOW   % Slight golden hue to set it apart from mug of brew
 
 messages:
 

--- a/kod/object/item/passitem/numbitem/food/mug.kod
+++ b/kod/object/item/passitem/numbitem/food/mug.kod
@@ -19,7 +19,8 @@ resources:
    mug_name_rsc = "mug of stout"
    mug_icon_rsc = mug.bgf
    mug_desc_rsc = \
-      "A dark hazelnut stout with a thick head of foam."
+      "A dark hazelnut stout with a thick head of foam fills this large, "
+      "well-crafted mug."
 
    mug_name_plural_rsc = "mugs of stout"
 
@@ -55,6 +56,8 @@ properties:
    viFilling = 8
    viNutrition = 6
    piNumber = 1
+
+   piItem_flags = 57   % Slight golden hue to set it apart from mug of stout
 
 messages:
 

--- a/kod/object/item/passitem/numbitem/food/soup.kod
+++ b/kod/object/item/passitem/numbitem/food/soup.kod
@@ -49,6 +49,7 @@ properties:
    viFilling = 20
    viNutrition = 9
    piNumber = 1
+   piItem_flags = 82   % Slight blue hue to set it apart from bowl of stew
 
 messages:
 

--- a/kod/object/item/passitem/numbitem/food/soup.kod
+++ b/kod/object/item/passitem/numbitem/food/soup.kod
@@ -49,7 +49,7 @@ properties:
    viFilling = 20
    viNutrition = 9
    piNumber = 1
-   piItem_flags = 82   % Slight blue hue to set it apart from bowl of stew
+   piItem_flags = PT_BLEND25BLUE   % Slight blue hue to set it apart from bowl of stew
 
 messages:
 

--- a/kod/object/item/passitem/spelitem/scroll/makefile
+++ b/kod/object/item/passitem/spelitem/scroll/makefile
@@ -5,9 +5,9 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\scroll.bof
-BOFS = mrtrscrl.bof lghtscrl.bof darkscrl.bof discscrl.bof \
+BOFS = darkscrl.bof discscrl.bof \
       disilscl.bof earthscl.bof firitscl.bof flashscl.bof \
-      heatscrl.bof killfscl.bof lghtscrl.bof \
+      foflscrl.bof heatscrl.bof killfscl.bof lghtscrl.bof \
       mrtrscrl.bof pfogscrl.bof sporescl.bof trucescl.bof \
       windscrl.bof
 

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -4838,6 +4838,7 @@ messages:
       plItemTemplates = cons(create(&Arrow),plItemTemplates);
       plItemTemplates = cons(create(&SilverArrow),plItemTemplates);
       plItemTemplates = cons(create(&NeruditeArrow),plItemTemplates);
+      plItemTemplates = cons(create(&FireArrow),plItemTemplates);
 
       plItemTemplates = cons(create(&Apple),plItemTemplates);
       plItemTemplates = cons(create(&Bread),plItemTemplates);
@@ -4979,6 +4980,7 @@ messages:
       plItemTemplates = cons(create(&DispellIllusionScroll),plItemTemplates);
       plItemTemplates = cons(create(&FinalRitesScroll),plItemTemplates);
       plItemTemplates = cons(create(&FlashScroll),plItemTemplates);
+      plItemTemplates = cons(create(&ForcesOfLightScroll),plItemTemplates);
       plItemTemplates = cons(create(&HeatScroll),plItemTemplates);
       plItemTemplates = cons(create(&KillingFieldScroll),plItemTemplates);
       plItemTemplates = cons(create(&MartyrScroll),plItemTemplates);


### PR DESCRIPTION
This cleans up some minor grammatical mistakes in a few items, recolors certain stackable foods with duplicate appearances, and adds a scroll that was left out of the makefile:

- mug of stout:  Given a lighter goldish hue to set it apart from mug of brew.  Also expanded its very basic description a bit.
- copper pekonch mugs:  improperly named singular name (copper pekonch mugs) changed to "mug of Pekonch" to match its plural form.  Cleaned up its weirdly-phrased description a bit.
- bowl of soup:  Given a very slight bluish hue to set it apart from bowl of stew.
- goblet of wine:  Changed to a pewter color to set it apart from goblet of ale.
- fire arrow:  Fixed the grammatical mess in its description.  Also properly added it to the item templates.
- scroll makefile:  Added missing forces of light scroll, then added it to the item templates.  Removed duplicate entries for 2 other scrolls.