### PR TITLE
Colhorr weapon att fix

### DIFF
--- a/kod/object/passive/itematt/weapatt/waexpert.kod
+++ b/kod/object/passive/itematt/weapatt/waexpert.kod
@@ -88,10 +88,10 @@ messages:
          return damage;
       }
       
-      Damage = damage - iPower;      
+      damage = damage - iPower;      
 
       % Results in proficiency percent of 2 * damage bonus
-      iProf = Bound(((iProf*(2*iPower))/100),1,$);
+      iProf = Bound((((iProf+1)*(2*iPower))/100),1,$);
       damage = damage + iProf;
                        
       return damage;
@@ -123,7 +123,7 @@ messages:
       hitroll = hitroll - iPower;
 
       % Results in proficiency percent of 2 * to-hit bonus
-      iProf = Bound(((iProf*(2*iPower))/100),10,$);
+      iProf = Bound((((iProf+1)*(2*iPower))/100),10,$);
       hitroll = hitroll + iProf;
 
       return hitroll;


### PR DESCRIPTION
The equations for Colhorr weapons are incorrect. The lack of a +1 on the proficiency value means proficiency maxes out at 99 from the skill, which later leads to a truncation that cuts off a point of damage. This is why Colhorr weapons never 'felt like they did anything' - in many cases they quite literally did not. E.g. +1 damage became +0, +2 became +1. This, combined with the fact that Colhorr weapons actually _subtract_ their bonuses from low proficiency wielders, meant the community simply assumed these don't work at all.