### PR TITLE
Restorate update

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5511,7 +5511,7 @@ messages:
          }
       }
 
-      return bound(iTime,1000,40000);
+      return bound(iTime,1000,25000);
    }
 
    CalculateManaTime()

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5506,7 +5506,7 @@ messages:
                iTime = Send(oJalaSpell,@AdjustHealthTime,#time=iTime,
                             #iSpellPower=iJalaPower);
 
-               return bound(iTime,750,25000);
+               return bound(iTime,670,25000);
             }
          }
       }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5506,7 +5506,7 @@ messages:
                iTime = Send(oJalaSpell,@AdjustHealthTime,#time=iTime,
                             #iSpellPower=iJalaPower);
 
-               return bound(iTime,625,25000);
+               return bound(iTime,700,25000);
             }
          }
       }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5501,12 +5501,12 @@ messages:
             if IsClass(oJalaSpell,&Restorate)
             {
                iJalaPower = Nth(Nth(lJalaInfo,3),3);
-               
+
                iTime = bound(iTime,1000,40000);
                iTime = Send(oJalaSpell,@AdjustHealthTime,#time=iTime,
                             #iSpellPower=iJalaPower);
 
-               return = bound(iTime,650,40000);
+               return bound(iTime,650,40000);
             }
          }
       }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5502,11 +5502,11 @@ messages:
             {
                iJalaPower = Nth(Nth(lJalaInfo,3),3);
 
-               iTime = bound(iTime,1000,40000);
+               iTime = bound(iTime,1000,25000);
                iTime = Send(oJalaSpell,@AdjustHealthTime,#time=iTime,
                             #iSpellPower=iJalaPower);
 
-               return bound(iTime,625,40000);
+               return bound(iTime,625,25000);
             }
          }
       }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5502,16 +5502,16 @@ messages:
             {
                iJalaPower = Nth(Nth(lJalaInfo,3),3);
 
-               iTime = bound(iTime,1000,25000);
+               iTime = bound(iTime,1000,60000);
                iTime = Send(oJalaSpell,@AdjustHealthTime,#time=iTime,
                             #iSpellPower=iJalaPower);
 
-               return bound(iTime,670,25000);
+               return bound(iTime,670,60000);
             }
          }
       }
 
-      return bound(iTime,1000,25000);
+      return bound(iTime,1000,60000);
    }
 
    CalculateManaTime()

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5501,12 +5501,8 @@ messages:
             if IsClass(oJalaSpell,&Restorate)
             {
                iJalaPower = Nth(Nth(lJalaInfo,3),3);
-
-               iTime = bound(iTime,1000,60000);
-               iTime = Send(oJalaSpell,@AdjustHealthTime,#time=iTime,
+               return Send(oJalaSpell,@AdjustHealthTime,#time=iTime,
                             #iSpellPower=iJalaPower);
-
-               return bound(iTime,670,60000);
             }
          }
       }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5506,7 +5506,7 @@ messages:
                iTime = Send(oJalaSpell,@AdjustHealthTime,#time=iTime,
                             #iSpellPower=iJalaPower);
 
-               return bound(iTime,650,40000);
+               return bound(iTime,625,40000);
             }
          }
       }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5506,7 +5506,7 @@ messages:
                iTime = Send(oJalaSpell,@AdjustHealthTime,#time=iTime,
                             #iSpellPower=iJalaPower);
 
-               return bound(iTime,700,25000);
+               return bound(iTime,750,25000);
             }
          }
       }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5501,13 +5501,17 @@ messages:
             if IsClass(oJalaSpell,&Restorate)
             {
                iJalaPower = Nth(Nth(lJalaInfo,3),3);
+               
+               iTime = bound(iTime,1000,40000);
                iTime = Send(oJalaSpell,@AdjustHealthTime,#time=iTime,
                             #iSpellPower=iJalaPower);
+
+               return = bound(iTime,650,40000);
             }
          }
       }
 
-      return bound(iTime,1000,60000);
+      return bound(iTime,1000,40000);
    }
 
    CalculateManaTime()

--- a/kod/object/passive/spell/jala/restorat.kod
+++ b/kod/object/passive/spell/jala/restorat.kod
@@ -14,6 +14,9 @@ constants:
 
    include blakston.khd
 
+   SPELL_POWER_INTERCEPT = 40    % Hypothetical zero spell power restorate effect coefficient
+   SPELL_POWER_SLOPE = 400       % 1.12 to 1.51 times faster HP regen, linear effect on time per tick
+
 resources:
 
    Restorate_name_rsc = "restorate"
@@ -37,9 +40,7 @@ classvars:
    viMana = 5           % Mana is amount used upon inititiation
    viManaDrain = 3      % Drain is amount used every viDrainTime milliseconds
    viDrainTime = 5000   % Drain some mana every viDrainTime milliseconds
-   viSpellPowerIntercept = 40    % Hypothetical zero spell power restorate effect coefficient
-   viSpellPowerSlope = 400       % 1.12 to 1.51 times faster HP regen, linear effect on time per tick
-   
+      
    viSpellExertion = 10      
    viChance_To_Increase = 20
 
@@ -65,7 +66,7 @@ messages:
    {
       local iTime;
 
-      iTime = (time * (viSpellPowerSlope - (viSpellPowerIntercept + iSpellPower))) / viSpellPowerSlope;
+      iTime = (time * (SPELL_POWER_SLOPE - (SPELL_POWER_INTERCEPT + iSpellPower))) / SPELL_POWER_SLOPE;
 
       return iTime;
    }

--- a/kod/object/passive/spell/jala/restorat.kod
+++ b/kod/object/passive/spell/jala/restorat.kod
@@ -65,10 +65,10 @@ messages:
    "Reduces time passed in so that health regens faster.  Returns reduced time."
    {
       local iTime;
-
+      % Bound time to normal HP regen range before applying spell effect
+      time = bound(time,1000,60000);
       iTime = (time * (SPELL_POWER_SLOPE - (SPELL_POWER_INTERCEPT + iSpellPower))) / SPELL_POWER_SLOPE;
-
-      return iTime;
+      return bound(iTime,670,60000);
    }
 
 

--- a/kod/object/passive/spell/jala/restorat.kod
+++ b/kod/object/passive/spell/jala/restorat.kod
@@ -63,7 +63,7 @@ messages:
    {
       local iTime;
 
-      iTime = (time * (200-iSpellPower)) / 200;
+      iTime = (time * (275-iSpellPower)) / 275;
 
       return iTime;
    }

--- a/kod/object/passive/spell/jala/restorat.kod
+++ b/kod/object/passive/spell/jala/restorat.kod
@@ -63,7 +63,7 @@ messages:
    {
       local iTime;
 
-      iTime = (time * (330-iSpellPower)) / 360;
+      iTime = (time * (290-iSpellPower)) / 320;
 
       return iTime;
    }

--- a/kod/object/passive/spell/jala/restorat.kod
+++ b/kod/object/passive/spell/jala/restorat.kod
@@ -63,7 +63,7 @@ messages:
    {
       local iTime;
 
-      iTime = (time * (225-iSpellPower)) / 225;
+      iTime = (time * (330-iSpellPower)) / 360;
 
       return iTime;
    }

--- a/kod/object/passive/spell/jala/restorat.kod
+++ b/kod/object/passive/spell/jala/restorat.kod
@@ -37,6 +37,8 @@ classvars:
    viMana = 5           % Mana is amount used upon inititiation
    viManaDrain = 3      % Drain is amount used every viDrainTime milliseconds
    viDrainTime = 5000   % Drain some mana every viDrainTime milliseconds
+   viSpellPowerIntercept = 40    % Hypothetical zero spell power restorate effect coefficient
+   viSpellPowerSlope = 400       % 1.12 to 1.51 times faster HP regen, linear effect on time per tick
    
    viSpellExertion = 10      
    viChance_To_Increase = 20
@@ -63,7 +65,7 @@ messages:
    {
       local iTime;
 
-      iTime = (time * (290-iSpellPower)) / 320;
+      iTime = (time * (viSpellPowerSlope - (viSpellPowerIntercept + iSpellPower))) / viSpellPowerSlope;
 
       return iTime;
    }

--- a/kod/object/passive/spell/jala/restorat.kod
+++ b/kod/object/passive/spell/jala/restorat.kod
@@ -63,7 +63,7 @@ messages:
    {
       local iTime;
 
-      iTime = (time * (275-iSpellPower)) / 275;
+      iTime = (time * (225-iSpellPower)) / 225;
 
       return iTime;
    }


### PR DESCRIPTION
This PR addresses a gameplay issue where the Jala spell Restorate has no effect for players in the instances where they are most likely to use the spell.  The reason for this is that the HP regeneration rate has a strict lower bound of 1000ms per tick.  Most players reach this lower limit without Restorate being active and therefore the spell has no effect.  For reference: a player with 45 stamina at 100hp or higher hits the limit at 162 vigor.

To solve this problem we lower the lower bound for HP regeneration if the spell Restorate is active.

This solution does create another small gameplay problem: Any reasonable lower limit for HP tick rates makes it so that the maximum effect of the spell tops out at a low spell power.  We solve this problem by reducing the spell power slope and introducing a small y-axis offset to the spell power line.  This means that the spell still has some marginal effect at very low spell powers and this effect gradually scales up to a spell power of 80% where we begin to flirt with the lower limit for HP regeneration tick-rates.

I've attached some plots to show the problem and solution since there are a number of design constraints to balance.
![image](https://github.com/Meridian59/Meridian59/assets/132171402/f44fb130-a251-42b9-80bc-e3e7aec03fed)
Here we want to select a lower limit that allows for spell power to matter as much as possible.  I've chosen 670 ms as the lower limit since spell power seems to matter up to about 80% and since this means at maximum spell power our players will gain about 50% more HP per unit of time than the otherwise would.  Notice that the chart includes the current lower limit of 1,000 ms at which point the spell has no effect at any spell power for our reference player (red rectangle).

![image](https://github.com/Meridian59/Meridian59/assets/132171402/1c770452-93a0-49cd-8c1d-03d06865af18)
Here the new spell power curve (expressed as a ratio of HP regeneration to baseline HP regeneration) is plotted with the proposed lower limit as a function of spell power.

![image](https://github.com/Meridian59/Meridian59/assets/132171402/89768088-9f3e-4a75-9565-75f6af56baab)
Finally we plot the spell power slope in terms of ms per HP tick.
