### PR TITLE
Block Kraanan Enchantment from applying to Nerudite Swords

### DIFF
--- a/kod/object/passive/itematt/weapatt/waench.kod
+++ b/kod/object/passive/itematt/weapatt/waench.kod
@@ -77,6 +77,11 @@ messages:
    {
       if send(oItem,@getattackspell) > 0
       { return FALSE; }
+      
+      if Send(oItem,@CheckTypeFlag,#flag=ATCK_WEAP_NERUDITE)
+      {
+         return FALSE;
+      }
 
       return TRUE;
    }

--- a/kod/object/passive/spell/enchwp.kod
+++ b/kod/object/passive/spell/enchwp.kod
@@ -21,6 +21,8 @@ resources:
    enchantweapon_fails = "The %s is strangely unaffected by the spell."
    enchantweapon_already_done = \
       "This weapon is already dedicated to Kraanan."
+   enchantweapon_cannot_enchant_nerudite = \
+      "Nerudite cannot be enchanted in such a manner."
 
    enchantweapon_name_rsc = "enchant weapon"
    enchantweapon_icon_rsc = ienchant.bgf
@@ -93,6 +95,11 @@ messages:
       {
 	 Send(who, @MsgSendUser, #message_rsc=enchantweapon_already_done);
 	 return False;
+      }
+      if Send(oWeapon,@CheckTypeFlag,#flag=ATCK_WEAP_NERUDITE)
+      {
+         Send(who,@MsgSendUser,#message_rsc=enchantweapon_cannot_enchant_nerudite);
+         return False;
       }
       propagate;   % Check other things higher up
    }


### PR DESCRIPTION
When Kraanan Enchantments wear off, they apply a ATCK_WEAP_NONMAGIC flag that permanently messes up a nerudite sword's attack type. Striking a troll, for example, will no longer make the troll shiver and suffer.

I would just fix that part, but the Kraan enchant itself applies ATCK_WEAP_MAGIC to a weapon, which gives nerudite swords both ATCK_WEAP_NERUDITE and ATCK_WEAP_MAGIC at the same time. This probably shouldn't happen, given that they are treated exclusively elsewhere, and lore-wise nerudite is an anti-magic metal.

Prior to a Kraan enchantment, a nerudite sword is neither magical nor non-magical (0x10040). The enchantment makes this 0x10044, and then 0x10042 when it wears off, with no way to fix that. A magical nerudite sword with 0x10044 will probably screw up or bypass calculations somewhere unintended. In the past, I have found nerudite swords that deal nonmagic slashing damage (0x10082) which leads me to believe either this issue compounds somewhere/somehow, or there's another problem with nerudite attack types we need to find.

In terms of gameplay, I don't think this commit changes anything. There are no situations that I could find where a Kraan-enchanted nerudite sword was necessary or advantageous for something. The ATCK_WEAP_MAGIC flag has no function in PvP at all, and in PvE, there is no monster resistance combination where having both nerudite and magic benefits in some non-trivial way.

Qor and Shal enchants still work on nerudite swords without issue as far as I can tell, and those do have uses in PvP and PvE. Lore-wise, I would suggest these shouldn't work on nerudite swords either due to nerudite's anti-magic properties, but that's a separate discussion.