### PR TITLE
Added a reroll command

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -3463,6 +3463,7 @@ messages:
       }
 
       oBank = Send(SYS,@FindBankByNum,#num=Send(self,@GetBankNum));
+      
       Post(who,@SomeoneSaid,#what=self,#type=SAY_RESOURCE,
            #string=Lm_bnkr_balance,#parm1=Send(oBank,@GetAccount,#what=who));
 

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -3463,7 +3463,6 @@ messages:
       }
 
       oBank = Send(SYS,@FindBankByNum,#num=Send(self,@GetBankNum));
-      
       Post(who,@SomeoneSaid,#what=self,#type=SAY_RESOURCE,
            #string=Lm_bnkr_balance,#parm1=Send(oBank,@GetAccount,#what=who));
 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -204,24 +204,23 @@ resources:
    user_blocked_send = "%s is ignoring messages from you."
 
    user_cant_suicide = \
-      "You just can't bear to kill yourself because you have too much to live "
-      "for.  You must abdicate the leadership of your guild before you can "
-      "commit suicide."
+      "You just can't bear to reroll. You must abdicate the leadership of "
+      "your guild before you can reroll."
 
    user_cant_suicide_justicar = \
-      "It would be unseemly for such a high official to take his own life!"
+      "It would be unseemly for such a high official to reroll!"
 
    user_cant_suicide_yet = \
-      "You can't seem to kill yourself, you feel you've only just begun this "
+      "You can't seem to reroll, you feel you've only just begun this "
       "life. Give it a day."
 
    user_cant_suicide_token = \
-      "You can't kill yourself now, not when you're the sacred guardian of a "
+      "You can't reroll now, not when you're the sacred guardian of a "
       "Meridian token!"
 
    user_cant_suicide_OOG = \
       "Somehow, even though you deserve it, you are unable to bear the "
-      "thought of killing yourself now."
+      "thought of rerolling now."
 
    user_no_seller = "You can't buy anything here."
 

--- a/module/merintr/merintr.c
+++ b/module/merintr/merintr.c
@@ -332,6 +332,7 @@ static TypedCommand commands[] = {
 { "stand",       CommandStand, },
 { "suicid",      CommandSuicid, },
 { "suicide",     CommandSuicide, },
+{ "reroll",      CommandSuicide, },
 { "neutral",     CommandNeutral, },
 { "happy",       CommandHappy, },
 { "sad",         CommandSad, },

--- a/module/merintr/merintr.rc
+++ b/module/merintr/merintr.rc
@@ -34,9 +34,9 @@ STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Neuerschaffung eines Charakters"
 FONT 8, "MS Sans Serif"
 BEGIN
-    GROUPBOX        "�berpr�fung",-1,7,28,228,33
-    LTEXT           "Harakiri zerst�rt Deinen Charakter und legt einen neuen an.  Es ist alleine Deine Verantwortung, jetzt ein neues Spiel zu beginnen.",-1,7,4,235,18
-    LTEXT           "Zur Best�tigung gibst Du jetzt bitte Dein g�ltiges Passwort ein:",-1,14,40,106,19
+    GROUPBOX        "Überprüfung",-1,7,28,228,33
+    LTEXT           "Harakiri zerstört Deinen Charakter und legt einen neuen an.  Es ist alleine Deine Verantwortung, jetzt ein neues Spiel zu beginnen.",-1,7,4,235,18
+    LTEXT           "Zur Bestätigung gibst Du jetzt bitte Dein gültiges Passwort ein:",-1,14,40,106,19
     EDITTEXT        1260,131,42,97,12,ES_PASSWORD | ES_AUTOHSCROLL
     DEFPUSHBUTTON   "Harakiri",1,7,65,107,14
     PUSHBUTTON      "Abbrechen",2,120,65,115,14
@@ -47,7 +47,7 @@ STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Kurzbefehle"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
-    LTEXT           "Um einen Kurzbefehl zu definieren mu� die Abk�rzung bei Wort eingetragen werden und danach der Befehl ausgeschrieben werden. BEISPIEL: Wort: lacht   Kurzbefehl: ego lacht.""",-1,4,4,215,27
+    LTEXT           "Um einen Kurzbefehl zu definieren muß die Abkürzung bei Wort eingetragen werden und danach der Befehl ausgeschrieben werden. BEISPIEL: Wort: lacht   Kurzbefehl: ego lacht.""",-1,4,4,215,27
     GROUPBOX        "",-1,4,29,211,170
     LTEXT           "Wort:",-1,10,38,18,8
     EDITTEXT        1260,49,36,50,12,ES_AUTOHSCROLL
@@ -56,7 +56,7 @@ BEGIN
     PUSHBUTTON      "&Entfernen",1002,157,37,50,11
     LTEXT           "Befehl:",-1,10,51,23,8
     CONTROL         "",1263,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SORTASCENDING | LVS_NOLABELWRAP | LVS_NOSORTHEADER | WS_TABSTOP,10,64,199,128,WS_EX_CLIENTEDGE
-    PUSHBUTTON      "Best�tigen",1,24,205,50,14
+    PUSHBUTTON      "Bestätigen",1,24,205,50,14
     PUSHBUTTON      "Abbrechen",2,82,205,50,14
     PUSHBUTTON      "Funktionstasten ...",1264,139,205,76,14
 END
@@ -70,14 +70,14 @@ BEGIN
     LTEXT           "Gildenpasswort:",1242,10,34,51,8
     EDITTEXT        1239,65,32,101,14,ES_AUTOHSCROLL
     PUSHBUTTON      "Gildenhalle aufgeben!",1235,171,32,76,14
-    PUSHBUTTON      "Ja, hiermit best�tige ich die Aufl�sung meiner Gilde!",1224,4,56,248,14
+    PUSHBUTTON      "Ja, hiermit bestätige ich die Auflösung meiner Gilde!",1224,4,56,248,14
 END
 
 160 DIALOG  0, 0, 282, 178
 STYLE DS_SETFONT | WS_CHILD
 FONT 8, "MS Sans Serif"
 BEGIN
-    LTEXT           "Verb�ndete Gilden:",-1,4,26,62,8
+    LTEXT           "Verbündete Gilden:",-1,4,26,62,8
     LISTBOX         1225,4,36,75,118,LBS_SORT | LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
     PUSHBUTTON      ">>",1228,84,46,13,12
     PUSHBUTTON      "<<",1230,84,72,13,12
@@ -88,7 +88,7 @@ BEGIN
     LTEXT           "Verfeindete Gilden:",-1,200,26,61,8
     LISTBOX         1227,203,36,75,118,LBS_SORT | LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
     LTEXT           "",1232,4,161,274,8
-    LTEXT           "Benutze die << und >> Tasten um Allianzen zu schlie�en oder Feinde zu erkl�ren.",1236,11,4,257,8
+    LTEXT           "Benutze die << und >> Tasten um Allianzen zu schließen oder Feinde zu erklären.",1236,11,4,257,8
 END
 
 159 DIALOGEX 0, 0, 308, 122
@@ -102,9 +102,9 @@ BEGIN
     PUSHBUTTON      "Mitglied &rauswerfen",1212,123,30,132,12
     PUSHBUTTON      "Den Rang &abtreten an:",1205,98,91,96,12
     LTEXT           "",1209,199,92,105,10,SS_SUNKEN
-    PUSHBUTTON      "Neues Mitglied &unterst�tzen:",1203,98,73,96,14
+    PUSHBUTTON      "Neues Mitglied &unterstützen:",1203,98,73,96,14
     LTEXT           "",1211,199,75,105,10,SS_SUNKEN
-    LTEXT           "Unterst�tztes Mitglied:",-1,98,59,71,8
+    LTEXT           "Unterstütztes Mitglied:",-1,98,59,71,8
     LTEXT           "cha",1214,199,58,105,10,SS_SUNKEN
     PUSHBUTTON      "Die Gilde &verlassen",1208,4,106,87,12
     LTEXT           "",1223,124,17,93,8,SS_SUNKEN
@@ -123,7 +123,7 @@ FONT 8, "MS Sans Serif"
 BEGIN
     GROUPBOX        "Gildenschild:",-1,3,0,120,116
     CONTROL         "",1001,"Button",BS_OWNERDRAW,7,10,108,102
-    LTEXT           "W�hle eine Farb- && Musterkombination:",-1,137,14,128,8
+    LTEXT           "Wähle eine Farb- && Musterkombination:",-1,137,14,128,8
     LTEXT           "Farbe 1:",-1,148,29,27,8
     PUSHBUTTON      "<",1019,181,27,17,11,WS_GROUP
     PUSHBUTTON      ">",1022,199,27,17,11
@@ -133,9 +133,9 @@ BEGIN
     LTEXT           "Muster:",-1,147,59,24,8
     PUSHBUTTON      "<",1016,181,57,17,11,WS_GROUP
     PUSHBUTTON      ">",1017,199,57,17,11
-    LTEXT           "Das Design wurde bereits von der Gilde %s gew�hlt.",1266,137,77,124,20,SS_SUNKEN
+    LTEXT           "Das Design wurde bereits von der Gilde %s gewählt.",1266,137,77,124,20,SS_SUNKEN
     PUSHBUTTON      "Anspruch auf das Design erheben.",1265,137,102,129,13,WS_GROUP
-    LTEXT           "Das Design ist nicht verf�gbar.",1208,137,68,129,8,NOT WS_VISIBLE
+    LTEXT           "Das Design ist nicht verfügbar.",1208,137,68,129,8,NOT WS_VISIBLE
 END
 
 140 DIALOGEX 0, 0, 286, 373
@@ -145,10 +145,10 @@ FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     LTEXT           "Gruppen:",-1,8,7,30,8
     COMBOBOX        1243,8,17,97,65,CBS_DROPDOWNLIST | CBS_SORT | WS_VSCROLL | WS_TABSTOP
-    PUSHBUTTON      "Gruppe l�schen",1244,114,16,58,14,WS_DISABLED
+    PUSHBUTTON      "Gruppe löschen",1244,114,16,58,14,WS_DISABLED
     LTEXT           "Neue Gruppe:",1252,180,6,46,8
     EDITTEXT        1251,180,16,58,14,ES_AUTOHSCROLL
-    LTEXT           "Eine Nachricht an die ausgew�hlte Gruppe versenden:",-1,8,39,174,8
+    LTEXT           "Eine Nachricht an die ausgewählte Gruppe versenden:",-1,8,39,174,8
     EDITTEXT        1255,8,49,270,14,ES_AUTOHSCROLL
     LTEXT           "Gruppenmitglieder:",-1,8,73,60,8
     LTEXT           "(rote Namen sind im Spiel)",-1,8,81,82,8
@@ -160,7 +160,7 @@ BEGIN
     LTEXT           "Anwesende Spieler:",-1,180,80,64,8
     LISTBOX         1246,180,91,97,255,LBS_SORT | LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
     LTEXT           "",1256,8,354,174,8
-    PUSHBUTTON      "Best�tigen",1254,227,354,50,14
+    PUSHBUTTON      "Bestätigen",1254,227,354,50,14
 END
 
 107 DIALOGEX 0, 0, 249, 259
@@ -168,14 +168,14 @@ STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Eine Gildenhalle mieten"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
-    DEFPUSHBUTTON   "Best�tigen",1,66,238,50,14
+    DEFPUSHBUTTON   "Bestätigen",1,66,238,50,14
     PUSHBUTTON      "Abbrechen",2,132,238,50,14
     CONTROL         "",1201,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,5,16,238,162,WS_EX_CLIENTEDGE
-    LTEXT           "W�hle eine Gildenhalle aus:",-1,6,4,89,8
+    LTEXT           "Wähle eine Gildenhalle aus:",-1,6,4,89,8
     LTEXT           "Gildenpasswort:",-1,6,219,51,8
     EDITTEXT        1239,60,217,94,12,ES_AUTOHSCROLL
-    LTEXT           "Das Passwort sch�tzt Teile der Gildenhalle vor unbefugtem Zugriff.",-1,6,204,210,8
-    LTEXT           "Ausgew�hlte Gildenhalle:",-1,6,186,80,8
+    LTEXT           "Das Passwort schützt Teile der Gildenhalle vor unbefugtem Zugriff.",-1,6,204,210,8
+    LTEXT           "Ausgewählte Gildenhalle:",-1,6,186,80,8
     LTEXT           "",1215,89,185,129,11,SS_SUNKEN
 END
 
@@ -184,26 +184,26 @@ STYLE DS_SETFONT | WS_CHILD
 FONT 8, "MS Sans Serif"
 BEGIN
     LISTBOX         1202,60,32,98,86,LBS_SORT | LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "W�hle die Person, der Du die Einladung �berreichen willst:",-1,4,33,51,58
+    LTEXT           "Wähle die Person, der Du die Einladung überreichen willst:",-1,4,33,51,58
     PUSHBUTTON      "Einladen",1001,4,106,45,12
-    LTEXT           "Du kannst nur Spieler zum Beitritt auffordern, die sich im gleichen Raum befinden. Au�erdem darf nur eine Einladung ausstehen.",-1,4,4,157,24
+    LTEXT           "Du kannst nur Spieler zum Beitritt auffordern, die sich im gleichen Raum befinden. Außerdem darf nur eine Einladung ausstehen.",-1,4,4,157,24
 END
 
 105 DIALOG  0, 0, 269, 180
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "Neue Gilde gr�nden"
+CAPTION "Neue Gilde gründen"
 FONT 8, "MS Sans Serif"
 BEGIN
     LTEXT           "Name der Gilde:",-1,9,12,53,8
     EDITTEXT        1215,66,10,95,14,ES_AUTOHSCROLL
     GROUPBOX        "Rangfolge in der Gilde:",-1,10,30,247,114
-    LTEXT           "M�nner:",-1,21,45,27,8
+    LTEXT           "Männer:",-1,21,45,27,8
     EDITTEXT        1220,21,57,83,14,ES_AUTOHSCROLL
     EDITTEXT        1219,21,73,83,14,ES_AUTOHSCROLL
     EDITTEXT        1218,21,89,83,14,ES_AUTOHSCROLL
     EDITTEXT        1217,21,105,83,14,ES_AUTOHSCROLL
     EDITTEXT        1216,21,121,83,14,ES_AUTOHSCROLL
-    LTEXT           "h�chster",-1,119,59,28,8
+    LTEXT           "höchster",-1,119,59,28,8
     LTEXT           "niedrigster",-1,118,124,33,8
     LTEXT           "Frauen:",-1,163,45,25,8
     EDITTEXT        1226,163,57,83,14,ES_AUTOHSCROLL
@@ -211,11 +211,11 @@ BEGIN
     EDITTEXT        1224,163,89,83,14,ES_AUTOHSCROLL
     EDITTEXT        1223,163,105,83,14,ES_AUTOHSCROLL
     EDITTEXT        1222,163,121,83,14,ES_AUTOHSCROLL
-    CONTROL         "eine geheime Gilde gr�nden. (Die Gildenangeh�rigkeit ist nicht sichtbar)",1221,
+    CONTROL         "eine geheime Gilde gründen. (Die Gildenangehörigkeit ist nicht sichtbar)",1221,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,10,147,240,8
-    LTEXT           "Gr�ndungskosten:",-1,10,163,59,8
+    LTEXT           "Gründungskosten:",-1,10,163,59,8
     LTEXT           "",1237,74,163,41,10,SS_SUNKEN
-    DEFPUSHBUTTON   "Best�tigen",1,156,162,50,14
+    DEFPUSHBUTTON   "Bestätigen",1,156,162,50,14
     PUSHBUTTON      "Abbrechen",2,215,162,50,14
 END
 
@@ -270,7 +270,7 @@ BEGIN
     RTEXT           "F12",15,9,185,13,8
     EDITTEXT        1011,29,184,159,12,ES_AUTOHSCROLL
     CONTROL         "",1210,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,194,185,13,9
-    DEFPUSHBUTTON   "Best�tigen",IDOK,19,208,50,14
+    DEFPUSHBUTTON   "Bestätigen",IDOK,19,208,50,14
     PUSHBUTTON      "Abbrechen",IDCANCEL,77,208,50,14
     PUSHBUTTON      "Kurzbefehle....",1264,136,208,76,14
 END
@@ -306,9 +306,9 @@ END
 STRINGTABLE 
 BEGIN
     1                       "Zaubern"
-    2                       "&Zauberspr�che"
-    3                       "Gegenst�nde wegwerfen"
-    4                       "Gegenst�nde nehmen"
+    2                       "&Zaubersprüche"
+    3                       "Gegenstände wegwerfen"
+    4                       "Gegenstände nehmen"
     5                       "Sagen"
     6                       "Zaubern"
     7                       "Kartenmodus"
@@ -318,25 +318,25 @@ BEGIN
     11                      "Lebenskraft"
     12                      "Zauberkraft"
     13                      "Ausdauer"
-    14                      "L�cheln"
+    14                      "Lächeln"
     15                      "Grimmig"
 END
 
 STRINGTABLE 
 BEGIN
     16                      "Niemand mit diesem Namen ist im Spiel."
-    17                      "Dieser Name tritt h�ufiger auf."
-    18                      "Der Name dieser Gruppe tritt h�ufiger auf."
-    19                      "Du kannst keine zus�tzlichen Gruppen mehr anlegen."
+    17                      "Dieser Name tritt häufiger auf."
+    18                      "Der Name dieser Gruppe tritt häufiger auf."
+    19                      "Du kannst keine zusätzlichen Gruppen mehr anlegen."
     20                      "Die %.*s-Gruppe ist voll."
     21                      "Niemand von dieser Gruppe ist im Spiel."
     22                      "Es gibt keine Gruppe mit diesem Namen."
     23                      "Es gibt bereits eine Gruppe mit diesem Namen."
-    24                      "Der Name dieses Zauberspruchs tritt h�ufiger auf."
+    24                      "Der Name dieses Zauberspruchs tritt häufiger auf."
     25                      "Es gibt keinen Zauber mit diesem Namen."
-    26                      "Bist Du Dir auch wirklich sicher, diesen Charakter zu l�schen? \nDiese Entscheidung ist unwiderruflich."
-    27                      "Du mu�t angeben wieviel Du abheben m�chtest."
-    28                      "Du mu�t angeben wieviel Du einzahlen m�chtest."
+    26                      "Bist Du Dir auch wirklich sicher, diesen Charakter zu löschen? \nDiese Entscheidung ist unwiderruflich."
+    27                      "Du mußt angeben wieviel Du abheben möchtest."
+    28                      "Du mußt angeben wieviel Du einzahlen möchtest."
     29                      "Diese Gruppe ist voll."
     30                      "Der Spieler konnte nicht in die Gruppe aufgenommen werden."
     31                      "Es konnte keine neue Gruppe angelegt werden."
@@ -348,17 +348,17 @@ BEGIN
     33                      "Mitglieder der %.*s-Gruppe (~rrot~n = im Spiel):"
     34                      "Du hast keine Gruppen angelegt."
     35                      "Du hast folgende Gruppen angelegt:"
-    36                      "Gruppe wurde gel�scht."
+    36                      "Gruppe wurde gelöscht."
     37                      "%d Name wurde aus der Gruppe entfernt."
     38                      "Die Gruppe wurde erstellt."
     39                      "Du rastest."
-    40                      "Du h�rst auf Dich auszuruhen."
+    40                      "Du hörst auf Dich auszuruhen."
     41                      "Du ruhst Dich bereits aus."
     42                      "Du ruhst Dich gar nicht aus."
     43                      "Du kannst keine Zauber sprechen, solange Du rastest."
     44                      "Du kannst Deine Arme nicht bewegen um den Zauber zu sprechen!"
     45                      "Gebe ""suicide"" ein, um einen neuen Charakter zu erschaffen."
-    46                      "Du mu�t einen Gildennamen festlegen."
+    46                      "Du mußt einen Gildennamen festlegen."
     47                      "Meridian 59 --- %s"
 END
 
@@ -377,8 +377,8 @@ BEGIN
     58                      "Heldin"
     59                      "Gildenmeisterin"
     60                      "Die Gilde %s sieht Dich weder als Feind noch als Freund."
-    61                      "Willst Du die Gilde wirklich aufl�sen?"
-    62                      "Die Gilde %s sieht Dich als Verb�ndeten an."
+    61                      "Willst Du die Gilde wirklich auflösen?"
+    62                      "Die Gilde %s sieht Dich als Verbündeten an."
     63                      "Die Gilde %s sieht Dich als Feind an."
 END
 
@@ -388,17 +388,17 @@ BEGIN
     65                      "Gildeneinstellungen"
     66                      "Einladen"
     67                      "Mitgliedschaft"
-    68                      "B�ndnisse"
+    68                      "Bündnisse"
     69                      "Gildenmeister"
     70                      "Niemand"
     71                      "Fertig"
     72                      "Kosten"
-    73                      "T�gliche Miete"
+    73                      "Tägliche Miete"
     74                      "Name der Gilde"
-    75                      "Du mu�t ein Gildenpasswort festlegen."
+    75                      "Du mußt ein Gildenpasswort festlegen."
     76                      "Schild"
     77                      "Eigenschaften"
-    78                      "Zauberspr�che"
+    78                      "Zaubersprüche"
     79                      "Fertigkeiten"
 END
 
@@ -414,17 +414,17 @@ BEGIN
     87                      "Inventar"
     88                      "Was bitte? Benutz die Hilfe ""help""."
     89                      "&Wer spielt"
-    90                      "Eine ung�ltige Anweisung wurde f�r den Kurzbefehl festgelegt."
-    91                      "Diesen Befehl gibt es h�ufiger."
+    90                      "Eine ungültige Anweisung wurde für den Kurzbefehl festgelegt."
+    91                      "Diesen Befehl gibt es häufiger."
     92                      "Der Kurzbefehl wurde definiert."
-    93                      "Der Kurzbefehl wurde gel�scht."
+    93                      "Der Kurzbefehl wurde gelöscht."
     94                      "Wort"
     95                      "Befehl"
 END
 
 STRINGTABLE 
 BEGIN
-    191                     "Du kannst das ausgew�hlte Ziel nicht sehen."
+    191                     "Du kannst das ausgewählte Ziel nicht sehen."
 END
 
 STRINGTABLE 
@@ -444,7 +444,7 @@ END
 
 STRINGTABLE 
 BEGIN
-    IDS_MENU_HAPPY          "Gl�&cklich"
+    IDS_MENU_HAPPY          "Glü&cklich"
     IDS_MENU_SAD            "T&raurig"
     IDS_MENU_NEUTRAL        "&Neutral"
     IDS_MENU_WRY            "Gri&mmig"

--- a/module/merintr/merintr.rc
+++ b/module/merintr/merintr.rc
@@ -34,9 +34,9 @@ STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Neuerschaffung eines Charakters"
 FONT 8, "MS Sans Serif"
 BEGIN
-    GROUPBOX        "Überprüfung",-1,7,28,228,33
-    LTEXT           "Harakiri zerstört Deinen Charakter und legt einen neuen an.  Es ist alleine Deine Verantwortung, jetzt ein neues Spiel zu beginnen.",-1,7,4,235,18
-    LTEXT           "Zur Bestätigung gibst Du jetzt bitte Dein gültiges Passwort ein:",-1,14,40,106,19
+    GROUPBOX        "ï¿½berprï¿½fung",-1,7,28,228,33
+    LTEXT           "Harakiri zerstï¿½rt Deinen Charakter und legt einen neuen an.  Es ist alleine Deine Verantwortung, jetzt ein neues Spiel zu beginnen.",-1,7,4,235,18
+    LTEXT           "Zur Bestï¿½tigung gibst Du jetzt bitte Dein gï¿½ltiges Passwort ein:",-1,14,40,106,19
     EDITTEXT        1260,131,42,97,12,ES_PASSWORD | ES_AUTOHSCROLL
     DEFPUSHBUTTON   "Harakiri",1,7,65,107,14
     PUSHBUTTON      "Abbrechen",2,120,65,115,14
@@ -47,7 +47,7 @@ STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Kurzbefehle"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
-    LTEXT           "Um einen Kurzbefehl zu definieren muß die Abkürzung bei Wort eingetragen werden und danach der Befehl ausgeschrieben werden. BEISPIEL: Wort: lacht   Kurzbefehl: ego lacht.""",-1,4,4,215,27
+    LTEXT           "Um einen Kurzbefehl zu definieren muï¿½ die Abkï¿½rzung bei Wort eingetragen werden und danach der Befehl ausgeschrieben werden. BEISPIEL: Wort: lacht   Kurzbefehl: ego lacht.""",-1,4,4,215,27
     GROUPBOX        "",-1,4,29,211,170
     LTEXT           "Wort:",-1,10,38,18,8
     EDITTEXT        1260,49,36,50,12,ES_AUTOHSCROLL
@@ -56,7 +56,7 @@ BEGIN
     PUSHBUTTON      "&Entfernen",1002,157,37,50,11
     LTEXT           "Befehl:",-1,10,51,23,8
     CONTROL         "",1263,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SORTASCENDING | LVS_NOLABELWRAP | LVS_NOSORTHEADER | WS_TABSTOP,10,64,199,128,WS_EX_CLIENTEDGE
-    PUSHBUTTON      "Bestätigen",1,24,205,50,14
+    PUSHBUTTON      "Bestï¿½tigen",1,24,205,50,14
     PUSHBUTTON      "Abbrechen",2,82,205,50,14
     PUSHBUTTON      "Funktionstasten ...",1264,139,205,76,14
 END
@@ -70,14 +70,14 @@ BEGIN
     LTEXT           "Gildenpasswort:",1242,10,34,51,8
     EDITTEXT        1239,65,32,101,14,ES_AUTOHSCROLL
     PUSHBUTTON      "Gildenhalle aufgeben!",1235,171,32,76,14
-    PUSHBUTTON      "Ja, hiermit bestätige ich die Auflösung meiner Gilde!",1224,4,56,248,14
+    PUSHBUTTON      "Ja, hiermit bestï¿½tige ich die Auflï¿½sung meiner Gilde!",1224,4,56,248,14
 END
 
 160 DIALOG  0, 0, 282, 178
 STYLE DS_SETFONT | WS_CHILD
 FONT 8, "MS Sans Serif"
 BEGIN
-    LTEXT           "Verbündete Gilden:",-1,4,26,62,8
+    LTEXT           "Verbï¿½ndete Gilden:",-1,4,26,62,8
     LISTBOX         1225,4,36,75,118,LBS_SORT | LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
     PUSHBUTTON      ">>",1228,84,46,13,12
     PUSHBUTTON      "<<",1230,84,72,13,12
@@ -88,7 +88,7 @@ BEGIN
     LTEXT           "Verfeindete Gilden:",-1,200,26,61,8
     LISTBOX         1227,203,36,75,118,LBS_SORT | LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
     LTEXT           "",1232,4,161,274,8
-    LTEXT           "Benutze die << und >> Tasten um Allianzen zu schließen oder Feinde zu erklären.",1236,11,4,257,8
+    LTEXT           "Benutze die << und >> Tasten um Allianzen zu schlieï¿½en oder Feinde zu erklï¿½ren.",1236,11,4,257,8
 END
 
 159 DIALOGEX 0, 0, 308, 122
@@ -102,9 +102,9 @@ BEGIN
     PUSHBUTTON      "Mitglied &rauswerfen",1212,123,30,132,12
     PUSHBUTTON      "Den Rang &abtreten an:",1205,98,91,96,12
     LTEXT           "",1209,199,92,105,10,SS_SUNKEN
-    PUSHBUTTON      "Neues Mitglied &unterstützen:",1203,98,73,96,14
+    PUSHBUTTON      "Neues Mitglied &unterstï¿½tzen:",1203,98,73,96,14
     LTEXT           "",1211,199,75,105,10,SS_SUNKEN
-    LTEXT           "Unterstütztes Mitglied:",-1,98,59,71,8
+    LTEXT           "Unterstï¿½tztes Mitglied:",-1,98,59,71,8
     LTEXT           "cha",1214,199,58,105,10,SS_SUNKEN
     PUSHBUTTON      "Die Gilde &verlassen",1208,4,106,87,12
     LTEXT           "",1223,124,17,93,8,SS_SUNKEN
@@ -123,7 +123,7 @@ FONT 8, "MS Sans Serif"
 BEGIN
     GROUPBOX        "Gildenschild:",-1,3,0,120,116
     CONTROL         "",1001,"Button",BS_OWNERDRAW,7,10,108,102
-    LTEXT           "Wähle eine Farb- && Musterkombination:",-1,137,14,128,8
+    LTEXT           "Wï¿½hle eine Farb- && Musterkombination:",-1,137,14,128,8
     LTEXT           "Farbe 1:",-1,148,29,27,8
     PUSHBUTTON      "<",1019,181,27,17,11,WS_GROUP
     PUSHBUTTON      ">",1022,199,27,17,11
@@ -133,9 +133,9 @@ BEGIN
     LTEXT           "Muster:",-1,147,59,24,8
     PUSHBUTTON      "<",1016,181,57,17,11,WS_GROUP
     PUSHBUTTON      ">",1017,199,57,17,11
-    LTEXT           "Das Design wurde bereits von der Gilde %s gewählt.",1266,137,77,124,20,SS_SUNKEN
+    LTEXT           "Das Design wurde bereits von der Gilde %s gewï¿½hlt.",1266,137,77,124,20,SS_SUNKEN
     PUSHBUTTON      "Anspruch auf das Design erheben.",1265,137,102,129,13,WS_GROUP
-    LTEXT           "Das Design ist nicht verfügbar.",1208,137,68,129,8,NOT WS_VISIBLE
+    LTEXT           "Das Design ist nicht verfï¿½gbar.",1208,137,68,129,8,NOT WS_VISIBLE
 END
 
 140 DIALOGEX 0, 0, 286, 373
@@ -145,10 +145,10 @@ FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     LTEXT           "Gruppen:",-1,8,7,30,8
     COMBOBOX        1243,8,17,97,65,CBS_DROPDOWNLIST | CBS_SORT | WS_VSCROLL | WS_TABSTOP
-    PUSHBUTTON      "Gruppe löschen",1244,114,16,58,14,WS_DISABLED
+    PUSHBUTTON      "Gruppe lï¿½schen",1244,114,16,58,14,WS_DISABLED
     LTEXT           "Neue Gruppe:",1252,180,6,46,8
     EDITTEXT        1251,180,16,58,14,ES_AUTOHSCROLL
-    LTEXT           "Eine Nachricht an die ausgewählte Gruppe versenden:",-1,8,39,174,8
+    LTEXT           "Eine Nachricht an die ausgewï¿½hlte Gruppe versenden:",-1,8,39,174,8
     EDITTEXT        1255,8,49,270,14,ES_AUTOHSCROLL
     LTEXT           "Gruppenmitglieder:",-1,8,73,60,8
     LTEXT           "(rote Namen sind im Spiel)",-1,8,81,82,8
@@ -160,7 +160,7 @@ BEGIN
     LTEXT           "Anwesende Spieler:",-1,180,80,64,8
     LISTBOX         1246,180,91,97,255,LBS_SORT | LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
     LTEXT           "",1256,8,354,174,8
-    PUSHBUTTON      "Bestätigen",1254,227,354,50,14
+    PUSHBUTTON      "Bestï¿½tigen",1254,227,354,50,14
 END
 
 107 DIALOGEX 0, 0, 249, 259
@@ -168,14 +168,14 @@ STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Eine Gildenhalle mieten"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
-    DEFPUSHBUTTON   "Bestätigen",1,66,238,50,14
+    DEFPUSHBUTTON   "Bestï¿½tigen",1,66,238,50,14
     PUSHBUTTON      "Abbrechen",2,132,238,50,14
     CONTROL         "",1201,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,5,16,238,162,WS_EX_CLIENTEDGE
-    LTEXT           "Wähle eine Gildenhalle aus:",-1,6,4,89,8
+    LTEXT           "Wï¿½hle eine Gildenhalle aus:",-1,6,4,89,8
     LTEXT           "Gildenpasswort:",-1,6,219,51,8
     EDITTEXT        1239,60,217,94,12,ES_AUTOHSCROLL
-    LTEXT           "Das Passwort schützt Teile der Gildenhalle vor unbefugtem Zugriff.",-1,6,204,210,8
-    LTEXT           "Ausgewählte Gildenhalle:",-1,6,186,80,8
+    LTEXT           "Das Passwort schï¿½tzt Teile der Gildenhalle vor unbefugtem Zugriff.",-1,6,204,210,8
+    LTEXT           "Ausgewï¿½hlte Gildenhalle:",-1,6,186,80,8
     LTEXT           "",1215,89,185,129,11,SS_SUNKEN
 END
 
@@ -184,26 +184,26 @@ STYLE DS_SETFONT | WS_CHILD
 FONT 8, "MS Sans Serif"
 BEGIN
     LISTBOX         1202,60,32,98,86,LBS_SORT | LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "Wähle die Person, der Du die Einladung überreichen willst:",-1,4,33,51,58
+    LTEXT           "Wï¿½hle die Person, der Du die Einladung ï¿½berreichen willst:",-1,4,33,51,58
     PUSHBUTTON      "Einladen",1001,4,106,45,12
-    LTEXT           "Du kannst nur Spieler zum Beitritt auffordern, die sich im gleichen Raum befinden. Außerdem darf nur eine Einladung ausstehen.",-1,4,4,157,24
+    LTEXT           "Du kannst nur Spieler zum Beitritt auffordern, die sich im gleichen Raum befinden. Auï¿½erdem darf nur eine Einladung ausstehen.",-1,4,4,157,24
 END
 
 105 DIALOG  0, 0, 269, 180
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "Neue Gilde gründen"
+CAPTION "Neue Gilde grï¿½nden"
 FONT 8, "MS Sans Serif"
 BEGIN
     LTEXT           "Name der Gilde:",-1,9,12,53,8
     EDITTEXT        1215,66,10,95,14,ES_AUTOHSCROLL
     GROUPBOX        "Rangfolge in der Gilde:",-1,10,30,247,114
-    LTEXT           "Männer:",-1,21,45,27,8
+    LTEXT           "Mï¿½nner:",-1,21,45,27,8
     EDITTEXT        1220,21,57,83,14,ES_AUTOHSCROLL
     EDITTEXT        1219,21,73,83,14,ES_AUTOHSCROLL
     EDITTEXT        1218,21,89,83,14,ES_AUTOHSCROLL
     EDITTEXT        1217,21,105,83,14,ES_AUTOHSCROLL
     EDITTEXT        1216,21,121,83,14,ES_AUTOHSCROLL
-    LTEXT           "höchster",-1,119,59,28,8
+    LTEXT           "hï¿½chster",-1,119,59,28,8
     LTEXT           "niedrigster",-1,118,124,33,8
     LTEXT           "Frauen:",-1,163,45,25,8
     EDITTEXT        1226,163,57,83,14,ES_AUTOHSCROLL
@@ -211,11 +211,11 @@ BEGIN
     EDITTEXT        1224,163,89,83,14,ES_AUTOHSCROLL
     EDITTEXT        1223,163,105,83,14,ES_AUTOHSCROLL
     EDITTEXT        1222,163,121,83,14,ES_AUTOHSCROLL
-    CONTROL         "eine geheime Gilde gründen. (Die Gildenangehörigkeit ist nicht sichtbar)",1221,
+    CONTROL         "eine geheime Gilde grï¿½nden. (Die Gildenangehï¿½rigkeit ist nicht sichtbar)",1221,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,10,147,240,8
-    LTEXT           "Gründungskosten:",-1,10,163,59,8
+    LTEXT           "Grï¿½ndungskosten:",-1,10,163,59,8
     LTEXT           "",1237,74,163,41,10,SS_SUNKEN
-    DEFPUSHBUTTON   "Bestätigen",1,156,162,50,14
+    DEFPUSHBUTTON   "Bestï¿½tigen",1,156,162,50,14
     PUSHBUTTON      "Abbrechen",2,215,162,50,14
 END
 
@@ -270,7 +270,7 @@ BEGIN
     RTEXT           "F12",15,9,185,13,8
     EDITTEXT        1011,29,184,159,12,ES_AUTOHSCROLL
     CONTROL         "",1210,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,194,185,13,9
-    DEFPUSHBUTTON   "Bestätigen",IDOK,19,208,50,14
+    DEFPUSHBUTTON   "Bestï¿½tigen",IDOK,19,208,50,14
     PUSHBUTTON      "Abbrechen",IDCANCEL,77,208,50,14
     PUSHBUTTON      "Kurzbefehle....",1264,136,208,76,14
 END
@@ -306,9 +306,9 @@ END
 STRINGTABLE 
 BEGIN
     1                       "Zaubern"
-    2                       "&Zaubersprüche"
-    3                       "Gegenstände wegwerfen"
-    4                       "Gegenstände nehmen"
+    2                       "&Zaubersprï¿½che"
+    3                       "Gegenstï¿½nde wegwerfen"
+    4                       "Gegenstï¿½nde nehmen"
     5                       "Sagen"
     6                       "Zaubern"
     7                       "Kartenmodus"
@@ -318,25 +318,25 @@ BEGIN
     11                      "Lebenskraft"
     12                      "Zauberkraft"
     13                      "Ausdauer"
-    14                      "Lächeln"
+    14                      "Lï¿½cheln"
     15                      "Grimmig"
 END
 
 STRINGTABLE 
 BEGIN
     16                      "Niemand mit diesem Namen ist im Spiel."
-    17                      "Dieser Name tritt häufiger auf."
-    18                      "Der Name dieser Gruppe tritt häufiger auf."
-    19                      "Du kannst keine zusätzlichen Gruppen mehr anlegen."
+    17                      "Dieser Name tritt hï¿½ufiger auf."
+    18                      "Der Name dieser Gruppe tritt hï¿½ufiger auf."
+    19                      "Du kannst keine zusï¿½tzlichen Gruppen mehr anlegen."
     20                      "Die %.*s-Gruppe ist voll."
     21                      "Niemand von dieser Gruppe ist im Spiel."
     22                      "Es gibt keine Gruppe mit diesem Namen."
     23                      "Es gibt bereits eine Gruppe mit diesem Namen."
-    24                      "Der Name dieses Zauberspruchs tritt häufiger auf."
+    24                      "Der Name dieses Zauberspruchs tritt hï¿½ufiger auf."
     25                      "Es gibt keinen Zauber mit diesem Namen."
-    26                      "Bist Du Dir auch wirklich sicher, diesen Charakter zu löschen? \nDiese Entscheidung ist unwiderruflich."
-    27                      "Du mußt angeben wieviel Du abheben möchtest."
-    28                      "Du mußt angeben wieviel Du einzahlen möchtest."
+    26                      "Bist Du Dir auch wirklich sicher, diesen Charakter zu lï¿½schen? \nDiese Entscheidung ist unwiderruflich."
+    27                      "Du muï¿½t angeben wieviel Du abheben mï¿½chtest."
+    28                      "Du muï¿½t angeben wieviel Du einzahlen mï¿½chtest."
     29                      "Diese Gruppe ist voll."
     30                      "Der Spieler konnte nicht in die Gruppe aufgenommen werden."
     31                      "Es konnte keine neue Gruppe angelegt werden."
@@ -348,17 +348,17 @@ BEGIN
     33                      "Mitglieder der %.*s-Gruppe (~rrot~n = im Spiel):"
     34                      "Du hast keine Gruppen angelegt."
     35                      "Du hast folgende Gruppen angelegt:"
-    36                      "Gruppe wurde gelöscht."
+    36                      "Gruppe wurde gelï¿½scht."
     37                      "%d Name wurde aus der Gruppe entfernt."
     38                      "Die Gruppe wurde erstellt."
     39                      "Du rastest."
-    40                      "Du hörst auf Dich auszuruhen."
+    40                      "Du hï¿½rst auf Dich auszuruhen."
     41                      "Du ruhst Dich bereits aus."
     42                      "Du ruhst Dich gar nicht aus."
     43                      "Du kannst keine Zauber sprechen, solange Du rastest."
     44                      "Du kannst Deine Arme nicht bewegen um den Zauber zu sprechen!"
     45                      "Gebe ""suicide"" ein, um einen neuen Charakter zu erschaffen."
-    46                      "Du mußt einen Gildennamen festlegen."
+    46                      "Du muï¿½t einen Gildennamen festlegen."
     47                      "Meridian 59 --- %s"
 END
 
@@ -377,8 +377,8 @@ BEGIN
     58                      "Heldin"
     59                      "Gildenmeisterin"
     60                      "Die Gilde %s sieht Dich weder als Feind noch als Freund."
-    61                      "Willst Du die Gilde wirklich auflösen?"
-    62                      "Die Gilde %s sieht Dich als Verbündeten an."
+    61                      "Willst Du die Gilde wirklich auflï¿½sen?"
+    62                      "Die Gilde %s sieht Dich als Verbï¿½ndeten an."
     63                      "Die Gilde %s sieht Dich als Feind an."
 END
 
@@ -388,17 +388,17 @@ BEGIN
     65                      "Gildeneinstellungen"
     66                      "Einladen"
     67                      "Mitgliedschaft"
-    68                      "Bündnisse"
+    68                      "Bï¿½ndnisse"
     69                      "Gildenmeister"
     70                      "Niemand"
     71                      "Fertig"
     72                      "Kosten"
-    73                      "Tägliche Miete"
+    73                      "Tï¿½gliche Miete"
     74                      "Name der Gilde"
-    75                      "Du mußt ein Gildenpasswort festlegen."
+    75                      "Du muï¿½t ein Gildenpasswort festlegen."
     76                      "Schild"
     77                      "Eigenschaften"
-    78                      "Zaubersprüche"
+    78                      "Zaubersprï¿½che"
     79                      "Fertigkeiten"
 END
 
@@ -414,17 +414,17 @@ BEGIN
     87                      "Inventar"
     88                      "Was bitte? Benutz die Hilfe ""help""."
     89                      "&Wer spielt"
-    90                      "Eine ungültige Anweisung wurde für den Kurzbefehl festgelegt."
-    91                      "Diesen Befehl gibt es häufiger."
+    90                      "Eine ungï¿½ltige Anweisung wurde fï¿½r den Kurzbefehl festgelegt."
+    91                      "Diesen Befehl gibt es hï¿½ufiger."
     92                      "Der Kurzbefehl wurde definiert."
-    93                      "Der Kurzbefehl wurde gelöscht."
+    93                      "Der Kurzbefehl wurde gelï¿½scht."
     94                      "Wort"
     95                      "Befehl"
 END
 
 STRINGTABLE 
 BEGIN
-    191                     "Du kannst das ausgewählte Ziel nicht sehen."
+    191                     "Du kannst das ausgewï¿½hlte Ziel nicht sehen."
 END
 
 STRINGTABLE 
@@ -444,7 +444,7 @@ END
 
 STRINGTABLE 
 BEGIN
-    IDS_MENU_HAPPY          "Glü&cklich"
+    IDS_MENU_HAPPY          "Glï¿½&cklich"
     IDS_MENU_SAD            "T&raurig"
     IDS_MENU_NEUTRAL        "&Neutral"
     IDS_MENU_WRY            "Gri&mmig"
@@ -706,14 +706,14 @@ END
 
 IDD_SUICIDE DIALOG  0, 0, 242, 95
 STYLE DS_SETFONT | DS_MODALFRAME | DS_3DLOOK | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "Meridian Character Suicide"
+CAPTION "Meridian Character Reroll"
 FONT 8, "MS Sans Serif"
 BEGIN
     GROUPBOX        "Verification",IDC_STATIC,7,38,228,43
-    LTEXT           "Performing a suicide will destroy your character, and will create a new character for you to start over.  You are responsible for your own choice to begin the game again.",IDC_STATIC,7,7,228,27
+    LTEXT           "Performing a reroll will destroy your character, and will create a new character for you to start over.  You are responsible for your own choice to begin the game again.",IDC_STATIC,7,7,228,27
     LTEXT           "To verify that you wish to do this, enter your current account password here.",IDC_STATIC,14,50,114,26
     EDITTEXT        IDC_SUICIDE_PASSWORD,131,52,97,12,ES_PASSWORD | ES_AUTOHSCROLL
-    DEFPUSHBUTTON   "Suicide",IDOK,131,74,46,14
+    DEFPUSHBUTTON   "Reroll",IDOK,131,74,46,14
     PUSHBUTTON      "Cancel",IDCANCEL,184,74,46,14
 END
 


### PR DESCRIPTION
I was reading this issue with an alternative word for rerolling a character, a more modern game language
https://github.com/Meridian59/Meridian59/issues/660

This change however only adds an alternative command, the old suicide still exists and in some text it still refers to the word "suicide" and "kill youself". Creating this pull request to start a discussion about it, should we keep the suicide command or remove it, shoud we alter any other texts or prompts like this one: 
![bild](https://github.com/Meridian59/Meridian59/assets/2507034/9a2b3de3-d661-4fb1-a9a3-a9e243c27be4)
![bild](https://github.com/Meridian59/Meridian59/assets/2507034/df315a18-c116-49f7-be4c-132959c796ed)
