### PR TITLE
Rentable room update 4:  Secure key copy option

### DIFF
--- a/kod/object/item/passitem/roomkeyc.kod
+++ b/kod/object/item/passitem/roomkeyc.kod
@@ -47,6 +47,7 @@ classvars:
    vrName = RoomKeyCopy_name_rsc
    vrIcon = RoomKeyCopy_icon_rsc
    vrDesc = RoomKeyCopy_desc_rsc
+   vrVanish = RoomKeyCopy_vanishes
 
    viItem_type = ITEMTYPE_SPECIAL
 
@@ -86,13 +87,27 @@ messages:
       return piRID;
    }
 
+   GetRenter()
+   {
+      local oRoom, oRenter;
+
+      oRenter = $;
+      oRoom = Send(SYS, @FindRoomByNum, #num=piRID);
+      if oRoom <> $
+      {
+         oRenter = Send(oRoom, @GetRenter);      
+      }
+
+      return oRenter;
+   }
+
    OriginalDeleted()
    {
       if (poOwner <> $) and isClass(poOwner,&User)
       {
          if send(poOwner,@IsLoggedOn)
          {
-            send(poOwner,@MsgSendUser,#message_rsc=RoomKeyCopy_vanishes);
+            send(poOwner,@MsgSendUser,#message_rsc=vrVanish);
          }
          else
          {
@@ -150,6 +165,10 @@ messages:
    
    SendAnimation()
    {
+      if (piItem_flags & ITEM_PALETTE_MASK) <> 0
+      {
+         AddPacket(1, ANIMATE_TRANSLATION, 1, piItem_flags & ITEM_PALETTE_MASK);
+      }
       AddPacket(1,ANIMATE_NONE,2,2);
 
       return;
@@ -157,6 +176,10 @@ messages:
 
    SendLookAnimation()
    {
+      if (piItem_flags & ITEM_PALETTE_MASK) <> 0
+      {
+         AddPacket(1, ANIMATE_TRANSLATION, 1, piItem_flags & ITEM_PALETTE_MASK);
+      }
       AddPacket(1,ANIMATE_NONE,2,2);
 
       return;
@@ -164,6 +187,10 @@ messages:
 
    SendInventoryAnimation()
    {
+      if (piItem_flags & ITEM_PALETTE_MASK) <> 0
+      {
+         AddPacket(1, ANIMATE_TRANSLATION, 1, piItem_flags & ITEM_PALETTE_MASK);
+      }
       AddPacket(1,ANIMATE_NONE,2,1);
 
       return;
@@ -224,6 +251,11 @@ messages:
       }
 
       propagate;
+   }
+
+   IsKeyCopy()
+   {
+      return TRUE;
    }
 
    CanSwap()

--- a/kod/object/item/passitem/roomkeyc.kod
+++ b/kod/object/item/passitem/roomkeyc.kod
@@ -88,6 +88,7 @@ messages:
    }
 
    GetRenter()
+   "Attempts to look up the room's renter, if one exists."
    {
       local oRoom, oRenter;
 
@@ -254,6 +255,7 @@ messages:
    }
 
    IsKeyCopy()
+   "Asks a key whether it's a copy or the original."
    {
       return TRUE;
    }

--- a/kod/object/item/passitem/roomkeyc/makefile
+++ b/kod/object/item/passitem/roomkeyc/makefile
@@ -5,6 +5,6 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\roomkeyc.bof
-BOFS = roomkey.bof
+BOFS = roomkey.bof rmkeysec.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/item/passitem/roomkeyc/rmkeysec.kod
+++ b/kod/object/item/passitem/roomkeyc/rmkeysec.kod
@@ -1,0 +1,123 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+RoomKeySecureCopy is RoomKeyCopy
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   RoomKeySecureCopy_name_rsc = "bronze room key"
+   RoomKeySecureCopy_icon_rsc = roomkeyc.bgf
+   RoomKeySecureCopy_desc_rsc = "This crudely-fashioned bronze key copy is used to gain "
+      "access to a private room at an inn."
+   RoomKeySecureCopy_appendspecial_rsc = "On the back is an additional inscription: \""
+   RoomKeySecureCopy_appendspecial_renter_rsc = "You may give this key to anyone.  Once given, "
+      "the recipient may only return it to either you or the innkeeper.\""
+   RoomKeySecureCopy_appendspecial_not_renter_rsc = "This key can only be returned to "
+      "the room owner or the innkeeper.\""
+
+   RoomKeySecureCopy_vanishes = \
+      "Your bronze room key dissolves into a strange metallic liquid, then "
+      "evaporates into an orange mist and is gone."
+   RoomKeySecureCopy_no_drop_not_yours = \
+      "You can't just carelessly discard %s's room key like that!  You must return "
+      "it to either them or the innkeeper."
+classvars:
+
+   vrName = RoomKeySecureCopy_name_rsc
+   vrIcon = RoomKeySecureCopy_icon_rsc
+   vrDesc = RoomKeySecureCopy_desc_rsc
+   vrVanish = RoomKeySecureCopy_vanishes
+
+   viItem_type = ITEMTYPE_SPECIAL
+
+   viBulk = 10
+   viWeight = 10
+   viValue_average = 80
+
+   viUse_type = ITEM_SINGLE_USE
+
+properties:
+
+   piItem_flags = PT_GRAY_TO_ORANGE
+
+messages:
+
+   AppendSpecial()
+   "Appends text to the description relevant to specific key classes."
+   {
+      AppendTempString(RoomKeySecureCopy_appendspecial_rsc);
+      if poOwner = Send(self, @GetRenter)
+      {
+         AppendTempString(RoomKeySecureCopy_appendspecial_renter_rsc);
+      }
+      else
+      {
+         AppendTempString(RoomKeySecureCopy_appendspecial_not_renter_rsc);
+      }
+
+
+      return;
+   }
+   
+   ReqNewOwner(what=$)
+   {
+      local oRenter;
+
+      % If the key holder isn't the renter, don't allow it to be given
+      % to a new owner other than the renter.
+      oRenter = Send(self, @GetRenter);
+      if IsClass(poOwner, &User) AND poOwner <> oRenter AND what <> oRenter
+      {
+         Send(poOwner, @MsgSendUser, #message_rsc=RoomKeySecureCopy_no_drop_not_yours,
+            #parm1=Send(oRenter, @GetName));
+
+         return FALSE;
+      }
+
+      propagate;
+   }
+
+   CanSwap()
+   {
+      return FALSE;
+   }
+
+   CanShatter()
+   {
+      return FALSE;
+   }
+
+   ReqDMDelete()
+   "Keys are not deleted with the DM clear inventory command."
+   {
+      return FALSE;
+   }
+   
+   CanBeStoredInVault()   
+   {
+      return FALSE;
+   }
+
+   CanBeGivenToNPC()
+   {
+      return FALSE;
+   }
+
+   DropOnDeath()
+   {
+      return FALSE;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/roomkeyc/rmkeysec.kod
+++ b/kod/object/item/passitem/roomkeyc/rmkeysec.kod
@@ -30,8 +30,9 @@ resources:
       "Your bronze room key dissolves into a strange metallic liquid, then "
       "evaporates into an orange mist and is gone."
    RoomKeySecureCopy_no_drop_not_yours = \
-      "You can't just carelessly discard %s's room key like that!  You must return "
+      "You can't just carelessly discard %q's room key like that!  You must return "
       "it to either them or the innkeeper."
+
 classvars:
 
    vrName = RoomKeySecureCopy_name_rsc
@@ -66,21 +67,22 @@ messages:
          AppendTempString(RoomKeySecureCopy_appendspecial_not_renter_rsc);
       }
 
-
       return;
    }
-   
+
    ReqNewOwner(what=$)
    {
-      local oRenter;
+      local oRenter, sName;
 
       % If the key holder isn't the renter, don't allow it to be given
       % to a new owner other than the renter.
       oRenter = Send(self, @GetRenter);
-      if IsClass(poOwner, &User) AND poOwner <> oRenter AND what <> oRenter
+      if IsClass(poOwner, &User) AND oRenter <> $ AND poOwner <> oRenter AND what <> oRenter
       {
+         sName = CreateString();
+         SetString(sName, Send(oRenter, @GetName));
          Send(poOwner, @MsgSendUser, #message_rsc=RoomKeySecureCopy_no_drop_not_yours,
-            #parm1=Send(oRenter, @GetName));
+            #parm1=sName);
 
          return FALSE;
       }

--- a/kod/object/item/passitem/roomkeyc/roomkey.kod
+++ b/kod/object/item/passitem/roomkeyc/roomkey.kod
@@ -101,11 +101,19 @@ messages:
       return;
    }
 
-   Copy()
+   Copy(bSecure=FALSE)
    {
       local oCopy;
       
-      oCopy = Create(&RoomKeyCopy,#iRID=piRID);
+      if bSecure
+      {
+         oCopy = Create(&RoomKeySecureCopy, #iRID=piRID);
+      }
+      else
+      {
+         oCopy = Create(&RoomKeyCopy, #iRID=piRID);
+      }
+
       plCopies = cons(oCopy,plCopies);
       
       return oCopy;
@@ -178,6 +186,11 @@ messages:
       }
       
       propagate;
+   }
+
+   IsKeyCopy()
+   {
+      return FALSE;
    }
 
    CanShatter()

--- a/kod/object/item/passitem/roomkeyc/roomkey.kod
+++ b/kod/object/item/passitem/roomkeyc/roomkey.kod
@@ -189,6 +189,7 @@ messages:
    }
 
    IsKeyCopy()
+   "As this is the original/master key to a room, this should be FALSE."
    {
       return FALSE;
    }

--- a/kod/util/rntmaint.kod
+++ b/kod/util/rntmaint.kod
@@ -34,6 +34,7 @@ resources:
    RoomMaintenance_command_rent = "rent"
    RoomMaintenance_command_cost = "cost"
    RoomMaintenance_command_copy_key = "copy key"
+   RoomMaintenance_command_secure = "secure"
    RoomMaintenance_command_change_lock = "change lock"
 
    RoomMaintenance_innkeeper_say_room_rented = \
@@ -164,7 +165,8 @@ messages:
       % Command: Copy Key
       if StringContain(speech, RoomMaintenance_command_copy_key)
       {
-         rSayRsc = send(self, @CopyKey, #who=what, #iLocation=innRid, #iCost=keyCopyCost);
+         rSayRsc = send(self, @CopyKey, #who=what, #iLocation=innRid, #iCost=keyCopyCost,
+            #bSecure=StringContain(speech, RoomMaintenance_command_secure));
 
          % tell the player.
          Post(Send(who, @GetOwner), @SomeoneSaid, #type=SAY_RESOURCE, #what=who, #string=rSayRsc);
@@ -263,7 +265,7 @@ messages:
       % Is the item a key copy?  If so, destroy it.
       for oItem in itemList
       {
-         if GetClass(oItem) = &RoomKeyCopy
+         if IsClass(oItem, &RoomKeyCopy) AND Send(oItem, @IsKeyCopy)
          {
             % Say something and delete the key.
             Send(what, @MsgSendUser, #message_rsc=RoomMaintenance_innkeeper_say_destroy_key_copy_template,
@@ -313,7 +315,7 @@ messages:
       return $;
    }   
 
-   CopyKey(who=$,iLocation=$,iCost=500)
+   CopyKey(who=$, iLocation=$, iCost=500, bSecure=FALSE)
    {
       local lPassive, oObject, oKey, bHasRoomKey, bFound, oMoney;
       
@@ -369,7 +371,7 @@ messages:
       send(oMoney,@SubtractNumber,#number=iCost);
 
       % copy the key and give it to the player.
-      send(who,@NewHold,#what=send(oKey,@Copy));
+      send(who, @NewHold, #what=send(oKey, @Copy, #bSecure=bSecure));
 
       return RoomMaintenance_key_copied;
    }

--- a/kod/util/rntmaint.kod
+++ b/kod/util/rntmaint.kod
@@ -265,6 +265,8 @@ messages:
       % Is the item a key copy?  If so, destroy it.
       for oItem in itemList
       {
+         % RoomKeyCopy is the superclass of all room keys, so we need to know if the item
+         % is a room key.  If so, we can then ask it if it's a copy or the original.
          if IsClass(oItem, &RoomKeyCopy) AND Send(oItem, @IsKeyCopy)
          {
             % Say something and delete the key.

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -4968,6 +4968,7 @@ messages:
 
       plItemTemplates = cons(create(&RoomKey),plItemTemplates);
       plItemTemplates = cons(create(&RoomKeyCopy),plItemTemplates);
+      plItemTemplates = cons(create(&RoomKeySecureCopy),plItemTemplates);
       plItemTemplates = cons(create(&Mint),plItemTemplates);
 
       plItemTemplates = cons(create(&RedHeartStone),plItemTemplates);


### PR DESCRIPTION
Silver room keys (key copies) are nice because you can pass them out and share your room with friends, alts, mules, etc, however the risk of losing these keys, either on purpose or accident, exists.

This PR adds an alternate type of key copy option, the bronze room key, which the owner of the room can drop or trade freely, but anyone else cannot drop it, nor can they give it to anyone who isn't the owner or the innkeeper.  

![image](https://github.com/Meridian59/Meridian59/assets/22806592/f39714fe-8d0f-479e-997e-ce6cd89b5dbc)

Edit:  Image updated to reflect latest changes