### PR TITLE
Add GetTickCount function for greater timing accuracy

### DIFF
--- a/blakcomp/function.c
+++ b/blakcomp/function.c
@@ -60,6 +60,7 @@ function_type Functions[] = {
 {"LoadRoom",            CREATEROOMDATA,  AEXPRESSION,   ANONE},
 {"GetClass",            GETCLASS,        AEXPRESSION,   ANONE},
 {"GetTime",             GETTIME,         ANONE},
+{"GetTickCount",        GETTICKCOUNT,    ANONE},
 {"CanMoveInRoom",       CANMOVEINROOM,   AEXPRESSION,   AEXPRESSION,AEXPRESSION,
     AEXPRESSION,AEXPRESSION,ANONE},
 {"CanMoveInRoomFine",CANMOVEINROOMFINE,AEXPRESSION,AEXPRESSION,AEXPRESSION,

--- a/blakdeco/blakdeco.c
+++ b/blakdeco/blakdeco.c
@@ -557,6 +557,7 @@ const char * name_function(int fnum)
    case MOVELISTELEM : return "MoveListElem";
 
    case GETTIME : return "GetTime";
+   case GETTICKCOUNT : return "GetTickCount";
 
    case ABS: return "Abs";
    case BOUND: return "Bound";

--- a/blakserv/adminfn.c
+++ b/blakserv/adminfn.c
@@ -2085,6 +2085,7 @@ void AdminShowCalls(int session_id,admin_parm_type parms[],
 		case FINDLISTELEM : strcpy(c_name, "FindListElem"); break;
 		case MOVELISTELEM : strcpy(c_name, "MoveListElem"); break;
 		case GETTIME : strcpy(c_name, "GetTime"); break;
+		case GETTICKCOUNT : strcpy(c_name, "GetTickCount"); break;
 		case ABS : strcpy(c_name, "Abs"); break;
 		case BOUND : strcpy(c_name, "Bound"); break;
 		case SQRT : strcpy(c_name, "Sqrt"); break;

--- a/blakserv/ccode.h
+++ b/blakserv/ccode.h
@@ -193,6 +193,10 @@ blak_int C_GetTime(int object_id,local_var_type *local_vars,
 	      int num_normal_parms,parm_node normal_parm_array[],
 	      int num_name_parms,parm_node name_parm_array[]);
 
+blak_int C_GetTickCount(int object_id,local_var_type *local_vars,
+	      int num_normal_parms,parm_node normal_parm_array[],
+	      int num_name_parms,parm_node name_parm_array[]);
+
 blak_int C_Random(int object_id,local_var_type *local_vars,
 	     int num_normal_parms,parm_node normal_parm_array[],
 	     int num_name_parms,parm_node name_parm_array[]);

--- a/blakserv/sendmsg.c
+++ b/blakserv/sendmsg.c
@@ -157,6 +157,7 @@ void InitBkodInterpret(void)
 	ccall_table[MOVELISTELEM] = C_MoveListElem;
 	
 	ccall_table[GETTIME] = C_GetTime;
+	ccall_table[GETTICKCOUNT] = C_GetTickCount;
 	
 	ccall_table[CREATETABLE] = C_CreateTable;
 	ccall_table[ADDTABLEENTRY] = C_AddTableEntry;

--- a/include/bkod.h
+++ b/include/bkod.h
@@ -161,6 +161,7 @@ enum
    MOVELISTELEM = 112,
 
    GETTIME = 120,
+   GETTICKCOUNT = 121,
 
    ABS = 131,
    BOUND = 132,


### PR DESCRIPTION
This is my first pull in a step by step attempt to fix 'melee lag' as people call it, by reverse engineering other pull requests and things done on open source. 

This pull intends to add GetTickCount, which will allow kod to access timing in ms.

However, I can't build it, and I need help figuring out why.  This is the error I get when trying to build it:

Making in .\blakserv
sendmsg.c
ccode.c
.\sendmsg.c(160): error C2440: '=': cannot convert from 'int (__cdecl *)(int,local_var_type *,int,parm_node [],int,parm_node [])' to 'ccall_proc'
.\sendmsg.c(160): note: This conversion requires a reinterpret_cast, a C-style cast or parenthesized function-style cast
.\ccode.c(1971): error C2220: the following warning is treated as an error
.\ccode.c(1971): warning C4244: 'return': conversion from 'blak_int' to 'int', possible loss of data
NMAKE : fatal error U1077: 'cl -nologo -DBLAK_PLATFORM_WINDOWS -DWIN32  -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE  -D_WINSOCK_DEPRECATED_NO_WARNINGS /wd4996 /wd4312  -TP -WX -GR- -EHsc- -MP -Zi -W3 -DBLAKDEBUG /MT /FpCpch /Fddebug\vc90.pdb /Fodebug/ -c .\sendmsg.c .\ccode.c ' : return code '0x2'
Stop.
NMAKE : fatal error U1077: 'nmake -nologo /S                  ' : return code '0x2'
Stop.


I don't know what this means, can't look it up anywhere, and it looks identical to GetTime() in every way but the function's internal code. What am I missing?