### PR TITLE
Rentable room invalid mail fix

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -7839,7 +7839,7 @@ messages:
             j = 1;
             while j <= Length(stuff)
             {
-               if (Nth(stuff,j+1) = $)
+               if (Nth(stuff,j+1) = $) OR Nth(stuff, j + 1) = RentableRoom_expiry_warning
 	       {
 	          Debug("found bad mail",self);
 		  plNew_mail = DelListElem(plNew_mail, lNew_mail);

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -7837,9 +7837,13 @@ messages:
 	 if (Length(stuff) > 1)
 	 {
             j = 1;
+            % Note:  The line containing a check for RentableRoom_expiry_warning
+            % can safely be removed once it's done it's job.  By approximately
+            % November 1, 2023.
             while j <= Length(stuff)
             {
-               if (Nth(stuff,j+1) = $) OR Nth(stuff, j + 1) = RentableRoom_expiry_warning
+               if (Nth(stuff,j+1) = $)
+                 OR Nth(stuff, j + 1) = RentableRoom_expiry_warning
 	       {
 	          Debug("found bad mail",self);
 		  plNew_mail = DelListElem(plNew_mail, lNew_mail);

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -6574,22 +6574,6 @@ messages:
       }
       return total;
    }
-
-   CleanAllBadMail()
-   "Repeatedly calls CleanBadMail on all users until no bad mails remain."
-   {
-      local i, total, grandTotal;
-
-      total = Send(self, @CleanBadMail);
-      grandTotal = total;
-      while total > 0
-      {
-         total = Send(self, @CleanBadMail);
-         grandTotal = grandTotal + total;
-      }
-
-      return grandTotal;
-   }
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -6574,6 +6574,22 @@ messages:
       }
       return total;
    }
+
+   CleanAllBadMail()
+   "Repeatedly calls CleanBadMail on all users until no bad mails remain."
+   {
+      local i, total, grandTotal;
+
+      total = Send(self, @CleanBadMail);
+      grandTotal = total;
+      while total > 0
+      {
+         total = Send(self, @CleanBadMail);
+         grandTotal = grandTotal + total;
+      }
+
+      return grandTotal;
+   }
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
This adds a check for the expiry warning resource (now intended to be a whisper and thus not formatted for user mails) to CleanBadMail in user.kod.  It should allow CleanBadMail to effectively remove all of the invalid innkeeper expiry warning mails while leaving any others untouched.

After being run once and saving, this change can be safely reverted as it will no longer be relevant.

Send o 0 CleanAllBadMail should allow it to run on every single user in one go.

Testing:  I tested this on a character with an invalid expiry mail plus a mail from another user, as well as a mail from the guardian angel--all unread.  It deleted the expiry mail while leaving the others untouched.