### PR TITLE
Correct mended text for all Robes

### DIFF
--- a/kod/object/item/passitem/defmod/armor/robe.kod
+++ b/kod/object/item/passitem/defmod/armor/robe.kod
@@ -37,7 +37,7 @@ resources:
    robe_rightarm_female =brd.bgf
 
    robe_condition_exc = " are in immaculate condition."
-   robe_condition_exc_mended = " are in excellent condition, but have been patched before.."
+   robe_condition_exc_mended = " are in excellent condition, but have been patched before."
    robe_condition_good = " are scuffed and slightly worn."
    robe_condition_med = " have a few unsightly rips."
    robe_condition_poor = " are in tatters, and barely holding together."


### PR DESCRIPTION
Remove an extra full stop :)
![image](https://github.com/Meridian59/Meridian59/assets/7548210/914d82b8-5839-40c6-9d16-747917262651)
This puts it inline with the other items when mended:
![image](https://github.com/Meridian59/Meridian59/assets/7548210/a2d611ba-73ce-4669-836b-341566770e77)
