### PR TITLE
Revert skill improvement penalty in Origin of the Kriipa

### DIFF
--- a/kod/object/active/holder/room/monsroom/kcforest/kc4.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/kc4.kod
@@ -118,19 +118,5 @@ messages:
       return AVARCLAN_ANTIMAGIC;
    }
 
-   ModifyChanceToImprove(who=$,oSpellSkill=$,chance=0)
-   "This takes a spell/skill that who is trying to advance and modifies the improve_chance."
-   {
-      % Penalize skills because there's an obvious chokepoint here.
-      if oSpellSkill <> $
-         AND IsClass(oSpellSkill,&Skill)
-      {
-         return (chance / 10);
-      }
-      
-      return chance;
-   }
-
-
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Long ago, the Origin of the Kriipa map had single-file choke points at the north and south exits that a player could stand in, hold down attack, and just afk-kill enemies as they lined up.  To discourage this, a skill improvement penalty was added.

The map has since been changed to remove these choke points, so this penalty is no longer necessary.