### PR TITLE
Update Solomon's (Cor Noth grocer) willing-to-buy list

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/crnthtwn/cngrocer.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/crnthtwn/cngrocer.kod
@@ -57,26 +57,7 @@ messages:
          send(self,@SetMood,#new_mood=piMood - 5);
          return;
       }
-      
-      if why = MOODMOD_ACCEPT_ITEM
-      {
-         if IsClass(what, &OrcPitBossHead)
-         {
-            send(self,@SetMood,#new_mood=piMood + 10);
-            return;
-         }
-         if IsClass(what, &NeruditeOreChunk)
-         {
-            send(self,@SetMood,#new_mood=piMood + 5);
-            return;
-         }
-         if IsClass(what, &InkyCap)
-         {
-            send(self,@SetMood,#new_mood=piMood + 5);
-            return;
-         }
-      }
-      
+
       if(why = MOODMOD_SELL_ITEM)
       {
          send(self,@SetMood,#new_mood=piMood + 1);
@@ -103,7 +84,10 @@ messages:
    ObjectDesired(what = $)
    {
       if Send(what, @CanBeGiventoNPC) AND
-         (Send(self, @IsObjectReagent, #what=what) OR Send(self, @IsObjectSundry, #what=what))
+         (Send(self, @IsObjectReagent, #what=what)
+         OR Send(self, @IsObjectSundry, #what=what)
+         OR IsClass(what, &NeruditeOreChunk)
+         OR IsClass(what, &OrcPitBossHead))
       {
          return TRUE;
       }


### PR DESCRIPTION
This PR was made in response to issue #628

Originally, Solomon was supposed to accept inky caps, chunks of nerudite, and orc pit boss heads as gifts to elevate his mood.  That doesn't work and hasn't for a long time.  There is also little to nothing affecting his mood actually does, even if the player knows about how it works.

This removes that dead code and adds the orc pit boss head and chunk of nerudite to his willing-to-buy list.  Inky caps are already covered by IsObjectSundry.