### PR TITLE
Remove defunct Gaze of the Basilisk code

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2017,7 +2017,6 @@
    SID_SHALBANE = 118                  % use SID_SHALLILEBANE
    SID_WARPTIME = 122                  % use SID_WARP_TIME
    SID_DETECT_INVIS = 123              % use SID_DETECT_INVISIBILITY
-   SID_PARALYZE = 127                  % use SID_GAZE_OF_THE_BASILISK
    SID_SUMMON_WEB = 136                % use SID_SPIDER_WEB
    SID_REFLECT = 138                   % use SID_DEFECT
    SID_LIGHTNINGWALL = 140             % use SID_LIGHTNING_WALL
@@ -2154,7 +2153,7 @@
    PFLAG2_DETECT_GOOD      = 0x000004
    PFLAG2_DETECT_EVIL      = 0x000008
    PFLAG2_DETECT_INVIS     = 0x000010
-   PFLAG2_PARALYZED        = 0x000020
+   % Not currently used    = 0x000020 
    PFLAG2_HUNTED           = 0x000040
    % DM set only.  No chance of revenants.
    PFLAG2_NOHAUNT          = 0x000080

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4472,14 +4472,6 @@ messages:
          damage = 1;
       }
 
-      if damage > 0
-      {
-         if Send(self,@CheckPlayerFlag,#flag=PFLAG2_PARALYZED,#flagset=2)
-         {
-            Send(self,@RemoveEnchantment,#what=Send(SYS,@FindSpellByNum,#num=SID_PARALYZE));
-         }
-      }
-
       if NOT absolute
       {
          % If we have more health than twice our max, no percent limit on damage.


### PR DESCRIPTION
I stumbled upon a piece of code in AssessDamage in player.kod that, when a player is damaged, removes a type of paralysis we no longer use, from the old version of Gaze of the Basilisk. There is no other reference to this anywhere else now, meaning PFLAG2_PARALYZED is a player flag that could be used by something else.