### PR TITLE
SpellItem bugfixes

### DIFF
--- a/kod/object/item/passitem/spelitem.kod
+++ b/kod/object/item/passitem/spelitem.kod
@@ -193,7 +193,8 @@ messages:
    }
    
    CastSpell(what = $, apply_on = $)
-   "Casts the spell set by the spell object"
+   "Casts the spell set by the spell object, returning TRUE\n"
+   "If successful, or FALSE if the spell failed for whatever reason."
    {
       local oSpell,iSpellPower,iRand,iInt,lTargets;
 
@@ -206,18 +207,16 @@ messages:
          AND IsClass(apply_on,&Monster)
          AND NOT Send(apply_on,@CanMonsterFight,#who=poOwner,#oStroke=self)
       {
-         return;
+         return FALSE;
       }
 
       % Karma check?
       if pbCheckKarma AND NOT Send(oSpell, @KarmaCheck, #who = poOwner)
       {
-         Debug("user karma = ", Send(poOwner, @GetKarma), " spell needs = ",
-             Send(oSpell, @GetLevel));
          Post(what, @MsgSendUser, #message_rsc = SpellItem_bad_karma,
               #parm1 = Send(self, @GetDef),
               #parm2 = Send(self, @GetName));
-         return;
+         return FALSE;
       }
 
       if piSpellPower = $
@@ -228,10 +227,11 @@ messages:
       {
          iSpellpower = piSpellpower;
       }
-      
+
       if (vbFailSafe)
          OR ( (Send(oSpell,@CanPayCosts,#who=poOwner,#lTargets=lTargets,
-                    #iSpellPower=iSpellPower,#bItemCast=TRUE,#bMade=pbMade))
+                    #iSpellPower=iSpellPower,#bItemCast=TRUE,
+                    #bCheckKarma=pbCheckKarma))
               AND (Send(Send(what,@GetOwner),@ReqSpellCast,#who=what,#oSpell=oSpell))
               AND ((NOT Send(oSpell,@IsHarmful))
                    OR Send(Send(what,@GetOwner),@ReqSomethingAttack,#what=what,
@@ -243,9 +243,11 @@ messages:
       else 
       {
          Send(self,@DoFailure,#what=what,#lTargets=lTargets);
+
+         return FALSE;
       }
 
-      return;
+      return TRUE;
    }
 
    DoFailure(what = $,lTargets=$)
@@ -288,12 +290,23 @@ messages:
    "Casts the spell specified by the item (see subclass) on whatever it"
    "is being applied to, then reduces 1 charge--break the item if last charge"
    {
+      % Attempt to cast the spell specific to the Spellitem, and only
+      % do the follow-up if the spell actually succeeds.
+      if Send(self, @CastSpell, #what=what, #apply_on=apply_on)
+      {
+         Send(self, @OnSuccessfulApply, #what=what, #apply_on=apply_on);
+      }
+      
+      return;
+   }
+
+   OnSuccessfulApply(what=$, apply_on=$)
+   "If the item is successfully applied to the user, this is everything"
+   "we want to happen besides the spell effect itself."
+   {
       piHits = piHits - 1;
 
-      % Cast the spell specific to the Spellitem
-      Send(self,@CastSpell,#what=what,#apply_on=apply_on);
-      
-      % Check and see if that does in the Spellitem 
+      % Check and see if that uses up the Spellitem 
       if piHits <= 0
       {
          % Post this so it prints AFTER the spell message.
@@ -309,7 +322,7 @@ messages:
             Post(self,@Delete);
          }
       }
-      
+
       return;
    }
 

--- a/kod/object/item/passitem/spelitem.kod
+++ b/kod/object/item/passitem/spelitem.kod
@@ -194,7 +194,7 @@ messages:
    
    CastSpell(what = $, apply_on = $)
    "Casts the spell set by the spell object, returning TRUE\n"
-   "If successful, or FALSE if the spell failed for whatever reason."
+   "if successful, or FALSE if the spell failed for whatever reason."
    {
       local oSpell,iSpellPower,iRand,iInt,lTargets;
 

--- a/kod/object/item/passitem/spelitem/potion.kod
+++ b/kod/object/item/passitem/spelitem/potion.kod
@@ -105,15 +105,22 @@ messages:
 
       propagate;
    }
+
+   OnSuccessfulApply(what=$, apply_on=$)
+   {
+
+      if IsClass(apply_on, &User) 
+      {
+         Send(apply_on, @WaveSendUser, #wave_rsc=Potion_gulp_sound);
+      }
+      Send(apply_on, @EatSomething, #nutrition=0, #filling=viFilling);
+
+      propagate;
+   }
    
    NewApplied(what = $,apply_on = $)
    {
       local oSpell;
-
-      if isClass(apply_on,&User) 
-      {
-         send(apply_on,@WaveSendUser,#wave_rsc=Potion_gulp_sound);
-      }
 
       if pbBad
       {
@@ -135,12 +142,12 @@ messages:
                  #duration=(POISON_DURATION*Random(8,12)/10));
          }
 
-         send(self,@Delete);
+         % Even though the desired effect didn't happen, we still technically
+         % applied the potion to the user, so do the follow-up.
+         Send(self, @OnSuccessfulApply, #what=what, #apply_on=apply_on);
 
          return;
       }
-
-      Send(apply_on,@EatSomething,#nutrition=0,#filling=viFilling);
 
       propagate;
    }

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -795,8 +795,10 @@ messages:
       }
 
       % Moved from CanPayManaVigor, because it doesn't relate to paying vigor 
-      % or mana!  Spells cast from items should follow Karma restrictions
-      % unless set to bypass them.
+      % or mana!
+      
+      % Spells cast from items should follow Karma restrictions
+      % unless set to bypass them by setting bCheckKarma to FALSE.
       if bCheckKarma AND NOT Send(self, @KarmaCheck, #who=who)
       {
          if viSchool = SS_SHALILLE

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -687,7 +687,7 @@ messages:
    }
 
    CanPayCosts(who = $, lTargets = $, iSpellPower = 0, bItemCast = FALSE,
-               bMade = FALSE)
+               bCheckKarma = TRUE)
    {
       local iLists, oUserObject, iNum, i, oOwner, oVictim, oRoom, iRand,
             oSpell;
@@ -717,7 +717,7 @@ messages:
          Send(who, @MsgSendUser, #message_rsc = vrToo_few_hp);
          return FALSE;
       }
-      
+
       if not bItemCast
       {
          % In a time and position to use the spell?
@@ -795,29 +795,24 @@ messages:
       }
 
       % Moved from CanPayManaVigor, because it doesn't relate to paying vigor 
-      %  or mana!  Spells cast from items should follow Karma restrictions
-
-      % If the spell is being cast by a made item then there are no Karma
-      %  restrictions.
-      if NOT (bMade OR Send(self,@KarmaCheck,#who=who))
+      % or mana!  Spells cast from items should follow Karma restrictions
+      % unless set to bypass them.
+      if bCheckKarma AND NOT Send(self, @KarmaCheck, #who=who)
       {
-         if NOT bItemCast
+         if viSchool = SS_SHALILLE
+         {  
+            Send(who,@MsgSendUser,#message_rsc=spell_not_good_enough,
+                 #parm1=vrName);
+         }
+         else
          {
-            if viSchool = SS_SHALILLE
-            {  
-               Send(who,@MsgSendUser,#message_rsc=spell_not_good_enough,
-                    #parm1=vrName);
-            }
-            else
-            {
-               Send(who,@MsgSendUser,#message_rsc=spell_not_evil_enough,
-                    #parm1=vrName);
-            }
+            Send(who,@MsgSendUser,#message_rsc=spell_not_evil_enough,
+                 #parm1=vrName);
          }
 
          return FALSE;
       }
-      
+
       % Out of range?
       for i in lTargets
       {

--- a/kod/object/passive/spell/purify.kod
+++ b/kod/object/passive/spell/purify.kod
@@ -95,6 +95,7 @@ messages:
       % If there's no target by now, something weird is going on.
       if target = $
       {
+         Debug("No valid target found for purify.");
          return FALSE;
       }  
 

--- a/kod/object/passive/spell/purify.kod
+++ b/kod/object/passive/spell/purify.kod
@@ -79,19 +79,24 @@ messages:
    {
       local target, i, lEnchantment, bHasEnchantment, oSpell;
 
-      % If it's only self cast, spoof self as target for following code
+      % If castable on others, there can be only one target.
+      if pbCan_Cast_on_others AND Length(lTargets) = 1
+      {
+         target = First(lTargets);
+      }
+
+      % If it's only self cast, spoof self as target for the
+      % rest of the checks.
       if NOT pbCan_Cast_on_others
       {
-         lTargets = Cons(who, lTargets);
+         target = who;
       }
       
-      % Can cast spell if the 1 target item is a user
-      if Length(lTargets) <> 1
+      % If there's no target by now, something weird is going on.
+      if target = $
       {
          return FALSE;
       }  
-
-      target = First(lTargets);
 
       if not IsClass(target, &User)
       {


### PR DESCRIPTION
Currently, the SpellItem subclasses, particularly potions, have some broken logic that causes them to expend charges vs invalid targets, fail due to karma when karma is flagged to not matter, or even not work at all.

- purify.kod:  Fixed some bad target logic that caused purify potions to fail 100% of the time in all situations when the purify spell was set to self-cast only.
- spell.kod:  Removed a weird check for made items (distill) vs normal potions that was causing normal potions to always consider the user's karma, even when flagged not to (remove curse potion, etc)
- spelitem.kod, potion.kod:  Fixed some buggy logic that caused spellitem charges to be consumed whether or not their effects could be utilized.  (Drinking a remove curse potion without a cursed item equipped, etc)