### PR TITLE
Reflections and Evil Twins don't change karma upon being killed, except at the Riija Temple

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4802,6 +4802,12 @@ messages:
       }
 
       if IsClass(what,&Monster)
+         AND NOT (IsClass(what,&Reflection)
+            AND NOT (Send(self,@GetOwner) <> $
+               AND Send(Send(self,@GetOwner),@GetRoomNum) = RID_TEMPLE_RIIJA))
+         AND NOT (IsClass(what,&EvilTwin)
+            AND NOT (Send(self,@GetOwner) <> $
+               AND Send(Send(self,@GetOwner),@GetRoomNum) = RID_TEMPLE_RIIJA))
       {         
          Send(self,@AddKarma,#amount=Send(self,@CalculateKarmaChangeFromKill,
               #karma_victim=Send(what,@GetKarma),#karma_killer=Send(self,@GetKarma)),


### PR DESCRIPTION
By player request, Evil Twins and Reflections no longer ruin your karma except at the Temple of Riija.

Notably, this preserves them actually having karma values for the purposes of spells and abilities. It just doesn't alter a player's karma upon killing one unless they are at the Temple of Riija. The purpose of the Temple exception is 1: because illusions are more real there, and 2: to preserve the player behavior of 'fixing your karma' by purposely killing the reflections of an ally or mule. You can still do that, you'll just have to do it at the Riija Temple.