### PR TITLE
Remove 'Unresolved Externals' spam

### DIFF
--- a/blakcomp/kodbase.c
+++ b/blakcomp/kodbase.c
@@ -547,8 +547,8 @@ int save_kodbase()
    external_list = table_get_all(st.missingvars);
    numexternals = save_externals(kodbase, external_list);
    
-   if (numexternals != 0)
-      simple_warning("%d unresolved externals", numexternals);
+//   if (numexternals != 0)
+//      simple_warning("%d unresolved externals", numexternals);
 
    fclose(kodbase);
    return True;


### PR DESCRIPTION
There's a message that spams rather heavily during nmake that makes it difficult to see if anything went wrong. I'd like to remove that message - I don't believe it's serving a purpose. This commit simply comments out the 'unresolved externals' warning.