### PR TITLE
Add a GitHub PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,8 @@
 #### Description
-<!-- Please provide a brief summary of the changes and the problem it solves. -->
+<!-- Please provide a concise summary of the changes made and the problem being solved. -->
 
 #### Related Issue
 <!-- If your PR is related to any existing issue, please link it here. -->
-
-#### Changes Proposed
-<!-- List the changes proposed in this PR. -->
 
 #### Testing Instructions
 <!-- Please provide steps to test the changes made in this PR. -->
@@ -16,14 +13,10 @@
 #### Checklist:
 <!-- Please check the items below that apply to your PR. -->
 
-- [ ] I have read the contribution guidelines and followed them.
-- [ ] My code follows the code style of this project.
 - [ ] I have performed a self-review of my own code.
-- [ ] I have commented my code, particularly in hard-to-understand areas.
 - [ ] I have made corresponding changes to the documentation, if necessary.
 - [ ] My changes generate no new warnings or errors.
 - [ ] I have added tests that prove my fix is effective or that my feature works.
-- [ ] New and existing unit tests pass locally with my changes.
 
 #### Additional Information
 <!-- Add any other context or screenshots about the pull request here. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+#### Description
+<!-- Please provide a brief summary of the changes and the problem it solves. -->
+
+#### Related Issue
+<!-- If your PR is related to any existing issue, please link it here. -->
+
+#### Changes Proposed
+<!-- List the changes proposed in this PR. -->
+
+#### Testing Instructions
+<!-- Please provide steps to test the changes made in this PR. -->
+
+#### Screenshots (if applicable)
+<!-- If your changes include UI/UX modifications or additions, please include screenshots here. -->
+
+#### Checklist:
+<!-- Please check the items below that apply to your PR. -->
+
+- [ ] I have read the contribution guidelines and followed them.
+- [ ] My code follows the code style of this project.
+- [ ] I have performed a self-review of my own code.
+- [ ] I have commented my code, particularly in hard-to-understand areas.
+- [ ] I have made corresponding changes to the documentation, if necessary.
+- [ ] My changes generate no new warnings or errors.
+- [ ] I have added tests that prove my fix is effective or that my feature works.
+- [ ] New and existing unit tests pass locally with my changes.
+
+#### Additional Information
+<!-- Add any other context or screenshots about the pull request here. -->


### PR DESCRIPTION
This PR adds a PR template, so that all subsequent PRs follow a similar format. I kept it simple and wanted to open this up to discussion. There's also the option of setting up [issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository) so that issues are submitted via a structured form.

Per GitHub:
> When you add a pull request template to your repository, project contributors will automatically see the template's contents in the pull request body. You can store your pull request template in the repository's visible root directory, the docs folder, or the hidden .github directory.

A few of us have talked about wanting/needing something like this for some time. The intent is to make PRs more consistent and hold us all accountable to covering all the necessary information.