### PR TITLE
Admin-friendly QoL changes to OrnamentalObject

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2661,6 +2661,8 @@
    OO_RR_PLANT2 = 153
    OO_RR_TABLE = 154
    OO_RR_BASIN = 155
+   OO_SIGNPOST = 156
+   OO_NEWBSIGN = 157
 
    %%% Shrines
 

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm/admin.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm/admin.kod
@@ -40,6 +40,7 @@ resources:
    admin_mortal_command = "mortal"
    admin_immortal_command = "immortal"
    admin_create_dynamic_light_command = "place dynamic light"
+   admin_create_ornamental_object = "place ornament"
    admin_logoffghost_on_command = "logoffghost on"
    admin_logoffghost_off_command = "logoffghost off"
    admin_logoffghost_temp_off_command = "logoffghost temp off"
@@ -320,6 +321,15 @@ messages:
          Send(self,@MsgSendUser,#message_rsc=admin_currently_in,#parm1=send(poOwner,@GetName),
             #parm2=send(poOwner,@GetRoomResource));
 
+         return;
+      }
+
+      %%% Code for placing an ornamental object
+      if StringEqual(string, admin_create_ornamental_object)
+      {
+         oObject = Create(&OrnamentalObject, #type=OO_DUNG);
+         Send(oObject, @PlaceAt, #what=self);
+         
          return;
       }
 

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm/admin.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm/admin.kod
@@ -325,7 +325,7 @@ messages:
       }
 
       %%% Code for placing an ornamental object
-      if StringEqual(string, admin_create_ornamental_object)
+      if type = SAY_DM AND StringContain(string, admin_create_ornamental_object)
       {
          oObject = Create(&OrnamentalObject, #type=OO_DUNG);
          Send(oObject, @PlaceAt, #what=self);

--- a/kod/object/passive/ornobj.kod
+++ b/kod/object/passive/ornobj.kod
@@ -721,9 +721,6 @@ properties:
    % This value overrides the standard resource description when set.
    psCustomDesc = $
 
-   % Optional timer used to delete the object upon expiring.
-   ptDecayTimer = $
-
 messages:
 
    Constructor(type=0, rName=$, rIcon=$, rDesc=$)
@@ -772,56 +769,6 @@ messages:
       }
 
       propagate;
-   }
-
-   StartDecayTimer(days=0, hours=0, minutes=0, seconds=0)
-   "Admin supported\n"
-   "Starts a timer for this object which will automatically delete it upon expiring.\n"
-   "Can specify the time using values for any or all of the parameters.\n"
-   "These parameters are: days, hours, minutes, and/or seconds."
-   {
-      local iTime;
-
-      iTime = (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
-      if iTime > 0
-      {
-         if days < 21
-         {
-            Send(self, @ClearDecayTimer);
-            ptDecayTimer = CreateTimer(self, @DecayTimerExpired, iTime);
-         }
-         else
-         {
-            Debug("Time must be 20 or fewer days to avoid undesirable timer results.");
-         }
-      }
-      else
-      {
-         Debug("Timer duration must be greater than zero.");
-      }
-
-      return;
-   }
-
-   ClearDecayTimer()
-   "Admin supported\n"
-   "Clears this object's active decay timer if it exists."
-   {
-      if ptDecayTimer <> $
-      {
-         DeleteTimer(ptDecayTimer);
-      }
-      ptDecayTimer = $;
-
-      return;
-   }
-
-   DecayTimerExpired()
-   {
-      ptDecayTimer = $;
-      Send(self, @Delete);
-
-      return;
    }
 
    PlaceAt(what=$)
@@ -959,9 +906,6 @@ messages:
 
       % Clear the custom description, if any
       Send(self, @ClearCustomDesc);
-
-      % Clear the current decay timer, if any
-      Send(self, @ClearDecayTimer);
 
       if type = OO_3_CLOTH_BOLTS
       {  vrName = oo_3bolts_name;  vrIcon = oo_3bolts_icon;  vrDesc = oo_3bolts_desc;  }
@@ -1438,7 +1382,6 @@ messages:
 
    Delete()
    {
-      Send(self, @ClearDecayTimer);
       Send(self, @ClearCustomDesc);
 
       propagate;

--- a/kod/object/passive/ornobj.kod
+++ b/kod/object/passive/ornobj.kod
@@ -789,7 +789,6 @@ messages:
          {
             Send(self, @ClearDecayTimer);
             ptDecayTimer = CreateTimer(self, @DecayTimerExpired, iTime);
-            Debug("iTime:", iTime, " | ptDecayTime:", GetTimeRemaining(ptDecayTimer));
          }
          else
          {

--- a/kod/object/passive/ornobj.kod
+++ b/kod/object/passive/ornobj.kod
@@ -717,7 +717,11 @@ properties:
    piXlat = $
    piGroup = 1
 
+   % Custom description string to be displayed for the object.
+   % This value overrides the standard resource description when set.
    psCustomDesc = $
+
+   % Optional timer used to delete the object upon expiring.
    ptDecayTimer = $
 
 messages:
@@ -770,22 +774,31 @@ messages:
       propagate;
    }
 
-   StartDecayTimer(d=0, h=0, m=0, s=0)
+   StartDecayTimer(days=0, hours=0, minutes=0, seconds=0)
    "Admin supported\n"
    "Starts a timer for this object which will automatically delete it upon expiring.\n"
-   "Can specify the time using h for hours, m for minutes, and/or s for seconds."
+   "Can specify the time using values for any or all of the parameters.\n"
+   "These parameters are: days, hours, minutes, and/or seconds."
    {
       local iTime;
 
-      iTime = d * 86400000 + h * 3600000 + m * 60000 + s * 1000;
-
-      if (iTime > 0)
+      iTime = (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
+      if iTime > 0
       {
-         ptDecayTimer = CreateTimer(self, @DecayTimerExpired, iTime);
+         if days < 21
+         {
+            Send(self, @ClearDecayTimer);
+            ptDecayTimer = CreateTimer(self, @DecayTimerExpired, iTime);
+            Debug("iTime:", iTime, " | ptDecayTime:", GetTimeRemaining(ptDecayTimer));
+         }
+         else
+         {
+            Debug("Time must be 20 or fewer days to avoid undesirable timer results.");
+         }
       }
       else
       {
-         Send(self, @ClearDecayTimer);
+         Debug("Timer duration must be greater than zero.");
       }
 
       return;
@@ -946,7 +959,7 @@ messages:
       pbLook = FALSE;
 
       % Clear the custom description, if any
-      psCustomDesc = $;
+      Send(self, @ClearCustomDesc);
 
       % Clear the current decay timer, if any
       Send(self, @ClearDecayTimer);
@@ -1427,7 +1440,7 @@ messages:
    Delete()
    {
       Send(self, @ClearDecayTimer);
-      psCustomDesc = $;
+      Send(self, @ClearCustomDesc);
 
       propagate;
    }
@@ -1437,7 +1450,7 @@ messages:
    %%%%%%%%%%%%%%%%%%%%%%%%
    Duplicate()
    {
-      local oDuplicate;
+      local oDuplicate, sDuplicateDesc;
 
       oDuplicate = create(&OrnamentalObject,#rName=vrName,#rIcon=vrIcon,#rDesc=vrDesc);
       if send(self,@GetObjectFlags) & OF_HANGING
@@ -1455,6 +1468,12 @@ messages:
       if NOT Send(self, @GetObjectFlags) & LOOK_NO
       {
          Send(oDuplicate, @SetLookable, #value=TRUE);
+      }
+      if psCustomDesc <> $
+      {
+         sDuplicateDesc = CreateString();
+         SetString(sDuplicateDesc, psCustomDesc);
+         Send(oDuplicate, @SetCustomDesc, #text=sDuplicateDesc);
       }
 
       return oDuplicate;

--- a/kod/object/passive/ornobj.kod
+++ b/kod/object/passive/ornobj.kod
@@ -1407,7 +1407,7 @@ messages:
       {
          Send(oDuplicate, @SetFlickering, #value=TRUE);
       }
-      if NOT Send(self, @GetObjectFlags) & LOOK_NO
+      if NOT (Send(self, @GetObjectFlags) & LOOK_NO)
       {
          Send(oDuplicate, @SetLookable, #value=TRUE);
       }

--- a/kod/object/passive/ornobj.kod
+++ b/kod/object/passive/ornobj.kod
@@ -692,6 +692,16 @@ resources:
       "kept eternally full of cool, fresh water, is ideal for rejuvenating the "
       "spirits of a traveller."
 
+   oo_signpost_name = "sign"
+   oo_signpost_icon = sign.bgf
+   oo_signpost_desc = "Whatever was once written on this signpost has long since faded."
+
+   oo_newbsign_name = "sign"
+   oo_newbsign_icon = newbsign.bgf
+   oo_newbsign_desc = "There's something written on this sign, but you can't quite seem to make it out."
+
+   oo_custom_template_rsc = "%q"
+
 classvars:
 
 properties:
@@ -700,11 +710,15 @@ properties:
    vrIcon = $
    vrDesc = $
 
+   pbLook = FALSE
    pbHanging = FALSE
    pbNoMoveOn = FALSE
    pbFlicker = FALSE
    piXlat = $
    piGroup = 1
+
+   psCustomDesc = $
+   ptDecayTimer = $
 
 messages:
 
@@ -735,12 +749,141 @@ messages:
    {
       local f;
 
-      f = LOOK_NO;
+      f = 0;
+      if NOT pbLook { f = f | LOOK_NO; }
       if pbHanging { f = f | OF_HANGING; }
       if pbFlicker { f = f | FLICKERING_YES; }
       if pbNoMoveOn { f = f | MOVEON_NO; }
       
       return f;
+   }
+
+   ShowDesc()
+   {
+      if psCustomDesc <> $
+      {
+         AddPacket(4, oo_custom_template_rsc, 4, psCustomDesc);
+
+         return;
+      }
+
+      propagate;
+   }
+
+   StartDecayTimer(d=0, h=0, m=0, s=0)
+   "Admin supported\n"
+   "Starts a timer for this object which will automatically delete it upon expiring.\n"
+   "Can specify the time using h for hours, m for minutes, and/or s for seconds."
+   {
+      local iTime;
+
+      iTime = d * 86400000 + h * 3600000 + m * 60000 + s * 1000;
+
+      if (iTime > 0)
+      {
+         ptDecayTimer = CreateTimer(self, @DecayTimerExpired, iTime);
+      }
+      else
+      {
+         Send(self, @ClearDecayTimer);
+      }
+
+      return;
+   }
+
+   ClearDecayTimer()
+   "Admin supported\n"
+   "Clears this object's active decay timer if it exists."
+   {
+      if ptDecayTimer <> $
+      {
+         DeleteTimer(ptDecayTimer);
+      }
+      ptDecayTimer = $;
+
+      return;
+   }
+
+   DecayTimerExpired()
+   {
+      ptDecayTimer = $;
+      Send(self, @Delete);
+
+      return;
+   }
+
+   PlaceAt(what=$)
+   "Admin supported\n"
+   "Moves this ornamental object as close to <what>'s current room and location as possible."
+   {
+      local lPos, oRoom;
+
+      if what <> $
+      {
+         lPos = Send(what, @GetPos);
+         oRoom = Send(SYS, @UtilGetRoom, #what=what);
+         if lPos <> $ AND oRoom <> $
+         {
+            if oRoom <> poOwner
+            {
+               Send(oRoom, @NewHold, #what=self,
+                  #new_row=First(lPos), #new_col=Nth(lPos, 2),
+                  #fine_row=Nth(lPos, 3), #fine_col=Nth(lPos, 4),
+                  #new_angle=Send(what, @GetAngle));
+            }
+            else
+            {
+               Send(SYS, @UtilGoNearSquare, #what=self, #where=oRoom,
+                  #new_row=First(lPos), #new_col=Nth(lPos, 2),
+                  #fine_row=Nth(lPos, 3), #fine_col=Nth(lPos, 4),
+                  #new_angle=Send(what, @GetAngle));
+            }
+         }
+      }
+
+      return;
+   }
+
+   SetCustomDesc(text=$)
+   "Admin supported\n"
+   "Sets a custom string as the OrnamentalObject's description."
+   {
+      if (text = GetTempString())
+      {
+         psCustomDesc = CreateString();
+         SetString(psCustomDesc, text);
+      }
+      else
+      {
+         psCustomDesc = text;
+      }
+
+      return;
+   }
+
+   ClearCustomDesc()
+   "Admin supported\n"
+   "Removes the custom description from the OrnamentalObject."
+   {
+      psCustomDesc = $;
+
+      return;
+   }
+
+   SetLookable(value=FALSE)
+   {
+      pbLook = value;
+      if poOwner { Send(poOwner, @SomethingChanged, #what=self); }
+
+      return;
+   }
+
+   SetFlickering(value=FALSE)
+   {
+      pbFlicker = value;
+      if poOwner { Send(poOwner, @SomethingChanged, #what=self); }
+
+      return;
    }
 
    SetHanging(value = TRUE)
@@ -800,6 +943,13 @@ messages:
       pbHanging = FALSE;
       pbNoMoveOn = FALSE;
       pbFlicker = FALSE;
+      pbLook = FALSE;
+
+      % Clear the custom description, if any
+      psCustomDesc = $;
+
+      % Clear the current decay timer, if any
+      Send(self, @ClearDecayTimer);
 
       if type = OO_3_CLOTH_BOLTS
       {  vrName = oo_3bolts_name;  vrIcon = oo_3bolts_icon;  vrDesc = oo_3bolts_desc;  }
@@ -1223,6 +1373,10 @@ messages:
       if type = OO_RR_BASIN
       {  vrName = oo_RRwashbasin_name;  vrIcon = oo_RRwashbasin_icon;  vrDesc = oo_RRwashbasin_desc;  }
 
+      if type = OO_SIGNPOST
+      {  vrName = oo_signpost_name;  vrIcon = oo_signpost_icon;  vrDesc = oo_signpost_desc;  pbLook = TRUE; }
+      if type = OO_NEWBSIGN
+      {  vrName = oo_newbsign_name;  vrIcon = oo_newbsign_icon;  vrDesc = oo_newbsign_desc;  pbLook = TRUE; }
 
       %% tell the room we changed, unless this is in constructor
       if (NOT const) AND poOwner <> $
@@ -1270,6 +1424,14 @@ messages:
       propagate;
    }
 
+   Delete()
+   {
+      Send(self, @ClearDecayTimer);
+      psCustomDesc = $;
+
+      propagate;
+   }
+
    %%%%%%%%%%%%%%%%%%%%%%%%
    % Object copying stuff %
    %%%%%%%%%%%%%%%%%%%%%%%%
@@ -1285,6 +1447,14 @@ messages:
       if send(self,@GetObjectFlags) & MOVEON_NO
       {
          send(oDuplicate,@SetNoMoveOn,#value=TRUE);
+      }
+      if Send(self, @GetObjectFlags) & FLICKERING_YES
+      {
+         Send(oDuplicate, @SetFlickering, #value=TRUE);
+      }
+      if NOT Send(self, @GetObjectFlags) & LOOK_NO
+      {
+         Send(oDuplicate, @SetLookable, #value=TRUE);
       }
 
       return oDuplicate;


### PR DESCRIPTION
Currently, it's a bit tough and cumbersome for admins to spice up the game with ornamental objects.  This adds a number of features to the OrnamentalObject class to greatly simplify this process:

- DM create ornament:  Adds a dm command to admin.kod and above to place an ornamental object at their current location.
- Adds two signposts to the preset ornament list.
- SetFlickering(value):  Adds a function to allow easier control over an OrnamentalObject's flicker flag.
- SetLookable(value):  Adds a function to set an OrnamentalObject to be viewable with the look command.
- SetCustomDesc(text):  Adds a function to set safe (no dynamic resources) custom descriptions onto OrnamentalObjects.
- ClearCustomDesc():  Adds a function to clear custom descriptions.
- StartDecayTimer(d, h, m, s):  Adds a function to start a decay timer onto an OrnamentalObject, automatically deleting it when the timer expires.  The duration can be entered using any or all of the parameters.  (Just days, just seconds, just hours, minutes and seconds together, etc)
- ClearDecayTimer():  Adds a function to clear the current decay timer, if one is present.
- PlaceAt(what):  Adds a function to easily move the OrnamentalObject to the target object's current room/location.  Generally, this will be the admin setting it up, but it can be other things that exist in rooms as well.