### PR TITLE
Show the damage caused with the hit message

### DIFF
--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -39,7 +39,7 @@ resources:
    % battler_defender_hit - Psychochild wounds you with his scimitar.
    % battler_defender_miss - You block Psychochild's attack.
 
-   battler_attacker_hit = "%sYour %s %s %s%s."       
+   battler_attacker_hit = "%sYour %s %s %s%s: %i"       
    battler_attacker_miss = "%s%s%s %s your attack."    
    battler_defender_hit = "%s%s%s %s you with %s %s."  
    battler_defender_miss = "%sYou %s %s%s's attack."   
@@ -959,7 +959,7 @@ messages:
 
          Send(self,@MsgSendUser,#message_rsc=battler_attacker_hit,
               #parm1=rColor,#parm2=rWeaponName,#parm3=rDamageDesc,
-              #parm4=Send(what,@GetDef),#parm5=Send(what,@GetName));
+              #parm4=Send(what,@GetDef),#parm5=Send(what,@GetName),#parm6=iDmg);
       }
 
       if IsClass(what,&Player)


### PR DESCRIPTION
Added a parameter, `battler_attacker_hit`, to store the damage value. Updated the `AssessHit` function to display the damage to the user.

### Why?

The purpose is to inform the user about the amount of damage being dealt to the monster, enhancing the player's awareness of their own attacks.