### PR TITLE
Linux kod makefiles abort on error

### DIFF
--- a/kod/kod.mak.linux
+++ b/kod/kod.mak.linux
@@ -29,9 +29,10 @@ all : $(BOFS) $(BOFS2) $(BOFS3) $(BOFS4) $(BOFS5) $(BOFS6) $(BOFS7) $(BOFS8)
 				-e "/kod.mak/ s:\\\\:\/:" \
 				-e "/DEPEND/ s:\\\\:\/:" \
 				makefile >makefile.linux; \
-				$(MAKE) -j 1 -f makefile.linux TOPDIR=../$(TOPDIR); \
+				$(MAKE) -j 1 -f makefile.linux TOPDIR=../$(TOPDIR) || FAILED=$$? ; \
 				$(RM) makefile.linux; \
 				cd ..; \
+				if [ -n "$$FAILED" ]; then exit $$FAILED; fi; \
 		fi; \
 	done
 

--- a/kod/makefile.linux
+++ b/kod/makefile.linux
@@ -35,9 +35,10 @@ all : $(BOFS) $(BOFS2) $(BOFS3) $(BOFS4) $(BOFS5) $(BOFS6) $(BOFS7) $(BOFS8)
 			-e "/kod.mak/ s:\\\\:\/:" \
 			-e "/DEPEND/ s:\\\\:\/:" \
 				makefile >makefile.linux; \
-		$(MAKE) -sf makefile.linux TOPDIR=../$(TOPDIR); \
+		$(MAKE) -sf makefile.linux TOPDIR=../$(TOPDIR) || FAILED=$$? ; \
 		$(RM) makefile.linux; \
 		cd ..; \
+		if [ -n "$$FAILED" ]; then exit $$FAILED; fi; \
 	done
 	@echo Copying kodbase.txt and kod include files
 	-@$(CP) $(KODDIR)/kodbase.txt $(BLAKSERVRUNDIR) 2>&1


### PR DESCRIPTION
With the recursive makefile structure, a compilation error was
not propagated to outer levels, meaning that kod bugs would
not cause the build to fail.

This does seem to break make -k, however (it will still stop on
the first error).