### PR TITLE
Change message when you try to attack yourself

### DIFF
--- a/clientd3d/client.rc
+++ b/clientd3d/client.rc
@@ -1728,6 +1728,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_TARGETNOTVISIBLEFORATTACK "You can't see your selected target."
+    IDS_CANTATTACKSELF      "You can't attack yourself."
     IDS_DEPOSIT_ITEMS       "Deposit Items"
     IDS_CANTSENDREQUEST     "Unable to send an HTTP request for the file %s to the server %s."
     IDS_CANTGETFILESIZE     "Unable to get size of file %s from the server %s."

--- a/clientd3d/gameuser.c
+++ b/clientd3d/gameuser.c
@@ -96,7 +96,10 @@ void UserAttackClosest(int action)
 		if (FindVisibleObjectById(idTarget))
 			RequestAttack(ATTACK_NORMAL, idTarget);
 		else
-			GameMessage(GetString(hInst, IDS_TARGETNOTVISIBLEFORATTACK));
+         if (idTarget == player.id)
+            GameMessage(GetString(hInst, IDS_CANTATTACKSELF));
+         else
+			   GameMessage(GetString(hInst, IDS_TARGETNOTVISIBLEFORATTACK));
 		return;
 	}
 	

--- a/clientd3d/resource.h
+++ b/clientd3d/resource.h
@@ -231,6 +231,7 @@
 #define IDS_UNVERIFIED                  202
 #define IDS_RESENDAPI                   203
 #define IDS_SIGNUPMSG                   204
+#define IDS_CANTATTACKSELF              205
 #define IDC_PORTNUM                     1000
 #define IDC_HOST                        1001
 #define IDC_ITEMLIST                    1002


### PR DESCRIPTION
This PR changes the message the player receives when they try to hit themselves with any weapon.  Previously the message the player receives is: "You can't see your selected target."  This is the same message players get often when they are trying to attack a moving enemy or an enemy like ground worms who sometimes dive below the surface of the ground.  This can lead to temporary player confusion as the player often assumes they are targeting the monster only to realize later that they didn't correctly switch away from self-targeting.

In addition, telling the player that they can't attack themselves because they can't see themselves is strange.