### PR TITLE
Update GetJalaInfo to consider multiple Jala spells in room

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5510,7 +5510,7 @@ messages:
    CalculateManaTime()
    "Calculate # of milliseconds until user will gain a mana point"
    {
-      local iTime, lJalaInfo, oJalaSpell, iJalaPower, oSpell, i;
+      local iTime, lJalaInfo, oJalaSpell, iJalaPower, oSpell, lJalaElement;
 
       if piMana > piMax_mana
       {
@@ -5533,12 +5533,12 @@ messages:
 
             if lJalaInfo <> $
             {
-               for i in lJalaInfo
+               for lJalaElement in lJalaInfo
                {
-                  oJalaSpell = Nth(i,2);
+                  oJalaSpell = Nth(lJalaInfo,2);
                   if IsClass(oJalaSpell,&Rejuvenate)
                   {
-                     iJalaPower = Nth(Nth(i,3),3);
+                     iJalaPower = Nth(Nth(lJalaInfo,3),3);
                      iTime = Send(oJalaSpell,@AdjustManaTime,#time=iTime,
                                  #iSpellPower=iJalaPower);
                   }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5473,7 +5473,7 @@ messages:
    CalculateHealthTime()
    "Calculate # of milliseconds until user will gain a health point"
    {
-      local iTime, iMaxHealth, lJalaInfo, oJalaSpell, iJalaPower;
+      local iTime, iMaxHealth, lJalaInfo, oJalaSpell, iJalaPower, i;
       
       % Faster regen with higher vigor
       iTime = ((200-piVigor)*(200-piVigor))/6 + 1000;
@@ -5491,12 +5491,15 @@ messages:
 
          if lJalaInfo <> $
          {
-            oJalaSpell = Nth(lJalaInfo,2);
-            if IsClass(oJalaSpell,&Restorate)
+            for i in lJalaInfo
             {
-               iJalaPower = Nth(Nth(lJalaInfo,3),3);
-               return Send(oJalaSpell,@AdjustHealthTime,#time=iTime,
-                            #iSpellPower=iJalaPower);
+               oJalaSpell = Nth(i,2);
+               if IsClass(oJalaSpell,&Restorate)
+               {
+                  iJalaPower = Nth(Nth(i,3),3);
+                  return Send(oJalaSpell,@AdjustHealthTime,#time=iTime,
+                              #iSpellPower=iJalaPower);
+               }
             }
          }
       }
@@ -5507,7 +5510,7 @@ messages:
    CalculateManaTime()
    "Calculate # of milliseconds until user will gain a mana point"
    {
-      local iTime, lJalaInfo, oJalaSpell, iJalaPower, oSpell;
+      local iTime, lJalaInfo, oJalaSpell, iJalaPower, oSpell, i;
 
       if piMana > piMax_mana
       {
@@ -5530,12 +5533,15 @@ messages:
 
             if lJalaInfo <> $
             {
-               oJalaSpell = Nth(lJalaInfo,2);
-               if IsClass(oJalaSpell,&Rejuvenate)
+               for i in lJalaInfo
                {
-                  iJalaPower = Nth(Nth(lJalaInfo,3),3);
-                  iTime = Send(oJalaSpell,@AdjustManaTime,#time=iTime,
-                               #iSpellPower=iJalaPower);
+                  oJalaSpell = Nth(i,2);
+                  if IsClass(oJalaSpell,&Rejuvenate)
+                  {
+                     iJalaPower = Nth(Nth(i,3),3);
+                     iTime = Send(oJalaSpell,@AdjustManaTime,#time=iTime,
+                                 #iSpellPower=iJalaPower);
+                  }
                }
             }
          
@@ -9751,7 +9757,7 @@ messages:
 
    GetRestTime()
    {
-      local iTime, lJalaInfo, oJalaSpell, iJalaPower;
+      local iTime, lJalaInfo, oJalaSpell, iJalaPower, i;
 
       iTime = 1000 + (30* (51-Send(self,@getStamina))); 
 
@@ -9761,11 +9767,14 @@ messages:
 
          if lJalaInfo <> $
          {
-            oJalaSpell = Nth(lJalaInfo,2);
-            if IsClass(oJalaSpell,&Invigorate)
+            for i in lJalaInfo
             {
-               iJalaPower = Nth(Nth(lJalaInfo,3),3);
-               iTime = Send(oJalaSpell,@AdjustVigorTime,#time=iTime,#iSpellPower=iJalaPower);
+               oJalaSpell = Nth(i,2);
+               if IsClass(oJalaSpell,&Invigorate)
+               {
+                  iJalaPower = Nth(Nth(i,3),3);
+                  iTime = Send(oJalaSpell,@AdjustVigorTime,#time=iTime,#iSpellPower=iJalaPower);
+               }
             }
          }
       }

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3380,18 +3380,24 @@ messages:
    "Returns all the info about the current Jala spell.  Returns a list of "
    "[timer, spell object, state]."
    {
-      local i,oSpell;
+      local i, oSpell, lJalaInfo;
 
       for i in plEnchantments
       {
          oSpell = Nth(i,2);
          if Send(oSpell,@GetSchool) = SS_JALA
          {
-            return i;
+            lJalaInfo = Cons(i,lJalaInfo);
          }
       }
-
-      return $;
+      if Length(lJalaInfo) > 0
+      {
+         return lJalaInfo;
+      }
+      else
+      {
+         return $;
+      }
    }
 
    GetShalilleBonus()

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3381,7 +3381,7 @@ messages:
    "[timer, spell object, state]."
    {
       local i, oSpell, lJalaInfo;
-
+      lJalaInfo = $;
       for i in plEnchantments
       {
          oSpell = Nth(i,2);
@@ -3390,14 +3390,7 @@ messages:
             lJalaInfo = Cons(i,lJalaInfo);
          }
       }
-      if Length(lJalaInfo) > 0
-      {
-         return lJalaInfo;
-      }
-      else
-      {
-         return $;
-      }
+      return lJalaInfo;
    }
 
    GetShalilleBonus()

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3375,8 +3375,8 @@ messages:
    }
 
    GetJalaInfo()
-   "Returns all the info about the current Jala spell.  Returns a list of "
-   "[timer, spell object, state]."
+   "Returns all the info about active Jala spells.  Returns a list of lists"
+   "[timer, spell object, state],  [timer, spell object, state], etc."
    {
       local i, oSpell, lJalaInfo;
       lJalaInfo = $;

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3387,7 +3387,7 @@ messages:
          oSpell = Nth(i,2);
          if Send(oSpell,@GetSchool) = SS_JALA
          {
-            lJalaInfo = Cons(i,lJalaInfo);
+            lJalaInfo = cons(i,lJalaInfo);
          }
       }
       return lJalaInfo;

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -489,7 +489,7 @@ messages:
    CanCastHere(who = $, where = $, lTargets = $, iSpellPower = 0,
                bItemCast = FALSE, report = TRUE)
    {
-      local oSpell, lState, iJalaPower, oTarget, i;
+      local oSpell, lState, iJalaPower, oTarget, lJalaElement;
 
       if IsClass(who,&DM)
       {

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -489,7 +489,7 @@ messages:
    CanCastHere(who = $, where = $, lTargets = $, iSpellPower = 0,
                bItemCast = FALSE, report = TRUE)
    {
-      local oSpell, lState, iJalaPower, oTarget;
+      local oSpell, lState, iJalaPower, oTarget, i;
 
       if IsClass(who,&DM)
       {
@@ -509,7 +509,14 @@ messages:
          {
             % The spell's spellpower is the third element of the state, which
             %  is the third element of Jala info stored by room.
-            iJalaPower = Nth(Nth(Send(where,@GetJalaInfo),3),3);
+            % first get the list of Jala spells in room and iterate over list
+            for i in Send(where,@GetJalaInfo)
+            {
+               if Nth(i,2) = oSpell
+               {
+                  iJalaPower = Nth(Nth(i,3),3);
+               }
+            }
 
             % Does Spellbane overpower the spell?
             % Spellbane always works on monsters that can be silenced
@@ -1160,7 +1167,7 @@ messages:
    "figure their success in player.kod."
    {
       local num, iRequisiteStat, lJalaInfo, oJalaSpell, lJalaState,
-      iDistance, oTarget, oRing;
+      iDistance, oTarget, oRing, lJalaElement, tempnum;
 
       oRing = Send(who,@FindHolding,#class=&ReagentRing);
 
@@ -1182,14 +1189,25 @@ messages:
 
       if lJalaInfo <> $
       {
-         % lJalaInfo is of form: [room timer, spell object, state]
-         oJalaSpell = Nth(lJalaInfo,2);
-         if IsClass(oJalaSpell,&HinderSpell)
+         % Each element of lJalaInfo is of form: [room timer, spell object, state]
+         for lJalaElement in lJalaInfo
          {
-            lJalaState = Nth(lJalaInfo,3);
-            % Jala State is of the form: [volume, caster, spellpower]
-            num = Send(oJalaSpell,@GetAlteredChance,#chance=num,#what=self,
-                       #iSpellPower=Nth(lJalaState,3));
+            oJalaSpell = Nth(lJalaElement,2);
+            if IsClass(oJalaSpell,&HinderSpell)
+            {
+               lJalaState = Nth(lJalaElement,3);
+               % Jala State is of the form: [volume, caster, spellpower]
+               % GetAlteredChance returns either 
+               %    the unchanged chance if oJalaSpell <> viHinderedSchool
+               %    or the altered chance if oJalaSpell = viHinderedSchool
+               %    since we are only looking at HinderSpells we can return the minimum num 
+               tempnum = Send(oJalaSpell,@GetAlteredChance,#chance=num,#what=self,
+                        #iSpellPower=Nth(lJalaState,3));
+               if tempnum < num
+               {
+                  num = tempnum;
+               }
+            }
          }
       }
 

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -508,13 +508,13 @@ messages:
          if (Send(where,@IsEnchanted,#what=oSpell))
          {
             % The spell's spellpower is the third element of the state, which
-            %  is the third element of Jala info stored by room.
-            % first get the list of Jala spells in room and iterate over list
-            for i in Send(where,@GetJalaInfo)
+            % is the third element of Jala info element stored by room.
+            % Get the list of Jala spells in room and iterate over list
+            for lJalaElement in Send(where,@GetJalaInfo)
             {
-               if Nth(i,2) = oSpell
+               if Nth(lJalaElement,2) = oSpell
                {
-                  iJalaPower = Nth(Nth(i,3),3);
+                  iJalaPower = Nth(Nth(lJalaElement,3),3);
                }
             }
 

--- a/kod/object/passive/spell/jala.kod
+++ b/kod/object/passive/spell/jala.kod
@@ -103,17 +103,23 @@ messages:
    CastSpell(who=$, iSpellPower=0)
    "Initiation point for the spell."
    {
-      local oRoom, oldVolume, thisVolume, iJalaInfo;
+      local oRoom, oldVolume, thisVolume, lJalaInfo, lJalaElement, tempVolume;
 
       oRoom = Send(who,@GetOwner);
 
-      iJalaInfo = Send(oRoom,@GetJalaInfo);
+      lJalaInfo = Send(oRoom,@GetJalaInfo);
       oldVolume = 0;
-
-      if iJalaInfo <> $
+      tempVolume = 0;
+      if lJalaInfo <> $
       {
-         % Our state information is the third item return from JalaInfo
-         oldVolume = Nth(Nth(iJalaInfo,3),1);
+         for lJalaElement in lJalaInfo
+         {
+            tempVolume = Nth(Nth(lJalaElement,3),1);
+            if tempVolume > oldVolume
+            {
+               oldVolume = tempVolume;
+            }
+         }
       }
 
       thisVolume = Send(self,@CalculateVolume,#who=who,

--- a/kod/object/passive/spell/roomench/silence.kod
+++ b/kod/object/passive/spell/roomench/silence.kod
@@ -92,7 +92,7 @@ messages:
    CastSpell(who = $, iSpellPower = 0)
    "Initiation point for the spell."
    {
-      local oRoom, lJalaInfo, lJalaState;
+      local oRoom, lJalaInfo, lJalaElement, lJalaState;
 
       oRoom = Send(who,@GetOwner);
 
@@ -102,26 +102,29 @@ messages:
            #time=send(self,@GetDuration,#iSpellPower=iSpellPower),#iSpellPower=iSpellPower,#lastcall=FALSE);
       Send(who,@SetTranceFlag);
 
-      % See if there's a Jala song going on and try to kill it
-      % Format of lJalaInfo is: [timer, spell object, state]
+      % Iterate over any Jala spells in the room and try to kill them
+      % Format of lJalaInfo is a list of lists: [timer, spell object, state]
       lJalaInfo = send(oRoom,@GetJalaInfo);
 
       if lJalaInfo <> $
       {
-         % Format of lJalaState is: [volume, caster, spellpower]
-         lJalaState = Nth(lJalaInfo,3);
+         for lJalaElement in lJalaInfo
+         {
+            % Format of lJalaState is: [volume, caster, spellpower]
+            lJalaState = Nth(lJalaElement,3);
 
-         if random(iSpellPower/2,iSpellPower) > Nth(lJalaState,1)
-         {
-            % We have blocked the Jala song.
-            send(Nth(lJalaState,2),@MsgSendUser,#message_rsc=Silence_blocked_jala_victim);
-            send(oRoom,@RemoveEnchantment,#what=Nth(lJalaInfo,2));
-         }
-         else
-         {
-            % The Jala song continues on!
-            send(who,@MsgSendUser,#message_rsc=Silence_cant_block_jala_caster);
-            send(Nth(lJalaState,2),@MsgSendUser,#message_rsc=Silence_cant_block_jala_victim);
+            if random(iSpellPower/2,iSpellPower) > Nth(lJalaState,1)
+            {
+               % We have blocked the Jala song.
+               send(Nth(lJalaState,2),@MsgSendUser,#message_rsc=Silence_blocked_jala_victim);
+               send(oRoom,@RemoveEnchantment,#what=Nth(lJalaElement,2));
+            }
+            else
+            {
+               % The Jala song continues on!
+               send(who,@MsgSendUser,#message_rsc=Silence_cant_block_jala_caster);
+               send(Nth(lJalaState,2),@MsgSendUser,#message_rsc=Silence_cant_block_jala_victim);
+            }
          }
       }
 


### PR DESCRIPTION
In current production multiple Jala spells can be active in any one room at once.  The room enchantment icons correctly reflect the active room enchantments.

PR606 removed the ability for any one bard to sing multiple songs at once but it is still very possible for two Jala spellcasters to sing two different songs simultaneously.

While users might expect that both Jala spells are effecting the room, for most spells this isn't true.  Everywhere that GetJalaInfo() is used to measure the effectiveness of a Jala spell we are currently only returning the information on the first Jala spell in plEchantments.  This means that if one player casts Restorate and a second player casts Rejuvinate only the Restorate spell has any effect.

In current production some spells do work as the second Jala spell: Jig, Mirth, and Melancholy currently work this way. Currently spell bane 'works' as the second spell but in a problematic way: If spellbane is the second Jala spell the room will count that Spellbane as active but will then use the first Jala spell's spellpower in any Spellbane related calculations.

This PR updates this behavior by changing GetJalaInfo() to return a list of lists of all Jala spell related info.  We then update everywhere in the database where GetJalaInfo is used and iterate over the list of Jala spells that we receive to calculate the Jala spell effects.

Casting a new Jala spell still requires the caster to have a higher volume than all other active Jala spells.  This could be updated in the future.  

This update does not allow for players to stack the effects of any one Jala spell.  For example, if a first player casts Restorate and a second player also casts Restorate - only the first player's spell has any effect.  This could be updated in the future with a harmonize skill or something similar but the total effect of each spell should still be capped to whatever the maximum spell power is for each spell.  This is to prevent power-gaming and for reasons of balance.  Each spell was only ever intended to have a maximum effect based on spell power.  

