### PR TITLE
Minor tweaks to ring description behavior:  added durability, itematt bugfix, ring of lethargy self-reveal

### DIFF
--- a/kod/object/item/passitem/ring.kod
+++ b/kod/object/item/passitem/ring.kod
@@ -22,6 +22,13 @@ resources:
    ring_identified_name_rsc = "generic magical ring"
    ring_identified_description_rsc = "The has some magical effect."
 
+   ring_condition_exc = " is in pristine condition."
+   ring_condition_exc_mended = " is in pristine condition, although it appears to have been weakened somehow."
+   ring_condition_good = " has a minor scratch or two."
+   ring_condition_med = " is fairly tarnished from use."
+   ring_condition_poor = " is dull, cracked, and ready to break."
+   ring_condition_broken = " is broken and beyond repair."
+
 classvars:
 
    viUse_type = ITEM_USE_FINGER
@@ -31,6 +38,14 @@ classvars:
 
    vrRealName = ring_identified_name_rsc
    vrRealDesc = ring_identified_name_rsc
+
+   vbShow_condition = TRUE
+   vrCondition_exc = ring_condition_exc
+   vrCondition_exc_mended = ring_condition_exc_mended
+   vrCondition_good = ring_condition_good
+   vrCondition_med = ring_condition_med
+   vrCondition_poor = ring_condition_poor
+   vrCondition_broken = ring_condition_broken
 
 properties:
 
@@ -63,14 +78,25 @@ messages:
 
    RevealHiddenAttributes()
    {
+      local i, bDone;
+
+      bDone = FALSE;
+      for i in plItem_Attributes
+      {
+         if NOT Send(self, @GetIDStatusFromCompound, #compound=First(i))
+         {
+            SetNth(i, 1, (First(i) + 1));
+            bDone = TRUE;
+         }
+      }
       if vrName <> vrRealName
       {
          vrName = vrRealName;
          vrDesc = vrRealDesc;
-         return TRUE;
+         bDone = TRUE;
       }
       
-      return FALSE;
+      return bDone;
    }
 
    GetTrueName()

--- a/kod/object/item/passitem/ring.kod
+++ b/kod/object/item/passitem/ring.kod
@@ -81,6 +81,8 @@ messages:
       local i, bDone;
 
       bDone = FALSE;
+      % Iterate through the item's properties and reveal any that are
+      % currently unrevealed.
       for i in plItem_Attributes
       {
          if NOT Send(self, @GetIDStatusFromCompound, #compound=First(i))
@@ -89,6 +91,7 @@ messages:
             bDone = TRUE;
          }
       }
+      % Reveal the true name and description of the item.
       if vrName <> vrRealName
       {
          vrName = vrRealName;

--- a/kod/object/item/passitem/ring/lethring.kod
+++ b/kod/object/item/passitem/ring/lethring.kod
@@ -64,6 +64,11 @@ properties:
 
    pbIn_use = FALSE
 
+   % This cursed ring wants to players to think it's possibly one of the 
+   % beneficial ones.  Once identified, flip this to FALSE because it
+   % doesn't actually use piHits for anything.
+   vbShow_condition = TRUE
+
    piVigorRestThresholdChange = 20
 
 messages:
@@ -77,6 +82,13 @@ messages:
          return;
       }
       
+      propagate;
+   }
+
+   RevealHiddenAttributes()
+   {
+      vbShow_condition = FALSE;
+
       propagate;
    }
 
@@ -100,6 +112,14 @@ messages:
       if (iVigorRestThreshold - piVigorRestThresholdChange < 10)
       {
          piVigorRestThresholdChange = iVigorRestThreshold - 10;
+      }
+
+      % Reveal the true nature of the ring to the player when they put it on, because
+      % at this point, it's pretty obvious it's not helping them.
+      if Send(self, @RevealHiddenAttributes)
+      {
+         Send(self, @RevealHiddenColor);
+         Send(poOwner, @SomethingChanged, #what=self);
       }
 
       Send(poOwner,@MsgSendUser,#message_rsc=ringoflethargy_use_rsc);

--- a/kod/object/item/passitem/ring/ringsgnt.kod
+++ b/kod/object/item/passitem/ring/ringsgnt.kod
@@ -28,6 +28,8 @@ classvars:
    vrIcon = ringsignet_icon_rsc
    vrRealDesc = ringsignet_desc_rsc
 
+   vbShow_condition = FALSE
+
    viHits_init_min = 30
    viHits_init_max = 70
 

--- a/kod/object/item/passitem/ring/ringwedd.kod
+++ b/kod/object/item/passitem/ring/ringwedd.kod
@@ -31,6 +31,8 @@ classvars:
    vrIcon = ringwedding_icon_rsc
    vrRealDesc = ringwedding_desc_rsc
 
+   vbShow_condition = FALSE
+
    viHits_init_min = 3
    viHits_init_max = 7
 


### PR DESCRIPTION
This PR does a few things related to ring descriptions:

- Adds generral durability condition text to rings' descriptions, if applicable, since currently there's no way to determine how many hits a ring has remaining, short of remembering.
- Fixes a bug where rings with unrevealed item attributes can't have those attributes revealed.
- Changed ring of lethargy to now officially reveals its name/description/color/etc when put on, because it already informally does so the moment a player picks it up.  Until then, it continues to blend in perfectly with beneficial rings.

![image](https://github.com/Meridian59/Meridian59/assets/22806592/62a8c5bb-0e89-4346-a7bb-7f1a4491fb4a)
