### PR TITLE
Crystalize mana - exit out of periodic enchantment if we can't hold the mana crystal

### DIFF
--- a/kod/object/passive/spell/jala/crysmana.kod
+++ b/kod/object/passive/spell/jala/crysmana.kod
@@ -96,6 +96,8 @@ messages:
 
             % Stop the spell, use EVENT_STEER because we want it to break.
             Post(oCaster,@BreakTrance,#event=EVENT_STEER);
+
+            propagate;
          }
       }
 


### PR DESCRIPTION
This PR fixes a bug whereby a player casting crystalize mana while their inventory is full would result in the server attempting to send a message to a deleted object.

StartPeriodicEnchantment checks if the player can hold the mana cyrstal and if not deletes the crystal object and breaks the player's trance.  Prior to this PR the StartPeriodicEnchantment message continued and sended an IncreaseMana message to the deleted Crystal.

The proposed fix is to propagate out of the message when the object is deleted as we don't need the other actions.  Its possible that changing the break-trance message from a Post to a Send would accomplish the same goal.  However, break trance results in a huge cascade of messages and propagating out of the message prevents sending any messages to the deleted object even if we change BreakTrance() in the future.

To test: Load up a current synched fork test-server and fill your inventory then cast Crystalize Mana.  The server will show two error messages.  Doing the same thing with the additional propagate command stops this.