### PR TITLE
Additional commands and copied key control for rented room management

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqinnk.kod
@@ -36,6 +36,7 @@ resources:
    BarloqueInnkeeper_cost4 = " shillings if thou wishest to share thine room with a special someone."
 
    BarloqueInnkeeper_days_left = "I thanketh thee.  Thou hast %q days left at my luxurious inn."
+   BarloqueInnkeeper_days_left_check = "Thy room hast %q Meridian days left.  ~I(%q days in real time.)"
    BarloqueInnkeeper_too_long = "It pleaseth me that ye liketh thine room, but thou hast paid enough in rent already!  I canst not accept more from you right now."
 
    BarloqueInnkeeper_destroy_key_copy = "~kPritchett tells you, \"I will discardeth the key for thou.\""
@@ -44,6 +45,8 @@ resources:
    BqInn_rent_command = "rent"
    BqInn_cost_command = "cost"
    BqInn_copy_key_command = "copy key"
+   BqInn_change_lock_command = "change lock"
+   BqInn_help_command = "help"
 
 classvars:
 
@@ -155,7 +158,7 @@ messages:
 
    SomeoneSaid(what = $,type = $,string = $)
    {
-      local oRoomMaint, rSayRsc;
+      local oRoomMaint, rSayRsc, iDaysLeft;
       
       if isClass(what,&User)
       {
@@ -184,6 +187,39 @@ messages:
 
             % tell the player.
             Post(poOwner,@SomeoneSaid,#type=SAY_RESOURCE,#what=self,#string=rSayRsc);
+
+            return;
+         }
+
+         if (StringContain(string, BqInn_room_command) AND StringContain(string, BqInn_help_command))
+            OR (StringContain(string, "room") AND StringContain(string, "help"))
+         {
+            Send(oRoomMaint, @GetHelpMessage, #who=what, #iRentCost=piInitialRoomCost,
+               #iCopyCost=piKeyCopyCosts, #iDayCost=piPerDayCost);
+
+            return;
+         }
+
+         if StringContain(string, BqInn_change_lock_command)
+            OR (StringContain(string, "change") AND StringContain(string, "lock"))
+         {
+            rSayRsc = Send(oRoomMaint, @ChangeLock, #who=what, #iLocation=RID_BAR_INN);
+
+            Post(poOwner, @SomeoneSaid, #type=SAY_RESOURCE, #what=self, #string=rSayRsc);
+
+            return;
+         }
+
+         if StringContain(string, BqInn_rent_command) OR StringContain(string, "rent")
+         {
+            iDaysLeft = Send(oRoomMaint, @CheckRent, #who=what, #iLocation=RID_BAR_INN);
+
+            if iDaysLeft <> $
+            {
+               Post(poOwner, @SomeoneSaid, #type=SAY_RESOURCE, #what=self, #string=BarloqueInnkeeper_days_left_check,
+                  #parm1=Send(SYS, @IntToString, #num=iDaysLeft), #type1=STRING_RESOURCE,
+                  #parm2=Send(SYS, @IntToString, #num=iDaysLeft / 12), #type2=STRING_RESOURCE);
+            }
 
             return;
          }

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcinnk.kod
@@ -45,6 +45,7 @@ resources:
    KocatanInnkeeper_days_left = \
       "You like it here, I see.  There are %q days until you should "
       "pay me again."
+   KocatanInkeeper_days_left_check = "The room is yours for %q Meridian days.  ~I(%q days in real time.)"
    KocatanInnkeeper_too_long = \
       "Oh, I can't be responsible for holding so much money!  Pay me again "
       "later when you don't have so many days left on your tab."
@@ -57,6 +58,8 @@ resources:
    KoIk_rent_command = "rent"
    KoIk_cost_command = "cost"
    KoIk_copy_key_command = "copy key"
+   KoIk_change_lock_command = "change lock"
+   KoIk_help_command = "help"
 
 classvars:
 
@@ -194,7 +197,7 @@ messages:
 
    SomeoneSaid(what=$,string=$)
    {
-      local oRoomMaint, rSayRsc;
+      local oRoomMaint, rSayRsc, iDaysLeft;
       
       if IsClass(what,&User)
       {
@@ -226,6 +229,39 @@ messages:
             % Tell the player.
             Post(poOwner,@SomeoneSaid,#type=SAY_RESOURCE,
                   #what=self,#string=rSayRsc);
+
+            return;
+         }
+
+         if (StringContain(string, KoIk_room_command) AND StringContain(string, KoIk_help_command))
+            OR (StringContain(string, "room") AND StringContain(string, "help"))
+         {
+            Send(oRoomMaint, @GetHelpMessage, #who=what, #iRentCost=piInitialRoomCost,
+               #iCopyCost=piKeyCopyCosts, #iDayCost=piPerDayCost);
+
+            return;
+         }
+
+         if StringContain(string, KoIk_change_lock_command)
+            OR (StringContain(string, "change") AND StringContain(string, "lock"))
+         {
+            rSayRsc = Send(oRoomMaint, @ChangeLock, #who=what, #iLocation=RID_KOC_INN);
+
+            Post(poOwner, @SomeoneSaid, #type=SAY_RESOURCE, #what=self, #string=rSayRsc);
+
+            return;
+         }
+
+         if StringContain(string, KoIk_rent_command) OR StringContain(string, "rent")
+         {
+            iDaysLeft = Send(oRoomMaint, @CheckRent, #who=what, #iLocation=RID_KOC_INN);
+
+            if iDaysLeft <> $
+            {
+               Post(poOwner, @SomeoneSaid, #type=SAY_RESOURCE, #what=self, #string=KocatanInkeeper_days_left_check,
+                  #parm1=Send(SYS, @IntToString, #num=iDaysLeft), #type1=STRING_RESOURCE,
+                  #parm2=Send(SYS, @IntToString, #num=iDaysLeft / 12), #type2=STRING_RESOURCE);
+            }
 
             return;
          }

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/marntwn/mrinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/marntwn/mrinnk.kod
@@ -33,6 +33,7 @@ resources:
    MarionInnkeeper_cost4 = " shillings to make.  I know you'll like your room."
 
    MarionInnkeeper_days_left = "You like it here, I see.  There are %q days until you should pay me again."
+   MarionInnkeeper_days_left_check = "The room is yours for %q Meridian days.  ~I(%q days in real time.)"
    MarionInnkeeper_too_long = "Oh, I can't be responsible for holding so much money!  Pay me again later when you don't have so many days left on your tab."
 
    MarionInnkeeper_destroy_key_copy = "~kMorrigan tells you, \"Oh, yes. I can get rid of this key for you.  No problem.\""
@@ -41,6 +42,8 @@ resources:
    MrIk_rent_command = "rent"
    MrIk_cost_command = "cost"
    MrIk_copy_key_command = "copy key"
+   MrIk_change_lock_command = "change lock"
+   MrIk_help_command = "help"
 
 classvars:
 
@@ -62,7 +65,7 @@ messages:
    % special handling to make him laugh at Tova's chatter
    SomeoneSaid(what=$,string=$)
    {
-      local oRoomMaint, rSayRsc;
+      local oRoomMaint, rSayRsc, iDaysLeft;
 
       % if it's Tova talking
       if IsClass(what, &MarionBartender)
@@ -107,6 +110,39 @@ messages:
             return;
          }
 
+         if (StringContain(string, MrIk_room_command) AND StringContain(string, MrIk_help_command))
+            OR (StringContain(string, "room") AND StringContain(string, "help"))
+         {
+            Send(oRoomMaint, @GetHelpMessage, #who=what, #iRentCost=piInitialRoomCost,
+               #iCopyCost=piKeyCopyCosts, #iDayCost=piPerDayCost);
+
+            return;
+         }
+
+         if StringContain(string, MrIk_change_lock_command)
+            OR (StringContain(string, "change") AND StringContain(string, "lock"))
+         {
+            rSayRsc = Send(oRoomMaint, @ChangeLock, #who=what, #iLocation=RID_MAR_INN);
+
+            Post(poOwner, @SomeoneSaid, #type=SAY_RESOURCE, #what=self, #string=rSayRsc);
+
+            return;
+         }
+
+         if StringContain(string, MrIk_rent_command) OR StringContain(string, "rent")
+         {
+            iDaysLeft = Send(oRoomMaint, @CheckRent, #who=what, #iLocation=RID_MAR_INN);
+
+            if iDaysLeft <> $
+            {
+               Post(poOwner, @SomeoneSaid, #type=SAY_RESOURCE, #what=self, #string=MarionInnkeeper_days_left_check,
+                  #parm1=Send(SYS, @IntToString, #num=iDaysLeft), #type1=STRING_RESOURCE,
+                  #parm2=Send(SYS, @IntToString, #num=iDaysLeft / 12), #type2=STRING_RESOURCE);
+            }
+
+            return;
+         }
+
          if (StringContain(string,MrIk_room_command) AND StringContain(string,MrIk_cost_command))
             OR (StringContain(string,"room") AND StringContain(string,"cost"))
          {
@@ -123,7 +159,7 @@ messages:
                  #parm1=GetTempString(),#type1=0);
 
             return;
-         }          
+         }
       }
 
       propagate;

--- a/kod/object/item/passitem/roomkeyc.kod
+++ b/kod/object/item/passitem/roomkeyc.kod
@@ -33,6 +33,10 @@ resources:
 
    RoomKeyCopy_no_drop_room = "You cannot drop your key here."
 
+   RoomKeyCopy_no_drop_not_yours = \
+      "You can't just carelessly discard %s's room key like that!  You must return "
+      "it to either them or the innkeeper."
+
    RoomKeyCopy_no_token = "You can't let go of your token to fit your key into the lock."
 
 classvars:
@@ -191,6 +195,22 @@ messages:
 
    ReqNewOwner(what=$)
    {
+      local oRoom, oRenter;
+
+      oRoom = Send(SYS, @FindRoomByNum, #num=piRID);
+      oRenter = Send(oRoom, @GetRenter);
+
+      % If you're not the room owner, don't allow the key to be given to
+      % anyone besides the owner or dropped somewhere.  This gives the
+      % room owner more control over who has their various copies.
+      if IsClass(poOwner, &User) AND poOwner <> oRenter AND what <> oRenter
+      {
+         Send(poOwner, @MsgSendUser, #message_rsc=RoomKeyCopy_no_drop_not_yours,
+            #parm1=Send(oRenter, @GetName));
+
+         return FALSE;
+      }
+
       % No dropping in rentable rooms to circumvent the room expiration code
       if what <> $ AND isClass(what,&RentableRoom)
       {

--- a/kod/object/item/passitem/roomkeyc/roomkey.kod
+++ b/kod/object/item/passitem/roomkeyc/roomkey.kod
@@ -63,6 +63,30 @@ messages:
       return oCopy;
    }
 
+   HasCopies()
+   {
+      if plCopies <> $
+      {
+         return TRUE;
+      }
+      return FALSE;
+   }
+
+   DeleteCopies()
+   {
+      local oKeyCopy;
+      for oKeyCopy in plCopies
+      {
+         % Despite the name, this function just deletes the copy and
+         % informs the user if they're online.
+         Send(oKeyCopy, @OriginalDeleted);
+      }
+
+      plCopies = $;
+
+      return;
+   }
+
    RoomExpired(iRID=$)
    {
       if (iRID = $) or (iRID <> piRID)

--- a/kod/util/rntmaint.kod
+++ b/kod/util/rntmaint.kod
@@ -23,6 +23,21 @@ resources:
    RoomMaintenance_no_key = "Where is the key from this inn to copy?"
    RoomMaintenance_no_copy_copy = "You may not copy a copy of a room key."
    RoomMaintenance_copy_no_money = "You cannot afford a copy of your room key."
+   RoomMaintenance_change_lock = \
+      "Very well, I'll change the lock to your room.  This will destroy all "
+      "existing copies of your room key."
+   RoomMaintenance_no_copies_change_lock = \
+      "There aren't currently any copies of your room key out in circulation."
+   RoomMaintenance_no_key_change_lock = \
+      "You don't even have a room here, so how could I change the lock?"
+   RoomMaintenance_help_message = \
+      "~BHelp Room:~B  Displays this message.\n"
+      "~BRent Room:~B  Rents a room at this particular location.  ~ICost: %i~I\n"
+      "~BCopy Key:~B  Creates a tradeable copy of your room key.  ~ICost: %i~I\n"
+      "~BChange Lock:~B  Destroys all copies of your room key in circulation.\n"
+      "~BRent:~B  Displays the amount of time remaining for your room.\n"
+      "To buy additional time, offer shillings to the innkeeper.  ~ICost: %i "
+      "per Meridian day (2 hours real time), %i Meridian days maximum.~I"
 
 properties:
 
@@ -107,7 +122,48 @@ messages:
 
       % Return $ so that the innkeeper gives a friendly message in the local flavor.
       return $;
-   }   
+   }
+
+   ChangeLock(who=$, iLocation=$)
+   {
+      local lPassive, oObject, oKey, bHasRoomKey;
+
+      % Check for gold room key.
+      bHasRoomKey = FALSE;
+      lPassive = Send(who, @GetHolderPassive);
+
+      for oObject in lPassive
+      {
+         oKey = oObject;
+         if IsClass(oKey, &RoomKey)
+         {
+            if IsClass(Send(SYS, @FindRoomByNum, #num=Send(oKey, @GetRID)),
+               Send(self, @GetRoomClassByLocation, #iLocation=iLocation))
+            {
+               bHasRoomKey = TRUE;
+               break;
+            }
+         }
+      }
+
+      if bHasRoomKey
+      {
+         % See if there are any copies of this key present
+         if Send(oKey, @HasCopies)
+         {
+            % Great, now delete them
+            Send(oKey, @DeleteCopies);
+            return RoomMaintenance_change_lock;
+         }
+         else
+         {
+            % No copies out?  Okay tell them.
+            return RoomMaintenance_no_copies_change_lock;
+         }      }
+
+      % No key?  Tell them they can't change the lock on a room they don't have.
+      return RoomMaintenance_no_key_change_lock;
+   }
 
    CopyKey(who=$,iLocation=$,iCost=500)
    {
@@ -168,6 +224,31 @@ messages:
       send(who,@NewHold,#what=send(oKey,@Copy));
 
       return RoomMaintenance_key_copied;
+   }
+
+   GetHelpMessage(who=$, iRentCost=$, iCopyCost=$, iDayCost=$)
+   {
+      if who <> $ AND iRentCost <> $ AND iCopyCost <>$ AND iDayCost <> $
+      {
+         Send(who, @MsgSendUser, #message_rsc=RoomMaintenance_help_message,
+            #parm1=iRentCost, #parm2=iCopyCost, #parm3=iDayCost, #parm4=piRentableDaysMax);
+      }
+      return;
+   }
+
+   CheckRent(who=$, iLocation=$)
+   {
+      local oRoom;
+
+      oRoom = Send(self, @FindRoomByPlayer, #who=who, #iLocation=iLocation);
+
+      % If there's no room, do nothing
+      if oRoom = $
+      {
+        return;
+      }
+
+      return Send(oRoom, @GetDaysLeft);
    }
 
    GotRent(who=$,iAmount=0,iCost=150,iLocation=$)


### PR DESCRIPTION
Currently, room rental is a bit opaque in terms of commands the innkeeper accepts as well as time remaining.  Additionally, control over key copies is pretty much nonexistent, and once stolen, your room is compromised.  This PR enhances these aspects of room management:

- Room Help:  Say this to any innkeeper to get a list of commands related to renting rooms, including prices, maximum rentable days, etc.

- Change Lock:  Say this to an innkeeper you have a room with and they'll destroy any copies of your key that are currently in circulation.

- Rent:  Say this to an innkeeper you have a room with and they'll tell you how much time is left on your room, including a conversion to real life days.

Increased security for copied keys:  Key copies, which are not intended to be dropped on death, shattered, swapped, vaulted, etc can still be dropped accidentally.  This PR changes this behavior so that only the room owner can drop or trade copied keys to other players freely.  Any player who receives a copy of someone else's room key can only offer it back to the room's owner, or give it to an innkeeper to destroy it.  They'll be informed of this if they try to discard it improperly.