### PR TITLE
Change Hunt to only work on outlaws and murderers

### DIFF
--- a/kod/object/passive/spell/multicst/hunt.kod
+++ b/kod/object/passive/spell/multicst/hunt.kod
@@ -44,6 +44,9 @@ resources:
    hunt_lost_trackers = "You seem to have managed to lose your trackers!"
    hunt_gain_trackers = "You sense that someone knows where you are..."
 
+   hunt_must_be_outlaw_or_murderer = \
+      "The soul of an innocent has no negative energies to track. The spell fails."
+
 classvars:
 
    vrName = Hunt_name_rsc
@@ -103,6 +106,16 @@ messages:
       local i, oTarget;
 
       oTarget = First(lTargets);
+
+      if NOT Send(oTarget,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
+         AND NOT Send(oTarget,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
+      {
+         for i in Send(oPrism,@GetCasters)
+         {
+            Send(i,@MsgSendUser,#message_rsc=hunt_must_be_outlaw_or_murderer);
+         }
+         return;
+      }
 
       for i in Send(oPrism,@GetCasters)
       {


### PR DESCRIPTION
Change Hunt to only work on outlaws and murderers. As predicted in [this pull from 11 years ago](https://github.com/Meridian59/Meridian59/pull/204), Hunt has been used by veteran PKs to harass specific newbies to an egregious degree. This should really be a tool to hunt PKs, not to be used by them. We did this on OS and it generally improved the overall situation. Although the PK / hunter / builder overall system still needs tons of work in other ways.

I'm putting up this change again because, after doing some research, Hunt has caused a much bigger headache for everyone. Looking back at Discord, the IP limit for all players was permanently lowered to 3 because of one PK using Hunt to harass a player last year. That's extremely inconvenient to the rest of us, so we need a fundamental fix for this so we can remove that bandaid. To elaborate a little more on that frustration, an IP limit this low cuts off entire pieces of content - prism spells - which apparently it was actually intended to do at the time I guess - but on top of that, some of us are trying to play w/ family members, and juggling accounts has become onerous and frustrating. I'm really hoping fixing Hunt can let us revert to classic settings.

For some context, I actually came back to Meridian after a recent server crash where the IP limit was accidentally reverted to 6. So that's all I knew. That does still cut off the use of 7-sided prisms, but it felt fair. It didn't feel frustrating.