### PR TITLE
Fix for the bugged/inaccurate "has been repaired before" text on low/high/nerudite quality weapons

### DIFF
--- a/kod/object/item/passitem/weapon.kod
+++ b/kod/object/item/passitem/weapon.kod
@@ -53,11 +53,6 @@ constants:
    WEAPON_RANGE_MID  = 2
    WEAPON_RANGE_HIGH = 3
 
-   % Quality mods to number of hits
-   % Deprecated
-   WEAPON_LOW_QUALITY_HITS  = -50
-   WEAPON_HIGH_QUALITY_HITS = 100
-   WEAPON_NERUDITE_HITS = 200
 
    % Quality mods to hit modifier
    WEAPON_LOW_QUALITY_HITMOD  = 0

--- a/kod/object/item/passitem/weapon.kod
+++ b/kod/object/item/passitem/weapon.kod
@@ -54,6 +54,7 @@ constants:
    WEAPON_RANGE_HIGH = 3
 
    % Quality mods to number of hits
+   % Deprecated
    WEAPON_LOW_QUALITY_HITS  = -50
    WEAPON_HIGH_QUALITY_HITS = 100
    WEAPON_NERUDITE_HITS = 200
@@ -154,28 +155,6 @@ properties:
    piUsed = UNUSED
 
 messages:
-
-   Constructed()
-   {
-      % Modify the hits depending on the weapon's quality.
-      if viWeaponQuality = WEAPON_QUALITY_LOW
-      {
-         piHits_init = piHits_init + WEAPON_LOW_QUALITY_HITS;
-         piHits = piHits + WEAPON_LOW_QUALITY_HITS;
-      }
-      if viWeaponQuality = WEAPON_QUALITY_HIGH
-      {
-         piHits_init = piHits_init + WEAPON_HIGH_QUALITY_HITS;
-         piHits = piHits + WEAPON_HIGH_QUALITY_HITS;
-      }
-      if viWeaponQuality = WEAPON_NERUDITE
-      {
-         piHits_init = piHits_init + WEAPON_NERUDITE_HITS;
-         piHits = piHits + WEAPON_NERUDITE_HITS;
-      }
-
-      propagate;
-   }
 
    %%% Hard Stats Functions
    %%% (Range, hit chance, damage, etc)

--- a/kod/object/item/passitem/weapon/huntsw.kod
+++ b/kod/object/item/passitem/weapon/huntsw.kod
@@ -108,8 +108,8 @@ classvars:
    viDamage_min = 10    % the damage done to the user if unworthy
    viDamage_max = 20
 
-   viHits_init_min = 500
-   viHits_init_max = 500
+   viHits_init_min = 600
+   viHits_init_max = 600
 
    viItem_type = ITEMTYPE_WEAPON | ITEMTYPE_SPECIAL
 

--- a/kod/object/item/passitem/weapon/mace.kod
+++ b/kod/object/item/passitem/weapon/mace.kod
@@ -42,6 +42,9 @@ classvars:
    viWeight = 60
    viBulk = 60
 
+   viHits_init_min = 200
+   viHits_init_max = 250
+
    vrWeapon_window_overlay = mace_window_overlay_rsc
 
    vrWeapon_overlay = mace_player_overlay

--- a/kod/object/item/passitem/weapon/mystswrd.kod
+++ b/kod/object/item/passitem/weapon/mystswrd.kod
@@ -42,6 +42,9 @@ classvars:
    viWeight = 60 
    viBulk = 60
 
+   viHits_init_min = 350
+   viHits_init_max = 400
+
    vrWeapon_window_overlay = mysticsword_window_overlay_rsc
    vrWeapon_overlay = mysticsword_player_overlay
 

--- a/kod/object/item/passitem/weapon/neruswd.kod
+++ b/kod/object/item/passitem/weapon/neruswd.kod
@@ -44,6 +44,9 @@ classvars:
    viWeight = 80
    viBulk = 70
 
+   viHits_init_min = 450
+   viHits_init_max = 500
+
    vrWeapon_window_overlay = NeruditeSword_window_overlay_rsc
    vrWeapon_overlay = NeruditeSword_player_overlay
 

--- a/kod/object/item/passitem/weapon/riijaswd.kod
+++ b/kod/object/item/passitem/weapon/riijaswd.kod
@@ -34,8 +34,8 @@ classvars:
    vrIcon = RiijaSword_icon_rsc
    vrDesc = RiijaSword_desc_rsc
 
-   viHits_init_min = 600
-   viHits_init_max = 650
+   viHits_init_min = 700
+   viHits_init_max = 750
 
    % Riija Swords are high quality thrusting weapons
    viWeaponType = WEAPON_TYPE_THRUST

--- a/kod/object/item/passitem/weapon/scimitar.kod
+++ b/kod/object/item/passitem/weapon/scimitar.kod
@@ -40,6 +40,9 @@ classvars:
    viWeight = 85
    viBulk = 70
 
+   viHits_init_min = 350
+   viHits_init_max = 400
+
    vrWeapon_window_overlay = scimitar_window_overlay_rsc
    vrWeapon_overlay = scimitar_player_overlay
 

--- a/kod/object/item/passitem/weapon/shrtswrd.kod
+++ b/kod/object/item/passitem/weapon/shrtswrd.kod
@@ -41,6 +41,9 @@ classvars:
    viWeight = 50
    viBulk = 50
 
+   viHits_init_min = 200
+   viHits_init_max = 250
+
    viGround_group = 1
    viInventory_group = 3
    viBroken_group = 2

--- a/kod/object/item/passitem/weapon/spirhamm.kod
+++ b/kod/object/item/passitem/weapon/spirhamm.kod
@@ -43,6 +43,9 @@ classvars:
    viWeight = 15
    viBulk = 60
 
+   viHits_init_min = 350
+   viHits_init_max = 400
+
    vrWeapon_window_overlay = spirithammer_window_overlay_rsc
    vrWeapon_overlay = spirithammer_player_overlay
 

--- a/kod/object/item/passitem/weapon/unique.kod
+++ b/kod/object/item/passitem/weapon/unique.kod
@@ -51,6 +51,9 @@ classvars:
    viBulk = 35
    viWeight = 25
 
+   viHits_init_min = 200
+   viHits_init_max = 250
+
    viGround_group = 1
    viInventory_group = 1
    viBroken_group = 3


### PR DESCRIPTION
Newly-created maces and short swords always show "...but has been repaired before" in their descriptions due to the low quality initial hits modifier being negative, and the repaired-before text displaying if piHits_init is below viHits_init_min, which is possible due to the negative durability value applied to low quality weapons.

While less obvious, high and nerudite quality weapons were shy about showing "has been repaired before" right away because they had an extra buffer of bonus hits before they were considered below the minimum possible durability.

This addresses both issues by removing the quality-based adjustment to piHits and piHits_init done in weapon.kod upon object creation and instead sets the intended values directly in each low, high, and nerudite quality weapon's kod file.  This gives each weapon access to the correct viHits_init_min value for determining whether or not it's been repaired before.