### PR TITLE
Use BaxMaseHealth instead of MaxHealth in Distill calculations

### DIFF
--- a/kod/object/passive/spell/distill.kod
+++ b/kod/object/passive/spell/distill.kod
@@ -283,7 +283,7 @@ messages:
       %  point total to reward built characters.
       iPotionPower = Bound(((iAbility * (iSkill + 1)) / 100),20,99);
       iPotionPower = iPotionPower - bound((iLevel*15)
-                     - (Send(caster,@GetMaxHealth)-20),0,$);
+                     - (Send(caster,@GetBaseMaxHealth)-20),0,$);
       iPotionPower = iPotionPower + Random(-20,(iSpellPower/10));
       iPotionPower = Bound(iPotionPower,5,SPELLPOWER_MAXIMUM);
 


### PR DESCRIPTION
The calculation for potion power in Distill uses Max Health, which invisibly lowers your power if you don a circlet, and also allows you to cheese the restriction by morphing into something with high health. Switching to Base Max Health fixes that issue.