### PR TITLE
Remove too-low bounding of Jala instrument spellpower

### DIFF
--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -2167,6 +2167,13 @@ messages:
             iItemModifier = iItemModifier/2;
          }
       }
+
+      iPowerBonus = Send(Send(SYS,@GetParliament),@GetFactionSpellPowerBonus,
+                         #who=who,#theSpell=self);
+
+      % Bind the bonuses to reasonable values.
+      iPrimaryBonus = bound(iPrimaryBonus,0,30);
+      iSecondaryBonus = bound(iSecondaryBonus,0,10);
       
       if viSchool = SS_JALA
       {
@@ -2177,15 +2184,8 @@ messages:
          %  with normal combat, etc.
          % Secondary bonus is based off of HPs.  Non-mules get bigger bonuses.
          iPrimaryBonus = Send(who,@GetInstrumentLevel);
-         iSecondaryBonus = Send(who,@GetMaxHealth)/12;
+         iSecondaryBonus = bound(Send(who,@GetMaxHealth)/12,0,10);
       }
-
-      iPowerBonus = Send(Send(SYS,@GetParliament),@GetFactionSpellPowerBonus,
-                         #who=who,#theSpell=self);
-
-      % Bind the bonuses to reasonable values.
-      iPrimaryBonus = bound(iPrimaryBonus,0,30);
-      iSecondaryBonus = bound(iSecondaryBonus,0,10);
 
       iSpellPower = iPrimaryBonus + iSecondaryBonus + iPowerBonus + iBase;
            


### PR DESCRIPTION
Jala's notes in GetSpellpower explicitly state Jala's primary bonus is supposed to go up to 40. True Lutes also offer 40 instrument level. However, there was a bound after this that limited it to 30, meaning all this time fine lutes and true lutes were functionally identical.