### PR TITLE
Fellowship groups

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -176,6 +176,8 @@ resources:
    player_aggressor = "Shal'ille frowns upon your unprovoked attack."
    player_safety_caught = \
       "Hey!  You almost hit %s%s!  Good thing your safety was on!"
+   fellowship_no_attack = \
+      "You can't attack %s, %s's a member of your fellowship!"
 
    player_safe_server = \
       "You are not allowed to attack other players in this world."
@@ -747,6 +749,8 @@ properties:
    % player starts unguilded--doesn't do much yet
    poGuild = $
    piGuildRejoinTimestamp = 0
+
+   poFellowship = $
 
    % list of spells we know, in the form of a 3-part compound
    plSpells = $
@@ -3647,6 +3651,15 @@ messages:
    {
       local oEnemyGuild, oSoldierShield;
 
+	  % Fellowships prevent combat between members.
+	  if Send(self,@GetFellowship) <> $
+	     AND IsClass(victim,&Player)
+		 AND Send(victim,@GetFellowship) = Send(self,@GetFellowship)
+      {
+         Send(self,@MsgSendUser,#message_rsc=fellowship_no_attack,#parm1=Send(victim,@GetName),#parm2=Send(victim,@GetHeShe));
+         return FALSE;
+      }
+
       % Don't care about monsters.
       % And, free attacks on token holders.
       if IsClass(victim,&Monster)
@@ -6489,6 +6502,18 @@ messages:
       }
       
       return;
+   }
+   
+   SetFellowship(fellowship_obj=$)
+   "Sets the player's poFellowship to be equal to the fellowship object."
+   {
+      poFellowship = fellowship_obj;
+      return;
+   }
+   
+   GetFellowship()
+   {
+      return poFellowship;
    }
 
    %%%  Spells Stuff

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2395,8 +2395,10 @@ messages:
                      iFlags = (iFlags | PLAYER_IS_GUILDMATE);
                   }
 
-                  if Send(poGuild,@IsAlly,#otherguild=oOtherGuild)
-                     AND Send(oOtherGuild,@IsAlly,#otherguild=poGuild)
+                  if (Send(poGuild,@IsAlly,#otherguild=oOtherGuild)
+                     AND Send(oOtherGuild,@IsAlly,#otherguild=poGuild))
+                     OR (Send(self,@GetFellowship) <> $
+                        AND Send(self,@GetFellowship) = Send(what,@GetFellowship))
                   {
                      iFlags = (iFlags | PLAYER_IS_FRIEND);
                   }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -652,6 +652,11 @@ messages:
       Send(self,@BreakTrance);
       pbLogged_on = FALSE;
 
+      if Send(self,@GetFellowship) <> $
+      {
+         Send(Send(self,@GetFellowship),@RemoveFromFellowship,#who=self,#logoff=TRUE);
+      }
+
       Send(self,@CancelIfOffer);
       Send(self,@UserLogoffHook);
 

--- a/kod/object/passive/fellowship.kod
+++ b/kod/object/passive/fellowship.kod
@@ -32,9 +32,6 @@ resources:
    fellowship_induct_already_fellowed = "You are already the member of a fellowship."
    fellowship_induct_already_member = "You are already a member of this fellowship."
 
-   fellowship_allies_defunct = "~BYour allied fellowship, %s%q, has disbanded."
-   fellowship_enemies_defunct = "~BYour enemy fellowship, %s%q, has disbanded."
-
    fellowship_ranks_full = \
       "~BYou could not be accepted into %s%q because the fellowship is already full."
    fellowship_ranks_full_inductor = \
@@ -257,6 +254,11 @@ messages:
          {
             Send(oOwner,@SomethingChanged,#what=who);
          }
+      
+         if plMembers = $
+         {
+            Post(self,@Delete);
+         }
 
          return TRUE;
       }
@@ -264,19 +266,6 @@ messages:
       DEBUG("Was not a member of this fellowship!");
       
       return FALSE;
-   }
-
-   DefunctFellowship(what=$)
-   {
-      local i;
-
-      % Reset friend/foe colors
-      for i in plMembers
-      {
-         Send(i,@ToCliRoomContents);
-      }
-
-      return;
    }
 
    Delete()

--- a/kod/object/passive/fellowship.kod
+++ b/kod/object/passive/fellowship.kod
@@ -1,0 +1,340 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Fellowship is PassiveObject 
+
+constants:
+
+   include blakston.khd
+   include protocol.khd
+
+   % maximum number of people allowed in a fellowship.
+   MAX_MEMBERS = 10
+
+resources:
+
+   fellowship_name_rsc = "fellowship"
+   fellowship_icon_rsc = light.bgf
+   fellowship_desc_rsc = "A loose grouping of individuals on an adventure."
+
+   fellowship_title = "Member"
+
+   fellowship_newly_formed = "~BYour new fellowship has been formed."
+
+   fellowship_welcome = "~BPlease welcome the newest member of %s%q, %s."
+   fellowship_induct_already_fellowed = "You are already the member of a fellowship."
+   fellowship_induct_already_member = "You are already a member of this fellowship."
+
+   fellowship_allies_defunct = "~BYour allied fellowship, %s%q, has disbanded."
+   fellowship_enemies_defunct = "~BYour enemy fellowship, %s%q, has disbanded."
+
+   fellowship_ranks_full = \
+      "~BYou could not be accepted into %s%q because the fellowship is already full."
+   fellowship_ranks_full_inductor = \
+      "~B%s%s could not be accepted into %s%q because the fellowship is already full."
+
+   fellowship_invitation_one = \
+      "You may only have one outstanding fellowship invitation at a time."
+   fellowship_invitation_one_inductee = \
+      "Someone in your fellowship has already issued %s%s an invitation."
+   
+classvars:
+
+   vrIcon = fellowship_icon_rsc
+   vrDesc = fellowship_desc_rsc
+
+properties:
+
+   % Settable by players
+   vrName = fellowship_name_rsc
+
+   % This is a list of members
+   plMembers = $
+
+   % Secret fellowships do not advertise their existence.
+   pbSecret = FALSE
+
+   % These are stored only so that, if the fellowship goes while an invitation is
+   %  extended, the invitation disappears.
+   plInvitations = $
+
+   % Leader can set and unset certain options
+   pbCanFellowshipLoot = TRUE
+   pbCanAnyMemberInvite = TRUE
+   
+messages:
+
+   Constructor(fellowshipname = fellowship_name_rsc, secret = FALSE, master = $)
+   {
+      vrName = fellowshipname;
+
+      % Is the fellowship secret?
+      pbSecret = secret;
+
+      plMembers = cons(master, plMembers);
+
+      Send(master,@SetFellowship,#fellowship_obj=self);
+      Send(master,@MsgSendUser,#message_rsc=fellowship_newly_formed);
+
+      Send(SYS,@NewFellowship,#what=self);
+
+      propagate;
+   }
+
+   IsSecret()
+   {
+      return pbSecret;
+   }
+
+   CheckInvitationList(inductor = $, inductee = $)
+   {
+      local i;
+
+      for i in plInvitations
+      {
+         if Send(i,@GetInductor) = inductor
+         {
+            Send(inductor,@MsgSendUser,#message_rsc=fellowship_invitation_one);
+            
+            return FALSE;
+         }
+      }
+      
+      for i in plInvitations
+      {
+         if Send(i,@GetInductee) = inductee
+         {
+            Send(inductor,@MsgSendUser,
+                 #message_rsc=fellowship_invitation_one_inductee,
+                 #parm1=Send(inductee,@GetDef),
+                 #parm2=Send(inductee,@GetName));
+                 
+            return FALSE;
+         }
+      }
+
+      return TRUE;
+   }
+
+%   AddInvitation(invite_obj = $)
+%  "Adds the invitation to the list.  This list is stored only so it can"
+%   "be deleted if the fellowship is deleted."
+%   {
+%      plInvitations = cons(invite_obj, plInvitations);
+%      
+%      return;
+%   }
+
+%   RemoveInvitation(invite_obj = $)
+%   {
+%      local i;
+%
+%      for i in plInvitations
+%      {
+%         if i = invite_obj
+%         {
+%            plInvitations = DelListElem(plInvitations, i);
+%            
+%            return TRUE;
+%         }
+%      }
+%      
+%      DEBUG("invitation wasn't here!");
+%      
+%      return FALSE;
+%   }
+
+   GetMemberList()
+   {
+      return plMembers;
+   }
+
+   IsMember(who=$)
+   {
+      local i;
+
+      for i in plMembers
+      {
+         if i = who
+         {
+            return TRUE;
+         }
+      }
+      
+      return FALSE;
+   }
+
+   InductNewMember(who=$,inductor=$)
+   {
+      local i;
+
+      if length(plMembers) >= MAX_MEMBERS
+      {
+         Send(who,@MsgSendUser,#message_rsc=fellowship_ranks_full,
+              #parm1=Send(self,@GetDef),#parm2=vrName);
+              
+         if inductor <> $
+         {
+            Send(inductor,@MsgSendUser,#message_rsc=fellowship_ranks_full_inductor,
+                 #parm1=Send(who,@getcapdef),#parm2=Send(who,@GetName),
+                 #parm3=Send(self,@GetDef),#parm4=vrName);
+         }
+         
+         return FALSE;
+      }
+      
+      for i in plMembers
+      {
+         if i = who
+         {
+            Send(who,@MsgSendUser,#message_rsc = fellowship_induct_already_member);
+            
+            return FALSE;
+         }
+      }
+      
+      if Send(who,@GetFellowship) <> $
+      {
+         Send(who,@MsgSendUser,#message_rsc = fellowship_induct_already_fellowed);
+         
+         return FALSE;
+      }
+     
+      % Cleared checks.  Go ahead and set the fellowship.
+
+      Send(who,@SetFellowship,#fellowship_obj=self);
+      plMembers = cons(who,plMembers);
+
+      for i in plMembers
+      {
+         Send(i,@MsgSendUser,#message_rsc=fellowship_welcome,
+              #parm1=Send(self,@GetDef),#parm2=Send(self,@GetName),
+              #parm3=Send(who,@GetTrueName));
+
+         % Reset friend/foe colors
+         Send(i,@ToCliRoomContents);
+      }
+
+      return TRUE;
+   }
+
+   RemoveFromFellowship(who=$,logoff=FALSE)
+   {
+      local i, bFound, oOwner;
+
+      bFound = FALSE;
+
+      for i in plMembers
+      {
+         if i = who
+         {
+            plMembers = DelListElem(plMembers,i);
+            bFound = TRUE;
+         }
+
+         % Reset friend/foe colors for everyone
+         if NOT logoff
+         {
+            Send(i,@ToCliRoomContents);
+         }
+      }
+      
+      if bFound = TRUE
+         AND NOT logoff
+      {
+         % If this player has an owner (is logged on), then let the room know
+         %  something changed so that other players can reset friend/foe
+         %  colors.
+         oOwner = Send(who,@GetOwner);
+         if oOwner <> $
+         {
+            Send(oOwner,@SomethingChanged,#what=who);
+         }
+
+         return TRUE;
+      }
+      
+      DEBUG("Was not a member of this fellowship!");
+      
+      return FALSE;
+   }
+
+   DefunctFellowship(what=$)
+   {
+      local i;
+
+      % Reset friend/foe colors
+      for i in plMembers
+      {
+         Send(i,@ToCliRoomContents);
+      }
+
+      return;
+   }
+
+   Delete()
+   "Kick all members out First!"
+   {
+      local i;
+
+      for i in plMembers
+      {
+         Send(self,@RemoveFromFellowship,#who=i);
+      }
+      
+      if plMembers <> $
+      {
+         debug("plMembers not fully empty!",Send(self,@GetName));
+         
+         plMembers = $;
+      }
+
+      % Delete any outstanding invites
+      for i in plInvitations
+      {
+         Send(i,@InvitationVanish);
+      }
+      
+      plInvitations = $;
+
+      Send(SYS,@DefunctFellowship,#what=self);
+
+      propagate;
+   }
+
+   GetMaxMembers()
+   {
+      return MAX_MEMBERS;
+   }
+
+   SetCanFellowshipLoot(value=TRUE)
+   {
+      pbCanFellowshipLoot = value;
+      return;
+   }
+
+   SetCanAnyMemberInvite(value=TRUE)
+   {
+      pbCanAnyMemberInvite = value;
+      return;
+   }
+
+   GetCanFellowshipLoot()
+   {
+      return pbCanFellowshipLoot;
+   }
+
+   GetCanAnyMemberInvite()
+   {
+      return pbCanAnyMemberInvite;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/itematt/iacorptr.kod
+++ b/kod/object/passive/itematt/iacorptr.kod
@@ -56,9 +56,23 @@ messages:
 
    CanGetAffectedItem(lData = $, who = $, oItem = $)
    {
-      local oCorpse;
+      local oCorpse, sCorpseName, oPlayer;
      
       oCorpse = nth(lData,3);
+      
+      if Send(who,@GetFellowship) <> $
+         AND Send(Send(who,@GetFellowship),@CanFellowshipLoot)
+      {
+         sCorpseName = Send(oCorpse,@GetCorpseName);
+         
+         for oPlayer in Send(Send(who,@GetFellowship),@GetMemberList)
+         {
+            if Send(oPlayer,@GetTrueName) = sCorpseName
+            {
+               return TRUE;
+            }
+         }
+      }
      
       % If the corpse object is pointing at who, then 'who' can pick up this item.
       if NOT send(oCorpse,@CanGetMe,#what=who)

--- a/kod/object/passive/makefile
+++ b/kod/object/passive/makefile
@@ -18,6 +18,6 @@ BOFS = tree.bof spell.bof boulder.bof news.bof trestype.bof arsign01.bof \
         bookped.bof flikerer.bof pfirewll.bof viewglbe.bof trgtglbe.bof \
 	pltngwll.bof nectome.bof modlnode.bof wrmtrail.bof fogcloud.bof \
 	bell.bof dflycage.bof pillow.bof ghostitm.bof ventstem.bof shrinfog.bof \
-	psporec.bof evntsign.bof maillist.bof
+	psporec.bof evntsign.bof maillist.bof fellowship.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -260,6 +260,7 @@ properties:
    plBanks = $
    plVaults = $
    plGuilds = $
+   plFellowships = $
    plGuild_halls = $
    plBrains = $
    plAbility_totals = $
@@ -4114,6 +4115,26 @@ messages:
       return TRUE;
    }
 
+   NewFellowship(what=$)
+   "Adds the fellowship to the system's master list of fellowships."
+   {
+      local i;
+
+      for i in plFellowships
+      {
+         if i = what
+         {
+            Debug("tried to add a fellowship to system that already existed!",what);
+
+            return FALSE;
+         }
+      }
+   
+      plFellowships = cons(what,plFellowships);
+
+      return TRUE;
+   }
+
    ResetGuilds()
    "This will delete all the guilds, and also recreate all of the guild halls."
    "Admin/testing command only."
@@ -4172,9 +4193,40 @@ messages:
       return;
    }
 
+   DefunctFellowship(what = $)
+   "Removes the fellowship in question from the fellowship list."
+   {
+      local i, found_elem;
+
+      found_elem = $;
+
+      for i in plFellowships
+      {
+         if i = what
+         {
+            found_elem = i;
+         }
+      }
+
+      if found_elem <> $
+      {
+         plFellowships = DelListElem(plFellowships,found_elem);
+      }
+      else
+      {
+         Debug("Defuncted a fellowship that didn't exist!");
+      }
+      return;
+   }
+
    GetGuilds()
    {
       return plGuilds;
+   }
+
+   GetFellowships()
+   {
+      return plFellowships;
    }
 
    SetSafety()


### PR DESCRIPTION
Created by player request, as seen in the Feedback & Ideas Discord channel.

A Fellowship is an incredibly simplified association limited to 10 members max. Members are kicked when they log off, they can join and leave at any time, and the Fellowship ceases to exist when no members remain. The Fellowship does not alter any PvP state except preventing members from attacking each other, so that whites / oranges / reds / soldiers can safely play together if desired.

I have not yet added any sort of UI for a non-admin to actually create and manage a Fellowship. There are a great many ways that could actually be done, which is a whole other discussion. This pull request is intended to gauge interest, no sense in making some complex interface unless this is actually a desired addition. In the event we want it, I would suggest it's just a command we give all players, 'create fellowship,' and perhaps create a simple screen like the guild UI that is accessed by typing 'fellowship,' complete with invites, member list, and some options to check.

System.kod change:
Adding a global list of fellowships that can be added to or removed from.

Player.kod change:
Fellowships prevent members from attacking each other.

User.kod changes:
Fellowship members appear as 'ally' green dots.
Users are removed from a fellowship upon logoff.

Corpse pointer change:
Fellowships allow members to loot from each other's kills without waiting for the loot timer, if that option is set for the fellowship.