### PR TITLE
Fix withdraw shillings from boxes

### DIFF
--- a/kod/object/active/holder.kod
+++ b/kod/object/active/holder.kod
@@ -284,11 +284,12 @@ messages:
    GetNumberCanHold(what = $)
    {
       local iBulk_can_hold, iWeight_can_hold, iUnit_bulk, iUnit_weight;
-
+      debug("Shilling Message Go Here?")
       if NOT IsClass(what,&NumberItem)
          OR send(self,@GetBulkMax) = $
          OR send(self,@GetWeightMax) = $
       {
+         debug("Returning NULL")
          return $;
       }
       return Send(what,@GetNumberCanHold,

--- a/kod/object/active/holder.kod
+++ b/kod/object/active/holder.kod
@@ -284,6 +284,7 @@ messages:
    GetNumberCanHold(what = $)
    {
       local iBulk_can_hold, iWeight_can_hold, iUnit_bulk, iUnit_weight;
+      
       if NOT IsClass(what,&NumberItem)
          OR send(self,@GetBulkMax) = $
          OR send(self,@GetWeightMax) = $

--- a/kod/object/active/holder.kod
+++ b/kod/object/active/holder.kod
@@ -284,12 +284,12 @@ messages:
    GetNumberCanHold(what = $)
    {
       local iBulk_can_hold, iWeight_can_hold, iUnit_bulk, iUnit_weight;
-      debug("Shilling Message Go Here?")
+      debug("Shilling Message Go Here?");
       if NOT IsClass(what,&NumberItem)
          OR send(self,@GetBulkMax) = $
          OR send(self,@GetWeightMax) = $
       {
-         debug("Returning NULL")
+         debug("Returning NULL");
          return $;
       }
       return Send(what,@GetNumberCanHold,

--- a/kod/object/active/holder.kod
+++ b/kod/object/active/holder.kod
@@ -284,12 +284,10 @@ messages:
    GetNumberCanHold(what = $)
    {
       local iBulk_can_hold, iWeight_can_hold, iUnit_bulk, iUnit_weight;
-      debug("Shilling Message Go Here?");
       if NOT IsClass(what,&NumberItem)
          OR send(self,@GetBulkMax) = $
          OR send(self,@GetWeightMax) = $
       {
-         debug("Returning NULL");
          return $;
       }
       return Send(what,@GetNumberCanHold,

--- a/kod/object/active/holder.kod
+++ b/kod/object/active/holder.kod
@@ -284,7 +284,7 @@ messages:
    GetNumberCanHold(what = $)
    {
       local iBulk_can_hold, iWeight_can_hold, iUnit_bulk, iUnit_weight;
-      
+
       if NOT IsClass(what,&NumberItem)
          OR send(self,@GetBulkMax) = $
          OR send(self,@GetWeightMax) = $

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3650,6 +3650,7 @@ messages:
             % iCan_hold of $ intended to signal infinite capacity
             % Therefore set iCan_hold to number of items requested
             if iCan_hold = $
+               OR iCan_hold = INFINITE_COUNT
             {
                iCan_hold = number;
             }


### PR DESCRIPTION
The bounding logic for withdrawing shillings from storage boxes results in setting iNumber to -1.  The result was that users can't remove shillings from guild hall chests and other boxes.  Now we set iCan_hold to number in this instance in the same manner we deal with DMs who return NULL for GetNumberCanHold().  The logic is: if the item has no weight and no bulk then we can hold any amount of that item so we set the number we can hold equal to the amount we want to grab and move on.