### PR TITLE
Give The Aerie Guest House a ROOM_HOMETOWN flag

### DIFF
--- a/kod/object/active/holder/room/kocarm/kocinn.kod
+++ b/kod/object/active/holder/room/kocarm/kocinn.kod
@@ -47,7 +47,7 @@ classvars:
    viTeleport_col = 5
 
    viTerrain_Type = TERRAIN_CITY | TERRAIN_SHOP
-   viPermanent_flags = ROOM_NO_COMBAT | ROOM_SANCTUARY | ROOM_SAFELOGOFF
+   viPermanent_flags = ROOM_NO_COMBAT | ROOM_SANCTUARY | ROOM_SAFELOGOFF | ROOM_HOMETOWN
 
 properties:
 


### PR DESCRIPTION
This may be an extremely obscure thing to notice, but there is custom text to describe a citizen of Ko'catan in that player's bio.

player_citizen_kocatan = " has lived in Ko'catan"

However, the Aerie Guest House is missing a ROOM_HOMETOWN flag, so anyone who actually becomes a citizen of Ko'catan will lose that hometown if they ever cast rescue, logoff pen, or get sent home by an admin. You cannot currently choose Ko'catan as a hometown in the hall of Genealogy, but it is not impossible for this situation to happen, and also seems like a natural thing that someone might one day add. It's also possible to give this hometown out as an admin event prize or the like.

ROOM_HOMETOWN flags have no extra functionality, and are found in many non-chooseable-hometown rooms, like OOG or Brahma & Falcon, so it seems like sometimes the flag was placed haphazardly...