### PR TITLE
Remove extra space in Enchant Weapon item description

### DIFF
--- a/kod/object/passive/itematt/weapatt/waench.kod
+++ b/kod/object/passive/itematt/weapatt/waench.kod
@@ -36,7 +36,7 @@ constants:
 resources:
    
    waEnchant_gone = "Your %s suddenly seems a little more... ordinary."
-   waEnchanted = "  This weapon has been dedicated to Kraanan's glory."
+   waEnchanted = " This weapon has been dedicated to Kraanan's glory."
    waEnchanted_name = "enchanted %s"
    enchanted_dm = "enchanted"
 


### PR DESCRIPTION
![image](https://github.com/Meridian59/Meridian59/assets/7548210/c3c49f94-3642-48f5-b636-aa50eba368b2)
Removal of an additional space