### PR TITLE
Revert xlat on mug of stout, goblet of wine, and bowl of soup

### DIFF
--- a/kod/object/item/passitem/numbitem/food/gobletwn.kod
+++ b/kod/object/item/passitem/numbitem/food/gobletwn.kod
@@ -44,7 +44,6 @@ properties:
    viFilling = 8
    viNutrition = 6
    piNumber = 1
-   piItem_flags = PT_GRAYSCALE_MEDIUM    % Pewter color to set it apart from goblet of ale
 
 messages:
 

--- a/kod/object/item/passitem/numbitem/food/mug.kod
+++ b/kod/object/item/passitem/numbitem/food/mug.kod
@@ -57,8 +57,6 @@ properties:
    viNutrition = 6
    piNumber = 1
 
-   piItem_flags = PT_BLEND25YELLOW   % Slight golden hue to set it apart from mug of brew
-
 messages:
 
    SendTaste(what = $,apply_on = $)

--- a/kod/object/item/passitem/numbitem/food/soup.kod
+++ b/kod/object/item/passitem/numbitem/food/soup.kod
@@ -49,7 +49,6 @@ properties:
    viFilling = 20
    viNutrition = 9
    piNumber = 1
-   piItem_flags = PT_BLEND25BLUE   % Slight blue hue to set it apart from bowl of stew
 
 messages:
 


### PR DESCRIPTION
Not long ago, these items (mug of stout, goblet of wine, and bowl of soup) were recolored to set them apart from items using the same image (mug of brew, goblet of ale, bowl of stew).  After seeing them in game for awhile with their new colors, it's become apparent that this isn't the best way to set them apart from their look-alikes.

This PR restores them to their original colors.  It would still be nice to give these 3 items a distinct look of their own, however it should be done through a unique image rather than recoloring images that weren't set up to use the xlat system in the first place.

![image](https://github.com/Meridian59/Meridian59/assets/22806592/566ee936-71a1-4791-93c6-e014acadd270)
Recolors on the left, original colors to be restored on the right.