### PR TITLE
Rentable room update 3: Time remaining and other details in key descriptions

### DIFF
--- a/kod/object/active/holder/room/rentroom.kod
+++ b/kod/object/active/holder/room/rentroom.kod
@@ -88,10 +88,9 @@ resources:
       "could opt to have nothing on the wall."
 
    RentableRoom_expiry_warning = \
-      "Subject: Room check-out reminder notice\n"
-      "This is a courtesy notice to remind you that your room rental will "
-      "expire in %q days.  Please be sure to clear your room of any personal "
-      "effects before then.  I hope you are enjoying your stay."
+      "~k%s tells you, ~I\"Your room is about to expire.  You only have %i "
+      "Meridian days left to pay your rent.\""
+
    RentableRoom_expiry = \
       "Subject: Room check-out\n"
       "Your room rental has expired, and the room has been cleared of any "
@@ -1387,13 +1386,6 @@ messages:
          return;
       }
 
-      % Send warning every 12 Meridian days (2 real days), and when we have 4 hours left
-      if (piDaysLeft <= 2)
-         OR ((piDaysLeft mod 12) = 0)
-      {
-         Send(self,@SendExpiryWarningMail);
-      }
-
       return;
    }
 
@@ -1406,14 +1398,35 @@ messages:
       return piDaysLeft;
    }
 
-   SendExpiryWarningMail()
+   RenterLoggedOn()
    {
-      Send(poRenter,@ReceiveNestedMail,#from=vrLandlord,
-            #dest_list=[poRenter],
-            #nest_list=[4,RentableRoom_expiry_warning,
-                        6,Send(SYS,@IntToString,#num=piDaysLeft)]);
+      if Send(self, @IsRoomExpiringSoon)
+      {
+         Send(self, @SendExpiryWarningMessage);
+      }
 
       return;
+   }
+
+   SendExpiryWarningMessage()
+   {
+      if poRenter <> $
+      {
+         Send(poRenter, @MsgSendUser, #message_rsc=RentableRoom_expiry_warning,
+            #parm1=vrLandlord, #parm2=piDaysLeft);
+      }
+
+      return;
+   }
+
+   IsRoomExpiringSoon()
+   {
+      if piDaysLeft < Send(Send(SYS, @GetRentableRoomMaintenance), @WarningDaysThreshold)
+      {
+         return TRUE;
+     }
+
+      return FALSE;
    }
 
    RoomExpired()

--- a/kod/object/item/passitem/roomkeyc.kod
+++ b/kod/object/item/passitem/roomkeyc.kod
@@ -18,8 +18,15 @@ resources:
 
    RoomKeyCopy_name_rsc = "silver room key"
    RoomKeyCopy_icon_rsc = roomkeyc.bgf
-   RoomKeyCopy_desc_rsc = "This solid silver key bears an inscription which reads:\n"
-   RoomKeyCopy_desc2_rsc = "'s room at "
+   RoomKeyCopy_desc_rsc = "This crudely-fashioned silver key copy is used to gain "
+      "access to a private room at an inn."
+   RoomKeyCopy_append_renter_rsc = "  It bears an inscription which reads: \""
+   RoomKeyCopy_append_renter2_rsc = "'s room at "
+   RoomKeyCopy_append_renter3_rsc = ".\"  "
+   RoomKeyCopy_appendspecial_rsc = "On the back is an additional inscription: \""
+      "If found, please return this key to them or the innkeeper.\""
+   RoomKeyCopy_append_days_remaining_rsc = "Rent for this room has been paid for the next "
+   RoomKeyCopy_append_days_remaining2_rsc = " days."
 
    RoomKeyCopy_vanishes = \
       "Your silver room key dissolves into a strange silver liquid, then "
@@ -101,9 +108,9 @@ messages:
       return;
    }
 
-   DoBaseDesc()
+   AppendDesc()
    {
-      local oRoom,rName,rLocation;
+      local oRoom, oRenter, rLocation, iDaysLeft;
 
       oRoom = Send(SYS,@FindRoomByNum,#num=piRID);
       if (oRoom = $)
@@ -112,15 +119,32 @@ messages:
          return;
       }
 
-      rName = Send(Send(oRoom,@GetRenter),@GetName);
-      rLocation = Send(oRoom,@GetLocationName);
+      oRenter = Send(oRoom, @GetRenter);
+      rLocation = Send(oRoom, @GetLocationName);
+      iDaysLeft = Send(oRoom, @GetDaysLeft);
 
-      ClearTempString();
-      AppendTempString(vrDesc);
-      AppendTempString(rName);
-      AppendTempString(RoomKeyCopy_desc2_rsc);
-      AppendTempString(rLocation);
+      if (oRenter <> $)
+      {
+         AppendTempString(RoomKeyCopy_append_renter_rsc);
+         AppendTempString(Send(oRenter, @GetName));
+         AppendTempString(RoomKeyCopy_append_renter2_rsc);
+         AppendTempString(rLocation);
+         AppendTempString(RoomKeyCopy_append_renter3_rsc);
+         Send(self, @AppendSpecial);
+      }
 
+      AppendTempString("\n\n");
+      AppendTempString(RoomKeyCopy_append_days_remaining_rsc);
+      AppendTempString(iDaysLeft);
+      AppendTempString(RoomKeyCopy_append_days_remaining2_rsc);
+
+      return;
+   }
+
+   AppendSpecial()
+   "Appends text to the description relevant to specific key classes."
+   {
+      AppendTempString(RoomKeyCopy_appendspecial_rsc);
       return;
    }
    

--- a/kod/object/item/passitem/roomkeyc/roomkey.kod
+++ b/kod/object/item/passitem/roomkeyc/roomkey.kod
@@ -19,7 +19,12 @@ resources:
    RoomKey_name_rsc = "gold room key"
    RoomKey_icon_rsc = roomkey.bgf
    RoomKey_desc_rsc = \
-      "This solid gold key bears an inscription which reads:\n"
+      "This finely-crafted golden key is used to gain "
+      "access to a private room at an inn."
+   RoomKey_appendspecial_rsc = "There's currently "
+   RoomKey_appendspecial_singular_rsc = " copy "
+   RoomKey_appendspecial_plural_rsc = " copies " 
+   RoomKey_appendspecial2_rsc = "of this key in circulation."
 
    RoomKey_vanishes = \
       "Your gold room key dissolves into a strange gold liquid, then "
@@ -47,6 +52,49 @@ properties:
    plCopies = $
 
 messages:
+
+   AppendSpecial()
+   "Appends the number of key copies in ciculation to the key's description."
+   {
+      local iCopyCount;
+
+      iCopyCount = Send(self, @NumberOfCopies);
+      % If there are no copies of this key in circulation, there's no reason to
+      % add text related to this statistic to the description.
+      if iCopyCount < 1
+      {
+         return;
+      }
+
+      AppendTempString(RoomKey_appendspecial_rsc);
+      AppendTempString(iCopyCount);
+      if iCopyCount = 1
+      {
+         AppendTempString(RoomKey_appendspecial_singular_rsc);
+      }
+      else
+      {
+         AppendTempString(RoomKey_appendspecial_plural_rsc);
+      }
+      AppendTempString(RoomKey_appendspecial2_rsc);
+
+      return;
+   }
+
+   UserLogOn()
+   {
+      local oRoom;
+
+      oRoom = Send(SYS, @FindRoomByNum, #num=piRID);
+      if oRoom <> $
+      {
+         Send(oRoom, @RenterLoggedOn);
+      }
+
+      propagate;
+   }
+
+
 
    OriginalDeleted()
    {

--- a/kod/util/rntmaint.kod
+++ b/kod/util/rntmaint.kod
@@ -62,6 +62,9 @@ properties:
    plRoomsRented = $
    % Max number of days a room can be rented for at one time. ~20 offline days.
    piRentableDaysMax = 240
+   % When fewer meridian days than this are left on a room's rent, user should be
+   % issued some kind of warning or notification.
+   piWarningDaysThreshold = 60
 
 messages: 
 
@@ -74,6 +77,11 @@ messages:
    Recreate()
    {
       return;
+   }
+
+   WarningDaysThreshold()
+   {
+      return piWarningDaysThreshold;
    }
 
    HoldRoomsDuringRecreate()


### PR DESCRIPTION
Currently, the only way users get notified about how much time is left on their room(s) is through a periodic (and somewhat annoying) mail.  This replaced that with the following changes:

- Room key descriptions updated to indicate the number of meridian days remaining.
- RoomKey objects (master/original keys) in particular also show the number of key copies they have in circulation, if any.
- Additionally, room key description generation in general has been cleaned up a bit.  Building all the extra details in DoBaseDesc was probably not how it should've been done since it interferes with added itemattribute descriptions, so now the extra details are built in AppendDesc.
- When a rented room's remaining days value is below a threshold specified in the RentableRoomMaintenance object, the user is also issued warning tell messages from the landlord NPC every time they log in.
- The periodic mails have been removed because nobody likes spam, however the checkout/expiration mail is still sent.

![image](https://github.com/Meridian59/Meridian59/assets/22806592/a7122fd0-85c5-4a5d-941c-5f3837837971)
