### PR TITLE
Bonkstick update:  Makes them suitable to be available as event rewar…

### DIFF
--- a/kod/object/item/passitem/specwand/bonkstik.kod
+++ b/kod/object/item/passitem/specwand/bonkstik.kod
@@ -23,6 +23,8 @@ resources:
    BonkStick_desc_rsc = \
       "This wand just drips of ludicrocity."
 
+   BonkStick_wav_rsc = Patk.wav
+
    bonkstick_bad_target = "You cannot use the bonkstick on %s%s."
    bonkstick_not_self = "You wouldn't feel right hitting yourself on the head with the bonkstick!"
 
@@ -41,8 +43,10 @@ classvars:
    viWeight = 25
    viValue_average = 150
 
-   viHits_init_min = 20000
-   viHits_init_max = 20000
+   % Greatly reduced hit value to allow these to be available to
+   % give to players in a reasonable way.
+   viHits_init_min = 20
+   viHits_init_max = 20
 
    viGround_group = 2
 
@@ -104,6 +108,8 @@ messages:
       Send(apply_on,@MsgSendUser,#message_rsc=bonked_bonkstick_msg,
            #parm1=Send(poOwner,@GetDef),#parm2=Send(poOwner,@GetName),
            #parm3=Send(poOwner,@GetHisHer));
+
+      Send(Send(apply_on, @GetOwner), @SomethingWaveRoom, #what=apply_on,#wave_rsc=BonkStick_wav_rsc);
 
       for i in lActive
       {

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -4874,6 +4874,7 @@ messages:
       plItemTemplates = cons(create(&HealWand),plItemTemplates);
       plItemTemplates = cons(create(&VampireWand),plItemTemplates);
       plItemTemplates = cons(create(&StaffOfJolting),plItemTemplates);
+      plItemTemplates = cons(create(&BonkStick),plItemTemplates);
 
       plItemTemplates = cons(create(&ShortSword),plItemTemplates);
       plItemTemplates = cons(create(&LongSword),plItemTemplates);


### PR DESCRIPTION
…ds for players

This PR makes the Bonkstick (a for-fun item) more reasonably available as an item that can be awarded to players through events, etc.

- Greatly reduced the total item uses from 20,000 (!) down to 20.
- Adds a "thud" sound effect centered upon the target's location.
- Adds the bonkstick to the item template list, allowing it to be properly created through DM commands.

Note that I'm interested in feedback on the total number of uses.  These shouldn't have any amount of permanency, but 20 is an arbitrary number.  Should it be lower or higher?  Should these also disappear after X hours have passed?