### PR TITLE
Remove lingering DurationSecs reference in animate.kod

### DIFF
--- a/kod/object/passive/spell/animate.kod
+++ b/kod/object/passive/spell/animate.kod
@@ -182,7 +182,7 @@ messages:
       }
 
       iDurationSecs = ( ((iSpellPower/2) + random(25,50)) * MAX_RISEN_CONTROL_SECS/100 );
-      send(oRisen,@SetMaster,#oMaster=who,#DurationSecs=iDurationSecs);
+      send(oRisen,@SetMaster,#oMaster=who);
       send(oRisen,@SetSummoned,#value=TRUE);
       Send(oRisen, @StartEnchantment, #what=self, #time=iDurationSecs * 1000);
       Post(oRisen,@ResetBehaviorFlags);  


### PR DESCRIPTION
Removes the DurationSecs parameter animate.kod tries to pass into monster.kod's SetMaster function.  This is a leftover from when zombie.kod had its own version of SetMaster to handle animate's duration via timer, and is no longer relevant.