### PR TITLE
Set Jala potions to never expire

### DIFF
--- a/kod/object/passive/spell/distill.kod
+++ b/kod/object/passive/spell/distill.kod
@@ -287,10 +287,8 @@ messages:
       iPotionPower = iPotionPower + Random(-20,(iSpellPower/10));
       iPotionPower = Bound(iPotionPower,5,SPELLPOWER_MAXIMUM);
 
-      % Potion has duration (In days) determined by distill spellpower and
-      %  spell level.
-      iGoBadTime = Bound((iSpellPower / iLevel) / 3,1,7);
-      iGoBadTime = iGoBadTime * 24 * 60 * 60 * 60 * 1000;
+      % Potion never goes bad.
+      iGoBadTime = -1;
 
       oPotion = Create(cPotionClass,#labelled=TRUE,#iSpellPower=iPotionPower,
                        #gobadtime=igobadtime,#maker=caster,#ability=iSkill);


### PR DESCRIPTION
Set the Go Bad Time for player-made potions to -1 so that they never expire and don't have Go Bad timers.

Formerly, Jala potions never went bad because they are 'labeled,' and the game does not start go bad timers on labeled spell items upon creation. However, the go bad timer could be potentially be restarted if the potion was sold to an NPC and repurchased. Not that such a thing would matter, because the time calculation was also massively off, resulting in go bad times that would have been over a year in length. Jala potions have not had this mechanic for over 20 years at this point, so I figured it's best just to officially set their go bad time to -1. I also don't think it's a good idea to add such a massive number of potential timers to the game, as every single Jala potion would have its own go bad timer of a week... while people are building, that could easily mean hundreds or thousands of timers just for a mechanic that wouldn't really add anything.