### PR TITLE
QoL Feature:  Removed durability damage from shirts, pants, and skirts

### DIFF
--- a/kod/object/item/passitem/defmod/pants.kod
+++ b/kod/object/item/passitem/defmod/pants.kod
@@ -20,16 +20,9 @@ resources:
    pants_desc_rsc = \
    "These pants will cover your legs but won't help much in the way of protection."
 
-   pants_condition_exc = " are in immaculate condition."
-   pants_condition_exc_mended = " are in excellent condition, but have been patched before.."
-   pants_condition_good = " are scuffed and slightly worn."
-   pants_condition_med = " have a few unsightly rips."
-   pants_condition_poor = " are in tatters, and barely holding together."
-   pants_condition_broken = " are covered in filth and ripped beyond use."
-
 classvars:
 
-   vbShow_condition = TRUE
+   vbShow_condition = FALSE
 
    viUse_type = ITEM_USE_LEGS
    viUse_amount = 1
@@ -47,14 +40,6 @@ classvars:
 
    viGround_group = 1
    viInventory_group = 2
-
-   vrShow_condition = TRUE
-   vrCondition_exc = pants_condition_exc 
-   vrCondition_exc_mended = pants_condition_exc_mended 
-   vrCondition_good = pants_condition_good 
-   vrCondition_med = pants_condition_med 
-   vrCondition_poor = pants_condition_poor 
-   vrCondition_broken = pants_condition_broken 
 
    vrItem_broken = defmod_broken_plural_clothes
 
@@ -132,7 +117,17 @@ messages:
       
    ReqRepair()
    {
-      return TRUE;
+      return FALSE;
+   }
+
+   CanMend()
+   {
+      return FALSE;
+   }
+
+   DefendingHit()
+   {
+      return;
    }
 
    IsPlural()

--- a/kod/object/item/passitem/defmod/pants/shrtskrt.kod
+++ b/kod/object/item/passitem/defmod/pants/shrtskrt.kod
@@ -34,12 +34,6 @@ classvars:
    vrLegs_female = ShortSkirt_female_player_rsc
 
    vrPoss_article = item_this
-   vrCondition_exc = item_condition_exc 
-   vrCondition_exc_mended = item_condition_exc_mended
-   vrCondition_good = item_condition_good 
-   vrCondition_med = item_condition_med 
-   vrCondition_poor = item_condition_poor 
-   vrCondition_broken = item_condition_broken 
    viBroken_group = 3
 
    vrItem_Broken = item_broken_battle_clothing

--- a/kod/object/item/passitem/defmod/pants/skirt.kod
+++ b/kod/object/item/passitem/defmod/pants/skirt.kod
@@ -34,12 +34,6 @@ classvars:
    vrLegs_female = Skirt_female_player_rsc
 
    vrPoss_article = item_this
-   vrCondition_exc = item_condition_exc 
-   vrCondition_exc_mended = item_condition_exc_mended
-   vrCondition_good = item_condition_good 
-   vrCondition_med = item_condition_med 
-   vrCondition_poor = item_condition_poor 
-   vrCondition_broken = item_condition_broken 
    viBroken_group = 3
 
    vrItem_Broken = item_broken_battle_clothing

--- a/kod/object/item/passitem/defmod/shirt.kod
+++ b/kod/object/item/passitem/defmod/shirt.kod
@@ -16,12 +16,6 @@ constants:
 
 resources:
 
-   shirt_condition_exc = " is in immaculate condition."
-   shirt_condition_good = " is scuffed and slightly worn."
-   shirt_condition_med = " has a few unsightly rips."
-   shirt_condition_poor = " is in tatters, and barely holding together."
-   shirt_condition_broken = " is covered in filth and ripped beyond use."
-   
    shirt_name_rsc = "shirt"
  
    shirt_desc_rsc = \
@@ -74,7 +68,7 @@ classvars:
    vrLeftarm_female = shirt_leftarm_female 
    vrRightarm_female = shirt_rightarm_female 
 
-   vbShow_Condition = TRUE
+   vbShow_Condition = FALSE
 
    viDefense_base = 5               % This is the default value for piDefense_bonus
 
@@ -172,7 +166,17 @@ messages:
 
    ReqRepair()
    {
-      return TRUE;
+      return FALSE;
+   }
+
+   CanMend()
+   {
+      return FALSE;
+   }
+
+   DefendingHit()
+   {
+      return;
    }
 
    NewUsed()


### PR DESCRIPTION
As cosmetic items, it's a bit silly that shirts, pants, and skirts take durability damage and eventually break with use.  This leads to people preferring to just hunt naked, or to not bother with these items at all due to the inconvenience of having to pick up new ones regularly.

Removing the durability aspect encourages people to dress up and look their best wherever they go--something they can already do with another cosmetic item:  masks.

This changes the following:
- Shirts (shirt, royalshirt, tanktop) and pants (pantsa, pantsb, pantsc, pantsd, skirt, and shortskirt) to no longer suffer a reduction in hits when the wearer is damaged.
- No longer displays their condition in descriptions.
- No longer mendable, since that doesn't matter anymore.