### PR TITLE
Update Containers: Withdraw selectable amount of number items and hierarchical sort

### DIFF
--- a/blakserv/sprocket.c
+++ b/blakserv/sprocket.c
@@ -34,6 +34,7 @@ client_def_table_type client_def_table[] =
 	{ BP_REQ_INVENTORY,        { {0, DONE_PARM} } },
 	{ BP_REQ_TURN,             { {4, TAG_OBJECT}, {2, TAG_INT}, {0, DONE_PARM} } },
 	{ BP_REQ_GET,              { {4, TAG_OBJECT}, {0, DONE_PARM} } },
+	{ BP_REQ_GET_FROM_CONTAINER,	{ {4, TAG_OBJECT}, {0, DONE_PARM} } },
 	{ BP_REQ_DROP,             { {4, TAG_OBJECT}, {0, DONE_PARM} } },
 	{ BP_REQ_INVENTORY_MOVE,   { {2, TAG_INT}, {2, TAG_INT}, {0, DONE_PARM} } },
 	{ BP_REQ_PUT,              { {4, TAG_OBJECT}, {4, TAG_OBJECT}, {0, DONE_PARM} } },

--- a/clientd3d/gameuser.c
+++ b/clientd3d/gameuser.c
@@ -136,8 +136,9 @@ void UserPickup(void)
  */
 void GotObjectContents(ID object_id, list_type contents)
 {
-   list_type sel_list, l;
+   list_type sel_list, l, sorted_list;
    room_contents_node *r;
+   sorted_list = NULL;
 
    r = GetRoomObjectById(object_id);
 
@@ -147,13 +148,18 @@ void GotObjectContents(ID object_id, list_type contents)
 	 GameMessagePrintf(GetString(hInst, IDS_EMPTY), LookupNameRsc(r->obj.name_res));
       return;
    }
-
-   sel_list = DisplayLookList(hMain, GetString(hInst, IDS_GET), contents, LD_MULTIPLESEL);   
+   // Separate contents into number items and other items and alpha sort
+   for (l = contents; l != Null; l = l->next)
+   {
+      sorted_list = list_add_sorted_item(sorted_list, (l->data), CompareObjectNameAndNumber);
+   }
+   sel_list = DisplayLookList(hMain, GetString(hInst, IDS_GET), sorted_list, LD_MULTIPLESEL | LD_AMOUNTS);   
 
    for (l = sel_list; l != NULL; l = l->next)
-      RequestPickup(((room_contents_node *) (l->data))->obj.id);
+      RequestPickupFromContainer(((room_contents_node *) (l->data)));
 
    ObjectListDestroy(sel_list);
+   ObjectListDestroy(sorted_list);
 }
 /************************************************************************/
 /*

--- a/clientd3d/gameuser.c
+++ b/clientd3d/gameuser.c
@@ -149,7 +149,7 @@ void GotObjectContents(ID object_id, list_type contents)
       return;
    }
    // Separate contents into number items and other items and alpha sort
-   for (l = contents; l != Null; l = l->next)
+   for (l = contents; l != NULL; l = l->next)
    {
       sorted_list = list_add_sorted_item(sorted_list, (l->data), CompareObjectNameAndNumber);
    }

--- a/clientd3d/object.c
+++ b/clientd3d/object.c
@@ -50,6 +50,29 @@ int CompareRoomObjectDistance(void *r1, void *r2)
 {
    return ((room_contents_node *) r1)->distance - ((room_contents_node *) r2)->distance;
 }
+/*************************************************************************/
+// Hierarchical compare objects - first on IsNumberObj then alphabetical
+//
+int CompareObjectNameAndNumber(void *obj1, void *obj2)
+{
+    // Cast obj1 and obj2 to the correct type
+   object_node *node1 = (object_node *)obj1;
+   object_node *node2 = (object_node *)obj2;
+
+   if (IsNumberObj(node1->id) != IsNumberObj(node2->id))
+   {
+      // Node2 before Node1 so that number objects are on top
+      return (IsNumberObj(node2->id) - IsNumberObj(node1->id));
+   }
+   else
+   {
+      // Extract strings to compare
+      const char *string1 = LookupNameRsc(node1->name_res);
+      const char *string2 = LookupNameRsc(node2->name_res);
+
+      return stricmp(string1, string2);
+   }
+}
 /*****************************************************************************/
 /*
  * OverlayListDestroy:  Free memory associated with a list of overlays, and return NULL.

--- a/clientd3d/object.h
+++ b/clientd3d/object.h
@@ -109,6 +109,7 @@ M59EXPORT Bool CompareIdObject(void *idnum, void *obj);
 Bool CompareId(void *id1, void *id2);
 Bool CompareIdRoomObject(void *idnum, void *obj);
 int  CompareRoomObjectDistance(void* p1, void* p2);
+int CompareObjectNameAndNumber(void *obj1, void *obj2);
 list_type    OverlayListDestroy(list_type overlays);
 M59EXPORT object_node *ObjectGetBlank(void);
 M59EXPORT object_node *ObjectCopy(object_node *obj);

--- a/clientd3d/protocol.c
+++ b/clientd3d/protocol.c
@@ -35,6 +35,7 @@ static client_message game_msg_table[] = {
 { BP_REQ_MOVE,             { PARAM_COORD, PARAM_COORD, PARAM_BYTE, PARAM_ID, PARAM_END }, },
 { BP_REQ_TURN,             { PARAM_ID, PARAM_WORD, PARAM_END }, },
 { BP_REQ_GET,              { PARAM_ID, PARAM_END }, },
+{ BP_REQ_GET_FROM_CONTAINER,   { PARAM_ID, PARAM_END }, },
 { BP_REQ_INVENTORY,        { PARAM_END }, },
 { BP_REQ_INVENTORY_MOVE,   { PARAM_WORD, PARAM_WORD, PARAM_END }, },
 { BP_REQ_DROP,             { PARAM_OBJECT, PARAM_END }, },

--- a/clientd3d/protocol.c
+++ b/clientd3d/protocol.c
@@ -35,7 +35,7 @@ static client_message game_msg_table[] = {
 { BP_REQ_MOVE,             { PARAM_COORD, PARAM_COORD, PARAM_BYTE, PARAM_ID, PARAM_END }, },
 { BP_REQ_TURN,             { PARAM_ID, PARAM_WORD, PARAM_END }, },
 { BP_REQ_GET,              { PARAM_ID, PARAM_END }, },
-{ BP_REQ_GET_FROM_CONTAINER,   { PARAM_ID, PARAM_END }, },
+{ BP_REQ_GET_FROM_CONTAINER,   { PARAM_OBJECT, PARAM_END }, },
 { BP_REQ_INVENTORY,        { PARAM_END }, },
 { BP_REQ_INVENTORY_MOVE,   { PARAM_WORD, PARAM_WORD, PARAM_END }, },
 { BP_REQ_DROP,             { PARAM_OBJECT, PARAM_END }, },

--- a/clientd3d/protocol.h
+++ b/clientd3d/protocol.h
@@ -76,7 +76,7 @@ ToServer(BP_REQ_MOVE, NULL, FinenessClientToKod(y) + KOD_FINENESS, \
 	 FinenessClientToKod(x) + KOD_FINENESS, speed, room)
 #define RequestObjectContents(id)    ToServer(BP_SEND_OBJECT_CONTENTS, NULL, id)
 #define RequestPickup(id)            ToServer(BP_REQ_GET, NULL, id)
-#define RequestPickupFromContainer(obj)   ToServer(BP_REQ_GET_FROM_CONTAINER, NULL, id)
+#define RequestPickupFromContainer(obj)   ToServer(BP_REQ_GET_FROM_CONTAINER, NULL, obj)
 #define RequestInventory()           ToServer(BP_REQ_INVENTORY, NULL)
 #define RequestDrop(obj)             ToServer(BP_REQ_DROP, NULL, obj)
 #define RequestInventoryMove(id1, id2) ToServer(BP_REQ_INVENTORY_MOVE, NULL, id1, id2)

--- a/clientd3d/protocol.h
+++ b/clientd3d/protocol.h
@@ -76,7 +76,7 @@ ToServer(BP_REQ_MOVE, NULL, FinenessClientToKod(y) + KOD_FINENESS, \
 	 FinenessClientToKod(x) + KOD_FINENESS, speed, room)
 #define RequestObjectContents(id)    ToServer(BP_SEND_OBJECT_CONTENTS, NULL, id)
 #define RequestPickup(id)            ToServer(BP_REQ_GET, NULL, id)
-#define RequestPickupFromContainer(id)   ToServer(BP_REQ_GET_FROM_CONTAINER, NULL, id)
+#define RequestPickupFromContainer(obj)   ToServer(BP_REQ_GET_FROM_CONTAINER, NULL, id)
 #define RequestInventory()           ToServer(BP_REQ_INVENTORY, NULL)
 #define RequestDrop(obj)             ToServer(BP_REQ_DROP, NULL, obj)
 #define RequestInventoryMove(id1, id2) ToServer(BP_REQ_INVENTORY_MOVE, NULL, id1, id2)

--- a/clientd3d/protocol.h
+++ b/clientd3d/protocol.h
@@ -76,6 +76,7 @@ ToServer(BP_REQ_MOVE, NULL, FinenessClientToKod(y) + KOD_FINENESS, \
 	 FinenessClientToKod(x) + KOD_FINENESS, speed, room)
 #define RequestObjectContents(id)    ToServer(BP_SEND_OBJECT_CONTENTS, NULL, id)
 #define RequestPickup(id)            ToServer(BP_REQ_GET, NULL, id)
+#define RequestPickupFromContainer(id)   ToServer(BP_REQ_GET_FROM_CONTAINER, NULL, id)
 #define RequestInventory()           ToServer(BP_REQ_INVENTORY, NULL)
 #define RequestDrop(obj)             ToServer(BP_REQ_DROP, NULL, obj)
 #define RequestInventoryMove(id1, id2) ToServer(BP_REQ_INVENTORY_MOVE, NULL, id1, id2)

--- a/include/proto.h
+++ b/include/proto.h
@@ -215,6 +215,7 @@ enum {
    BP_SECTOR_SCROLL         = 236,
    BP_SET_VIEW              = 237,
    BP_RESET_VIEW            = 238,
+   BP_REQ_GET_FROM_CONTAINER  = 239,
 };
 
 // User commands (in BP_USERCOMMAND message)

--- a/kod/include/protocol.khd
+++ b/kod/include/protocol.khd
@@ -160,6 +160,7 @@
    BP_SECTOR_SCROLL         = 236
    BP_SET_VIEW              = 237
    BP_RESET_VIEW            = 238
+   BP_REQ_GET_FROM_CONTAINER  = 239
 
    % user command protocol
    UC_SEND_QUIT = 1

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -962,8 +962,16 @@ messages:
       if liClient_cmd = BP_REQ_GET
       {
          oWhat = Nth(client_msg,2);
-         Send(self,@UserGet,#what=oWhat);
+         Send(self,@UserGet,#what=oWhat,#number=$);
          
+         return;
+      }
+
+      if liClient_cmd = BP_REQ_GET_FROM_CONTAINER
+      {
+         oWhat = Nth(client_msg,2);
+         Send(self,@UserGet,#what=oWhat,#number=number_stuff);
+
          return;
       }
       
@@ -3537,10 +3545,10 @@ messages:
       return;
    }
 
-   UserGet(what = $)
+   UserGet(what = $, number = $)
    {
       local oOldOwner, i, lItem_pos, iRow, iCol, iRow_dist, iCol_dist,
-            iCan_hold, oSplit, oCorpse;
+            iCan_hold, iNumber, oSplit, oCorpse;
 
       % User took an action!  Wake any AIs in the room to the user's presence!
       % bitflag check instead of function for speed.
@@ -3627,26 +3635,33 @@ messages:
               
          return;
       }
-        
-      if NOT Send(self,@ReqNewHold,#what=what) 
+      % Either we pass in a number or we didnt but cant hold it all
+      if number <> $
+         OR NOT Send(self,@ReqNewHold,#what=what)
       {
          if IsClass(what,&NumberItem)
          {
             iCan_hold = Send(self,@GetNumberCanHold,#what=what);
-            if iCan_hold > 0
+
+            % Get minimum of number or iCan_hold for split
+            iNumber = bound(number,$,iCan_hold);
+            if iNumber > 0
             {
-               oSplit = Send(what,@Split,#number=iCan_hold);
+               oSplit = Send(what,@Split,#number=iNumber);
                if Send(what,@ReqNewOwner,#what=oSplit)
                {
-                  Send(self,@MsgSendUser,#message_rsc=user_got_some,
-                       #parm1=Send(what,@GetName));
+                  if iCan_hold < number
+                  {
+                     Send(self,@MsgSendUser,#message_rsc=user_got_some,
+                        #parm1=Send(what,@GetName));
+                  }
                   Send(self,@NewHold,#what=oSplit);
                   
                   return;
                }
                else
                {
-                  Send(what,@AddNumber,#number=iCan_hold);
+                  Send(what,@AddNumber,#number=iNumber);
                   Send(self,@MsgSendUser,#message_rsc=user_disallow_get,
                        #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName));
                   Send(self, @WaveSendUser, #what=self, 
@@ -3665,6 +3680,7 @@ messages:
                return;
             }
          }
+         % Not a number item
          else
          {
             %  KLUDGE!!  -Asif

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -296,8 +296,6 @@ resources:
    user_safety_on_wav_rsc = safety_on.wav
    user_safety_off_wav_rsc = safety_off.wav
 
-   chestdebug = "Number was null."
-
 classvars:
 
    viIndefinite = ARTICLE_NONE
@@ -3551,10 +3549,7 @@ messages:
    {
       local oOldOwner, i, lItem_pos, iRow, iCol, iRow_dist, iCol_dist,
             iCan_hold, iNumber, oSplit, oCorpse;
-      if number = $
-      {
-         Send(self,@MsgSendUser,#message_rsc=chestdebug);
-      }
+
       % User took an action!  Wake any AIs in the room to the user's presence!
       % bitflag check instead of function for speed.
       if NOT (piFlags & PFLAG_MOVED_SINCE_ENTRY)  
@@ -3647,7 +3642,11 @@ messages:
          if IsClass(what,&NumberItem)
          {
             iCan_hold = Send(self,@GetNumberCanHold,#what=what);
-
+            % Admin's iCan_hold is $ and breaks the bound logic
+            if iCan_hold = $
+            {
+               iCan_hold = number;
+            }
             % Get minimum of number or iCan_hold for split
             iNumber = bound(iCan_hold,$,number);
             if iNumber > 0

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3656,7 +3656,7 @@ messages:
             if iNumber > 0
             {
                oSplit = Send(what,@Split,#number=iNumber);
-               % Split returns NULL if iNumber is greater than available total
+               % Split returns NULL if iNumber is greater than the available total
                if oSplit = $
                {
                   Send(self,@MsgSendUser,#message_rsc=user_pickup_too_many, 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3644,7 +3644,7 @@ messages:
             iCan_hold = Send(self,@GetNumberCanHold,#what=what);
 
             % Get minimum of number or iCan_hold for split
-            iNumber = bound(number,$,iCan_hold);
+            iNumber = bound(iCan_hold,$,number);
             if iNumber > 0
             {
                oSplit = Send(what,@Split,#number=iNumber);

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3644,7 +3644,8 @@ messages:
          if IsClass(what,&NumberItem)
          {
             iCan_hold = Send(self,@GetNumberCanHold,#what=what);
-            % Admin's iCan_hold is $ and breaks the bound logic
+            % iCan_hold of $ intended to signal infinite capacity
+            % Therefor set iCan_hold to number of items requested
             if iCan_hold = $
             {
                iCan_hold = number;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3546,6 +3546,8 @@ messages:
    }
 
    UserGet(what = $, number = $)
+   "Try to pick up one item (what) and for number items optionally specify"
+   "an amount of that item (number)."
    {
       local oOldOwner, i, lItem_pos, iRow, iCol, iRow_dist, iCol_dist,
             iCan_hold, iNumber, oSplit, oCorpse;
@@ -3635,7 +3637,7 @@ messages:
               
          return;
       }
-      % Either we pass in a number or we didnt but cant hold it all
+      % Either we pass in a number or we didn't but can't hold it all
       if number <> $
          OR NOT Send(self,@ReqNewHold,#what=what)
       {

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -296,6 +296,8 @@ resources:
    user_safety_on_wav_rsc = safety_on.wav
    user_safety_off_wav_rsc = safety_off.wav
 
+   chestdebug = "Number was null."
+
 classvars:
 
    viIndefinite = ARTICLE_NONE
@@ -3549,7 +3551,10 @@ messages:
    {
       local oOldOwner, i, lItem_pos, iRow, iCol, iRow_dist, iCol_dist,
             iCan_hold, iNumber, oSplit, oCorpse;
-
+      if number = $
+      {
+         Send(self,@MsgSendUser,#message_rsc=chestdebug);
+      }
       % User took an action!  Wake any AIs in the room to the user's presence!
       % bitflag check instead of function for speed.
       if NOT (piFlags & PFLAG_MOVED_SINCE_ENTRY)  

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -181,6 +181,7 @@ resources:
       "You can't carry all the items that %s%s has offered you."
 
    user_not_have_number = "You don't have that amount of %s to drop."
+   user_pickup_too_many = "You can't find that amount of %s to pick up."
    user_cant_deal_number = "You can't do anything with %i items."
    user_cant_attack_non_battler = "You can't attack %s%s."
    user_no_say_guild = \
@@ -962,7 +963,7 @@ messages:
       if liClient_cmd = BP_REQ_GET
       {
          oWhat = Nth(client_msg,2);
-         Send(self,@UserGet,#what=oWhat,#number=$);
+         Send(self,@UserGet,#what=oWhat);
          
          return;
       }
@@ -3645,7 +3646,7 @@ messages:
          {
             iCan_hold = Send(self,@GetNumberCanHold,#what=what);
             % iCan_hold of $ intended to signal infinite capacity
-            % Therefor set iCan_hold to number of items requested
+            % Therefore set iCan_hold to number of items requested
             if iCan_hold = $
             {
                iCan_hold = number;
@@ -3655,6 +3656,14 @@ messages:
             if iNumber > 0
             {
                oSplit = Send(what,@Split,#number=iNumber);
+               % Split returns NULL if iNumber is greater than available total
+               if oSplit = $
+               {
+                  Send(self,@MsgSendUser,#message_rsc=user_pickup_too_many, 
+                     #parm1=Send(what,@GetName));
+                 
+                  return;
+               }
                if Send(what,@ReqNewOwner,#what=oSplit)
                {
                   if iCan_hold < number


### PR DESCRIPTION
This PR updates storage boxes like guild hall chests, personal chests in rooms, and other chests that are available throughout the game (IE: Thrashers).

The goal is to make managing inventory easier for players. To that end we make two major changes:

We allow players to pickup a user-selectable number of items for number items
We sort all items in the list box. The sort is two steps: First number items are put at the top and sorted alphabetically then not-number items are sorted alphabetically against each other and appended to the bottom of the list.

This PR differs from draft PR #554 in an important way: We are looping over the list of selected items in C and sending the items to User.Kod one at a time.  This allows the server message to call UserGet and doesn't require a new message in User for getting items from a container.  A number argument is added to UserGet which can be NULL if needed.

Testing was done in RID_GUILDH9 and included:
- Withdrawing combinations of number items and not number items
- Grabbing combinations of items and number items from the ground
- Testing both situations where the user inventory is nearly full
- Testing both situations where the user inventory is completely full
- Opening the get menu and selecting items but removing those items with another user before the user can get the items