### PR TITLE
Hackish code for torches in mend fixed

### DIFF
--- a/kod/object/item/passitem/defmod/shield/torch.kod
+++ b/kod/object/item/passitem/defmod/shield/torch.kod
@@ -292,6 +292,11 @@ messages:
       return TORCH_LIGHT;
    }
 
+   CanMend()
+   {
+      return FALSE;
+   }
+
    ReqRepair()
    {
       % To prevent cheesy working of Mend by using/unusing torch repeatedly.

--- a/kod/object/passive/spell/mend.kod
+++ b/kod/object/passive/spell/mend.kod
@@ -79,15 +79,6 @@ messages:
          return FALSE;
       }
 
-      % Kludgey, yes, but spell wouldn't recognize ReqRepair in the Torch class.
-      if isClass(oTarget,&Torch)
-      {
-         Send(who,@MsgSendUser,#message_rsc=mend_not_weaponry,
-              #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
-
-         return FALSE;
-      }
-
       iHits = Send(oTarget,@GetHits);
       iMaxHits = Send(oTarget,@GetMaxHits);
 


### PR DESCRIPTION
The mend spell has a special exception in its logic to exclude the Torch class which is...gross.  I removed it and added an override for CanMend in the Torch class, because mend calls CanMend to determine if an item can be mended or not, not ReqRepair.

Note that this is a nitpick fix that doesn't affect the actual gameplay in any way.