### PR TITLE
Torch durability text fix

### DIFF
--- a/kod/object/item/passitem/defmod/shield/torch.kod
+++ b/kod/object/item/passitem/defmod/shield/torch.kod
@@ -32,7 +32,7 @@ resources:
    torch_condition_exc = " is in pristine condition."
    torch_condition_exc_mended = " is in pristine condition, but has been repaired before."
    torch_condition_good = " is slightly burnt, but is otherwise in good condition."
-   torch_condition_med = " is charred and well-used, but still servicable."
+   torch_condition_med = " is charred and well-used, but still serviceable."
    torch_condition_poor = " is nearly exhausted and may not last much longer."
    torch_condition_broken = " is blackened and charred beyond use."
   

--- a/kod/object/item/passitem/defmod/shield/torch.kod
+++ b/kod/object/item/passitem/defmod/shield/torch.kod
@@ -28,6 +28,13 @@ resources:
    torch_desc_rsc = \
       "A shaft of crudely hewn rough timber is topped by oily rags.  "
       "When used it will provide limited illumination."
+
+   torch_condition_exc = " is in pristine condition."
+   torch_condition_exc_mended = " is in pristine condition, but has been repaired before."
+   torch_condition_good = " is slightly burnt, but is otherwise in good condition."
+   torch_condition_med = " is charred and well-used, but still servicable."
+   torch_condition_poor = " is nearly exhausted and may not last much longer."
+   torch_condition_broken = " is blackened and charred beyond use."
   
    torch_flame_rsc = torchflm.bgf
    torch_overlay_rsc = torchov.bgf
@@ -39,6 +46,13 @@ classvars:
    vrName = torch_name_rsc
    vrIcon = torch_icon_rsc
    vrDesc = torch_desc_rsc
+
+   vrCondition_exc = torch_condition_exc 
+   vrCondition_exc_mended = torch_condition_exc_mended 
+   vrCondition_good = torch_condition_good 
+   vrCondition_med = torch_condition_med 
+   vrCondition_poor = torch_condition_poor 
+   vrCondition_broken = torch_condition_broken
 
    viUse_type = ITEM_USE_HAND
    viUse_amount = 1


### PR DESCRIPTION
Torches currently use the same durability text as shields, which doesn't make a lot of sense since torches don't shine or get dents, etc.  This PR adds durability text to the torch class that suits it better.

New durability text shown below:

![image](https://github.com/Meridian59/Meridian59/assets/22806592/fc838fde-bbc1-4559-a40e-84ec39a486bf)
