### PR TITLE
Rentable Room Update 6: Updated room help/cost command

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqinnk.kod
@@ -34,11 +34,6 @@ resources:
    BarloqueInnkeeper_room_rented = "Here is the key to thine room.  I trust you will findest "
       "our rooms to be most well-appointed.  Enjoyest thine stay!"
 
-   BarloqueInnkeeper_cost = \
-      "The rooms here are the finest.  I needeth %i shillings when thou ~Irent~neth a "
-      "~Iroom~n for for 85 days.  After that, I requireth %i per day up front.  Key copies "
-      "costeth %i shillings if thou wishest to share thine room with a special someone."
-
    BarloqueInnkeeper_days_left = "I thanketh thee.  Thou hast %i days left at my luxurious inn."
    BarloqueInnkeeper_too_long = "It pleaseth me that ye liketh thine room, but thou hast paid enough in rent already!  I canst not accept more from you right now."
 
@@ -160,7 +155,7 @@ messages:
       Send(Send(SYS, @GetRentableRoomMaintenance), @ParseInnkeeperCommands,
          #who=self, #what=what, #innRid=RID_BAR_INN, #speech=string,
          #initCost=piInitialRoomCost, #perDayCost=piPerDayCost, #keyCopyCost=piKeyCopyCosts,
-         #rscRoomRented=BarloqueInnkeeper_room_rented, #rscRoomCost=BarloqueInnkeeper_cost,
+         #rscRoomRented=BarloqueInnkeeper_room_rented,
          #rscChangeLock=BarloqueInnkeeper_change_lock);
       
       propagate;

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcinnk.kod
@@ -37,14 +37,6 @@ resources:
       "concerns, or if you want in on a rather lucrative prospect that's come to "
       "my attention recently!"
 
-   KocatanInnkeeper_cost = \
-      "You'll not find a better deal on the island!  It costs %i shillings to "
-      "~Irent~n a ~Iroom~n at my fine establishment for 85 days.  If you "
-      "want to stay longer, that'll be %i shillings per day, paid in advance.  "
-      "For a very modest fee of %i shillings, I can even provide you "
-      "with a copy of your room key.  Act now, because this offer won't last "
-      "long!  Space is very limited and my rooms are first-come, first-serve!"
-
    KocatanInnkeeper_days_left = \
       "Thank you, my friend!  I'll have triple this amount for you after "
       "an associate of mine can...  Oh right, you're just paying rent.  Your "
@@ -204,7 +196,7 @@ messages:
       Send(Send(SYS, @GetRentableRoomMaintenance), @ParseInnkeeperCommands,
          #who=self, #what=what, #innRid=RID_KOC_INN, #speech=string,
          #initCost=piInitialRoomCost, #perDayCost=piPerDayCost, #keyCopyCost=piKeyCopyCosts,
-         #rscRoomRented=KocatanInnkeeper_room_rented, #rscRoomCost=KocatanInnkeeper_cost,
+         #rscRoomRented=KocatanInnkeeper_room_rented,
          #rscChangeLock=KocatanInnkeeper_change_lock);
 
       propagate;

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/marntwn/mrinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/marntwn/mrinnk.kod
@@ -28,11 +28,6 @@ resources:
    MarionInnkeeper_room_rented = \
       "Here ya go then.  Hope you enjoy your stay, if you have any problems Tova "
       "will be glad to help you."
-   MarionInnkeeper_cost = \
-      "Oh, good, you should rest.  Let me see....  I charge %i shillings to ~Irent~n "
-      "a nice ~Iroom~n here for 85 days.  If you wish to stay longer, I charge %i "
-      "per day if you pre-pay.  Key copies, uh, key copies....  Oh, they cost %i "
-      "shillings to make.  I know you'll like your room."
    MarionInnkeeper_days_left = \
       "You like it here, I see.  There are %i days until you should pay me again."
    MarionInnkeeper_too_long = \
@@ -79,7 +74,7 @@ messages:
       Send(Send(SYS, @GetRentableRoomMaintenance), @ParseInnkeeperCommands,
          #who=self, #what=what, #innRid=RID_MAR_INN, #speech=string,
          #initCost=piInitialRoomCost, #perDayCost=piPerDayCost, #keyCopyCost=piKeyCopyCosts,
-         #rscRoomRented=MarionInnkeeper_room_rented, #rscRoomCost=MarionInnkeeper_cost,
+         #rscRoomRented=MarionInnkeeper_room_rented,
          #rscChangeLock=MarionInnkeeper_change_lock);
 
       propagate;

--- a/kod/util/rntmaint.kod
+++ b/kod/util/rntmaint.kod
@@ -33,6 +33,7 @@ resources:
    RoomMaintenance_command_room = "room"
    RoomMaintenance_command_rent = "rent"
    RoomMaintenance_command_cost = "cost"
+   RoomMaintenance_command_help = "help"
    RoomMaintenance_command_copy_key = "copy key"
    RoomMaintenance_command_secure = "secure"
    RoomMaintenance_command_change_lock = "change lock"
@@ -40,10 +41,6 @@ resources:
    RoomMaintenance_innkeeper_say_room_rented = \
       "Here you go.  I hope you enjoy your stay, and if you have any problems "
       "I will be glad to help you."
-   RoomMaintenance_innkeeper_say_cost = \
-      "I charge %i shillings to ~Irent~n a ~Iroom~n here for 85 days.  "
-      "If you want to stay longer, I charge %i per day if you pre-pay.  "
-      "Key copies cost %i shillings to make."
    RoomMaintenance_innkeeper_say_days_left = \
       "You like it here, I see.  There are %i days until you should "
       "pay me again."
@@ -56,6 +53,15 @@ resources:
       "I'll dispose of this key copy for you."
    RoomMaintenance_innkeeper_say_lock_changed = \
       "Very well, all existing key copies will be removed."
+
+   RoomMaintenance_help_message = \
+      "~BRoom Help/Room Cost:~B  Displays this message.\n"
+      "~BRent Room:~B  Rents a room at this particular location.  ~ICost: %i~I\n"
+      "~BCopy Key:~B  Creates a freely-tradeable copy of your room key.  ~ICost: %i~I\n"
+      "~BSecure Copy Key:~B  Creates a copy of your room key that only you can trade freely.  ~ICost: %i~I\n"
+      "~BChange Lock:~B  Destroys all copies of your room key in circulation.\n"
+      "To buy additional time, offer shillings to the innkeeper.  ~ICost: %i "
+      "per Meridian day (2 hours real time), %i Meridian days maximum.~I"
 
 properties:
 
@@ -117,7 +123,7 @@ messages:
 
    ParseInnkeeperCommands(who=$, what=$, innRid=$, speech=$,
       initCost=ROOM_INIT_RENT_COST_DEFAULT, perDayCost=ROOM_PER_DAY_COST_DEFAULT, keyCopyCost=ROOM_KEY_COPY_COST_DEFAULT,
-      rscRoomRented=$, rscRoomCost=$, rscChangeLock=$)
+      rscRoomRented=$, rscChangeLock=$)
    "This processes spoken player commands, so it must go into SomeoneSaid on any\n"
    "innkeeper who is supposed to rent rooms to players."
    {
@@ -143,7 +149,6 @@ messages:
 
       % Any of these not specified can just use generic defaults
       if rscRoomRented = $ { rscRoomRented = RoomMaintenance_innkeeper_say_room_rented; }
-      if rscRoomCost = $ { rscRoomCost = RoomMaintenance_innkeeper_say_cost; }
       if rscChangeLock = $ { rscChangeLock = RoomMaintenance_innkeeper_say_lock_changed; }
 
       % Command:  Rent Room
@@ -174,12 +179,14 @@ messages:
          return;
       }
 
-      % Command: Room Cost
-      if StringContain(speech, RoomMaintenance_command_room) AND StringContain(speech, RoomMaintenance_command_cost)
+      % Command: Room Cost/Room Help
+      if StringContain(speech, RoomMaintenance_command_room) AND
+         (StringContain(speech, RoomMaintenance_command_cost) OR
+         StringContain(speech, RoomMaintenance_command_help))
       {
-         Post(Send(who, @GetOwner), @SomeoneSaid, #type=SAY_RESOURCE, #what=who,
-            #string=rscRoomCost, 
-            #parm1=initCost, #parm2=perDayCost, #parm3=keyCopyCost);
+         Post(what, @MsgSendUser, #message_rsc=RoomMaintenance_help_message,
+            #parm1=initCost, #parm2=keyCopyCost, #parm3=keyCopyCost,
+            #parm4=perDayCost, #parm5=piRentableDaysMax);
 
          return;
       }


### PR DESCRIPTION
This PR updates the "room cost" command in the following ways:

- Added "room help" as a synonym, as this is a help message.
- Added info for the new commands "change lock" and "secure copy key."
- Added dynamic info for the maximum number of days a room can be rented.
- Removed the npc-specific room cost speech resources from each innkeeper, as well as the now-dead code related to them.

![image](https://github.com/Meridian59/Meridian59/assets/22806592/98c0d263-068b-46e9-9c07-95acb9071b79)
