### PR TITLE
Move the camera 90° Up/Down

### DIFF
--- a/clientd3d/move.c
+++ b/clientd3d/move.c
@@ -964,7 +964,7 @@ void UserFlipPlayer(void)
 // Move at most HEIGHT_INCREMENT per HEIGHT_DELAY milliseconds
 #define HEIGHT_INCREMENT (CLASSIC_HEIGHT / 4)    
 #define HEIGHT_DELAY     100
-#define HEIGHT_MAX_OFFSET (3 * CLASSIC_HEIGHT / 2)    // Farthest you can look up or down
+#define HEIGHT_MAX_OFFSET (3 * CLASSIC_HEIGHT)    // Farthest you can look up or down
 /************************************************************************/
 /* 
  * BounceUser:  Modify user's height a little to give appearance that 


### PR DESCRIPTION
Updated the `HEIGHT_MAX_OFFSET` to enable the camera to tilt up or down by 90°.

### Why?

This enhancement allows players to freely explore their surroundings, providing them with additional options to navigate the game world.