### PR TITLE
Prevent karma changes in the arena

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/tostwn/tswatch.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/tostwn/tswatch.kod
@@ -199,7 +199,7 @@ resources:
 
    TosWatcher_summoned_reflection_killed = "%s spoils an illusion, laying bare the deception of %s!"
    TosWatcher_summoned_twin_killed_other = "%s vanquishes the evil twin of %s!"
-   TosWatcher_summoned_twin_self_kill = "%s overpowers his evil twin!"
+   TosWatcher_summoned_twin_self_kill = "%s overpowers their evil twin!"
 
    TosWatcher_arena_help = \
       "Proceed all subcommands with the DM command.  'Start Tournament' "

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -6357,6 +6357,12 @@ messages:
       {
          return 0;
       }
+      
+      % No karma change in arenas.
+      if Send(oRoom,@IsArena)
+      {
+         return 0;
+      }
 
       % No karma changes from killing neutral monsters.
       if bIsMob AND karma_victim = NEUTRAL


### PR DESCRIPTION
Since reflections and evil twins will soon be functioning in the arena, I got in there and tested them out. Turns out, if you and your opponent are both high karma in the same direction, you will lose the ability to cast Karma-based spells above level 3 after only two reflection kills. Killing reflections in the arena should not affect karma, so I put in a check to prevent that. I put in the broadest prevention possible to shortcut any problems in the future - the Arena isn't real death combat, so Karma should never be changed by actions inside it.