### PR TITLE
Fix error messages at startup.

### DIFF
--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -871,6 +871,13 @@ messages:
    {
       local i;
 
+      % Recreate the hash tables.
+
+      Send(self,@CreateUserTable);
+      Send(self,@CreateRoomTable);
+      Send(self,@CreateSpellTable);
+      Send(self,@CreateItemAttTable);
+      
       % Player maintenance.
 
       for i in plUsers_logged_on
@@ -901,13 +908,6 @@ messages:
       poHolder2 = Create(&Holder);
 
       Send(self,@RecalcLightAndWeather);
-
-      % Recreate the hash tables.
-
-      Send(self,@CreateUserTable);
-      Send(self,@CreateRoomTable);
-      Send(self,@CreateSpellTable);
-      Send(self,@CreateItemAttTable);
 
       return;
    }


### PR DESCRIPTION
Users remain technically logged in when the server exits.  When it restarts, they're logged out, causing them to leave their room and break any trance.  This sends a message to other objects in the room; however, at this point in server initialization, the room hash table hasn't yet been created, causing error messages.

The hash table initialization was moved earlier so that the tables exist while this logging out process is happening.

Fixes #590.