### PR TITLE
Fix Underworld node potential server crash

### DIFF
--- a/kod/object/active/holder/room/monsroom/uworld.kod
+++ b/kod/object/active/holder/room/monsroom/uworld.kod
@@ -357,6 +357,7 @@ messages:
       }
 
       if oRoom = $
+         OR oRoom = self
       {
          send(who,@AdminGoToSafety);
          send(who,@GainHealthNormal,#amount=100);


### PR DESCRIPTION
While there *is* infinite loop crash protection now from my local testing (at least that's how I interpreted what I saw), trying the old exploit of dying on the underworld node platform and then using the corpse node to infinitely loop onto that spot still exists. This change will simply boot you to an inn if your corpse is in the Underworld, nixing all that nonsense.