### PR TITLE
Wedding Rings: Refactor NewUsed() to fix first time use bug

### DIFF
--- a/kod/object/item/passitem/ring/ringwedd.kod
+++ b/kod/object/item/passitem/ring/ringwedd.kod
@@ -115,8 +115,8 @@ messages:
 
    NewUnused(what = $)
    {
-      if what = poFirstHeld
-         OR what = poSecondHeld
+      if (what = poFirstHeld OR what = poSecondHeld)
+         AND poSecondHeld <> $
       {
          Send(what,@RemoveDefenseModifier,#what=self);
       }

--- a/kod/object/item/passitem/ring/ringwedd.kod
+++ b/kod/object/item/passitem/ring/ringwedd.kod
@@ -103,8 +103,8 @@ messages:
             }
          }
 
-         if what = poFirstHeld
-            OR what = poSecondHeld
+         if (what = poFirstHeld OR what = poSecondHeld)
+            AND poSecondHeld <> $
          {
             send(what,@AddDefenseModifier,#what=self);
          }

--- a/kod/object/item/passitem/ring/ringwedd.kod
+++ b/kod/object/item/passitem/ring/ringwedd.kod
@@ -86,27 +86,27 @@ messages:
 
       if what <> $ AND isClass(what,&Player)
       {
+
          if poFirstHeld = $
          {
             poFirstHeld = what;
-
-            propagate;
          }
          
-         if poSecondHeld = $
-         {
-            if what <> poFirstHeld
-            {
-               poSecondHeld = what;
-            }
-         }
          else
          {
-            if what = poFirstHeld
-               OR what = poSecondHeld
+            if poSecondHeld = $
             {
-               send(what,@AddDefenseModifier,#what=self);
+               if what <> poFirstHeld
+               {
+                  poSecondHeld = what;
+               }
             }
+         }
+
+         if what = poFirstHeld
+            OR what = poSecondHeld
+         {
+            send(what,@AddDefenseModifier,#what=self);
          }
       }
       


### PR DESCRIPTION
This PR fixes a bug whereby on the first use of a wedding ring the defense modifier isn't added for that very first time it is equipped.  The game still tries to remove a defense modifier when the ring is UnUsed.  This results in a debug message to the server but no other problems.

I've refactored the NewUsed() message to always apply the Defense Modifier if the player is one of the two players who are bonded by the ring in matrimony (or actually if they are listed on the ring at all - it doesn't matter any more since we removed the defense buff itself).

Note that the defense modifier effect is removed from the wedding rings.  This was done by simply returning when we call Modify Defense Power or Modify Defense Damage.  That change was made a long while ago.

After looking into that change, I believe that this method was chosen to avoid any problems with players who already had a defense bonus applied and have kept their wedding rings equipped (perhaps for many years).  If we simply removed the defense modifier qualities of wedding rings these players would have a permanent modifier in their plDefenseModifier lists.  These players could then generate errors whenever the game checks them for defense modifiers.  For this reason I believe the choice of zeroing out the defense effect of wedding rings was done in a reasonable manner.

Summary: NewUsed was implemented wrong and the game can't remove a defense modifier that it never applied.  This fixes that even though there is no gameplay change.

To test:  Load up a current branch without this PR, create a new wedding ring, equip and un-equip it.  You will see a note in the debug log about the missing defense modifier.  Rebuild from this branch and do the same and there will be no debug log.  Furthermore equip the ring and examine your test character to see that the ring is added to plDefenseModifier on first use.