### PR TITLE
Fix persistent Jala music after song ends

### DIFF
--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -187,6 +187,7 @@ DWORD OpenMidiFile(const char *lpszMIDIFileName, UINT deviceflag)
       debug(("can't MCI open new song \n"));
       mciSendCommand(MCI_ALL_DEVICE_ID, MCI_CLOSE, 0, 0);
       playing_music = False;
+      playing_midi = False;
       isMusicPaused = False;
       midi_element = 0;
       midi_bg_music_element = 0;
@@ -560,7 +561,6 @@ void UnpauseMusic(void)
    if (dwReturn == 0)
    {
       DWORD dwLength = mciStatusParms.dwReturn;
-      debug(("Music length = %ld \n", dwLength));
       if (music_pos + 20 > dwLength)
       {
          debug(("Music position near end of song, resetting to 0\n"));
@@ -644,10 +644,10 @@ void PlayMidiRsc(ID rsc)
       {
          playing_midi = False;
       }
-
-      PostMessage(hMain, BK_NEWSOUND, SOUND_MIDI, rsc);
-      return;
    }
+   // Always POST new music message if using MCI
+   PostMessage(hMain, BK_NEWSOUND, SOUND_MIDI, rsc);
+   return;
 #endif
    if (playing_midi)
    {

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -389,8 +389,16 @@ DWORD PlayMusicFile(HWND hWndNotify, const char *fname)
    // If already playing music, pick up where we left off
    if (isMusicPaused)
    {
-      UnpauseMusic();
-      return 0;
+      if (paused_music == bg_music)
+      {
+		   UnpauseMusic();
+		   return 0;
+      }
+      else
+      {
+         // The music was paused but we need different music so reset the flag
+         isMusicPaused = False;
+      }
    }
 
    if ((dwReturn = OpenMidiFile(fname, midi_bg_music_element)) != 0)

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -47,7 +47,6 @@ static BYTE *pMIDIImmediate;
 #endif
 
 enum {SOUND_MIDI, SOUND_MUSIC};
-//enum {LOAD_MUSIC, LOAD_MIDI}; /* Arguments for OpenMidiFile MCI device naming */
 typedef enum {BACKGROUND_MUSIC, GAMEPLAY_MUSIC} LoadMusicType;
 
 /* local functions */
@@ -335,11 +334,7 @@ DWORD PlayMusicFile(HWND hWndNotify, const char *fname)
          UnpauseMusic();
          return 0;
       }
-      else
-      {
-         // The music was paused but we need different music so reset the flag
-         isMusicPaused = False;
-      }
+      isMusicPaused = False;
 	}
    if (playing_midi)
    {

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -628,7 +628,7 @@ void PlayMusicRsc(ID rsc)
 	  {
         if (!stricmp(LookupNameRsc(rsc), LookupNameRsc(bg_music)))
         {
-		  debug(("DEBUG 11 - Already playing that music.\n" ));
+		  debug(("DEBUG Already playing that music.\n" ));
         return;
         }
         /* Playing music is true, not paused, need new bg music */

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -137,10 +137,10 @@ void MusicClose(void)
 //	Not used by MSS version
 /*
  * OpenMidiFile:  Open midi file for playing.
- *   The loadWhat argument instructs the client
- *   what to name the opened device ID.  If we pass in LOAD_MUSIC then
- *   we open the file and set the device ID to midi_bg_music_element.
- *   If LOAD_MIDI then the device ID is set to midi_element.
+ *   The music type argument instructs the client
+ *   what to name the opened device ID.  If we pass in BACKGROUND_MUSIC
+ *   then we open the file and set the device ID to midi_bg_music_element.
+ *   If GAMEPLAY_MUSIC then the device ID is set to midi_element.
  *   Returns 0 if successful; 1 for bad musicType, and 
  *   an MCI error code otherwise.
  */
@@ -155,7 +155,7 @@ DWORD OpenMidiFile(const char *lpszMIDIFileName, LoadMusicType musicType)
       debug(("Unable to get current directory!\n"));
 
    sprintf(filename, "%s%s", current_dir, lpszMIDIFileName);
-   debug(("music filename = %s \n", filename));
+   debug(("music filename = %s\n", filename));
    // Is it a background music or gameplay element music file?
    switch (musicType) {
       case BACKGROUND_MUSIC:

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -673,7 +673,7 @@ void NewMusic(WPARAM type, ID rsc)
 #ifdef M59_MSS
 			AIL_end_sample( hseqBackground );
 #else
-			mciSendCommand(midi_element, MCI_CLOSE, 0, 0); 
+			mciSendCommand(midi_bg_music_element, MCI_CLOSE, 0, 0); 
 #endif
 			playing_music = False;
 			return;

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -322,14 +322,14 @@ DWORD PlayMusicFile(HWND hWndNotify, const char *fname)
 	}
    if (playing_midi)
    {
-      playing_midi = False;
       AIL_end_sample(hseqImmediate);
+      playing_midi = False;
    }
 
    if (playing_music)
    {
-      playing_music = False;
       AIL_end_sample(hseqBackground);
+      playing_music = False;
    }
 	// free memory from previous background music
 	if (pMIDIBackground)
@@ -519,13 +519,13 @@ void UnpauseMusic(void)
 #ifdef M59_MSS
    if (playing_midi)
    {
-      playing_midi = False;
       AIL_end_sample(hseqImmediate);
+      playing_midi = False;
    }
 	if (isMusicPaused)
    {
-      isMusicPaused = False;
 		AIL_resume_sample(hseqBackground);
+      isMusicPaused = False;
    }
 	debug(( "Unpausing music. bg_music=%d, paused_music=%d\n", bg_music, paused_music));
 #else

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -431,8 +431,8 @@ DWORD PlayMusicFile(HWND hWndNotify, const char *fname)
                                  MCI_NOTIFY, (DWORD_PTR)(LPVOID) &mciPlayParms)) 
    {
       mciGetErrorString(dwReturn, temp, 80);
-      strcat(temp, " \n");
       debug((temp));
+      debug((" \n"));
       
       mciSendCommand(midi_bg_music_element, MCI_CLOSE, 0, 0);
       

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -137,11 +137,10 @@ void MusicClose(void)
 //	Not used by MSS version
 /*
  * OpenMidiFile:  Open midi file for playing.
- *   The deviceflag integer argument corresponds to either
- *   midi_bg_music_element (flag = 1) or midi_element (2).
- *   after opening a new MCI device this flag instructs the client
- *   what to name the device ID.  Background music is called midi_bg_music_element
- *   and any other gameplay element music is called midi_element.
+ *   The loadWhat argument instructs the client
+ *   what to name the opened device ID.  If we pass in LOAD_MUSIC then
+ *   we open the file and set the device ID to midi_bg_music_element.
+ *   If LOAD_MIDI then the device ID is set to midi_element.
  *   Returns 0 if successful; MCI error code otherwise.
  */
 DWORD OpenMidiFile(const char *lpszMIDIFileName, UINT loadWhat)

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -155,7 +155,7 @@ DWORD OpenMidiFile(const char *lpszMIDIFileName, LoadMusicType musicType)
       debug(("Unable to get current directory!\n"));
 
    sprintf(filename, "%s%s", current_dir, lpszMIDIFileName);
-   debug(("music filename = %s\n", filename));
+   debug(("music filename = %s \n", filename));
    // Is it a background music or gameplay element music file?
    switch (musicType) {
       case BACKGROUND_MUSIC:

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -492,11 +492,23 @@ void UnpauseMusic(void)
    if (!has_midi)
       return;
 #ifdef M59_MSS
-
+   if (playing_midi)
+   {
+      AIL_end_sample(hseqImmediate);
+      playing_midi = False;
+   }
 	if (isMusicPaused)
+   {
 		AIL_resume_sample(hseqBackground);
-	else
+      isMusicPaused = False;
+   }
+   // We are trying to unpause music but its not paused
+   // If needed we can restart the music
+   // but only if we are not playing a new midi song.
+	else if (!playing_midi)
+   {
 		AIL_start_sample(hseqBackground);
+   }
 	debug(( "Unpausing music.\n" ));
 #else
    DWORD dwReturn;

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -492,7 +492,6 @@ void UnpauseMusic(void)
    if (!has_midi)
       return;
 #ifdef M59_MSS
-
 	if (isMusicPaused)
 		AIL_resume_sample(hseqBackground);
 	else
@@ -631,6 +630,7 @@ void PlayMusicRsc(ID rsc)
         /* Playing music is true, not paused, need new bg music */
         /* so kill the current background music before continuing. */
         #ifdef M59_MSS
+            debug(("DEBUG AIL_end_sample( hseqBackground )\n" ));
 			   AIL_end_sample( hseqBackground );
         #else
 			   mciSendCommand(midi_bg_music_element, MCI_CLOSE, 0, 0); 

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -488,7 +488,6 @@ void PauseMusic(void)
  */
 void UnpauseMusic(void)
 {
-   char temp[81];
    if (!has_midi)
       return;
 #ifdef M59_MSS
@@ -500,6 +499,7 @@ void UnpauseMusic(void)
 	debug(( "Unpausing music.\n" ));
 #else
    DWORD dwReturn;
+   char temp[81];
    MCI_PLAY_PARMS mciPlayParms;
    MCI_SEEK_PARMS mciSeekParms;
    MCI_SET_PARMS  mciSetParms;
@@ -565,7 +565,6 @@ void UnpauseMusic(void)
 void PlayMidiRsc(ID rsc)
 {
    debug(("PlayMidiRsc %d\n", rsc));
-   DWORD dwReturn;
    // Save the rsc as latest_music in case our music is off in the config
    // This way if we toggle it on we have the correct rsc to play.
    latest_music = rsc;
@@ -587,6 +586,7 @@ void PlayMidiRsc(ID rsc)
    }
 
 #ifndef M59_MSS
+   DWORD dwReturn;
    /* If NOT playing music and IF playing midi...*/
    /* Stop the midi and prepare to restart a new one. */
    if (playing_midi)

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -176,7 +176,7 @@ DWORD OpenMidiFile(const char *lpszMIDIFileName, LoadMusicType musicType)
          }
          break;
       default:
-         debug(("OpenMidiFile: Invalid musicType\n"));
+         debug(("OpenMidiFile: Invalid musicType, type=%d\n", musicType));
          return 1;
    }
 
@@ -211,7 +211,7 @@ DWORD OpenMidiFile(const char *lpszMIDIFileName, LoadMusicType musicType)
          debug(("midi element = %d\n", midi_element));
          break;
       default:
-         debug(("OpenMidiFile: Invalid musicType\n"));
+         debug(("OpenMidiFile: Invalid musicType, type= %d\n", musicType));
          return 1;
    }
 

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -522,7 +522,7 @@ void UnpauseMusic(void)
    mciStatusParms.dwItem = MCI_STATUS_LENGTH;
    dwReturn = mciSendCommand(midi_bg_music_element, MCI_STATUS, 
                              MCI_STATUS_LENGTH, (DWORD_PTR)(LPVOID) &mciStatusParms);
-   if (dwReturn)
+   if (dwReturn == 0)
    {
       DWORD dwLength = mciStatusParms.dwReturn;
       if (music_pos > dwLength)

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -492,6 +492,7 @@ void UnpauseMusic(void)
    if (!has_midi)
       return;
 #ifdef M59_MSS
+
 	if (isMusicPaused)
 		AIL_resume_sample(hseqBackground);
 	else
@@ -630,7 +631,6 @@ void PlayMusicRsc(ID rsc)
         /* Playing music is true, not paused, need new bg music */
         /* so kill the current background music before continuing. */
         #ifdef M59_MSS
-            debug(("DEBUG AIL_end_sample( hseqBackground )\n" ));
 			   AIL_end_sample( hseqBackground );
         #else
 			   mciSendCommand(midi_bg_music_element, MCI_CLOSE, 0, 0); 

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -311,8 +311,8 @@ DWORD PlayMusicFile(HWND hWndNotify, const char *fname)
 	{
       if (paused_music == bg_music)
       {
-		   UnpauseMusic();
-		   return 0;
+         UnpauseMusic();
+         return 0;
       }
       else
       {
@@ -366,7 +366,7 @@ DWORD PlayMusicFile(HWND hWndNotify, const char *fname)
 
 	// set to loop indefinitely
 	AIL_set_sample_loop_count( hseqBackground, 0 );
-
+   
    // Set volume
    float vol = ((float) config.music_volume) / CONFIG_MAX_VOLUME;
 	AIL_set_sample_volume_levels(hseqBackground, vol, vol );
@@ -480,7 +480,7 @@ void PauseMusic(void)
 
 	if( AIL_sample_status( hseqBackground ) == SMP_PLAYING )
    {
-		AIL_stop_sample( hseqBackground );
+      AIL_stop_sample( hseqBackground );
    }
 	// indicate we are paused
 	isMusicPaused = True;
@@ -522,7 +522,7 @@ void UnpauseMusic(void)
       AIL_end_sample(hseqImmediate);
       playing_midi = False;
    }
-	if (isMusicPaused)
+   if (isMusicPaused)
    {
       AIL_resume_sample(hseqBackground);
       isMusicPaused = False;

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -29,8 +29,8 @@ static Bool playing_midi = False;  /* Is a MIDI file currently playing as an eff
 static Bool playing_music = False;  /* Is a MIDI file currently playing as background? */
 static Bool isMusicPaused = False;   /* Is background music paused? */
 
-static UINT midi_element;  /* Currently playing MIDI file ID */
-static UINT midi_bg_music_element;  /* Currently playing background music ID */
+static UINT midi_element;  /* Currently playing MIDI MCI device ID */
+static UINT midi_bg_music_element;  /* Currently playing background music MCI device ID */
 
 static ID    bg_music = 0;     /* Resource id of background music MIDI file; 0 if none */
 static ID    latest_music = 0;   /* Resource id of most recent music file played - regardless of type */

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -524,8 +524,7 @@ void UnpauseMusic(void)
 	if (isMusicPaused)
    {
       isMusicPaused = False;
-      if (paused_music == paused_music)
-		   AIL_resume_sample(hseqBackground);
+		AIL_resume_sample(hseqBackground);
    }
 	debug(( "Unpausing music. latestmusic=%d , bg_music=%d, paused_music=%d\n", latest_music, bg_music, paused_music));
 #else

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -50,7 +50,7 @@ enum {SOUND_MIDI, SOUND_MUSIC};
 typedef enum {BACKGROUND_MUSIC, GAMEPLAY_MUSIC} LoadMusicType;
 
 /* local functions */
-static DWORD OpenMidiFile(const char *lpszMIDIFileName, UINT loadWhat);
+static DWORD OpenMidiFile(const char *lpszMIDIFileName, LoadMusicType musicType);
 static DWORD RestartMidiFile(DWORD device);
 static void PauseMusic(void);
 static void UnpauseMusic(void);

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -154,7 +154,7 @@ DWORD OpenMidiFile(const char *lpszMIDIFileName, UINT deviceflag)
       debug(("Unable to get current directory!\n"));
 
    sprintf(filename, "%s%s", current_dir, lpszMIDIFileName);
-   debug(("music filename = %s, argument = %d\n", filename, deviceflag));
+   debug(("music filename = %s \n", filename));
    // Is it a background music or gameplay element music file?
    if (deviceflag == 1)
    {
@@ -317,7 +317,7 @@ DWORD PlayMusicFile(HWND hWndNotify, const char *fname)
 #ifdef M59_MSS
 	// If a sequence was paused and we are trying to play that music
    // then unpause it.
-	if (isMusicPaused)
+   if (isMusicPaused)
 	{
       if (paused_music == bg_music)
       {
@@ -604,7 +604,7 @@ void UnpauseMusic(void)
  * PlayMidiRsc:  Play MIDI file associated with given resource number.
  *
  * This function handles pausing or stopping music and midi files and
- * the posts a message which is handled and sends us to NewMusic.
+ * then posts a message which is handled and sends us to NewMusic.
  */
 void PlayMidiRsc(ID rsc)
 {
@@ -811,7 +811,7 @@ void MusicAbort(void)
 /*
  * MusicStart:  Start playing bg music if any (used when player toggles music on).
  *   If the latest music rsc matches the bg_music rsc than we use
- *   use PlayMusicRsc to start the music.  Otherwise we use PlayMidiRsc.
+ *   PlayMusicRsc to start the music.  Otherwise we use PlayMidiRsc.
  *   This maintains the correct music types and booleans.
  */
 void MusicStart(void)

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -256,7 +256,7 @@ DWORD PlayMidiFile(HWND hWndNotify, char *fname)
 	// start playing
 	AIL_start_sample(hseqImmediate);
 
-	debug(( "Playing Jala music file %s. LatestMusic=%d \n", fname, latest_music ));
+	debug(( "Playing midi music file %s. LatestMusic=%d \n", fname, latest_music ));
 	playing_midi = True;
 	return 0;
 #else
@@ -692,7 +692,6 @@ void PlayMusicRsc(ID rsc)
 void NewMusic(WPARAM type, ID rsc)
 {
    char *filename, fname[MAX_PATH + FILENAME_MAX];
-   debug(( "New Music call, playing_midi =%d, playing_music=%d, isMusicPaused=%d\n", playing_midi, playing_music, isMusicPaused));
 	// NULL rsc => abort any songs in progress
 	if( !rsc )
 	{

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -155,14 +155,14 @@ DWORD OpenMidiFile(const char *lpszMIDIFileName, UINT device)
    // Is it a background music or jala music file?
    if (device == midi_bg_music_element)
    {
-      if (playing_music != 0)
+      if (playing_music != False)
       {
          mciSendCommand(midi_bg_music_element, MCI_CLOSE, 0, 0);
       }
    }
    else if (device == midi_element)
    {
-      if (playing_midi != 0)
+      if (playing_midi != False)
       {
          mciSendCommand(midi_element, MCI_STOP, 0, 0);
          if (dwReturn = mciSendCommand(midi_element, MCI_CLOSE, 0, 0))
@@ -186,13 +186,13 @@ DWORD OpenMidiFile(const char *lpszMIDIFileName, UINT device)
    if (device == midi_bg_music_element)
    {
       midi_bg_music_element = mciOpenParms.wDeviceID;
-      playing_music = 1;
+      playing_music = True;
       debug(("midi_bg_music_element = %d\n", midi_bg_music_element));
    }
    else
    {
       midi_element = mciOpenParms.wDeviceID;
-      playing_midi = 1;
+      playing_midi = True;
       debug(("midi element = %d\n", midi_element));
    }
    return 0;
@@ -388,8 +388,8 @@ DWORD PlayMusicFile(HWND hWndNotify, const char *fname)
    {
       if (paused_music == bg_music)
       {
-		   UnpauseMusic();
-		   return 0;
+         UnpauseMusic();
+         return 0;
       }
       else
       {
@@ -524,10 +524,10 @@ void UnpauseMusic(void)
    }
 	if (isMusicPaused)
    {
-		AIL_resume_sample(hseqBackground);
+      AIL_resume_sample(hseqBackground);
       isMusicPaused = False;
    }
-	debug(( "Unpausing music. bg_music=%d, paused_music=%d\n", bg_music, paused_music));
+   debug(( "Unpausing music. bg_music=%d, paused_music=%d\n", bg_music, paused_music));
 #else
    DWORD dwReturn;
    char temp[81];
@@ -660,15 +660,15 @@ void PlayMusicRsc(ID rsc)
 	  {
         if (!stricmp(LookupNameRsc(rsc), LookupNameRsc(bg_music)))
         {
-		  debug(("DEBUG Already playing that music.\n" ));
+         debug(("DEBUG Already playing that music.\n" ));
         return;
         }
         /* Playing music is true, not paused, need new bg music */
         /* so kill the current background music before continuing. */
         #ifdef M59_MSS
-			   AIL_end_sample( hseqBackground );
+            AIL_end_sample( hseqBackground );
         #else
-			   mciSendCommand(midi_bg_music_element, MCI_CLOSE, 0, 0); 
+            mciSendCommand(midi_bg_music_element, MCI_CLOSE, 0, 0); 
          #endif
 	  }
 	}

--- a/clientd3d/music.c
+++ b/clientd3d/music.c
@@ -384,7 +384,7 @@ DWORD PlayMusicFile(HWND hWndNotify, const char *fname)
 
    if (playing_midi)
    {
-      // We're trying to play BG music, but Midi music is still playging.
+      // We're trying to play BG music, but Midi music is still playing.
       // This can happen if we toggle music off and on
       // with an active Jala spell.
       mciSendCommand(midi_element, MCI_STOP, 0, 0);
@@ -655,9 +655,8 @@ void PlayMusicRsc(ID rsc)
 void NewMusic(WPARAM type, ID rsc)
 {
    char *filename, fname[MAX_PATH + FILENAME_MAX];
-   debug(("NewMusic Call \n"));
 	// NULL rsc => abort midi in progress
-   // This is vestigial but could be used by KOD to stop music.
+   // This may be vestigial but can be used by KOD to stop music.
 	if( !rsc )
 	{
 		if( ( type == SOUND_MIDI ) && ( playing_midi ) )

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3339,7 +3339,7 @@ messages:
 
    MidiSendUser(midi_rsc = $)
    {
-      if (midi_rsc <> $) AND (pbLogged_on)
+      if pbLogged_On
       {
          AddPacket(1,BP_PLAY_MIDI);
          if midi_rsc = $

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -1790,6 +1790,20 @@ messages:
       return;
    }
 
+   RestartMusicAfterJala()
+   {
+      local i;
+
+      for i in Send(self,@GetHolderActive)
+      {
+         if IsClass(first(i),&user)
+         {
+            Send(first(i),@SendRoomMusic,#music_rsc=prMusic);
+         }
+      }
+      return;
+   }
+
    SendEnchantmentIcons(what = $)
    "Users send this after GC to redisplay the enchantments in the room"
    {

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -1790,7 +1790,7 @@ messages:
       return;
    }
 
-   RestartRoomBackgroundMusic()
+   ResendRoomBackgroundMusic()
    {
       local i;
 

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -1790,7 +1790,7 @@ messages:
       return;
    }
 
-   RestartMusicAfterJala()
+   RestartRoomBackgroundMusic()
    {
       local i;
 

--- a/kod/object/passive/spell/jala.kod
+++ b/kod/object/passive/spell/jala.kod
@@ -277,17 +277,17 @@ messages:
       local oCaster, lActive, each_obj, oRoom, i;
       oCaster = Nth(state,2);
 
-      if pbUserEffects
+      if where = $
       {
-         if where = $
-         {
-            oRoom = Send(oCaster,@GetOwner);
-         }
-         else
-         {
-            oRoom = where;
-         }
-         
+         oRoom = Send(oCaster,@GetOwner);
+      }
+      else
+      {
+         oRoom = where;
+      }
+
+      if pbUserEffects
+      {         
          lActive = Send(oRoom,@GetHolderActive);
          for i in lActive
          {
@@ -298,9 +298,10 @@ messages:
 
       Send(where,@SomeoneSaid,#type=SAY_MESSAGE,#string=jala_song_ends,
            #what=self);
-      % Send $ as midi_rsc to end music and resume default.
-      Send(self,@StartMusic,#oCaster=oCaster,#rMusic=$);
+
       Send(oCaster,@ClearTranceFlag);
+      % Send to room: restart the background music.
+      Post(oRoom,@RestartMusicAfterJala);
       
       return;
    }

--- a/kod/object/passive/spell/jala.kod
+++ b/kod/object/passive/spell/jala.kod
@@ -277,13 +277,10 @@ messages:
       local oCaster, lActive, each_obj, oRoom, i;
       oCaster = Nth(state,2);
 
-      if where = $
+      oRoom = where;
+      if oRoom = $
       {
          oRoom = Send(oCaster,@GetOwner);
-      }
-      else
-      {
-         oRoom = where;
       }
 
       if pbUserEffects
@@ -301,7 +298,7 @@ messages:
 
       Send(oCaster,@ClearTranceFlag);
       % Send to room: restart the background music.
-      Post(oRoom,@RestartRoomBackgroundMusic);
+      Post(oRoom,@ResendRoomBackgroundMusic);
       
       return;
    }

--- a/kod/object/passive/spell/jala.kod
+++ b/kod/object/passive/spell/jala.kod
@@ -301,7 +301,7 @@ messages:
 
       Send(oCaster,@ClearTranceFlag);
       % Send to room: restart the background music.
-      Post(oRoom,@RestartMusicAfterJala);
+      Post(oRoom,@RestartRoomBackgroundMusic);
       
       return;
    }


### PR DESCRIPTION
Currently Jala music is bugged such that when a song ends it keeps playing in the room.  Furthermore if the Jala player casts another Jala spell its possible for this bug to crash the client unexpectedly.

This PR aims to fix the issue with persistent Jala music in the hopes that doing so will fix the client crash bug.

To accomplish this goal we make a few minor changes in KOD:
1. Jala.kod was previously used to send a a StartMusic message with a null resource argument.  This was intended to tell the MIDI music handlers to abort the midi file. This has been changed such that EndSpell calls a new message to restart the room music after Jala.
2. The null argument eventually got to MidiSendUser() in User.KOD.  Here however the function just returns if the argument is NULL.  At some point these two functions fell out of synch with each other.
3. Room.kod now has a RestartMusicAfterJala() message which uses a variation of the machinery we use when a player enters a new room to restart the music in the room after the Jala spell ends.  This is sent to all users in the room.

The game is split into two types of music handlers - one for production and one for open-source users / servers.  The majority of this PR is fixing the open source implementation at this time as that implementation was lacking a few necessary features.

Testing the production music will require some collaboration and this PR will be updated based on that feedback.  We may be able to use the changes to the MIDI only music.c as a roadmap but I think the production music set-up isn't lacking any functions.  I would assume any problems remaining there is due to the handling of the various Boolean tracker variables.  

Music.C has numerous tracking variables.  I've tried to comment their uses when they are declared initially.  Of note: Playing_music tracks if we are supposed to be playing music, not if we are actively playing music.  The difference is that playing_music is true even when we are paused.

Paused_music is a new variable.  Previously we considered music paused if the music_pos variable was 0.  This isn't safe because the background music loops and it is very possible to pause the music at position 0.  In fact, entering a room and immediately casting a Jala spell frequently would pause the music at position 0.

Pausing and unpausing wasn't implemented in MIDI world.  We had the machinery to seek and find the music position but we never send an MCI_PLAY message.  This has been fixed.

Abort music was used inappropriately in PlayMusicRsc - this has been fixed.

Finally and most importantly - a second MIDI device has been added.  This allows us to pause the background music without removing the music file from memory.  Instead we open the second Midi device and load the Jala song into memory pointed to that second device.  The two midi devices are: Midi_element and midi_bg_music_element.  This change was made because of the significant lag caused by loading the background music into memory.  This lag is less noticeable when we are changing rooms but is very noticeable when interrupting a Jala song.

There are a few other changes and fixes.  I will comment those in-line in the as a review.

Finally - if needed I can make a flow-chart of the message flow in Music.c.  There are two starting points: PlayMidiRsc (this is always used for Jala songs) and PlayMusicRsc (this is used for background music - even if that music is a MIDI).

There is one outstanding issue: Tracking the current song while the music setting is toggled off works except in the case that a user turns off the music, sings a Jala song, then interrupts that song with a second Jala song and then toggles on the music setting.  In this event the user will get the room background music and not the second Jala song music.  I'm not yet sure why - but it certainly has to do with the latest_music tracking variable not being saved in the correct order.  I will either fix this issue or at least understand why it happens before switching this PR from a draft to a merge request.