### PR TITLE
Prevent larger resolutions from exceeding the maximum supported width

### DIFF
--- a/clientd3d/graphics.c
+++ b/clientd3d/graphics.c
@@ -175,9 +175,16 @@ void GraphicsAreaResize(int xsize, int ysize)
    int text_area_height = text_area_size + BOTTOM_BORDER + GetTextInputHeight() + TOP_BORDER + EDGETREAT_HEIGHT * 2;
    text_area_height += config.toolbar ? TOOLBAR_BUTTON_HEIGHT + MIN_TOP_TOOLBAR : MIN_TOP_NOTOOLBAR;
 
-   // Calculate the largest possible viewport size keeping the classic client aspect ratio
+   // Calculate the largest possible viewport size keeping the classic client aspect ratio.
    new_ysize = ysize - text_area_height;
    new_xsize = new_ysize * MAXYX_ASPECT_RATIO;
+
+   if (new_xsize > MAXX)
+   {
+       // Prevent larger resolutions from exceeding the maximum supported width.
+       new_xsize = MAXX;
+       new_ysize = new_xsize / MAXYX_ASPECT_RATIO;
+   }
 
    if ((new_xsize + INVENTORY_MIN_WIDTH) > xsize) {
       new_xsize = xsize - INVENTORY_MIN_WIDTH;


### PR DESCRIPTION
This prevents a crash when a large resolution is used that creates a viewport exceeding the maximum supported width.

For example 3840 by 2160 at 100% scale:
![image](https://github.com/Meridian59/Meridian59/assets/7548210/75bf7ad4-d694-44c6-b1ed-ab3756f1c83e)
