### PR TITLE
Stepwise Arena Fix - part 1 - Add isValidTarget to Necro Arena and fix GetWatcher implementation

### DIFF
--- a/kod/object/active/holder/room/necarena.kod
+++ b/kod/object/active/holder/room/necarena.kod
@@ -155,6 +155,32 @@ messages:
       return True;
    }
 
+   IsValidTarget(who=$)
+   {
+      local oWatcher;
+
+      if NOT Send(self,@CheckRoomFlag,#flag=ROOM_SAFE_DEATH)
+      {
+         return FALSE;
+      }
+
+      oWatcher = send(self,@GetWatcher);
+
+      if oWatcher = $
+      {
+         Debug("IsValidTarget called with no watcher in existence!");
+
+         return FALSE;
+      }
+
+      if Send(oWatcher,@IsCombatant,#who=who) AND Send(oWatcher,@FightInSession)
+      {
+         return TRUE;
+      }
+
+      return FALSE;
+   }
+
    NewHold(what = $,new_row = 22, new_col = 11)
    "will move anyone who enters in the playing field into the stands."
    "This should only be necessary for people who drop link."
@@ -626,7 +652,13 @@ messages:
 
    GetWatcher()
    {
-      return poWatcher;
+      local oWatcher;
+
+      % FindHoldingActive returns the first instance of Goad
+      % if Goad is in the room - otherwise returns $
+
+      oWatcher = send(self,@FindHoldingActive,#class=&Goad);
+      return oWatcher;
    }
 
    CheckLava(flag = TRUE)

--- a/kod/object/active/holder/room/necarena.kod
+++ b/kod/object/active/holder/room/necarena.kod
@@ -652,13 +652,7 @@ messages:
 
    GetWatcher()
    {
-      local oWatcher;
-
-      % FindHoldingActive returns the first instance of Goad
-      % if Goad is in the room - otherwise returns $
-
-      oWatcher = send(self,@FindHoldingActive,#class=&Goad);
-      return oWatcher;
+      return send(self,@FindHoldingActive,#class=&Goad);
    }
 
    CheckLava(flag = TRUE)


### PR DESCRIPTION
This PR adds an isValidTarget message to Necro Arena. 

This message is sent whenever a spell cast is made that requires a target.t and the caster is in an arena.  If the message propagates all the way up to Room.kod the return value is FALSE.  In the two arenas we therefore need some logic to return TRUE if the caster and target are both combatants and if a fight is in session.

This logic was included in Tos Arena but was not included in Necro Arena.  The result is that currently players can not cast attack spells at each other in Goad's Grinder arena.

The IsValidTarget message also relies on GetWatcher.  This PR fixes the necro arena getWatcher message to correctly look for the first instance of the Goad NPC in the room and return that object.  Prior to this change GetWatcher just returned the value of the poWatcher property which may or may not correctly identify the watcher object (for example - a DM has moved or somehow deleted the watcher).  The Goad object prevents multiple Goads from existing so returning the first Goad object is safe.

There is a tiny bit of repeated code now in Necro Arena and Tos Arena.  I believe this is unavoidable with the current class hierarchy.  Also - in the future it is possible we would want to allow more types of attacks in the Necro Arena which would be inappropriate for the Tos Arena.  The shared code allows for this with a simple update.
