### PR TITLE
Rentable room update 2:  Adds "change lock" command to rentable room innkeepers

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqinnk.kod
@@ -39,6 +39,9 @@ resources:
    BarloqueInnkeeper_too_long = "It pleaseth me that ye liketh thine room, but thou hast paid enough in rent already!  I canst not accept more from you right now."
 
    BarloqueInnkeeper_destroy_key_copy = "I will discardeth the key for thee."
+   BarloqueInnkeeper_change_lock = \
+      "Oh, hast thou misplaced one of thine key copies?  I shalt changeth thine room lock at once, "
+      "denying any unwashed miscreants access therein!"
    
 classvars:
 
@@ -153,7 +156,8 @@ messages:
       Send(Send(SYS, @GetRentableRoomMaintenance), @ParseInnkeeperCommands,
          #who=self, #what=what, #innRid=RID_BAR_INN, #speech=string,
          #initCost=piInitialRoomCost, #perDayCost=piPerDayCost, #keyCopyCost=piKeyCopyCosts,
-         #rscRoomRented=BarloqueInnkeeper_room_rented, #rscRoomCost=BarloqueInnkeeper_cost);
+         #rscRoomRented=BarloqueInnkeeper_room_rented, #rscRoomCost=BarloqueInnkeeper_cost,
+         #rscChangeLock=BarloqueInnkeeper_change_lock);
       
       propagate;
    }

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqinnk.kod
@@ -27,20 +27,20 @@ resources:
    BqInn_mace_sale = "Aye, ye might needeth one of them if ye plan on leavingeth our cultured city. I got some ye can buyeth."
    BqInn_unwanted_give = "~k%s%s tells you, \"Whyfore dost you offer me that?~n~k\""
 
-   BarloqueInnkeeper_room_rented = "Here is the key to thine room.  I trust you will findest "
+   BarloqueInnkeeper_room_rented = "Here is the key to thy room.  I trust you will findest "
       "our rooms to be most well-appointed.  Enjoyest thy stay!"
 
    BarloqueInnkeeper_cost = \
       "The rooms here are the finest.  I needeth %i shillings when thou ~Irent~neth a "
       "~Iroom~n for for 85 days.  After that, I requireth %i per day up front.  Key copies "
-      "costeth %i shillings if thou wishest to share thine room with a special someone."
+      "costeth %i shillings if thou wishest to share thy room with a special someone."
 
    BarloqueInnkeeper_days_left = "I thanketh thee.  Thou hast %i days left at my luxurious inn."
-   BarloqueInnkeeper_too_long = "It pleaseth me that ye liketh thine room, but thou hast paid enough in rent already!  I canst not accept more from you right now."
+   BarloqueInnkeeper_too_long = "It pleaseth me that ye liketh thy room, but thou hast paid enough in rent already!  I canst not accept more from you right now."
 
    BarloqueInnkeeper_destroy_key_copy = "I will discardeth the key for thee."
    BarloqueInnkeeper_change_lock = \
-      "Oh, hast thou misplaced one of thine key copies?  I shalt changeth thine room lock at once, "
+      "Oh, hast thou misplaced one of thy key copies?  I shalt changeth thy room lock at once, "
       "denying any unwashed miscreants access therein!"
    
 classvars:

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqinnk.kod
@@ -22,26 +22,30 @@ resources:
    Barloque_Innkeep_desc_rsc = "Of everyone in Barloque, the former sailor turned innkeeper Pritchett is "
       "the least haughty.  Perhaps it is because he was not originally from the Royal City and moved to "
       "North Barloque to buy a title."
+
+   % Note: Pritchett's manner of speaking is intentionally bad/incorrect due to him being 
+   % a non-native citizen of Barloque
+
    BqInn_entry_welcome = "I am gladeth to see you, mate."
 
    BqInn_mace_sale = "Aye, ye might needeth one of them if ye plan on leavingeth our cultured city. I got some ye can buyeth."
    BqInn_unwanted_give = "~k%s%s tells you, \"Whyfore dost you offer me that?~n~k\""
 
-   BarloqueInnkeeper_room_rented = "Here is the key to thy room.  I trust you will findest "
-      "our rooms to be most well-appointed.  Enjoyest thy stay!"
+   BarloqueInnkeeper_room_rented = "Here is the key to thine room.  I trust you will findest "
+      "our rooms to be most well-appointed.  Enjoyest thine stay!"
 
    BarloqueInnkeeper_cost = \
       "The rooms here are the finest.  I needeth %i shillings when thou ~Irent~neth a "
       "~Iroom~n for for 85 days.  After that, I requireth %i per day up front.  Key copies "
-      "costeth %i shillings if thou wishest to share thy room with a special someone."
+      "costeth %i shillings if thou wishest to share thine room with a special someone."
 
    BarloqueInnkeeper_days_left = "I thanketh thee.  Thou hast %i days left at my luxurious inn."
-   BarloqueInnkeeper_too_long = "It pleaseth me that ye liketh thy room, but thou hast paid enough in rent already!  I canst not accept more from you right now."
+   BarloqueInnkeeper_too_long = "It pleaseth me that ye liketh thine room, but thou hast paid enough in rent already!  I canst not accept more from you right now."
 
-   BarloqueInnkeeper_destroy_key_copy = "I will discardeth the key for thee."
+   BarloqueInnkeeper_destroy_key_copy = "I will discardeth the key for thou."
    BarloqueInnkeeper_change_lock = \
-      "Oh, hast thou misplaced one of thy key copies?  I shalt changeth thy room lock at once, "
-      "denying any unwashed miscreants access therein!"
+      "Oh, hast ye misplaced one of thine key copies?  I shalt changeth the room lock at once "
+      "for thou, denying any unwashed miscreants access therein!"
    
 classvars:
 

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcinnk.kod
@@ -60,6 +60,10 @@ resources:
    KocatanInnkeeper_destroy_key_copy = \
       "Oh, you don't want this key copy anymore?  "
       "Just this once, I'll take it off your hands for free as a courtesy."
+   KocatanInnkeeper_change_lock = \
+      "Alright, your existing key copies will be invalidated right away.  "
+      "If you want new copies, I'll of course be more than happy to sell you "
+      "some at a bargain price."
 
 classvars:
 
@@ -200,7 +204,8 @@ messages:
       Send(Send(SYS, @GetRentableRoomMaintenance), @ParseInnkeeperCommands,
          #who=self, #what=what, #innRid=RID_KOC_INN, #speech=string,
          #initCost=piInitialRoomCost, #perDayCost=piPerDayCost, #keyCopyCost=piKeyCopyCosts,
-         #rscRoomRented=KocatanInnkeeper_room_rented, #rscRoomCost=KocatanInnkeeper_cost);
+         #rscRoomRented=KocatanInnkeeper_room_rented, #rscRoomCost=KocatanInnkeeper_cost,
+         #rscChangeLock=KocatanInnkeeper_change_lock);
 
       propagate;
    }

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/marntwn/mrinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/marntwn/mrinnk.kod
@@ -40,6 +40,9 @@ resources:
       "when you don't have so many days left on your tab."
    MarionInnkeeper_destroy_key_copy = \
       "Oh, yes. I can get rid of this key for you.  No problem."
+   MarionInnkeeper_change_lock = \
+      "Ah yes, of course.  I'll ask Tova to change the lock to your room right away.  "
+      "Any existing copies of your room key won't work anymore."
 
 classvars:
 
@@ -76,7 +79,8 @@ messages:
       Send(Send(SYS, @GetRentableRoomMaintenance), @ParseInnkeeperCommands,
          #who=self, #what=what, #innRid=RID_MAR_INN, #speech=string,
          #initCost=piInitialRoomCost, #perDayCost=piPerDayCost, #keyCopyCost=piKeyCopyCosts,
-         #rscRoomRented=MarionInnkeeper_room_rented, #rscRoomCost=MarionInnkeeper_cost);
+         #rscRoomRented=MarionInnkeeper_room_rented, #rscRoomCost=MarionInnkeeper_cost,
+         #rscChangeLock=MarionInnkeeper_change_lock);
 
       propagate;
    }

--- a/kod/object/item/passitem/roomkeyc/roomkey.kod
+++ b/kod/object/item/passitem/roomkeyc/roomkey.kod
@@ -63,6 +63,26 @@ messages:
       return oCopy;
    }
 
+   NumberOfCopies()
+   {
+      return Length(plCopies);
+   }
+
+   DeleteCopies()
+   {
+      local oKeyCopy;
+      for oKeyCopy in plCopies
+      {
+         % Despite the name, OriginalDeleted just deletes the copy and
+         % informs the user if they're online.
+         Send(oKeyCopy, @OriginalDeleted);
+      }
+
+      plCopies = $;
+
+      return;
+   }
+
    RoomExpired(iRID=$)
    {
       if (iRID = $) or (iRID <> piRID)

--- a/kod/util/rntmaint.kod
+++ b/kod/util/rntmaint.kod
@@ -371,6 +371,11 @@ messages:
    }
 
    ChangeLock(who=$, iLocation=$)
+   "If the player has a gold room key, this command will delete any "
+   "existing copies of it and notify any player holding such a copy.\n"
+   "Returns a string resource for the NPC to respond with based on "
+   "an unsuccessful result, or $ on succcess as an indicator for the "
+   "NPC to respond with a confirmation line specific to them."
    {
       local oKey;
 
@@ -443,6 +448,8 @@ messages:
    }
 
    FindKeyByPlayer(who=$, iLocation=$)
+   "Returns the gold room key matching the specified inn RID held by the "
+   "specified player, or $ if no match is found."
    {
       local oKey, oObj, lPassive;
 

--- a/kod/util/rntmaint.kod
+++ b/kod/util/rntmaint.kod
@@ -138,8 +138,7 @@ messages:
       if rscChangeLock = $ { rscChangeLock = RoomMaintenance_innkeeper_say_lock_changed; }
 
       % Command:  Rent Room
-      if (StringContain(speech, RoomMaintenance_command_rent) AND StringContain(speech, RoomMaintenance_command_room))
-         OR (StringContain(speech, "rent") AND StringContain(speech, "room"))
+      if StringContain(speech, RoomMaintenance_command_rent) AND StringContain(speech, RoomMaintenance_command_room)
       {
          rSayRsc = Send(self, @RentRoom, #who=what, #iLocation=innRid, #iCost=initCost);
 
@@ -156,7 +155,6 @@ messages:
 
       % Command: Copy Key
       if StringContain(speech, RoomMaintenance_command_copy_key)
-         OR StringContain(speech,"copy key")
       {
          rSayRsc = send(self, @CopyKey, #who=what, #iLocation=innRid, #iCost=keyCopyCost);
 
@@ -167,8 +165,7 @@ messages:
       }
 
       % Command: Room Cost
-      if (StringContain(speech, RoomMaintenance_command_room) AND StringContain(speech, RoomMaintenance_command_cost))
-         OR (StringContain(speech, "room") AND StringContain(speech, "cost"))
+      if StringContain(speech, RoomMaintenance_command_room) AND StringContain(speech, RoomMaintenance_command_cost)
       {
          Post(Send(who, @GetOwner), @SomeoneSaid, #type=SAY_RESOURCE, #what=who,
             #string=rscRoomCost, 
@@ -179,7 +176,6 @@ messages:
       
       % Command: Change Lock
       if StringContain(speech, RoomMaintenance_command_change_lock)
-         OR StringContain(speech, "change lock")
       {
          rSayRsc = Send(self, @ChangeLock, #who=what, #iLocation=innRid);
 
@@ -448,8 +444,8 @@ messages:
    }
 
    FindKeyByPlayer(who=$, iLocation=$)
-   "Returns the gold room key matching the specified inn RID held by the "
-   "specified player, or $ if no match is found."
+   "Returns the RoomKey (original/master room key) matching the specified inn RID "
+   "held by the specified player, or $ if no match is found."
    {
       local oKey, oObj, lPassive;
 
@@ -458,7 +454,7 @@ messages:
 
       for oObj in lPassive
       {
-         % Check for gold (master) room key.
+         % Check to see if the player is holding an original/master room key
          if IsClass(oObj, &RoomKey)
          {
             % Make sure it's for the correct inn.

--- a/kod/util/rntmaint.kod
+++ b/kod/util/rntmaint.kod
@@ -27,11 +27,14 @@ resources:
    RoomMaintenance_no_key = "Where is the key from this inn to copy?"
    RoomMaintenance_no_copy_copy = "You may not copy a copy of a room key."
    RoomMaintenance_copy_no_money = "You cannot afford a copy of your room key."
+   RoomMaintenance_change_lock_no_copies = "There are no copies of your key in circulation." 
+   RoomMaintenance_change_lock_no_room = "You don't have a room here." 
 
    RoomMaintenance_command_room = "room"
    RoomMaintenance_command_rent = "rent"
    RoomMaintenance_command_cost = "cost"
    RoomMaintenance_command_copy_key = "copy key"
+   RoomMaintenance_command_change_lock = "change lock"
 
    RoomMaintenance_innkeeper_say_room_rented = \
       "Here you go.  I hope you enjoy your stay, and if you have any problems "
@@ -50,6 +53,8 @@ resources:
       "~k%q tells you, \"%s\""
    RoomMaintenance_innkeeper_say_destroy_key_copy = \
       "I'll dispose of this key copy for you."
+   RoomMaintenance_innkeeper_say_lock_changed = \
+      "Very well, all existing key copies will be removed."
 
 properties:
 
@@ -103,7 +108,7 @@ messages:
 
    ParseInnkeeperCommands(who=$, what=$, innRid=$, speech=$,
       initCost=ROOM_INIT_RENT_COST_DEFAULT, perDayCost=ROOM_PER_DAY_COST_DEFAULT, keyCopyCost=ROOM_KEY_COPY_COST_DEFAULT,
-      rscRoomRented=$, rscRoomCost=$)
+      rscRoomRented=$, rscRoomCost=$, rscChangeLock=$)
    "This processes spoken player commands, so it must go into SomeoneSaid on any\n"
    "innkeeper who is supposed to rent rooms to players."
    {
@@ -130,6 +135,7 @@ messages:
       % Any of these not specified can just use generic defaults
       if rscRoomRented = $ { rscRoomRented = RoomMaintenance_innkeeper_say_room_rented; }
       if rscRoomCost = $ { rscRoomCost = RoomMaintenance_innkeeper_say_cost; }
+      if rscChangeLock = $ { rscChangeLock = RoomMaintenance_innkeeper_say_lock_changed; }
 
       % Command:  Rent Room
       if (StringContain(speech, RoomMaintenance_command_rent) AND StringContain(speech, RoomMaintenance_command_room))
@@ -169,7 +175,26 @@ messages:
             #parm1=initCost, #parm2=perDayCost, #parm3=keyCopyCost);
 
          return;
-      }    
+      }
+      
+      % Command: Change Lock
+      if StringContain(speech, RoomMaintenance_command_change_lock)
+         OR StringContain(speech, "change lock")
+      {
+         rSayRsc = Send(self, @ChangeLock, #who=what, #iLocation=innRid);
+
+         % On success, rSayRsc will be $, so respond in the innkeeper's local flavor
+         if (rSayRsc = $)
+         {
+            Post(Send(who, @GetOwner), @SomeoneSaid, #type=SAY_RESOURCE, #what=who, #string=rscChangeLock);
+         }
+         else
+         {
+            Post(Send(who, @GetOwner), @SomeoneSaid, #type=SAY_RESOURCE, #what=who, #string=rSayRsc);
+         }
+
+         return;
+      }
 
       return;
    }
@@ -345,6 +370,30 @@ messages:
       return RoomMaintenance_key_copied;
    }
 
+   ChangeLock(who=$, iLocation=$)
+   {
+      local oKey;
+
+      oKey = Send(self, @FindKeyByPlayer, #who=who, #iLocation=iLocation);
+      if oKey <> $
+      {
+         % See if there are any copies of this key present
+         if Send(oKey, @NumberOfCopies) > 0
+         {
+            % Great, now delete them
+            Send(oKey, @DeleteCopies);
+            return $;
+         }
+         else
+         {
+            % No copies of their key?  Tell them.
+            return RoomMaintenance_change_lock_no_copies;
+         }
+      }
+
+      return RoomMaintenance_change_lock_no_room;
+   }
+
    GotRent(who=$,iAmount=0,iCost=150,iLocation=$)
    {
       local oMoney, iDays, oRoom, iDaysLeft;
@@ -391,7 +440,32 @@ messages:
 
       % RenewRental returns the new days left.
       return send(oRoom,@RenewRental,#iTimeAdded=iDays);
-   }      
+   }
+
+   FindKeyByPlayer(who=$, iLocation=$)
+   {
+      local oKey, oObj, lPassive;
+
+      oKey = $;
+      lPassive = Send(who, @GetHolderPassive);
+
+      for oObj in lPassive
+      {
+         % Check for gold (master) room key.
+         if IsClass(oObj, &RoomKey)
+         {
+            % Make sure it's for the correct inn.
+            if IsClass(Send(SYS, @FindRoomByNum, #num=Send(oObj, @GetRID)),
+               Send(self, @GetRoomClassByLocation, #iLocation=iLocation))
+            {
+               oKey = oObj;
+               break;
+            }
+         }
+      }
+
+      return oKey;
+   }
 
    FindRoomByPlayer(who=$,iLocation=$)
    {


### PR DESCRIPTION
Currently, there's nothing that can be done about a key copy that gets stolen, lost, or just somehow slips away from you.  This adds a command to innkeepers, "change lock" which let you to delete all existing copies of your room key for a particular inn.

As an added note, "change lock" will also allow any "ghost" key copies (copies offered to an innkeeper to be destroyed that don't get disposed because they're still in the master key's plCopies list) to be properly garbage collected.