### PR TITLE
Projectile y offset scaler correction for hardware renderer 

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -8059,17 +8059,21 @@ void D3DRenderProjectilesDrawNew(d3d_render_pool_new *pPool, room_type *room, Dr
 			(float)pProjectile->motion.y);
 		MatrixMultiply(&pChunk->xForm, &rot, &mat);
 
+		// Projectile pDib `y offset` values are perfectly tuned for the software renderer.
+		// To spawn in the correct center location we require 3 times the offset.
+		float yOffsetScaler = 3.0f;
+
 		pChunk->xyz[0].x = (float)pDib->width / (float)pDib->shrink * -8.0f + (float)pDib->xoffset;
-		pChunk->xyz[0].z = ((float)pDib->height / (float)pDib->shrink * 16.0f) - (float)pDib->yoffset * 4.0f;
+		pChunk->xyz[0].z = ((float)pDib->height / (float)pDib->shrink * 16.0f) - (float)pDib->yoffset * yOffsetScaler;
 
 		pChunk->xyz[1].x = (float)pDib->width / (float)pDib->shrink * -8.0f + (float)pDib->xoffset;
-		pChunk->xyz[1].z = -(float)pDib->yoffset * 4.0f;
+		pChunk->xyz[1].z = -(float)pDib->yoffset * yOffsetScaler;
 
 		pChunk->xyz[2].x = (float)pDib->width / (float)pDib->shrink * 8.0f + (float)pDib->xoffset;
-		pChunk->xyz[2].z = -(float)pDib->yoffset * 4.0f;
+		pChunk->xyz[2].z = -(float)pDib->yoffset * yOffsetScaler;
 
 		pChunk->xyz[3].x = (float)pDib->width / (float)pDib->shrink * 8.0f + (float)pDib->xoffset;
-		pChunk->xyz[3].z = ((float)pDib->height / (float)pDib->shrink * 16.0f) - (float)pDib->yoffset * 4.0f;
+		pChunk->xyz[3].z = ((float)pDib->height / (float)pDib->shrink * 16.0f) - (float)pDib->yoffset * yOffsetScaler;
 
 		{
 			float	oneOverW, oneOverH;


### PR DESCRIPTION
To spawn at the correct position in the 3d world, projectiles include a y offset value. This allows them to spawn at the expected position for example at the middle of a player firing an arrow, or casting a fireball.

These values are perfectly tuned for the original software renderer however the hardware renderer is slightly off in its tuned scaler. For example arrows fired currently spawn at the head of a player. This has both a negative impact when you see a projectile fired from another player and also, from the first person, when it spawns from the top of the screen.

To correct this problem we tune the y-offset scaler for projectiles, reducing from 4 to 3X.

A 4X y-offset scaler is used elsewhere for rendering objects, names and lighting and so perhaps this was the reason this original value is used. Please note that when these other occurrences of 4X y offsets are changed to 3X it causses other issues so the 4X is tuned correctly elsewhere. We also cannot change the offset values in the resource as this will break the position in the original software renderer.

Testing included: viewing from first person, from another player, various screen sizes (full and partial), using various types of arrows and projectile spells (fireball and lightning bold).

Before:
![image](https://github.com/Meridian59/Meridian59/assets/7548210/8a5d8e6d-ac41-43b8-8619-2a1ac72e3efd)

After:
![image](https://github.com/Meridian59/Meridian59/assets/7548210/47bea014-5a5f-4f24-955c-280175f9ced3)

Fixes: #469 