### PR TITLE
Correction to typo in animation details documentation

### DIFF
--- a/manual/appa.tex
+++ b/manual/appa.tex
@@ -1140,7 +1140,7 @@ then instead the format is
 \plineindent{animate\_translation}{special code that indicates the object with this}
 \plineindent{}{animation info should use a palette translation}
 \plineindent{1 byte}{palette translation type}
-\plineindent{\nt{animation}}{actual animation info (can't have aniamte\_translation)}
+\plineindent{\nt{animation}}{actual animation info (can't have animate\_translation)}
 Bitmap group numbers start at 1. \\
 \\
 \newnonterminal{say type}


### PR DESCRIPTION
Fixing a typo in the documentation