### PR TITLE
Generalize Soldier Shield equip checks

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -3211,23 +3211,6 @@ messages:
             return FALSE;
          }
 
-         % Soldier Shields allow bows or lutes to be wielded even if they
-         %  are taking up all the hand spaces.  But, you can't use a shield, bow,
-         %  lute, and book all simlutaneously!
-         if (IsClass(what,&Bow) OR IsClass(what,&Lute))
-            AND Send(self,@FindUsing,#class=&SoldierShield) <> $
-            AND Send(self,@FindUsing,#class=&Lute) = $
-            AND Send(self,@FindUsing,#class=&Book) = $
-         {
-            % Don't allow them to wield a lute if we already have a bow.
-            % Trying to wield a second bow will unwield the first bow automatically.
-            if NOT IsClass(what,&Lute)
-               OR (Send(self,@FindUsing,#class=&Bow) = $)
-            {
-               return TRUE;
-            }
-         }
-
          if type = ITEM_USE_HAND
          {
             Send(self,@MsgSendUser,#message_rsc=player_use_full_hands);
@@ -3371,6 +3354,43 @@ messages:
       Send(self,@ResetPlayerFlagList);
       
       return TRUE;
+   }
+
+   GetPositionSpace(type=ITEM_USE_HAND)
+   {
+      if type = ITEM_USE_HAND
+      {
+         return viHand_space;
+      }
+      if type = ITEM_USE_BODY
+      {
+         return viBody_space;
+      }
+      if type = ITEM_USE_QUIVER
+      {
+         return viQuiver_space;
+      }
+      if type = ITEM_USE_NECK
+      {
+         return viNeck_space;
+      }
+      if type = ITEM_USE_HEAD
+      {
+         return viHead_space;
+      }
+      if type = ITEM_USE_LEGS
+      {
+         return viLeg_space;
+      }
+      if type = ITEM_USE_FINGER
+      {
+         return viFinger_space;
+      }
+      if type = ITEM_USE_GAUNTLET
+      {
+         return viGauntlet_space;
+      }
+      return 0;
    }
 
    TryUnuseItem(what = $)

--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -424,9 +424,21 @@ messages:
    }
 
    NewUsed()
-   {      
+   {
+      local i;
+
       Send(self,@DoPlayerArt);
       
+      for i in Send(poOwner,@GetPlayerUsing)
+      {
+         Send(i,@NewUsedSomething,#what=self);
+      }
+      
+      return;
+   }
+   
+   NewUsedSomething(what = $)
+   {
       return;
    }
 
@@ -482,8 +494,20 @@ messages:
 
    NewUnused()
    {
-      Send(self,@UndoPlayerArt);
+      local i;
 
+      Send(self,@UndoPlayerArt);
+      
+      for i in Send(poOwner,@GetPlayerUsing)
+      {
+         Send(i,@NewUnusedSomething,#what=self);
+      }
+
+      return;
+   }
+   
+   NewUnusedSomething(what=$)
+   {
       return;
    }
 

--- a/kod/object/item/passitem/defmod/shield/soldshld.kod
+++ b/kod/object/item/passitem/defmod/shield/soldshld.kod
@@ -111,7 +111,7 @@ properties:
    % These can change if we put the shield on our back.
    piOverlayHotspot = HS_LEFT_WEAPON
    vrShield_window_overlay = SoldierShield_window_overlay_rsc
-   viUse_amount = 1
+   viUse_amount = 0
    vrShield_overlay = SoldierShield_icon_rsc
 
 messages:
@@ -451,6 +451,60 @@ messages:
       return FALSE;
    }
 
+   ReqUseSomething(what = $)
+   {
+      local iUse_type;
+
+      % No other shields.
+      if what <> $ AND IsClass(what,&Shield)
+      {
+         return FALSE;
+      }
+
+      % We will move out of the way for any other hand items
+      iUse_type = Send(what,@GetItemUseType);
+      if (iUse_type & ITEM_USE_HAND)
+      {
+         return TRUE;
+      }
+
+      propagate;
+   }
+   
+   NewUsedSomething(what = $)
+   {
+      local iUse_type;
+
+      iUse_type = Send(what,@GetItemUseType);
+
+      % Item could have been prevented from being equipped by something else,
+      %    so only sling on our backs when it is successfully equipped.
+      % Also, only sling if our hands are definitely full.
+      if (iUse_type & ITEM_USE_HAND)
+         AND NOT Send(poOwner,@CheckPosition,#what=what,#type=ITEM_USE_HAND,#space=Send(poOwner,@GetPositionSpace,#type=ITEM_USE_HAND))
+      {
+         Send(self,@SlingOnBack);
+         return;
+      }
+
+      propagate;
+   }
+   
+   NewUnusedSomething(what = $)
+   {
+      local iUse_type;
+
+      iUse_type = Send(what,@GetItemUseType);
+
+      % Only unsling if we have a free hand.
+      if (iUse_type & ITEM_USE_HAND)
+         AND Send(poOwner,@CheckPosition,#what=what,#type=ITEM_USE_HAND,#space=Send(poOwner,@GetPositionSpace,#type=ITEM_USE_HAND))
+      {
+         Send(self,@RemoveFromBack);
+      }
+      return;
+   }
+
    %%% For putting the shield on our back
 
    % This is used for Bows and Lutes, currently.
@@ -468,9 +522,6 @@ messages:
          %  NOTE: This doesn't actually remove the overlay, just make it appear
          %        "nowhere".
          Send(poOwner,@RemoveWindowOverlay,#what=self);
-
-         % This makes it not take a hand.
-         viUse_amount = 0;
 
          vrShield_overlay = SoldierShield_icon_back_rsc;
          Send(poOwner,@SetOverlay,#what=self);
@@ -492,9 +543,6 @@ messages:
          % Restore the shield window overlay
          vrShield_window_overlay = SoldierShield_window_overlay_rsc;
          Send(poOwner,@SetWindowOverlay,#what=self);
-
-         % This makes it take a hand slot again.
-         viUse_amount = 1;
 
          vrShield_overlay = SoldierShield_icon_rsc;
          Send(poOwner,@SetOverlay,#what=self);

--- a/kod/object/item/passitem/instrum/lute.kod
+++ b/kod/object/item/passitem/instrum/lute.kod
@@ -44,16 +44,7 @@ messages:
 
    NewUsed()
    {
-      local oSoldierShield, oRoom;
-      
-      % Check for shield
-      oSoldierShield = send(poOwner,@FindUsing,#class=&SoldierShield);
-
-      % Sling it on the back if it's there.
-      if oSoldierShield <> $
-      {
-         send(oSoldierShield,@SlingOnBack);
-      }
+      local oRoom;
 
       % Play a sound
       oRoom = Send(poOwner, @GetOwner);
@@ -65,22 +56,6 @@ messages:
 
       propagate;
    }
-
-   NewUnused()
-   {
-      local oSoldierShield;
-      
-      % Take shield off back.
-      oSoldierShield = send(poOwner,@FindUsing,#class=&SoldierShield);
-
-      if oSoldierShield <> $
-      {
-         send(oSoldierShield,@RemoveFromBack);
-      }
-
-      propagate;
-   }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/weapon/ranged/bow.kod
+++ b/kod/object/item/passitem/weapon/ranged/bow.kod
@@ -125,7 +125,6 @@ messages:
          if oSoldierShield <> $
          {
             iFaction = send(oSoldierShield,@GetFaction);
-            send(oSoldierShield,@SlingOnBack);
          }
 
          if iFaction = FACTION_NEUTRAL
@@ -164,21 +163,6 @@ messages:
 
       vrWeapon_window_overlay = prBowOverlay;
       vrWeapon_overlay = prBowBottom;
-
-      propagate;
-   }
-
-   NewUnused()
-   {
-      local oSoldierShield;
-      
-      % Take shield off back.
-      oSoldierShield = send(poOwner,@FindUsing,#class=&SoldierShield);
-
-      if oSoldierShield <> $
-      {
-         send(oSoldierShield,@RemoveFromBack);
-      }
 
       propagate;
    }


### PR DESCRIPTION
There were several problems with the way Soldier Shields checked for attempted equipping of other items and whether the Shield should sling onto a player's back. Soldier Shields were allowing players to equip a lute and a weapon, and also preventing players from wielding a second Jewel of Froz, among other annoyances.

This commit removes several specific class-based checks in favor of a system whereby the Soldier Shield simply slings on the player's back if their hands become full, and it always slings back down whenever the player has a free hand.  It will only prevent the equipping of another shield.

This includes some new very basic functions for items, such as informing your other equipment when something is newly used or unused, that I'd like to use to fix some other equipment issues later. There's also a function to ask a player how much space capacity they have in a given equipment slot, in case anything down the line modifies that.