### PR TITLE
Fix for shroud's improper appended description

### DIFF
--- a/kod/object/passive/spell/shroud.kod
+++ b/kod/object/passive/spell/shroud.kod
@@ -95,19 +95,19 @@ messages:
       if not Send(oItem,@CanEnchant,#oSpell = self)
       {
          Send(who, @MsgSendUser, #message_rsc=spell_resists,
-             #parm1=send(oItem,@getCapdef),#parm2=send(oItem,@getname));
-	      return;
+            #parm1=send(oItem,@getCapdef),#parm2=send(oItem,@getname));
+         return;
       }
       
       oItemAtt = send(SYS,@finditemattbynum,#num=IA_SHROUD);
 
       send(oItemAtt,@AddToItem,#oItem=oItem,
-          #timer_duration = send(self,@GetDuration,#iSpellPower=iSpellPower),
-          #iPower=random(iSpellPower/20,iSpellPower/10),
-          #random_gen=FALSE);
+         #timer_duration = send(self,@GetDuration,#iSpellPower=iSpellPower),
+         #iPower=random(iSpellPower/20,iSpellPower/10),
+         #random_gen=FALSE);
       Send(who, @MsgSendUser, #message_rsc=shroud_cast_rsc,
-          #parm1=Send(oItem,@GetName), 
-          #state3=send(self,@GetMakerInfo,#who=who));
+         #parm1=Send(oItem,@GetName), 
+         #state3=send(self,@GetMakerInfo,#who=who));
 
       propagate;
    }

--- a/kod/object/passive/spell/shroud.kod
+++ b/kod/object/passive/spell/shroud.kod
@@ -102,11 +102,12 @@ messages:
       oItemAtt = send(SYS,@finditemattbynum,#num=IA_SHROUD);
 
       send(oItemAtt,@AddToItem,#oItem=oItem,
-	      #timer_duration = send(self,@GetDuration,#iSpellPower=iSpellPower),
-	      #iPower=random(iSpellPower/20,iSpellPower/10));
+          #timer_duration = send(self,@GetDuration,#iSpellPower=iSpellPower),
+          #iPower=random(iSpellPower/20,iSpellPower/10),
+          #random_gen=FALSE);
       Send(who, @MsgSendUser, #message_rsc=shroud_cast_rsc,
-	      #parm1=Send(oItem,@GetName), 
-         #state3=send(self,@GetMakerInfo,#who=who));
+          #parm1=Send(oItem,@GetName), 
+          #state3=send(self,@GetMakerInfo,#who=who));
 
       propagate;
    }


### PR DESCRIPTION
This fixes a bug where the Shroud effect is flagged as unidentified when applied to an item using the Shroud spell.  Since shroud prevents items from also being identified, the identified version of its appended description was never shown under any circumstances short of DM intervention.

Also cleaned up a few minor tab/spacing anomalies nearby.

![image](https://github.com/Meridian59/Meridian59/assets/22806592/36546552-acb3-40ac-96df-dbb6c5f11316)
