### PR TITLE
Bugfix:  Monster hit effects shouldn't be usable via illusionary form

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4420,7 +4420,7 @@ messages:
 
       % Morphed?  Also apply the morphed monster's hit side effects, if any.
       oMonster = Send(self,@GetIllusionForm);
-      if (oMonster <> $ AND Send(self ,@CheckPlayerFlag, #flag=PFLAG_MORPHED))
+      if (oMonster <> $ AND Send(self, @CheckPlayerFlag, #flag=PFLAG_MORPHED))
       {
          Send(oMonster,@HitSideEffect,#what=what);
       }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4418,9 +4418,9 @@ messages:
               #use_weapon=Send(self,@GetWeapon));
       }      
 
-      % Morphed?  As a bonus, people in illusionary form get the hit side effect.  :)
+      % Morphed?  Also apply the morphed monster's hit side effects, if any.
       oMonster = Send(self,@GetIllusionForm);
-      if (oMonster <> $)
+      if (oMonster <> $ AND Send(self ,@CheckPlayerFlag, #flag=PFLAG_MORPHED))
       {
          Send(oMonster,@HitSideEffect,#what=what);
       }


### PR DESCRIPTION
Currently, a player using morph ***or*** illusionary form (and presumably brown potions) can apply the hit side effects (poison, disease, vigor drain, etc) to their attack targets.  Only the morph spell is supposed to be able to do this.

This fix adds a flag check to make sure the user is actually morphed before applying hit side effects, if any.