### PR TITLE
Move CalculateHealthTime bound to before Restorate calculation

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5476,6 +5476,8 @@ messages:
 
       iTime = iTime - Send(Send(SYS,@GetParliament),@GetFactionRegenBonus,
                            #who=self,#hpregen=TRUE);
+
+      iTime = bound(iTime,1000,60000);
       
       if poOwner <> $
       {
@@ -5493,7 +5495,7 @@ messages:
          }
       }
 
-      return bound(iTime,1000,60000);
+      return iTime;
    }
 
    CalculateManaTime()


### PR DESCRIPTION
Restorate has much or all of its benefit eliminated by a bound that comes after it. In Restorate's code, it specifically allows a reduction to 650 ms with enough spellpower, but this is immediately eliminated by a min 1000 bound in CalculateHealthTime's return code.

Below CalculateHealthTime, in CalculateManaTime, we can see that the bound for iTime comes before Rejuvenate and Mana Focus. Those spells can indeed lower the normal regen time bound. Based on that, I believe the Health Time bounding is a mistake, and it confirms my suspicions that Restorate has not actually functioned for the last 22 years. For players to notice an effect from Restorate, they would have had to keep vigor between a certain range (60 to 100 or so), and then Restorate _would_ have kept their HP regen at the same rate as if they had 100+ vigor. However, players don't behave like that (they keep their vigor high while building), so Restorate essentially did not function.