### PR TITLE
Allow advancement cap settings to be customized or disabled by admins

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -62,11 +62,6 @@ constants:
    % Number of ms to lose one boosted health or mana point.
    BOOST_DECAY_TIME = 30000 
 
-   % Currently: 10 improves every 15-22 minutes.
-   ADVANCE_TIMER_MIN =   900000
-   ADVANCE_TIMER_MAX =   1320000
-   ADVANCEMENT_LIMIT =   10
-
    PKPOINTER_TIME = 10*60*1000
 
    PLAYER_TRANSLATION_LEGS_MASK = 0xff
@@ -7450,15 +7445,18 @@ messages:
    "A player can only gain so many advancement points per hour, in spells"
    "And skills combined."
    {
-      local iTime;
+      local iTime, oSettings;
       
-      if ptAdvancement = $
+      oSettings = Send(SYS, @GetSettings);
+      if Send(oSettings, @IsAdvancementCapOn)
       {
-         iTime = random(ADVANCE_TIMER_MIN,ADVANCE_TIMER_MAX);
-         ptAdvancement = CreateTimer(self,@AdvancementTimer,iTime);
+         if ptAdvancement = $
+         {
+            iTime = Send(Send(SYS, @GetSettings), @GetAdvancementWait);
+            ptAdvancement = CreateTimer(self,@AdvancementTimer,iTime);
+         }
+         piAdvancement_points = piAdvancement_points + number;
       }
-      
-      piAdvancement_points = piAdvancement_points + number;
       
       return;
    }
@@ -7466,7 +7464,11 @@ messages:
    CheckAdvancementPoints()
    "Checks to be sure a player isn't at the limit yet."
    {
-      if piAdvancement_points < ADVANCEMENT_LIMIT
+      local oSettings;
+
+      oSettings = Send(SYS, @GetSettings);
+      if NOT Send(oSettings, @IsAdvancementCapOn) OR
+         piAdvancement_points < Send(oSettings, @GetAdvancementLimit)
       {
          return TRUE;
       }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -7452,7 +7452,7 @@ messages:
       {
          if ptAdvancement = $
          {
-            iTime = Send(Send(SYS, @GetSettings), @GetAdvancementWait);
+            iTime = Send(oSettings, @GetAdvancementWait);
             ptAdvancement = CreateTimer(self,@AdvancementTimer,iTime);
          }
          piAdvancement_points = piAdvancement_points + number;

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -53,6 +53,12 @@ properties:
 
    pbAtrophyOn = FALSE
 
+   % Skill/spell advancement cap settings
+   pbAdvancementCapOn = FALSE
+   piAdvanceTimerMin = 900000
+   piAdvanceTimerMax = 1320000
+   piAdvancementLimit = 10
+
    % DefaultDeathCost:  Should always be a value between 1 and 100.  Lowering
    %  this will lower the odds of a dead player losing health and skill/spell
    %  percents.
@@ -247,6 +253,21 @@ messages:
    IsAtrophyOn()
    {
       return pbAtrophyOn;
+   }
+
+   IsAdvancementCapOn()
+   {
+      return pbAdvancementCapOn;
+   }
+
+   GetAdvancementWait()
+   {
+      return Random(piAdvanceTimerMin, piAdvanceTimerMax);
+   }
+
+   GetAdvancementLimit()
+   {
+      return piAdvancementLimit;
    }
 
    GetMaxLearnPoints()


### PR DESCRIPTION
Currently the advancement cap (an antiquated anti-botting mechanic) is hardcoded and cannot be changed without editing player.kod.  This change allows for an admin to adjust the following aspects of the advancement cap:

- Min duration of advancement cap timer.
- Max duration of advancement cap timer.
- Number of improves allowed before being capped.
- Option to enable or disable advancement caps entirely.

Note:  This new setup disables the advancement cap by default for the following reasons:

- It confuses newbies who can't figure out why they're suddenly not improving anymore.
- It forces people who aren't botting to do weird rituals (run in and out of a room several times after 10 improves) in order to continue spell or skill practice.
- It doesn't actually deter botting.  Since the values are known, anyone determined to bot will just adjust their bot to stagger casts.
- Now that overall advancement is faster, and since PEs can be recast over and over, botting isn't even worth doing anymore in all but a few cases.

PS:  I tested this by:

- Cranking up the improvement rate on my test server to an absurd number, so that improves happened nearly every cast.
- Casting a spell with it off all the way from 11% to 50% in only a few minutes.
- Checking to make sure the test player's piAdvancement_points were 0 and that there was no ptAdvancement timer set.
- Casting several more times with the advancement cap on, and noting that now the player accumulates piAdvancement_points and that their ptAdvancement timer exists, was counting down, and that they ceased to improve after 10 casts (the current setting)
- Turning the advancement cap back off and noting that the player can improve again and that they do not accumulate further piAdvancement_points.  Their existing points/timer expire normally without issue with the advancement cap off, but have no effect on anything.

Added note:  The advancement cap timer is tied in with some weird old skill/spell atrophy system that I've never seen active in all my years of playing.  I don't know if it even works anymore, but if it does, it most likely requires the advancement cap system to be on in order to function properly.