### PR TITLE
Bugfix:  Spellpower modifier on bows not applying correctly

### DIFF
--- a/kod/object/item/passitem/weapon/ranged.kod
+++ b/kod/object/item/passitem/weapon/ranged.kod
@@ -206,6 +206,11 @@ messages:
       return viRange;
    }   
 
+   GetBaseSpellModifier(oSpell=$)
+   {
+      return viSpell_modifier;
+   }
+
    % This returns the weapon's attack name.  For ranged weapons, return the ammo name.
    GetAttackName()
    {


### PR DESCRIPTION
Currently, all bows get the same spellpower modifier of -10 even though each bow tries to define its own modifier.  This is due to weapon.kod trying to define everything based on weapon type.

This fix uses the values defined by each ranged weapon rather than the value weapon.kod assigns to thrusting weapons.