### PR TITLE
Fix for key copies not disposing correctly.

### DIFF
--- a/kod/object/active/holder/room/rentroom.kod
+++ b/kod/object/active/holder/room/rentroom.kod
@@ -1468,8 +1468,13 @@ messages:
 
    Delete()
    {
-      Send(Send(SYS,@GetRentableRoomMaintenance),@RoomDeleted,#what=self);
-      Send(&RoomKey,@RoomExpired,#iRID=piRoom_num);
+      local oMaintenance, oMasterKey;
+
+      oMaintenance = Send(SYS, @GetRentableRoomMaintenance);
+      oMasterKey = Send(oMaintenance, @FindKeyByPlayer, #who=poRenter, #iLocation=viLocation);
+      Send(oMasterKey, @DeleteCopies);
+      Send(oMaintenance, @RoomDeleted,#what=self);
+      Send(oMasterKey, @RoomExpired);
 
       if ptDecoratorArrives <> $
       {

--- a/kod/object/item/passitem/roomkeyc.kod
+++ b/kod/object/item/passitem/roomkeyc.kod
@@ -103,7 +103,7 @@ messages:
    }
 
    GetMasterKey()
-   "Attempts to look up the master key, if one exists."
+   "Attempts to look up the master key if one exists or $ if not."
    {
       local oMaintenance, oRenter, oRoom;
       oMaintenance = Send(SYS, @GetRentableRoomMaintenance);
@@ -113,8 +113,7 @@ messages:
       return Send(oMaintenance, @FindKeyByPlayer, #who=oRenter, #iLocation=Send(oRoom, @GetLocation));
    }
 
-   OriginalDeleted(bRemoveFromMasterKey=TRUE)
-   "In most cases, bRemoveFromMasterKey should use the default value of TRUE."
+   OriginalDeleted()
    {
       if (poOwner <> $) and isClass(poOwner,&User)
       {
@@ -131,7 +130,7 @@ messages:
          }
       }
       
-      Send(Self, @Delete, #bRemoveFromMasterKey=bRemoveFromMasterKey);
+      Send(Self, @Delete);
       
       return;
    }
@@ -266,16 +265,16 @@ messages:
       propagate;
    }
 
-   Delete(bRemoveFromMasterKey=TRUE)
-   "bRemoveFromMasterKey determines whether or not a key copy is removed from the master "
-   "key's copy list upon deletion. When exeucting this command from the console, this "
-   "should be left as the default value of TRUE."
+   Delete()
    {
       local oMasterKey;
-      if (bRemoveFromMasterKey AND Send(self, @IsKeyCopy))
+      if (Send(self, @IsKeyCopy))
       {
          oMasterKey = Send(self, @GetMasterKey);
-         Send(oMasterKey, @RemoveCopy, #what=self);
+         if (oMasterKey <> $)
+         {
+            Send(oMasterKey, @RemoveCopy, #what=self);
+         }
       }
 
       propagate;

--- a/kod/object/item/passitem/roomkeyc.kod
+++ b/kod/object/item/passitem/roomkeyc.kod
@@ -119,7 +119,7 @@ messages:
          }
       }
       
-      send(self,@Delete);
+      Send(Self, @Delete, #bRemoveFromMasterKey=FALSE);
       
       return;
    }
@@ -249,6 +249,16 @@ messages:
          send(self,@NoDropMessage);
            
          return FALSE;
+      }
+
+      propagate;
+   }
+
+   Delete(bRemoveFromMasterKey=TRUE)
+   {
+      if (bRemoveFromMasterKey AND Send(self, @IsKeyCopy))
+      {
+         Send(&RoomKey, @RemoveCopy, #what=self);
       }
 
       propagate;

--- a/kod/object/item/passitem/roomkeyc.kod
+++ b/kod/object/item/passitem/roomkeyc.kod
@@ -102,7 +102,19 @@ messages:
       return oRenter;
    }
 
-   OriginalDeleted()
+   GetMasterKey()
+   "Attempts to look up the master key, if one exists."
+   {
+      local oMaintenance, oRenter, oRoom;
+      oMaintenance = Send(SYS, @GetRentableRoomMaintenance);
+      oRoom = Send(SYS, @FindRoomByNum, #num=piRID);
+      oRenter = Send(self, @GetRenter);
+
+      return Send(oMaintenance, @FindKeyByPlayer, #who=oRenter, #iLocation=Send(oRoom, @GetLocation));
+   }
+
+   OriginalDeleted(bRemoveFromMasterKey=TRUE)
+   "In most cases, bRemoveFromMasterKey should use the default value of TRUE."
    {
       if (poOwner <> $) and isClass(poOwner,&User)
       {
@@ -119,7 +131,7 @@ messages:
          }
       }
       
-      Send(Self, @Delete, #bRemoveFromMasterKey=FALSE);
+      Send(Self, @Delete, #bRemoveFromMasterKey=bRemoveFromMasterKey);
       
       return;
    }
@@ -255,10 +267,15 @@ messages:
    }
 
    Delete(bRemoveFromMasterKey=TRUE)
+   "bRemoveFromMasterKey determines whether or not a key copy is removed from the master "
+   "key's copy list upon deletion. When exeucting this command from the console, this "
+   "should be left as the default value of TRUE."
    {
+      local oMasterKey;
       if (bRemoveFromMasterKey AND Send(self, @IsKeyCopy))
       {
-         Send(&RoomKey, @RemoveCopy, #what=self);
+         oMasterKey = Send(self, @GetMasterKey);
+         Send(oMasterKey, @RemoveCopy, #what=self);
       }
 
       propagate;

--- a/kod/object/item/passitem/roomkeyc/roomkey.kod
+++ b/kod/object/item/passitem/roomkeyc/roomkey.kod
@@ -52,6 +52,11 @@ properties:
    plCopies = $
 
 messages:
+   GetMasterKey()
+   "This IS the master key!"
+   {
+      return self;
+   }
 
    AppendSpecial()
    "Appends the number of key copies in ciculation to the key's description."
@@ -184,7 +189,11 @@ messages:
       
       for i in plCopies
       {
-         Send(i,@OriginalDeleted);
+         % Trying to remove each copy from the master key list during the
+         % deletion process of the room and this key will cause errors.
+         % It's unnecessary anyway since the copy list is removed when 
+         % this loop is finished.
+         Send(i, @OriginalDeleted, #bRemoveFromMasterKey=FALSE);
       }
       
       plCopies = $;

--- a/kod/object/item/passitem/roomkeyc/roomkey.kod
+++ b/kod/object/item/passitem/roomkeyc/roomkey.kod
@@ -124,6 +124,17 @@ messages:
       return Length(plCopies);
    }
 
+   RemoveCopy(what=$)
+   "Removes the specified key copy from the list of current key copies."
+   {
+      if (plCopies <> $)
+      {
+         plCopies = DelListElem(plCopies, what);
+      }
+
+      return;
+   }
+
    DeleteCopies()
    {
       local oKeyCopy;

--- a/kod/object/item/passitem/roomkeyc/roomkey.kod
+++ b/kod/object/item/passitem/roomkeyc/roomkey.kod
@@ -155,12 +155,8 @@ messages:
       return;
    }
 
-   RoomExpired(iRID=$)
+   RoomExpired()
    {
-      if (iRID = $) or (iRID <> piRID)
-      {
-         return;
-      }
       if (poOwner <> $) and isClass(poOwner,&User)
       {
          if Send(poOwner,@IsLoggedOn)
@@ -189,11 +185,7 @@ messages:
       
       for i in plCopies
       {
-         % Trying to remove each copy from the master key list during the
-         % deletion process of the room and this key will cause errors.
-         % It's unnecessary anyway since the copy list is removed when 
-         % this loop is finished.
-         Send(i, @OriginalDeleted, #bRemoveFromMasterKey=FALSE);
+         Send(i, @OriginalDeleted);
       }
       
       plCopies = $;


### PR DESCRIPTION
When given to an innkeeper, room key copies are deleted, but not garbage disposed correctly because a reference to the key remains on the master (gold) room key.  These "ghost keys" remain in limbo until the master key is also deleted when the room expires or the change lock command is used.  This provides a simple fix for that.

The following tests were conducted:

- Key copy given to innkeeper to destroy it.
- Key copies bulk-destroyed via the change lock command.
- All keys destroyed upon room expiration.

In every test, a save was performed immediately afterward and the copies were successfully garbage collected without incident.

Note:  This PR is very similar to #630 but with a slightly different approach that doesn't involve sending to an entire key class.