### PR TITLE
Goad Fixes Part 4 - Fix Style_No_Combat bug and remove Kludge message setup

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
@@ -267,7 +267,7 @@ messages:
    {
       if piCombat_Style = STYLE_ONE_ON_ONE
          AND (send(poOwner,@ShrineInUse) = FALSE)
-         AND length(plCombatants = 2)
+         AND length(plCombatants) = 2
       {
          return TRUE;
       }

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
@@ -605,7 +605,7 @@ messages:
        local index, i;
 
        %% Tell room to lower maze or get rid of pests, whatever.
-       Send(poOwner,@EndFight,#lCombatants = plCombatants);
+       Send(poOwner,@endfight,#lCombatants = plCombatants);
 
        %% Assume that everyone left in plCombatant is a winner.
 

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
@@ -49,7 +49,8 @@ resources:
    Goad_already_champion = "So generous . . . but, you are already mine."
    Goad_already_have_champion = "So you would be champion?  Nothing could be easier, simply challenge and kill %s%s.  Would you dare to challenge %s?"
 
-   Goad_challenge_offered = "%s%s has challenged you.  Will you crush %s's like the bug %s is?"
+   Goad_challenge_offered = "%s%s has challenged you.  Will you crush %s like the bug %s is?"
+   Goad_challenge_excitement = "%s%s has challenged %s%s to bloody battle!"
    Goad_must_accept = "Hurry fool!! You only have %i seconds left to accept %s%s's challenge."
 
    Goad_cant_renege = "You cannot renege unless you are a combatant!"
@@ -325,6 +326,10 @@ messages:
 
       if piCombat_style = STYLE_ONE_ON_ONE
       {
+         % Tell the room and then ask the champion if they accept
+         Send(self,@say,#message_rsc=Goad_challenge_excitement,
+            #parm1=send(who,@getcapdef),#parm2=send(who,@getname),
+            #parm3=send(poChampion,@getcapdef),#parm4=send(poChampion,@getname));
          Send(self,@SayToOne,#target=poChampion,#message_rsc=Goad_challenge_offered,
             #parm1=send(who,@getcapdef),#parm2=send(who,@getname),
             #parm3=send(who,@gethimher),#parm4=send(who,@gethimher)); 
@@ -1248,24 +1253,6 @@ messages:
       propagate;
    }
 
-   KludgeMessage(who=$)
-   {
-
-      
-      ClearTempString();
-      AppendTempString(send(who,@GetName));
-      AppendTempString(" has challenged you.  Will you crush ");
-      AppendTempString(send(who,@GetHimHer));
-      AppendTempString(" like the bug ");
-      AppendTempString(send(who,@GetHeShe));
-      AppendTempString(" is?");
-      Post(poOwner,@SomeoneSaid,#what=self,#type=SAY_RESOURCE,
-            #string=send(SYS,@GetPercentQRsc),#parm1=getTempString(),#type1=0);
-      return;
-   }
-
-
-   
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
@@ -314,7 +314,7 @@ messages:
          send(self,@sayToOne,#target=who,#message_rsc=Goad_Already_champion);
          return;
       }
-      if Send(self,@isCombatant,#who=who)
+      if send(self,@isCombatant,#who=who)
       {
          send(self,@sayToOne,#target=who,#message_rsc=Goad_Already_combatant);
          return;

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
@@ -733,7 +733,7 @@ messages:
    "champion, then make the talker the new champion."
    {
       % Set piCombat_style just in case of problems.
-      piCombat_style = STYLE_ONE_ON_ONE
+      piCombat_style = STYLE_ONE_ON_ONE;
 
       if not send(self,@AcceptingChampions)
       {
@@ -760,6 +760,7 @@ messages:
          send(self,@Say,#message_rsc=Goad_new_champion,
                     #parm1=send(poChampion,@getdef),#parm2=send(poChampion,@getname));
       }
+
       return;  
    }
 
@@ -769,7 +770,7 @@ messages:
    "will succeed only if there is a challenger spot open."
    {
       % Set piCombat_style just in case of problems.
-      piCombat_style = STYLE_ONE_ON_ONE
+      piCombat_style = STYLE_ONE_ON_ONE;
 
       if send(self,@FightInSession)
         {
@@ -794,7 +795,7 @@ messages:
    TrigAccept(what=$)
    {
       % Set piCombat_style just in case of problems.
-      piCombat_style = STYLE_ONE_ON_ONE
+      piCombat_style = STYLE_ONE_ON_ONE;
 
       if what <> poChampion
       {

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
@@ -569,20 +569,6 @@ messages:
                    }
                 }
              }
-
-             if oldChamp <> poChampion
-               {
-                  send(self,@say,#message_rsc=Goad_new_champion,
-                    #parm1=send(poChampion,@getdef),#parm2=send(poChampion,@getname));
-               }
-             else
-               {
-                  send(self,@say,#message_rsc = Goad_retain_title,
-                     #parm1 = send(poChampion,@getcapdef),
-                     #parm2 = send(poChampion,@getName),
-                     #parm3 = send(poChampion,@gethisher));
-               }
-             return;
           }   
           if oldChamp <> poChampion
             {

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
@@ -123,7 +123,7 @@ classvars:
 
 properties:
 
-   piCombat_style = STYLE_NO_FIGHT
+   piCombat_style = STYLE_ONE_ON_ONE
 
    ptAdvert = $               %% every now and then, the Watcher sends off
                               %% a blurb, asking people to fight for him
@@ -311,45 +311,41 @@ messages:
     {
       if who = poChampion
       {
-         send(self,@sayToOne,#target=who,#message_rsc=Goad_Already_champion);
+         Send(self,@SayToOne,#target=who,#message_rsc=Goad_Already_champion);
          return;
       }
-      if send(self,@isCombatant,#who=who)
+      if Send(self,@isCombatant,#who=who)
       {
-         send(self,@sayToOne,#target=who,#message_rsc=Goad_Already_combatant);
-
+         Send(self,@SayToOne,#target=who,#message_rsc=Goad_Already_combatant);
          return;
       }
       
-      If not send(self,@MaxCombatantCheck,#who=who)
+      If not Send(self,@MaxCombatantCheck,#who=who)
       { return FALSE; }
 
       if piCombat_style = STYLE_ONE_ON_ONE
       {
-         %%KLUDGE - REMOVE THIS
-         %send(self,@say,#message_rsc=Goad_challenge_offered,
-            %#parm1=send(who,@getcapdef),#parm2=send(who,@getname),
-            %#parm3=send(who,@gethimher),#parm4=send(who,@gethimher));
-         send(self,@KludgeMessage,#who=who);
-         %%END KLUDGE         
+         Send(self,@SayToOne,#target=poChampion,#message_rsc=Goad_challenge_offered,
+            #parm1=send(who,@getcapdef),#parm2=send(who,@getname),
+            #parm3=send(who,@gethimher),#parm4=send(who,@gethimher)); 
 
          pbAccept = FALSE;
          ptAccept = CreateTimer(self,@AcceptTimer,ACCEPT_DELAY); 
       }
       else
       {
-         send(self,@say,#message_rsc=Goad_new_combatant,
+         Send(self,@say,#message_rsc=Goad_new_combatant,
                   #parm1=send(who,@getcapdef),#parm2=send(who,@getname));
 
           if ptAccept = $
           {
-             pbAccept = FALSE;
-             send(self,@say,#message_rsc=Goad_more_combatants,
-                 #parm1=30);
-              ptAccept = CreateTimer(self,@AcceptTimer,ACCEPT_DELAY);
+            pbAccept = FALSE;
+            Send(self,@say,#message_rsc=Goad_more_combatants,
+               #parm1=30);
+            ptAccept = CreateTimer(self,@AcceptTimer,ACCEPT_DELAY);
           }
       }
-      send(self,@newCombatant,#who=who);
+      Send(self,@newCombatant,#who=who);
       return;
     }
 
@@ -791,12 +787,9 @@ messages:
    "Someone in the room said 'champion'.  Net effect, if there is no "
    "champion, then make the talker the new champion."
    {
-      if piCombat_style = STYLE_NO_FIGHT
-         {
-           %%Only one style availible: Duel.
-           %send(self,@say,#message_rsc=Goad_must_choose_style);
-           %return;    
-           post(self,@ChooseCombat,#style = STYLE_ONE_ON_ONE,#actor=what); 
+      if piCombat_style <> STYLE_ONE_ON_ONE
+         {  
+           Send(self,@ChooseCombat,#style = STYLE_ONE_ON_ONE); 
          }
       if not send(self,@AcceptingChampions)
       {
@@ -831,11 +824,9 @@ messages:
    "the match, but in general, this will fail if there is no champion, and "
    "will succeed only if there is a challenger spot open."
    {
-      if piCombat_style = STYLE_NO_FIGHT
+      if piCombat_style <> STYLE_ONE_ON_ONE
          {
-           post(self,@ChooseCombat,#style = STYLE_ONE_ON_ONE,#actor=what);
-           %send(self,@saytoOne,#target=what,#message_rsc=Goad_must_choose_style);
-           %return;     
+           Send(self,@ChooseCombat,#style = STYLE_ONE_ON_ONE);    
          }
       if send(self,@FightInSession)
         {
@@ -893,8 +884,9 @@ messages:
       return;
    }
 
-   ChooseCombat(style = STYLE_NO_FIGHT,actor=$)
+   ChooseCombat(style = STYLE_ONE_ON_ONE)
    {
+      % No changing style if there are already combatants
       if piCombat_style <> STYLE_NO_FIGHT AND plCombatants <> $
       {
          send(self,@say,#message_rsc=Goad_cant_switch);
@@ -1220,24 +1212,14 @@ messages:
       propagate;
    }
 
-   GetCombatName(style = $)
+   GetCombatName()
    {
-     if style = $
-       {
-         if piCombat_style = STYLE_ONE_ON_ONE
-           { return Goad_style_one_on_one; }
-         if piCombat_style = STYLE_LAST_MAN_STANDING
-           { return Goad_style_last_man_standing; }
-         DEBUG("GetCombatName called with invalid fighting style chosen!");
-         return;
-       }
-
-     if style = STYLE_ONE_ON_ONE
-        { return Goad_style_one_on_one; }
-     if style = STYLE_LAST_MAN_STANDING
-        { return Goad_style_last_man_standing; }
-
-     return;
+      if piCombat_style = STYLE_ONE_ON_ONE
+         { return Goad_style_one_on_one; }
+      if piCombat_style = STYLE_LAST_MAN_STANDING
+         { return Goad_style_last_man_standing; }
+      DEBUG("GetCombatName called with invalid fighting style chosen!");
+      return;
    }
 
    SomethingEntered(what=$)

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
@@ -605,7 +605,7 @@ messages:
        local index, i;
 
        %% Tell room to lower maze or get rid of pests, whatever.
-       Send(poOwner,@endfight,#lCombatants = plCombatants);
+       Send(poOwner,@EndFight,#lCombatants = plCombatants);
 
        %% Assume that everyone left in plCombatant is a winner.
 
@@ -767,12 +767,6 @@ messages:
             post(self,@ChooseCombat,#style = STYLE_ONE_ON_ONE);
             return FALSE;
          }
-         %%Rumble style cut due to insuficient test.
-         %if StringEqual(string,"rumble")
-         %{
-            %post(self,@ChooseCombat,#style = STYLE_LAST_MAN_STANDING);
-            %return FALSE;
-         %}
       }
       if send(self,@FightInSession)
       {

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
@@ -311,16 +311,16 @@ messages:
     {
       if who = poChampion
       {
-         Send(self,@SayToOne,#target=who,#message_rsc=Goad_Already_champion);
+         send(self,@sayToOne,#target=who,#message_rsc=Goad_Already_champion);
          return;
       }
       if Send(self,@isCombatant,#who=who)
       {
-         Send(self,@SayToOne,#target=who,#message_rsc=Goad_Already_combatant);
+         send(self,@sayToOne,#target=who,#message_rsc=Goad_Already_combatant);
          return;
       }
       
-      If not Send(self,@MaxCombatantCheck,#who=who)
+      If not send(self,@MaxCombatantCheck,#who=who)
       { return FALSE; }
 
       if piCombat_style = STYLE_ONE_ON_ONE
@@ -345,7 +345,7 @@ messages:
             ptAccept = CreateTimer(self,@AcceptTimer,ACCEPT_DELAY);
           }
       }
-      Send(self,@newCombatant,#who=who);
+      send(self,@newCombatant,#who=who);
       return;
     }
 

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
@@ -334,7 +334,7 @@ messages:
       }
       else
       {
-         Send(self,@say,#message_rsc=Goad_new_combatant,
+         send(self,@say,#message_rsc=Goad_new_combatant,
                   #parm1=send(who,@getcapdef),#parm2=send(who,@getname));
 
           if ptAccept = $
@@ -759,13 +759,13 @@ messages:
          
          if StringEqual(string,"duel")
          {
-            post(self,@ChooseCombat,#style = STYLE_ONE_ON_ONE,#actor=what);
+            post(self,@ChooseCombat,#style = STYLE_ONE_ON_ONE);
             return FALSE;
          }
          %%Rumble style cut due to insuficient test.
          %if StringEqual(string,"rumble")
          %{
-            %post(self,@ChooseCombat,#style = STYLE_LAST_MAN_STANDING,#actor=what);
+            %post(self,@ChooseCombat,#style = STYLE_LAST_MAN_STANDING);
             %return FALSE;
          %}
       }

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
@@ -247,8 +247,7 @@ messages:
    SetChampion(who=$)
    {
       if poChampion <> who
-      and (piCombat_style = STYLE_ONE_ON_ONE or
-           piCombat_style = STYLE_LAST_MAN_STANDING)
+         AND piCombat_style = STYLE_ONE_ON_ONE
       {
          poChampion = who;
          return;
@@ -263,12 +262,14 @@ messages:
    }
 
    ValidateFight()
+   "Validate fights with two combatants, with the correct fight style,"
+   "and where the shrine isn't used."
    {
-      if (piCombat_Style = STYLE_ONE_ON_ONE or piCombat_Style = STYLE_LAST_MAN_STANDING)
-      AND (send(poOwner,@ShrineInUse) = FALSE)
+      if piCombat_Style = STYLE_ONE_ON_ONE
+         AND (send(poOwner,@ShrineInUse) = FALSE)
+         AND length(plCombatants = 2)
       {
-         if length(plCombatants) > 1
-            { return TRUE; }
+         return TRUE;
       }
       
       return FALSE;
@@ -281,12 +282,11 @@ messages:
        return FALSE;
     }
 
-    AcceptingChallengers() %% How many can Brax fit?
+    AcceptingChallengers()
     {
        if length(plCombatants) < 2 AND piCombat_Style = STYLE_ONE_ON_ONE
        { return TRUE; }
-       if length(plCombatants) < 6 AND piCombat_Style = STYLE_LAST_MAN_STANDING  
-       { return TRUE; }   
+
        return FALSE;
     }
 
@@ -337,19 +337,7 @@ messages:
          pbAccept = FALSE;
          ptAccept = CreateTimer(self,@AcceptTimer,ACCEPT_DELAY); 
       }
-      else
-      {
-         send(self,@say,#message_rsc=Goad_new_combatant,
-                  #parm1=send(who,@getcapdef),#parm2=send(who,@getname));
 
-          if ptAccept = $
-          {
-            pbAccept = FALSE;
-            Send(self,@say,#message_rsc=Goad_more_combatants,
-               #parm1=30);
-            ptAccept = CreateTimer(self,@AcceptTimer,ACCEPT_DELAY);
-          }
-      }
       send(self,@newCombatant,#who=who);
       return;
     }
@@ -357,7 +345,7 @@ messages:
     MaxCombatantCheck(who=$)
     {
  
-       if length(plCombatants) > 6
+       if length(plCombatants) > 2
        {
          send(self,@SayToOne,#target=who,#message_rsc=Goad_Not_more);
          return FALSE;
@@ -398,10 +386,6 @@ messages:
              #parm3=send(nth(plCombatants,2),@getdef),
              #parm4=send(nth(plCombatants,2),@getname));
          }
-       if piCombat_style = STYLE_LAST_MAN_STANDING
-         {
-           send(self,@say,#message_rsc = Goad_ready_last_man);
-         }
        
        ptCommence=CreateTimer(self,@commencetimer,
           Random(COMMENCE_DELAY_MIN,COMMENCE_DELAY_MAX));
@@ -423,16 +407,10 @@ messages:
     Commence()
     "Called by CommenceTimer."
     {
-       local delay;
-
        send(self,@say,#message_rsc=Goad_commence);
        pbLastMinute = FALSE;
        pbWarned = FALSE;
-       delay = FIGHT_DELAY_LAST_MAN_STANDING;
-       if piCombat_style = STYLE_ONE_ON_ONE
-         {  delay = FIGHT_DELAY_ONE_ON_ONE;  }
-
-       ptFight = CreateTimer(self,@FightTimer,delay);
+       ptFight = CreateTimer(self,@FightTimer,FIGHT_DELAY_ONE_ON_ONE);
        return;
     }
 
@@ -478,18 +456,8 @@ messages:
       }
 
       send(self,@checkforwinner);
-     
-      %% scenario:  champion quits during signup for last man standing.
-      if poChampion = $ and length(plCombatants) >= 2
-      {
-         if piCombat_Style = STYLE_LAST_MAN_STANDING
-         {   
-            %% choose another champion - first player in line will do
-            poChampion = first(plCombatants);
-         }
-      }
-     
-       return;
+
+      return;
     }
 
     SomethingKilled(what=$,victim=$)
@@ -747,19 +715,11 @@ messages:
             post(self,@TrigRenege,#what=what);
             return FALSE;
          }
-         
-         if StringEqual(string,"duel")
-         {
-            post(self,@ChooseCombat,#style = STYLE_ONE_ON_ONE);
-            return FALSE;
-         }
       }
       if send(self,@FightInSession)
       {
          if StringEqual(string,"champion")
          or StringEqual(string,"challenge")
-         or StringEqual(string,"duel")
-         or StringEqual(string,"rumble")
          {
             send(what,@msgsenduser,#message_rsc=Goad_not_during_fight);
             return FALSE;
@@ -772,10 +732,9 @@ messages:
    "Someone in the room said 'champion'.  Net effect, if there is no "
    "champion, then make the talker the new champion."
    {
-      if piCombat_style <> STYLE_ONE_ON_ONE
-         {  
-           Send(self,@ChooseCombat,#style = STYLE_ONE_ON_ONE); 
-         }
+      % Set piCombat_style just in case of problems.
+      piCombat_style = STYLE_ONE_ON_ONE
+
       if not send(self,@AcceptingChampions)
       {
          if send(self,@AcceptingChallengers)
@@ -809,10 +768,9 @@ messages:
    "the match, but in general, this will fail if there is no champion, and "
    "will succeed only if there is a challenger spot open."
    {
-      if piCombat_style <> STYLE_ONE_ON_ONE
-         {
-           Send(self,@ChooseCombat,#style = STYLE_ONE_ON_ONE);    
-         }
+      % Set piCombat_style just in case of problems.
+      piCombat_style = STYLE_ONE_ON_ONE
+
       if send(self,@FightInSession)
         {
            send(self,@SayToOne,#target=what,#message_rsc=Goad_fight_in_progress);
@@ -835,10 +793,9 @@ messages:
 
    TrigAccept(what=$)
    {
-      if piCombat_style <> STYLE_ONE_ON_ONE
-      {
-         return FALSE;    %% you can only accept fights in traditional 2 man fights.
-      }
+      % Set piCombat_style just in case of problems.
+      piCombat_style = STYLE_ONE_ON_ONE
+
       if what <> poChampion
       {
          return FALSE;   %% Only the champion can accept a fight from a challenger
@@ -866,23 +823,6 @@ messages:
       else
          { send(self,@SayToOne,#target=what,#message_rsc=Goad_cant_renege); }
 
-      return;
-   }
-
-   ChooseCombat(style = STYLE_ONE_ON_ONE)
-   {
-      % No changing style if there are already combatants
-      if piCombat_style <> STYLE_NO_FIGHT AND plCombatants <> $
-      {
-         send(self,@say,#message_rsc=Goad_cant_switch);
-         return;
-      }
-      piCombat_style = style;
-      if piCombat_style <> STYLE_NO_FIGHT
-      {
-         send(self,@say,#message_rsc=Goad_new_combat_style,
-                   #parm1 = send(self,@getcombatname));
-      }
       return;
    }
 
@@ -1201,8 +1141,6 @@ messages:
    {
       if piCombat_style = STYLE_ONE_ON_ONE
          { return Goad_style_one_on_one; }
-      if piCombat_style = STYLE_LAST_MAN_STANDING
-         { return Goad_style_last_man_standing; }
       DEBUG("GetCombatName called with invalid fighting style chosen!");
       return;
    }

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
@@ -332,7 +332,7 @@ messages:
             #parm3=send(poChampion,@getcapdef),#parm4=send(poChampion,@getname));
          Send(self,@SayToOne,#target=poChampion,#message_rsc=Goad_challenge_offered,
             #parm1=send(who,@getcapdef),#parm2=send(who,@getname),
-            #parm3=send(who,@gethimher),#parm4=send(who,@gethimher)); 
+            #parm3=send(who,@gethimher),#parm4=send(who,@getheshe)); 
 
          pbAccept = FALSE;
          ptAccept = CreateTimer(self,@AcceptTimer,ACCEPT_DELAY); 


### PR DESCRIPTION
This PR fixes a bug that can happen only rarely.   The bug is if the Necro Arena is recreated and if the first player to attempt a fight says 'Champion' the player will get a window pop-up to update the game.  This is due to a message being sent that is missing parameters.

For clarity on this change here is the reason for the bug:

1. The default combat style was STYLE_NO_FIGHT
2. A player says Champion - TrigChampion gets called from SomeoneSaid.
3. Trig champion notices that Style is STYLE_NO_FIGHT and POSTS a message to ChooseCombat which will fix this and turn it into STYLE ONE ON ONE
4. Before the POST can run though, NewCombatant is called - this teleports the player into play and calls SetChampion()
5. Set Champion looks if the style is One-On-One or Last-Man-Standing, if it is it sets the player as the champion, if it is not it just returns - at this point because the style is still STYLE_NO_FIGHT the poChampion is still null.
6. Finally TrigChampion sends a say message with a resource which has a parameter defined by a message sent to poChampion (which is still null).  The game sees a message resource with a null arguments and this triggers the Update your client message.

7. After all that, the ChooseCombat message runs and sets the combat style to STYLE_ONE_ON_ONE.  This fixes the bug so it doesn't come up again until the next RecreateAllRooms.

I've fixed this bug in two ways.  First, I've set the default combat style to the only available combat style: one-on-one.  However, as an additional fix, even if an admin sets the combat style to some other style the game won't break.  This is because there was no reason to POST the ChooseCombat message.  Converting this message to a SEND fixes the bug as well.

TO TEST THE MESSAGE RESOURCE BUG:  
Use the admin console to set the piCombatStyle to 0 or any integer other than 1.  Then say champion and notice that the game correctly returns piCombatStyle to 1, sends a message to the client that Goad loves a good duel, and everything else works as intended.

Two additional small messaging changes are rolled into this PR.  Firstly, there was a really awkward (and self-described kludgy) set-up for conveying to the players that a player has challenged another.  We are slowly building up a string with the message we want to send and then using SomeoneSaid to send the message as a temporary string.  I can't figure out why this was done.  I've returned this set-up to the usual method.  While making that change I noticed that it was strange that we are essentially asking everyone in the room if they accept the challenge - not just the champion.  I have fixed this by changing the @ Say to an @ SayToOne(target=poChampion).  Now since we are only asking the champion if they accept we should also add a message for Goad to excitedly announce that the challenger has issued a challenge.  All players in the room see this message.  The champion sees this message and it is immediately followed up by Goad asking them if they will crush the challenger like a bug.

Finally two extra clean-ups are added to Goad.  First, ChooseCombat() had an unused actor argument.  I've removed this argument from the message definition and from every instance where the message is called with Goad as the target.  This is to avoid any bugs in the future if someone wanted to add some function for the actor argument without realizing that actor is always left as $ in the function calls.  Secondly, GetCombatName() was simplified.  We are never passing in a Style argument in Goad and so it doesn't make sense to have a bunch of repeated code for cases when Style is defined and for cases when it is null.  I've likewise removed the Style argument completely.

One note: There is lots of places where actions related to Last-man-standing have blocks of commented out code.  I've left these for now in order to keep the diffs clean and readable.  All of this dead code should be removed but doing so will probably also include simplifying numerous messages that check what the style is and then do some action.  As such it is outside of the scope of this PR.
