### PR TITLE
Remove most server-side sprintfs.

### DIFF
--- a/blakcomp/blakcomp.l
+++ b/blakcomp/blakcomp.l
@@ -391,7 +391,7 @@ FILE *open_include_file(char *filename)
    /* Loop through include directories and try to open file */
    for (i=0; i < num_include_dirs; i++)
    {
-      sprintf(tempbuf, "%s/%s", include_dirs[i], filename);
+      snprintf(tempbuf, sizeof(tempbuf), "%s/%s", include_dirs[i], filename);
       if ((fin = fopen(tempbuf, "r")) != NULL)
 	 return fin;
    }

--- a/blakdeco/blakdeco.c
+++ b/blakdeco/blakdeco.c
@@ -16,6 +16,8 @@
 #define MAX_CLASSES 100
 #define MAX_HANDLERS 500
 
+static const int TEXT_SIZE = 50000;
+
 /* function prototypes */
 bool open_file(char *s);
 void release_file();
@@ -276,7 +278,7 @@ void dump_bkod()
 {
    opcode_type opcode;
    int i, line;
-   char text[50000];
+   char text[TEXT_SIZE];
    char opcode_char;
    static int last_line = 0;
 
@@ -303,7 +305,7 @@ void dump_bkod()
    case CALL : dump_call(opcode,text); break;
    case RETURN : dump_return(opcode,text); break;
    case DEBUG_LINE : dump_debug_line(opcode,text); break;
-   default : sprintf(text,"INVALID"); break;
+   default : snprintf(text, sizeof(text), "INVALID"); break;
    }
 
    if (dump_hex)
@@ -331,7 +333,7 @@ void dump_unary_assign(opcode_type opcode,char *text)
    dest = get_int();
    source = get_int();
    source_str = strdup(str_constant(source));
-   sprintf(text,"%s %i = %s %s %s",name_var_type(opcode.dest),dest,
+   snprintf(text, TEXT_SIZE, "%s %i = %s %s %s",name_var_type(opcode.dest),dest,
 	   name_unary_operation(info),name_var_type(opcode.source1),
 	   source_str);
 }
@@ -347,7 +349,7 @@ void dump_binary_assign(opcode_type opcode,char *text)
    source2 = get_int();
    source1_str = strdup(str_constant(source1));
    source2_str = strdup(str_constant(source2));
-   sprintf(text,"%s %i = %s %s %s %s %s",name_var_type(opcode.dest),dest,
+   snprintf(text, TEXT_SIZE, "%s %i = %s %s %s %s %s",name_var_type(opcode.dest),dest,
 	   name_var_type(opcode.source1),source1_str,name_binary_operation(info),
 	   name_var_type(opcode.source2),source2_str);
 }
@@ -361,13 +363,13 @@ void dump_goto(opcode_type opcode,char *text)
 
    if (opcode.source1 == 0 && opcode.source2 == GOTO_UNCONDITIONAL)
    {
-      sprintf(text,"Goto absolute %08X",dest_addr+inst_start);
+      snprintf(text, TEXT_SIZE, "Goto absolute %08X",dest_addr+inst_start);
       return;
    }
    else
    {
       var = get_int();
-      sprintf(text,"If %s %s %s goto absolute %08X",
+      snprintf(text, TEXT_SIZE, "If %s %s %s goto absolute %08X",
 	      name_var_type(opcode.source1),str_constant(var),
 	      name_goto_cond(opcode.dest),dest_addr+inst_start);
    }
@@ -385,20 +387,20 @@ void dump_call(opcode_type opcode,char *text)
    {
    case CALL_NO_ASSIGN : /* return value ignored */
    {
-      sprintf(text,"Call %s--",name_function(info));
+      snprintf(text, TEXT_SIZE, "Call %s--",name_function(info));
       break;
    }
    case CALL_ASSIGN_LOCAL_VAR :
    case CALL_ASSIGN_PROPERTY :
    {
       assign_index = get_int();
-      sprintf(text,"%s %s = Call %s\n  : ",name_var_type(opcode.source1),
+      snprintf(text, TEXT_SIZE, "%s %s = Call %s\n  : ",name_var_type(opcode.source1),
 	      str_constant(assign_index),name_function(info));
       break;
    }
    default :
    {
-      sprintf(text,"INVALID");
+      snprintf(text, TEXT_SIZE, "INVALID");
       return;
    }
    }
@@ -426,7 +428,7 @@ void dump_call(opcode_type opcode,char *text)
       if (i != 0)
          strcat(text,", ");
       strcat(text,"Parm id ");
-      sprintf(tempbuf, "%d", name_id);
+      snprintf(tempbuf, sizeof(tempbuf), "%d", name_id);
       strcat(text, tempbuf);
       strcat(text," ");
       strcat(text,name_var_type(parm_type));
@@ -443,13 +445,13 @@ void dump_return(opcode_type return_op,char *text)
    {
    case PROPAGATE :
    {
-      sprintf(text,"Return propagate"); 
+      snprintf(text, TEXT_SIZE, "Return propagate"); 
       break;
    }
    case NO_PROPAGATE :
    {
       ret_val = get_int();
-      sprintf(text,"Return %s %s",name_var_type(return_op.source1),
+      snprintf(text, TEXT_SIZE, "Return %s %s",name_var_type(return_op.source1),
 	      str_constant(ret_val));
       break;
    }
@@ -563,7 +565,7 @@ const char * name_function(int fnum)
    case SQRT: return "Sqrt";
 
    case RANDOM  : return "Random";
-   default : sprintf(s,"Unknown function %i",fnum); return s;
+   default : snprintf(s, sizeof(s), "Unknown function %i",fnum); return s;
    }
 
    /* can't get here */
@@ -597,30 +599,30 @@ char *str_constant(int num)
    {
    case TAG_NIL : 
       if (bc.data == 0) 
-	 sprintf(s,"$");
+	 snprintf(s, sizeof(s), "$");
       else
-	 sprintf(s,"%i",bc.data);
+	 snprintf(s, sizeof(s),"%i",bc.data);
       break;
    case TAG_INT :
-      sprintf(s,"(int %i)",bc.data);
+      snprintf(s, sizeof(s),"(int %i)",bc.data);
       break;
    case TAG_RESOURCE :
-      sprintf(s,"(rsc %i)",bc.data);
+      snprintf(s, sizeof(s),"(rsc %i)",bc.data);
       break;
    case TAG_CLASS :
-      sprintf(s,"(class %i)",bc.data);
+      snprintf(s, sizeof(s),"(class %i)",bc.data);
       break;
    case TAG_MESSAGE :
-      sprintf(s,"(message %i)",bc.data);
+      snprintf(s, sizeof(s),"(message %i)",bc.data);
       break;
    case TAG_DEBUGSTR :
-      sprintf(s,"(debugging string %i)",bc.data);
+      snprintf(s, sizeof(s),"(debugging string %i)",bc.data);
       break;
    case TAG_OVERRIDE :
-      sprintf(s,"(overridden by property %i)",bc.data);
+      snprintf(s, sizeof(s),"(overridden by property %i)",bc.data);
       break;
    default :
-      sprintf(s,"INVALID");
+      snprintf(s, sizeof(s),"INVALID");
       break;
    }
    return s;
@@ -631,7 +633,7 @@ void dump_debug_line(opcode_type opcode,char *text)
    int line;
 
    line = get_int();
-   sprintf(text,"LINE %i",line);
+   snprintf(text, TEXT_SIZE, "LINE %i",line);
 }
 
 int find_linenum(int offset)

--- a/blakserv/adminfn.c
+++ b/blakserv/adminfn.c
@@ -1272,7 +1272,7 @@ void AdminMail(int session_id,admin_parm_type parms[],
 	char loadname[MAX_PATH+FILENAME_MAX];
 	char buf[MAIL_BUFSIZE + 2];
 
-	sprintf(loadname, "%s%s",ConfigStr(PATH_FORMS),NOTE_FILE);
+	snprintf(loadname, sizeof(loadname), "%s%s",ConfigStr(PATH_FORMS),NOTE_FILE);
 
 	if ((infile = open(loadname, O_RDONLY | O_TEXT)) == -1)
 	{
@@ -1539,9 +1539,9 @@ void AdminShowObject(int session_id,admin_parm_type parms[],
 		else
 			prop_name = GetPropertyNameByID(c,o->p[i].id);
 		if (prop_name == NULL)
-			sprintf(buf,": #%-19i",o->p[i].id);
+			snprintf(buf, sizeof(buf), ": #%-19i",o->p[i].id);
 		else
-			sprintf(buf,": %-20s",prop_name);
+			snprintf(buf, sizeof(buf), ": %-20s",prop_name);
 		aprintf("%s = %s %s\n",buf,GetTagName(o->p[i].val),
 			GetDataName(o->p[i].val));
 	}
@@ -1792,7 +1792,7 @@ void AdminShowOneAccount(account_node *a)
    if (a->suspend_time > 0)
    {
       // Print suspended time left in hours.
-      sprintf(buff,"%7.1fh",(a->suspend_time - GetTime())/(60.0*60.0));
+      snprintf(buff, sizeof(buff), "%7.1fh",(a->suspend_time - GetTime())/(60.0*60.0));
    }
    else
    {
@@ -2098,7 +2098,7 @@ void AdminShowCalls(int session_id,admin_parm_type parms[],
 		case RANDOM : strcpy(c_name, "Random"); break;
 
 		default :
-			sprintf(c_name,"Unknown (%i)",max_index);
+			snprintf(c_name, sizeof(c_name), "Unknown (%i)",max_index);
 			break;
 		}
 
@@ -2210,9 +2210,9 @@ void AdminShowClass(int session_id,admin_parm_type parms[],
 	{
 		classvar_name = GetClassVarNameByID(c,i);
 		if (classvar_name == NULL)
-			sprintf(buf,": VAR #%-19i",i);
+			snprintf(buf, sizeof(buf), ": VAR #%-19i",i);
 		else
-			sprintf(buf,": VAR %-20s",classvar_name);
+			snprintf(buf, sizeof(buf), ": VAR %-20s",classvar_name);
 		aprintf("%s = %s %s\n",buf,GetTagName(c->vars[i].val),
 				  GetDataName(c->vars[i].val));
 	}

--- a/blakserv/apndfile.c
+++ b/blakserv/apndfile.c
@@ -24,7 +24,7 @@ void AppendTextFile(session_node *s,const char *filename,
    char save_name[MAX_PATH+FILENAME_MAX];
    int i;
 
-   sprintf(save_name,"%s%s",ConfigStr(PATH_FORMS),filename);
+   snprintf(save_name, sizeof(save_name), "%s%s",ConfigStr(PATH_FORMS),filename);
    if ((appendfile = fopen(save_name,"at")) == NULL)
    {
       eprintf("AppendTextFile can't open %s to write out new text!\n",save_name);

--- a/blakserv/async.c
+++ b/blakserv/async.c
@@ -204,7 +204,7 @@ void AsyncSocketAccept(SOCKET sock,int event,int error,int connection_type)
 
 	memcpy(&peer_addr,(long *)&(peer_info.sin_addr),sizeof(struct in_addr));
 	memcpy(&conn.addr, &peer_addr, sizeof(struct in_addr));
-	sprintf(conn.name,"%s",inet_ntoa(peer_addr));
+	snprintf(conn.name, sizeof(conn.name), "%s",inet_ntoa(peer_addr));
 
 	if (connection_type == SOCKET_MAINTENANCE_PORT)
 	{
@@ -349,7 +349,7 @@ void AsyncEachSessionNameLookup(session_node *s)
 
 	if (s->conn.hLookup == name_lookup_handle)
 	{
-		sprintf(s->conn.name,"%s",((struct hostent *)&(s->conn.peer_data))->h_name);
+		snprintf(s->conn.name, sizeof(s->conn.name), "%s",((struct hostent *)&(s->conn.peer_data))->h_name);
 		InterfaceUpdateSession(s);
 	}
 }

--- a/blakserv/blakserv.rc
+++ b/blakserv/blakserv.rc
@@ -105,7 +105,7 @@ BEGIN
     LTEXT           "Version:",IDC_ABOUT_PIC_ICON,11,133,26,8
     LTEXT           "",IDC_ABOUT_TITLE,41,132,189,10,SS_SUNKEN
     LTEXT           "BlakSton Server",IDC_STATIC,11,58,220,8
-    LTEXT           "Copyright © 1994-2018 Andrew and Chris Kirmse",IDC_STATIC2,11,67,220,8
+    LTEXT           "Copyright © 1994-2024 Andrew and Chris Kirmse",IDC_STATIC2,11,67,220,8
     LTEXT           "All Rights Reserved",IDC_STATIC3,11,77,220,8
 END
 

--- a/blakserv/ccode.c
+++ b/blakserv/ccode.c
@@ -154,7 +154,7 @@ blak_int C_Debug(int object_id,local_var_type *local_vars,
 		return NIL;
 	}
 	
-	sprintf(buf,"[%s] ",BlakodDebugInfo());
+	snprintf(buf, sizeof(buf), "[%s] ",BlakodDebugInfo());
 	
 	for (i=0;i<num_normal_parms;i++)
 	{
@@ -318,7 +318,7 @@ blak_int C_DumpStack(int object_id,local_var_type *local_vars,
 {
 	char buf[2000];
 
-	sprintf(buf,"Stack:\n%s\n",BlakodStackInfo());
+	snprintf(buf, sizeof(buf), "Stack:\n%s\n",BlakodStackInfo());
 	dprintf("%s",buf);
 
 	return NIL;

--- a/blakserv/channel.c
+++ b/blakserv/channel.c
@@ -82,7 +82,7 @@ void dprintf(const char *fmt,...)
    char s[2000];
    va_list marker;
 
-   sprintf(s,"%s|",TimeStr(GetTime()));
+   snprintf(s, sizeof(s), "%s|",TimeStr(GetTime()));
 
    va_start(marker,fmt);
    vsprintf(s+strlen(s),fmt,marker);
@@ -100,7 +100,7 @@ void eprintf(const char *fmt,...)
    char s[2000];
    va_list marker;
 
-   sprintf(s,"%s | ",TimeStr(GetTime()));
+   snprintf(s, sizeof(s), "%s | ",TimeStr(GetTime()));
 
    va_start(marker,fmt);
    vsprintf(s+strlen(s),fmt,marker);
@@ -116,7 +116,7 @@ void bprintf(const char *fmt,...)
    char s[1000];
    va_list marker;
 
-   sprintf(s,"%s | [%s] ",TimeStr(GetTime()),BlakodDebugInfo());
+   snprintf(s, sizeof(s), "%s | [%s] ",TimeStr(GetTime()),BlakodDebugInfo());
 
    va_start(marker,fmt);
    vsprintf(s+strlen(s),fmt,marker);
@@ -134,7 +134,7 @@ void lprintf(const char *fmt,...)
    char s[1000];
    va_list marker;
 
-   sprintf(s,"%s | ",TimeStr(GetTime()));
+   snprintf(s, sizeof(s), "%s | ",TimeStr(GetTime()));
 
    va_start(marker,fmt);
    vsprintf(s+strlen(s),fmt,marker);
@@ -176,7 +176,8 @@ FILE *CreateFileChannel(int channel_id)
    } else {
        strftime(date_str, sizeof(date_str), "%Y-%m-%d", time_struct);
    }
-   sprintf(channel_file,"%s%s-%s.txt",ConfigStr(PATH_CHANNEL),channel_table[channel_id].file_name, date_str);
+   snprintf(channel_file, sizeof(channel_file),
+            "%s%s-%s.txt",ConfigStr(PATH_CHANNEL),channel_table[channel_id].file_name, date_str);
    pFile = fopen(channel_file, "ab");
 
    return pFile;

--- a/blakserv/dllist.c
+++ b/blakserv/dllist.c
@@ -202,7 +202,7 @@ void AddBuiltInDLlist()
 
    static const char *WHITESPACE = " \t\r\n";
    
-   sprintf(filename,"%s%s",ConfigStr(PATH_PACKAGE_FILE),PACKAGE_FILE);
+   snprintf(filename, sizeof(filename), "%s%s",ConfigStr(PATH_PACKAGE_FILE),PACKAGE_FILE);
    
    if ((packagefile = fopen(filename,"rt")) == NULL)
    {

--- a/blakserv/game.c
+++ b/blakserv/game.c
@@ -353,7 +353,7 @@ void GameWarnLowCredits(session_node *s)
    parm_node blak_parm[1];
    char text[100];
 
-   sprintf(text,"You have only %i credit%s remaining",s->account->credits/100,
+   snprintf(text, sizeof(text), "You have only %i credit%s remaining",s->account->credits/100,
 	   (s->account->credits/100 == 1) ? "" : "s");
 
    SetTempString(text, (int) strlen(text));
@@ -687,7 +687,7 @@ void GameDMCommand(session_node *s,int type,char *str)
 	 dprintf("DM Command GOROOM disabled for DMs; must be Admin.");
 	 break;
       }
-      sprintf(buf,"send object %i teleportto rid int %s",s->game->object_id,str);
+      snprintf(buf, sizeof(buf), "send object %i teleportto rid int %s",s->game->object_id,str);
       SendSessionAdminText(s->session_id,"~B> %s\n",buf); /* echo it to 'em */
       TryAdminCommand(s->session_id,buf); 
       break;
@@ -697,7 +697,7 @@ void GameDMCommand(session_node *s,int type,char *str)
 	 break;
       if (ConfigInt(RIGHTS_GOPLAYER) == ACCOUNT_ADMIN && acctype == ACCOUNT_DM)
 	 break;
-      sprintf(buf,"send object %i admingotoobject what object %s",s->game->object_id,str);
+      snprintf(buf, sizeof(buf), "send object %i admingotoobject what object %s",s->game->object_id,str);
       SendSessionAdminText(s->session_id,"~B> %s\n",buf); /* echo it to 'em */
       TryAdminCommand(s->session_id,buf); 
       break;
@@ -707,7 +707,7 @@ void GameDMCommand(session_node *s,int type,char *str)
 	 break;
       if (ConfigInt(RIGHTS_GETPLAYER) == ACCOUNT_ADMIN && acctype == ACCOUNT_DM)
 	 break;
-      sprintf(buf,"send object %s admingotoobject what object %i",str,s->game->object_id);
+      snprintf(buf, sizeof(buf), "send object %s admingotoobject what object %i",str,s->game->object_id);
       SendSessionAdminText(s->session_id,"~B> %s\n",buf); /* echo it to 'em */
       TryAdminCommand(s->session_id,buf); 
       break;

--- a/blakserv/interface.c
+++ b/blakserv/interface.c
@@ -287,11 +287,7 @@ LRESULT WINAPI InterfaceWindowProc(HWND hwnd,UINT message,WPARAM wParam,LPARAM l
 			
 		case WM_BLAK_LOGON :
 			sessions_logged_on++;
-			/*
-			sprintf(buf,"Connections: %i",sessions_logged_on);
-			SetDlgItemText(HWND_STATUS,IDC_CONNECTIONS_BORDER,buf);
-			*/
-			sprintf(buf,"%3i",sessions_logged_on);
+			snprintf(buf, sizeof(buf), "%3i",sessions_logged_on);
 			SendDlgItemMessage(hwndMain,IDS_STATUS_WINDOW,SB_SETTEXT,1,(LPARAM)buf);
 			
 			InterfaceAddList((int) lParam);
@@ -301,11 +297,7 @@ LRESULT WINAPI InterfaceWindowProc(HWND hwnd,UINT message,WPARAM wParam,LPARAM l
 			sessions_logged_on--;
 			if (sessions_logged_on < 0)
 				eprintf("InterfaceWindowProc sessions_logged_on just went negative!\n");
-				/*
-				sprintf(buf,"Connections: %i",sessions_logged_on);
-				SetDlgItemText(HWND_STATUS,IDC_CONNECTIONS_BORDER,buf);
-			*/
-			sprintf(buf,"%3i",sessions_logged_on);
+			snprintf(buf, sizeof(buf), "%3i",sessions_logged_on);
 			SendDlgItemMessage(hwndMain,IDS_STATUS_WINDOW,SB_SETTEXT,1,(LPARAM)buf);
 			
 			InterfaceRemoveList((int) lParam);
@@ -446,7 +438,7 @@ void InterfaceUpdateList(int session_id)
 		}
 		else
 		{
-			sprintf(buf,"%3i",s->account->account_id);
+			snprintf(buf, sizeof(buf), "%3i",s->account->account_id);
 			ListView_SetItemText(hwndLV,index,0,buf);
 			ListView_SetItemText(hwndLV,index,1,s->account->name);
 		}      
@@ -549,7 +541,7 @@ void StartupPrintf(const char *fmt,...)
 	va_list marker;
 	
 	va_start(marker,fmt);
-	vsprintf(s,fmt,marker);
+	vsnprintf(s, sizeof(s), fmt,marker);
 	
 	
 	if (strlen(s) > 0)
@@ -890,20 +882,20 @@ void InterfaceDrawText(HWND hwnd)
 	
 	if (TryEnterServerLock())
 	{
-		sprintf(s,"%zu bytes",GetMemoryTotal());
+		snprintf(s, sizeof(s),"%zu bytes",GetMemoryTotal());
 		SetDlgItemText(HWND_STATUS,IDC_MEMORY_VALUE,s);
 		
 		kstat = GetKodStats();
-		sprintf(s,"%s",TimeStr(kstat->system_start_time));
+		snprintf(s, sizeof(s),"%s",TimeStr(kstat->system_start_time));
 		SetDlgItemText(HWND_STATUS,IDC_STARTED_VALUE,s);
 		
-		sprintf(s,"%-200s",RelativeTimeStr(GetTime()-kstat->system_start_time));
+		snprintf(s, sizeof(s),"%-200s",RelativeTimeStr(GetTime()-kstat->system_start_time));
 		SetDlgItemText(HWND_STATUS,IDC_UP_FOR_VALUE,s);
 		
 		if (kstat->interpreting_time/1000.0 < 0.01) 
-			sprintf(s,"0/second");
+			snprintf(s, sizeof(s),"0/second");
 		else
-			sprintf(s,"%i/second",(int)(kstat->num_interpreted/(kstat->interpreting_time/1000.0)));
+			snprintf(s, sizeof(s),"%i/second",(int)(kstat->num_interpreted/(kstat->interpreting_time/1000.0)));
 		SetDlgItemText(HWND_STATUS,IDC_SPEED_VALUE,s);
 		
 		if (IsGameLocked())
@@ -1268,7 +1260,7 @@ void FatalErrorShow(const char *filename,int line,const char *str)
 {
 	char s[5000];
 	
-	sprintf(s,"File %s line %i\r\n\r\n%s",filename,line,str);
+	snprintf(s, sizeof(s),"File %s line %i\r\n\r\n%s",filename,line,str);
 	MessageBox(hwndMain,s,"Fatal Error",MB_ICONSTOP);
 	
 	exit(1);

--- a/blakserv/kodbase.c
+++ b/blakserv/kodbase.c
@@ -40,7 +40,7 @@ void LoadKodbase(void)
    char *type_char,*t1,*t2,*t3,*t4;
    char load_name[MAX_PATH+FILENAME_MAX];
 
-   sprintf(load_name,"%s%s",ConfigStr(PATH_KODBASE),KODBASE_FILE);
+   snprintf(load_name, sizeof(load_name), "%s%s",ConfigStr(PATH_KODBASE),KODBASE_FILE);
 
    if ((kodbase = fopen(load_name,"rt")) == NULL)
    {

--- a/blakserv/loadall.c
+++ b/blakserv/loadall.c
@@ -48,9 +48,9 @@ Bool LoadAll(void)
 		return False;
 	}
 	
-	sprintf(time_str,"%i",last_save_time);
+	snprintf(time_str, sizeof(time_str), "%i",last_save_time);
 	
-	sprintf(load_name,"%s%s%s",ConfigStr(PATH_LOADSAVE),ACCOUNT_FILE_SAVE,time_str);
+	snprintf(load_name, sizeof(load_name), "%s%s%s",ConfigStr(PATH_LOADSAVE),ACCOUNT_FILE_SAVE,time_str);
 	if (LoadAccounts(load_name) == False)
 	{
 		lprintf("LoadAll error loading accounts, initializing a new game\n");
@@ -81,7 +81,7 @@ Bool LoadAllButAccount(void)
 		return False;
 	}
 	
-	sprintf(time_str,"%i",last_save_time);
+	snprintf(time_str, sizeof(time_str), "%i",last_save_time);
 	
 	return LoadAllButAccountAtTime(time_str);
 }
@@ -93,11 +93,11 @@ Bool LoadAllButAccountAtTime(char *time_str)
 	
 	load_ok = True;
 	
-	sprintf(load_name,"%s%s%s",ConfigStr(PATH_LOADSAVE),STRING_FILE_SAVE,time_str);
+	snprintf(load_name, sizeof(load_name), "%s%s%s",ConfigStr(PATH_LOADSAVE),STRING_FILE_SAVE,time_str);
 	if (LoadBlakodStrings(load_name) == False)
 		load_ok = False;
 	
-	sprintf(load_name,"%s%s%s",ConfigStr(PATH_LOADSAVE),GAME_FILE_SAVE,time_str);
+	snprintf(load_name, sizeof(load_name), "%s%s%s",ConfigStr(PATH_LOADSAVE),GAME_FILE_SAVE,time_str);
 	if (!LoadGame(load_name)) 
 	{
 	/* If loadgame failed, create a system object which basically starts
@@ -111,7 +111,7 @@ Bool LoadAllButAccountAtTime(char *time_str)
 		SetSystemObjectID(CreateObject(SYSTEM_CLASS,0,NULL));
 	}
 	
-	sprintf(load_name,"%s%s%s",ConfigStr(PATH_LOADSAVE),DYNAMIC_RSC_FILE_SAVE,time_str);
+	snprintf(load_name, sizeof(load_name), "%s%s%s",ConfigStr(PATH_LOADSAVE),DYNAMIC_RSC_FILE_SAVE,time_str);
 	LoadDynamicRsc(load_name);
 	
 	return load_ok;
@@ -126,7 +126,7 @@ Bool LoadControlFile(int *last_save_time)
 	int lineno;
 	Bool found_lastsave;
 	
-	sprintf(load_name,"%s%s",ConfigStr(PATH_LOADSAVE),SAVE_CONTROL_FILE);
+	snprintf(load_name, sizeof(load_name), "%s%s",ConfigStr(PATH_LOADSAVE),SAVE_CONTROL_FILE);
 	if ((loadfile = fopen(load_name,"rt")) == NULL)
 		return False;
 	

--- a/blakserv/loadkod.c
+++ b/blakserv/loadkod.c
@@ -51,8 +51,8 @@ void LoadBof(void)
 	{
       for (StringVector::iterator it = files.begin(); it != files.end(); ++it)
       {
-			sprintf(file_load_path,"%s%s",ConfigStr(PATH_BOF), it->c_str());
-			sprintf(file_copy_path,"%s%s",ConfigStr(PATH_MEMMAP), it->c_str());
+        snprintf(file_load_path, sizeof(file_load_path), "%s%s",ConfigStr(PATH_BOF), it->c_str());
+        snprintf(file_copy_path, sizeof(file_copy_path), "%s%s",ConfigStr(PATH_MEMMAP), it->c_str());
 			if (BlakMoveFile(file_load_path,file_copy_path))
 				files_loaded++;
       }
@@ -70,7 +70,7 @@ void LoadBof(void)
 	{
 		for (StringVector::iterator it = files.begin(); it != files.end(); ++it)
 		{
-			sprintf(file_load_path,"%s%s",ConfigStr(PATH_MEMMAP), it->c_str());
+			snprintf(file_load_path, sizeof(file_load_path), "%s%s",ConfigStr(PATH_MEMMAP), it->c_str());
 			
 			if (LoadBofName(file_load_path))
 				files_loaded++;

--- a/blakserv/loadrsc.c
+++ b/blakserv/loadrsc.c
@@ -33,7 +33,7 @@ void LoadRsc(void)
 	{
 		for (StringVector::iterator it = files.begin(); it != files.end(); ++it)
 		{
-			sprintf(file_load_path,"%s%s",ConfigStr(PATH_RSC), it->c_str());
+			snprintf(file_load_path, sizeof(file_load_path), "%s%s",ConfigStr(PATH_RSC), it->c_str());
 			
 			if (RscFileLoad(file_load_path,EachLoadRsc))
 				files_loaded++;

--- a/blakserv/motd.c
+++ b/blakserv/motd.c
@@ -33,8 +33,8 @@ void LoadMotd(void)
    char file_load_path[MAX_PATH+FILENAME_MAX];
    char file_copy_path[MAX_PATH+FILENAME_MAX];
 
-   sprintf(file_load_path,"%s%s",ConfigStr(PATH_MOTD),MOTD_FILE);
-   sprintf(file_copy_path,"%s%s",ConfigStr(PATH_MEMMAP),MOTD_FILE);
+   snprintf(file_load_path, sizeof(file_load_path), "%s%s",ConfigStr(PATH_MOTD),MOTD_FILE);
+   snprintf(file_copy_path, sizeof(file_copy_path), "%s%s",ConfigStr(PATH_MEMMAP),MOTD_FILE);
 
    /* if there's a new motd file, move it in */
 
@@ -103,7 +103,7 @@ void SetMotd(char *new_motd)
 
    /* write file to memmap directory */
 
-   sprintf(filename,"%s%s",ConfigStr(PATH_MEMMAP),MOTD_FILE);
+   snprintf(filename, sizeof(filename), "%s%s",ConfigStr(PATH_MEMMAP),MOTD_FILE);
 
    fh = open(filename,O_CREAT | O_TRUNC | O_BINARY | O_WRONLY,S_IREAD | S_IWRITE);
 

--- a/blakserv/osd_linux.c
+++ b/blakserv/osd_linux.c
@@ -172,7 +172,7 @@ void StartupPrintf(const char *fmt,...)
 	va_list marker;
 
 	va_start(marker,fmt);
-	vsprintf(s,fmt,marker);
+	vsnprintf(s, sizeof(s), fmt,marker);
 
 
 	if (strlen(s) > 0)

--- a/blakserv/roomdata.c
+++ b/blakserv/roomdata.c
@@ -365,7 +365,7 @@ Bool LoadRoomFile(char *fname,room_type *file_info)
 {
    char s[MAX_PATH+FILENAME_MAX];
 
-   sprintf(s,"%s%s",ConfigStr(PATH_ROOMS),fname);
+   snprintf(s, sizeof(s), "%s%s",ConfigStr(PATH_ROOMS),fname);
 
    return BSPRooFileLoadServer(s,file_info);
 }

--- a/blakserv/saveall.c
+++ b/blakserv/saveall.c
@@ -45,25 +45,25 @@ INT64 SaveAll(void)
       We make our own copy since the time functions use a static
       buffer. */
    save_time = GetTime();
-   sprintf(time_str,"%lli",(long long) save_time);
+   snprintf(time_str, sizeof(time_str), "%lli",(long long) save_time);
    
    save_ok = True;
 
    lprintf("Saving game (time stamp %s)...\n", time_str);
    
-   sprintf(save_name,"%s%s%s",ConfigStr(PATH_LOADSAVE),GAME_FILE_SAVE,time_str);
+   snprintf(save_name, sizeof(save_name), "%s%s%s",ConfigStr(PATH_LOADSAVE),GAME_FILE_SAVE,time_str);
    if (SaveGame(save_name) == False)
       save_ok = False;
 
-   sprintf(save_name,"%s%s%s",ConfigStr(PATH_LOADSAVE),STRING_FILE_SAVE,time_str);
+   snprintf(save_name, sizeof(save_name), "%s%s%s",ConfigStr(PATH_LOADSAVE),STRING_FILE_SAVE,time_str);
    if (SaveStrings(save_name) == False)
       save_ok = False;
 
-   sprintf(save_name,"%s%s%s",ConfigStr(PATH_LOADSAVE),ACCOUNT_FILE_SAVE,time_str);
+   snprintf(save_name, sizeof(save_name), "%s%s%s",ConfigStr(PATH_LOADSAVE),ACCOUNT_FILE_SAVE,time_str);
    if (SaveAccounts(save_name) == False)
       save_ok = False;
 
-   sprintf(save_name,"%s%s%s",ConfigStr(PATH_LOADSAVE),DYNAMIC_RSC_FILE_SAVE,time_str);
+   snprintf(save_name, sizeof(save_name), "%s%s%s",ConfigStr(PATH_LOADSAVE),DYNAMIC_RSC_FILE_SAVE,time_str);
    if (!SaveDynamicRsc(save_name))
       save_ok = False;
 
@@ -84,7 +84,7 @@ void SaveControlFile(INT64 save_time)
    char save_name[MAX_PATH+FILENAME_MAX];
    FILE *savefile;
 
-   sprintf(save_name,"%s%s",ConfigStr(PATH_LOADSAVE),SAVE_CONTROL_FILE);
+   snprintf(save_name, sizeof(save_name), "%s%s",ConfigStr(PATH_LOADSAVE),SAVE_CONTROL_FILE);
    if ((savefile = fopen(save_name,"wt")) == NULL)
    {
       eprintf("SaveContrtolFile can't open %s to save date/time of successful save!!!\n",

--- a/blakserv/sendmsg.c
+++ b/blakserv/sendmsg.c
@@ -1117,15 +1117,15 @@ char *BlakodDebugInfo()
 
 	if (kod_stat.interpreting_class == INVALID_CLASS)
 	{
-		sprintf(s,"Server");
+		snprintf(s, sizeof(s), "Server");
 	}
 	else
 	{
 		c = GetClassByID(kod_stat.interpreting_class);
 		if (c == NULL)
-			sprintf(s,"Invalid class %i",kod_stat.interpreting_class);
+			snprintf(s, sizeof(s), "Invalid class %i",kod_stat.interpreting_class);
 		else
-			sprintf(s,"%s (%i)",c->fname,GetSourceLine(c,bkod));
+			snprintf(s, sizeof(s), "%s (%i)",c->fname,GetSourceLine(c,bkod));
 	}
 	return s;
 }
@@ -1142,13 +1142,13 @@ char *BlakodStackInfo()
 		char s[1000];
 		if (stack[i].class_id == INVALID_CLASS)
 		{
-			sprintf(s,"Server");
+			snprintf(s, sizeof(s), "Server");
 		}
 		else
 		{
 			c = GetClassByID(stack[i].class_id);
 			if (c == NULL)
-				sprintf(s,"Invalid class %i",stack[i].class_id);
+				snprintf(s, sizeof(s), "Invalid class %i",stack[i].class_id);
 			else
 			{
 				char *bp;
@@ -1168,14 +1168,14 @@ char *BlakodStackInfo()
 					class_name = c->class_name;
 				/* use %.*s with a fixed string of pluses to get exactly one plus per
 					propagate depth */
-				sprintf(s,"%.*s%s::%s",stack[i].propagate_depth,"++++++++++++++++++++++",class_name,GetNameByID(stack[i].message_id));
+				snprintf(s, sizeof(s), "%.*s%s::%s",stack[i].propagate_depth,"++++++++++++++++++++++",class_name,GetNameByID(stack[i].message_id));
 				strcat(s,"(");
 				parms[0] = '\0';
 				for (j=0;j<stack[i].num_parms;j++)
 				{
 					val_type val;
 					val.int_val = stack[i].parms[j].value;
-					sprintf(buf2,"#%s=%s %s",GetNameByID(stack[i].parms[j].name_id),
+					snprintf(buf2, sizeof(buf2), "#%s=%s %s",GetNameByID(stack[i].parms[j].name_id),
 							  GetTagName(val),GetDataName(val));
 					if (j > 0)
 						strcat(parms,",");
@@ -1183,7 +1183,7 @@ char *BlakodStackInfo()
 				}
 				strcat(s,parms);
 				strcat(s,")");
-				sprintf(buf2," %s (%i)",c->fname,GetSourceLine(c,bp));
+				snprintf(buf2, sizeof(buf2), " %s (%i)",c->fname,GetSourceLine(c,bp));
 				strcat(s,buf2);
 			}
 		}

--- a/blakserv/session.c
+++ b/blakserv/session.c
@@ -261,7 +261,7 @@ const char * GetStateName(session_node *s)
 				break;
 			}
 
-			if(1+sprintf(buf,"Transferring %i",s->syn->download_count)>50)
+			if(1+snprintf(buf, sizeof(buf), "Transferring %i",s->syn->download_count)>50)
 				eprintf("Overflowed buf in GetStateName session.c");
 
 			str = buf;

--- a/blakserv/string.c
+++ b/blakserv/string.c
@@ -276,6 +276,6 @@ void AppendNumToTempString(int iNum)
 {
    char numbuf[20];
 
-   sprintf(numbuf, "%d", iNum);
+   snprintf(numbuf, sizeof(numbuf), "%d", iNum);
    AppendTempString(numbuf, (int) strlen(numbuf));
 }

--- a/blakserv/synched.c
+++ b/blakserv/synched.c
@@ -477,7 +477,7 @@ void LogUserData(session_node *s)
 {
    char buf[500];
 
-   sprintf(buf,"LogUserData/4 got %i from %s, ",s->account->account_id,s->conn.name);
+   snprintf(buf, sizeof(buf), "LogUserData/4 got %i from %s, ",s->account->account_id,s->conn.name);
 
    switch (s->os_type)
    {

--- a/blakserv/term.c
+++ b/blakserv/term.c
@@ -87,7 +87,7 @@ const char * GetTagName(val_type val)
    case TAG_INVALID : return "INVALID";
    default :
       eprintf("GetTagName warning, can't identify tag %i\n",val.v.tag);
-      sprintf(s,"%i",(int) val.v.tag);
+      snprintf(s, sizeof(s), "%i",(int) val.v.tag);
       return s;
    }
 }
@@ -105,12 +105,12 @@ const char * GetDataName(val_type val)
       r = GetResourceByID(val.v.data);
       if (r == NULL)
       {
-        sprintf(s,"%lli",(long long) val.v.data);
+        snprintf(s, sizeof(s), "%lli",(long long) val.v.data);
 	 return s;
       }
       if (r->resource_name == NULL)
       {
-	 sprintf(s,"%i",r->resource_id);
+        snprintf(s, sizeof(s), "%i",r->resource_id);
 	 return s;
       }
       return r->resource_name;
@@ -119,7 +119,7 @@ const char * GetDataName(val_type val)
       if (c == NULL)
       {
 	 eprintf("GetTagData error, can't find class id %i\n",val.v.data);
-	 sprintf(s,"%lli",(long long) val.v.data);
+	 snprintf(s, sizeof(s),"%lli",(long long) val.v.data);
 	 return s;
       }
       return c->class_name;
@@ -131,7 +131,7 @@ const char * GetDataName(val_type val)
       /* write as positive int so no problem reading in */
       int_val.v.tag = val.v.tag;
       int_val.v.data = val.v.data;
-      sprintf(s,"%lli",(long long) int_val.v.data);
+      snprintf(s, sizeof(s),"%lli",(long long) int_val.v.data);
       return s;
    }
 }

--- a/blakserv/time.c
+++ b/blakserv/time.c
@@ -96,7 +96,7 @@ const char * RelativeTimeStr(time_t time)
 	
 	amount = (int) (time / (24*60*60));
 	if (amount != 0)
-		sprintf(s,"%i day%s ",amount,amount != 1 ? "s" : "");
+		snprintf(s, sizeof(s), "%i day%s ",amount,amount != 1 ? "s" : "");
 	
 	amount = (time / (60*60)) % 24;
 	if (amount != 0)
@@ -111,7 +111,7 @@ const char * RelativeTimeStr(time_t time)
 		sprintf(s+strlen(s),"%i second%s",amount,amount != 1 ? "s" : "");
 	
 	if (s[0] == 0)
-		sprintf(s,"0 sec");
+		snprintf(s, sizeof(s), "0 sec");
 	
 	return s;
 }

--- a/blakserv/user.c
+++ b/blakserv/user.c
@@ -64,7 +64,7 @@ user_node * CreateNewUser(int account_id,int class_id)
    p[0].value = system_id_const.int_val;
    p[0].name_id = SYSTEM_PARM;
 
-   sprintf(buf,"User%i%i%i",account_id, (int) GetTime()%100000, (int) (GetMilliCount()%1000));
+   snprintf(buf, sizeof(buf), "User%i%i%i",account_id, (int) GetTime()%100000, (int) (GetMilliCount()%1000));
    
    name_val.v.tag = TAG_RESOURCE;
    name_val.v.data = AddDynamicResource(buf);

--- a/club/club.c
+++ b/club/club.c
@@ -162,7 +162,7 @@ void RestartClient()
 
    if (!CreateProcess(restart_filename.c_str(),"",NULL,NULL,FALSE,0,NULL,NULL,&si,&pi))
    {
-      sprintf(s,GetString(hInst, IDS_CANTRESTART),GetLastError(),restart_filename.c_str());
+     snprintf(s, sizeof(string), GetString(hInst, IDS_CANTRESTART),GetLastError(),restart_filename.c_str());
       MessageBox(NULL,s,GetString(hInst, IDS_APPNAME),MB_ICONSTOP);
    }
 }
@@ -211,7 +211,7 @@ LRESULT WINAPI InterfaceWindowProc(HWND hwnd,UINT message,WPARAM wParam,LPARAM l
       SetFocus(GetDlgItem(hwnd, IDCANCEL));
 
       GetDlgItemText(hwnd, IDC_BYTES1, format, sizeof(format));
-      sprintf(string, format, transfer_progress, transfer_file_size);
+      snprintf(string, sizeof(string), format, transfer_progress, transfer_file_size);
       SetDlgItemText(hwnd, IDC_BYTES1, string);
 
       hCtrl = GetDlgItem(hwnd, IDC_ANIMATE1);
@@ -243,7 +243,7 @@ LRESULT WINAPI InterfaceWindowProc(HWND hwnd,UINT message,WPARAM wParam,LPARAM l
    case CM_FILESIZE:
       // Set max value
       transfer_file_size = (int) lParam;
-      sprintf(string, format, transfer_progress, transfer_file_size);
+      snprintf(string, sizeof(string), format, transfer_progress, transfer_file_size);
       SetDlgItemText(hwndMain, IDC_BYTES1, string);
       SendDlgItemMessage(hwnd, IDC_PROGRESS, PBM_SETRANGE, 0,
                          MAKELPARAM(0, transfer_file_size / 100));
@@ -252,7 +252,7 @@ LRESULT WINAPI InterfaceWindowProc(HWND hwnd,UINT message,WPARAM wParam,LPARAM l
    case CM_PROGRESS:
       // Set current value
       transfer_progress = (int) lParam;
-      sprintf(string, format, transfer_progress, transfer_file_size);
+      snprintf(string, sizeof(string), format, transfer_progress, transfer_file_size);
       SetDlgItemText(hwndMain, IDC_BYTES1, string);
       SendDlgItemMessage(hwnd, IDC_PROGRESS, PBM_SETPOS, transfer_progress / 100, 0);
       break;
@@ -290,7 +290,7 @@ void Status(char *fmt, ...)
    va_list marker;
     
    va_start(marker,fmt);
-   vsprintf(s,fmt,marker);
+   vsnprintf(s, sizeof(s), fmt,marker);
    va_end(marker);
 
    SetDlgItemText(hwndMain, IDC_STATUS, s);
@@ -306,7 +306,7 @@ void Error(char *fmt, ...)
    va_list marker;
     
    va_start(marker,fmt);
-   vsprintf(s,fmt,marker);
+   vsnprintf(s, sizeof(s), fmt,marker);
    va_end(marker);
 
    retval = DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_ERROR), hwndMain, ErrorDialogProc, 

--- a/club/club.h
+++ b/club/club.h
@@ -44,8 +44,6 @@
 #include "transfer.h"
 #include <string>
 
-#define sprintf wsprintf
-
 
 /* timer ID's */
 #define TIMER_START_TRANSFER 2

--- a/club/clubarchive.c
+++ b/club/clubarchive.c
@@ -143,7 +143,7 @@ void Dearchive(const char *dest_path, const char *zip_name)
          break;
       }
       
-      sprintf(msg, GetString(hInst, IDS_CANTUNPACK), GetString(hInst, extraction_error));
+      snprintf(msg, sizeof(msg), GetString(hInst, IDS_CANTUNPACK), GetString(hInst, extraction_error));
       
       if (MessageBox(hwndMain, msg, GetString(hInst, IDS_APPNAME), MB_YESNO) == IDNO)
       {

--- a/common.mak
+++ b/common.mak
@@ -72,8 +72,7 @@ PALETTEFILE = $(TOPDIR)\blakston.pal
 # /MP enables parallel compiling
 
 CCOMMONFLAGS = -nologo -DBLAK_PLATFORM_WINDOWS -DWIN32 \
-	     -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE \
-             -D_WINSOCK_DEPRECATED_NO_WARNINGS /wd4996 /wd4312 \
+             /wd4996 \
 	     -TP -WX -GR- -EHsc- -MP
 
 CNORMALFLAGS = $(CCOMMONFLAGS) -W2 /Ox

--- a/common.mak
+++ b/common.mak
@@ -67,12 +67,12 @@ PALETTEFILE = $(TOPDIR)\blakston.pal
 # /WX treats warnings as errors
 # /GR- turns off RTTI
 # /EHsc- turns off exceptions
-# /wd4996  disables warning (GetVersionExA has been deprecated)
+# /wd4996  disables warning (deprecated function called)
 # /wd4312  disables warning (cast 32-bit value to 64-bit pointer)
 # /MP enables parallel compiling
 
 CCOMMONFLAGS = -nologo -DBLAK_PLATFORM_WINDOWS -DWIN32 \
-             /wd4996 \
+             /wd4996 /wd4312 \
 	     -TP -WX -GR- -EHsc- -MP
 
 CNORMALFLAGS = $(CCOMMONFLAGS) -W2 /Ox


### PR DESCRIPTION
sprintf will give a warning/error on future versions of the compiler, at least on Linux.  This fixes the easy cases in the Blakod compiler and server, which build on Linux.