### PR TITLE
Add base items for Neo Ao3s & SotHs

### DIFF
--- a/kod/object/item/passitem/necklace/makefile
+++ b/kod/object/item/passitem/necklace/makefile
@@ -5,6 +5,6 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\necklace.bof
-BOFS = shadowam.bof qrcharm.bof krcharm.bof shcharm.bof rjcharm.bof frcharm.bof
+BOFS = shadowam.bof qrcharm.bof krcharm.bof shcharm.bof rjcharm.bof frcharm.bof neonecroam.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/item/passitem/necklace/neonecroam.kod
+++ b/kod/object/item/passitem/necklace/neonecroam.kod
@@ -1,0 +1,154 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+NeoNecromancerAmulet is Necklace
+
+constants:
+
+   include blakston.khd
+
+    % Four hours
+    HUNGER_TIME = 240000000
+%   HUNGER_1 = 2   %one session (assuming 3-4 hours of play per day)
+%   HUNGER_2 = 4   %one to two sessions
+%   HUNGER_3 = 6   %two sessions
+%   HUNGER_4 = 8   %two to three sessions
+%   HUNGER_5 = 10  %three sessions
+
+   %BASE_HUNGER_GAIN = 2
+
+resources:
+
+   NeoNecromancerAmulet_name_rsc = "Amulet of the Three"
+   NeoNecromancerAmulet_icon_rsc = necamlet.bgf
+   NeoNecromancerAmulet_desc_rsc = \
+   "There is something deeply disturbing about this amulet.  When you look at it in the corner of your eye, "
+   "you can almost see the evil pouring forth from it."
+
+   NeoNecromancerAmulet_newbie_pickup_good = "Your guardian angel says, \"That amulet is a thing of great "
+      "evil.  Even holding it in your possession would corrupt your soul, and eventually destroy you.\""
+   NeoNecromancerAmulet_newbie_pickup_evil = "Your guardian angel says, \"That amulet holds far too much "
+      "power for you to contain.  You must stay away from it, for now.\""
+
+   NeoNecromancerAmulet_holding_damage_wearing = \
+   "The unholy energy streaming from the Amulet of the Three seeps into you, racking your body with pain as it "
+   "corrupts your soul.  You must do something before it destroys you!"
+   NeoNecromancerAmulet_holding_damage = \
+   "The unholy energy streaming from the Amulet of the Three seeps into you, racking your body with pain as it "
+   "corrupts your soul."
+   NeoNecromancerAmulet_holding_unworthy_wearing = \
+   "The unholy energy streaming from the Amulet of the Three seeps into you, filling you with pleasure even as it "
+   "racks you with pain.  You must somehow remove it before it destroys you!"
+   NeoNecromancerAmulet_holding_unworthy = \
+   "The unholy energy streaming from the Amulet of the Three seeps into you, filling you with pleasure even as it "
+   "racks you with pain.  You feel a strong compulsion to put the amulet on and channel its full power, but you "
+   "know somehow that it would surely destroy you if you did."
+   NeoNecromancerAmulet_holding_tempt = \
+   "The unholy energy streaming from the Amulet of the Three seeps into you, filling you with pleasure.  You "
+   "cannot help but fantasize how wonderful it would feel to put the amulet on and channel its full power."
+
+   
+   NeoNecromancerAmulet_warning = \
+   "As you begin to place the amulet around your neck, you feel a strong sense of foreboding;  this is not likely "
+   "to be a reversible act."
+   NeoNecromancerAmulet_used_unworthy = \
+   "As you put the amulet on, a wave of power flows through your body, setting every nerve on fire with pleasure "
+   "and pain.  The amount of energy flowing into your body is enormous, and growing with every passing second - "
+   "the coppery taste of fear fills your mouth as you realize you may not be able to contain it all."
+   NeoNecromancerAmulet_used_rsc = \
+   "As you put the amulet on, a wave of power flows through your body, setting every nerve on fire with pleasure, "
+   "leaving every cell irrevocably changed in its wake.  Somewhere far inside your mind, underneath the feeling "
+   "of power, you can also feel something else, however - a kind of hunger gnawing at you, growing with every "
+   "passing second."
+
+   NeoNecromancerAmulet_try_unuse_rsc = \
+   "As you try to pull the amulet from your neck, you feel it tug painfully at your insides, as if it were "
+   "magically tethered to your innards, grafted permanently onto the blackest part of your soul."
+
+   NeoNecromancerAmulet_unused_rsc = \
+   "As the Amulet of the Three leaves your body, you feel something else rip free inside you, turning your "
+   "internal organs to jelly."
+
+   NeoNecromancerAmulet_hunger_1 = "You're starting to feel a little hungry."
+   NeoNecromancerAmulet_hunger_2 = "You're definitely hungry now."
+   NeoNecromancerAmulet_hunger_3 = "You are very hungry now.  The hunger is a burning knot somewhere inside your "
+      "skull.  It is time to feed."
+   NeoNecromancerAmulet_hunger_4 = "Your brain is on fire with but one impulse:  you must feed.  Every moment passes "
+      "like molasses, an eternity of suffering."
+   NeoNecromancerAmulet_hunger_5 = "Your body is now in so much pain that you can feel yourself pulling away from it, "
+      "drifting out and away.  You jerk yourself back with great effort - you must feed soon, or you will surely "
+      "be lost."
+
+   NeoNecromancerAmulet_illusion_slipped = "The illusion masking your true features slips, revealing your ghastly "
+      "appearance in all its obscene glory!"
+   NeoNecromancerAmulet_illusion_restored = "Your horrific appearance has once again been cloaked in illusion."
+
+   NeoNecromancerAmulet_hunger_assuaged = "You feel your amulet absorbing %s%s's life energy.  It washes through you "
+      "in waves, slaking your hunger and leaving you feeling strengthened."
+
+   NeoNecromancerAmulet_cant_eat = "You attempt to gag down %s%s, to no avail.  Mortal food will no longer assuage "
+      "the dark hunger that burns within your unholy body."
+
+   NeoNecromancerAmulet_cant_pay = "Your Dark Queen reaches out to grasp your amulet.  "
+      "She holds it for a moment, then pushes you away in disgust.\n"
+      "~kQueen Venya'cyr tells you, \"~rWeak fool. Thou art too hungry thyself to satisfy mine own hunger.~k\""
+   NeoNecromancerAmulet_pay_ouch = "Your Dark Queen reaches out to grasp your amulet.  "
+      "You gasp as she draws your life essence out of you into herself, leaving you drained and weak.\n"
+      "~kQueen Venya'cyr tells you, \"~rI thank thee, my loyal subject.  Thou had best go and feed thyself now.~k\""
+   NeoNecromancerAmulet_pay = "Your Dark Queen reaches out to grasp your amulet.  "
+      "You gasp as she draws your life essence out of you into herself.\n"
+      "~kQueen Venya'cyr tells you, \"~rAh, a truly refreshing soul thou hast.  Thou servest me well, dark one!~k\""
+
+   NeoNecromancerAmulet_drops = "As your essence dissolves away from this plane of existence, the amulet slips out "
+      "of your hands and drops to the ground."
+
+classvars:
+
+   viIndefinite = ARTICLE_AN
+
+   vrName = NeoNecromancerAmulet_name_rsc
+   vrIcon = NeoNecromancerAmulet_icon_rsc
+   vrDesc = NeoNecromancerAmulet_desc_rsc
+
+   viValue_average = 100
+
+   viBulk = 25
+   viWeight = 25
+   viUse_type = ITEM_USE_NECK
+   viItem_type = ITEMTYPE_NECKLACE | ITEMTYPE_SPECIAL
+
+   viUse_Amount = 1
+
+
+   viDamage_min = 10
+   viDamage_max = 20
+
+   viLight_change = 50
+
+properties:
+
+   plStatmods = $
+   
+   piHunger = 0
+   ptHungerTimer = $
+   piHpWorthyThreshold = 100
+
+   pbIllusioned = TRUE
+   piSavedSkinColor = $
+
+   pbOrderDisbanded = FALSE
+
+messages:
+
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+

--- a/kod/object/item/passitem/weapon/makefile
+++ b/kod/object/item/passitem/weapon/makefile
@@ -7,6 +7,6 @@
 DEPEND = ..\weapon.bof
 BOFS = shrtswrd.bof mystswrd.bof mace.bof bkdagger.bof spirhamm.bof\
         scimitar.bof longswrd.bof hammer.bof ranged.bof axe.bof goldswrd.bof \
-        riijaswd.bof neruswd.bof huntsw.bof unique.bof
+        riijaswd.bof neruswd.bof huntsw.bof unique.bof neohuntsw.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/item/passitem/weapon/neohuntsw.kod
+++ b/kod/object/item/passitem/weapon/neohuntsw.kod
@@ -1,0 +1,129 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+NeoHunterSword is Weapon
+
+constants:
+
+   include blakston.khd
+
+    % Four hours
+    HUNGER_TIME = 240000000
+%   HUNGER_1 = 2   %one session (assuming 3-4 hours of play per day)
+%   HUNGER_2 = 4   %one to two sessions
+%   HUNGER_3 = 6   %two sessions
+%   HUNGER_4 = 8   %two to three sessions
+%   HUNGER_5 = 10  %three sessions
+
+   %BASE_HUNGER_GAIN = 2
+
+resources:
+
+   NeoHunterSword_name_rsc = "Sword of the Hunt"
+   NeoHunterSword_icon_rsc = huntswrd.bgf
+   NeoHunterSword_desc_rsc = \
+      "This weapon is truly a fine piece of workmanship.  Intricate organic carvings "
+      "intertwine along the hilt, enclosing an exquisitely beautiful gem, almost as "
+      "if it were an eye gazing calmly back at you.  Indeed, every now and then out "
+      "of the corner of your eye you almost catch it blinking."
+
+   NeoHunterSword_window_overlay_rsc = povhunts.bgf
+   NeoHunterSword_player_overlay = huntswov.bgf
+
+
+   NeoHunterSword_holding_damage = \
+      "As you pick up the Sword of the Hunt, the carven tendrils on the hilt ~Ibite~I "
+      "your hand!  Taken aback, you fling it to the ground.  That sword does not like "
+      "you;  you'd best leave it alone."
+   NeoHunterSword_holding_damage_using = \
+      "The Sword of the Hunt's roots writhe painfully inside your chest with "
+      "displeasure.  You have done something to invoke the Sword's disapproval!"
+   
+   NeoHunterSword_warning = \
+      "You prepare to pick up the mighty Sword of the Hunt, but it twitches and you "
+      "hesitate for a moment.  This sword appears to be alive, and it may not allow "
+      "you to part with it once you have claimed it as your own.  Are you truly "
+      "prepared for that commitment?"
+   NeoHunterSword_used_rsc = \
+      "You steel your nerve and bravely pick up the Sword of the Hunt.  The hilt "
+      "immediately comes alive, writhing against the palm of your hand.  You gasp "
+      "as you feel invisible roots snaking into your chest and wrapping themselves "
+      "around your heart.  Strangely, you feel no pain throughout this process, "
+      "only a greatly pleasurable feeling of power and a nagging sense of hunger."
+
+   NeoHunterSword_try_unuse_rsc = \
+      "As you try to drop the sword, you feel it tug painfully on the roots that have "
+      "snaked their way inside your body.  This is not likely to be a productive exercise."
+
+   NeoHunterSword_hunger_1 = "Your sword thirsts for the hunt."
+   NeoHunterSword_hunger_2 = "Your sword is growing impatient for a hunt."
+   NeoHunterSword_hunger_3 = "Your sword hungers for impure blood.  It is time to hunt."
+   NeoHunterSword_hunger_4 = "Your sword hungers for impure blood.  Its roots are beginning to draw sustenance "
+      "from your body to compensate."
+   NeoHunterSword_hunger_5 = "Your sword hungers for impure blood.  Its roots twitch painfully inside your chest "
+      "as they suck at your life-essence."
+
+   NeoHunterSword_hunger_assuaged = "Your sword drinks in %s%s's impure blood.  You can feel it course along its roots "
+      "into your body, filling you with energy."
+
+   NeoHunterSword_lose_sword = "Your unworthiness has offended your sword of the hunt.  "
+      "Writhing violently in your hands for a few moments, the sword suddenly springs up and away out of sight."
+
+classvars:
+
+   viIndefinite = ARTICLE_A
+
+   vrName = NeoHunterSword_name_rsc
+   vrIcon = NeoHunterSword_icon_rsc
+   vrDesc = NeoHunterSword_desc_rsc
+
+   vrWeapon_window_overlay = NeoHunterSword_window_overlay_rsc
+   vrWeapon_overlay = NeoHunterSword_player_overlay
+
+   % Hunter swords are high quality thrusting weapons
+   viWeaponType = WEAPON_TYPE_THRUST
+   viWeaponQuality = WEAPON_QUALITY_HIGH
+
+   viProficiency_needed = SKID_PROFICIENCY_SWORD
+
+   viGround_group = 1
+   viInventory_group = 4
+   viBroken_group = 2
+
+   viValue_average = 4000
+   viBulk = 50
+   viWeight = 70
+
+   viDamage_min = 10    % the damage done to the user if unworthy
+   viDamage_max = 20
+
+   viHits_init_min = 600
+   viHits_init_max = 600
+
+   viItem_type = ITEMTYPE_WEAPON | ITEMTYPE_SPECIAL
+
+properties:
+
+   plStatmods = $
+
+   piHunger = 0
+   ptHungerTimer = $
+   piHpWorthyThreshold = 100
+   
+   piAttack_type = ATCK_WEAP_SLASH
+   piAttack_Spell = ATCK_SPELL_HUNTERSWORD
+
+   pbCheapDeath = FALSE
+
+messages:
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -4938,7 +4938,9 @@ messages:
       plItemTemplates = cons(create(&EagleEyesPotion),plItemTemplates);
 
       plItemTemplates = cons(create(&NecromancerAmulet),plItemTemplates);
+      plItemTemplates = cons(create(&NeoNecromancerAmulet),plItemTemplates);
       plItemTemplates = cons(create(&HunterSword),plItemTemplates);
+      plItemTemplates = cons(create(&NeoHunterSword),plItemTemplates);
       plItemTemplates = cons(create(&Prism),plItemTemplates);
 
       plItemTemplates = cons(create(&SwapWand),plItemTemplates);


### PR DESCRIPTION
Per enduring and popular demand, I'd like to essentially build an entirely new Necromancer & Hunter scenario (as I've done before elsewhere), but that's a rather complex process. In this first step, I'm adding internally named 'Neo' Amulets of the Three and Swords of the Hunt. These are separated from the Necromancer Balance utility functions and have had almost all of their code removed - for now.

I've tried for many years to decipher the unspecified 'problem' with the Necromancer scenario that necessitated its deactivation. Ultimately, it's just inscrutable, with mechanics we don't want to keep (including many factors that are reliant to and tied to the number of PKs per day). We really need to just ditch the NecBal utility and create something new, with a keen eye on the lessons learned from Soldier Shields.

Broad overview of the intended scenario:

* No limit on the number of Ao3s and SotHs in the game
* No spawning on the ground, instead you ask the Goad for an ao3 or Tendrath for a SotH
* HP requirement remains, or adjusted higher (100?)
* No karma requirements for either - there are Qor hunters and Shal PKs, karma does not equate to good or evil, a theme which is supported in other places in the game as well
* No relation to innocent, outlaw, or murderer status anymore
* Rebalanced stat boosts (if any)
* A much simpler hunger system that basically just requires wielders to go out and kill mobs daily
* Most importantly, Ao3 and SotH users will be able to attack each other legally under certain circumstances. In the previous Ao3/SotH scenario I built, this was simply always, but I think 101's style would be more suited to a situation where Ao3 wearers are attackable when dispel illusion reveals that they are undead - and we'll make it so that only a Hunter's dispel illusion _in a combat area_ can reveal this. The Hunter that dispelled then also becomes attackable by the Necromancer(s) he revealed. So the 'hunt' would involve traveling to places where people are building and dispelling to discover whether they're secretly undead.

I would also like to rebuild the Necromancer Guild, a subset of Ao3 users that raises and serves the Lich and uses the Brax guild hall. When she is killed, only Necromancer Guild members die and have their loot dropped there, rather than all ao3 users. I'd also fix all the bugs, so killing her is not something that can be cheesed.

I believe we can also come up with special and interesting powers and reasons to take these items to participate in a new form of 'legal' and thematic PvP, since Soldier Shields are great, but have become rather massively lopsided toward Jonas faction.

There should be some overarching goal that the Necromancers are trying to accomplish, and the the Hunters are trying to prevent, similar to the flagpole faction game. And the Necromancer Guild itself can have its own nefarious goals.