### PR TITLE
Server settings for greatly diminishing throwaway PK effectiveness, and for protecting low hp players from them

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4429,7 +4429,8 @@ messages:
    AssessDamage(what = $,damage = $, atype = 0, aspell = 0, stroke_obj = $,bonus = 0,
               report = True, report_resistance = TRUE, absolute = FALSE)
    {
-      local i, iResistance, oSoldierShield, color_rsc, iDuration, iLimit;
+      local i, iResistance, oSoldierShield, color_rsc, iDuration, iLimit, iMyMaxHP,
+            iPKMaxHp;
 
       color_rsc = player_hit_color_none;
       
@@ -4498,6 +4499,27 @@ messages:
             AND Send(oSoldierShield,@IsEnemyAttack,#what=self,#damage=TRUE)
          {
             damage = (damage * 115)/100;
+         }
+         
+         % Diminish throwaway PK damage output, and diminish PK damage to low hp innocents        
+         if NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
+            AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
+            AND (Send(what,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
+               OR Send(what,@CheckPlayerFlag,#flag=PFLAG_MURDERER))
+         {
+            iMyMaxHP = Send(self,@GetBaseMaxHealth);
+            iPKMaxHP = Send(what,@GetBaseMaxHealth);
+            
+            if Send(Send(SYS, @GetSettings),@DiminishPKDamageToNewbiesEnabled)
+               AND iMyMaxHP < 100
+            {
+               damage = (damage * iMyMaxHP)/100;
+            }
+            if Send(Send(SYS, @GetSettings),@DiminishPKMuleDamageEnabled)
+               AND iPKMaxHP < 100
+            {
+               damage = (damage * iPKMaxHP)/100;
+            }
          }
       }
 

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -146,6 +146,11 @@ properties:
    % ability to ask questions and socialize.  (Puts a damper on trivia
    % contests too!)  This value can be changed to tweak the penalty in realtime
    piBroadcastManaCostPercent = 50
+   
+   % Greatly diminish the damage output of throwaway outlaws and murderers,
+   % and the damage of PKs against low-hp innocents.
+   pbDiminishPKDamageToNewbies = TRUE
+   pbDiminishPKMuleDamage = TRUE
 
 messages:
 
@@ -352,6 +357,16 @@ messages:
    GetBroadcastManaCostPercent()
    {
       return piBroadcastManaCostPercent;
+   }
+
+   DiminishPKDamageToNewbiesEnabled()
+   {
+      return pbDiminishPKDamageToNewbies;
+   }
+
+   DiminishPKMuleDamageEnabled()
+   {
+      return pbDiminishPKMuleDamage;
    }
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Added a setting to scale damage dealt to innocents by murderers based on their hp below 100.

Added a setting to scale damage by low hp murderers based on their hp below 100.

So this is something that absolutely needed to happen 20 years ago, and 10 years ago, and today. Meridian's design has a fundamental problem at low levels. Completely unstoppable throwaway PKs can run in and kill newbies in 1-3 hits before they have time to react or even understand what's happening. This has led to a parasitic subculture of a select group of players who are absolutely unwilling to actually invest any time or energy into the game, but absolutely willing to roll up dozens of 30 hp tofers to grief newbies until the server empties out. This is a cycle we've seen over and over for most of our lives at this point. I could explain at great lengths how lopsided the time investment is for hunters to try to stop these guys, or how easy and effortless it is for the PKs because they're taking zero risks, but let's just take that as a given because it's been discussed to death. We're already slowly losing the new influx of players to this behavior.

This pull shifts the damage at low levels to a far more reasonable balance. I'm not preventing PK behaviors with this, I'm cutting their damage to something newbies can actually react to. A 40 hp player being attacked by a 30 hp ToFer will essentially take 1 or 2 damage instead of 12 or 13. The damage penalty softens the more hp the victim has, and the more hp the PKer has. A 100 hp+ murderer attacking a 100 hp+ victim will not suffer any penalty. In essence, this forces our parasitic subculture to either put in some actual time investment (and therefore risk) or stop cheese griefing our newbies.

To be honest, these PKs will still get some kills. Newbies are bad at the game, that's why they're newbies. However, they might actually have a chance to react, understand what's going on, and possibly even defend themselves. The murderers aren't protected the same way, so throwaway PKs will die in a couple hits if the newbie actually manages to turn around and hit them with their mace.

I surely expect this to be contentious, and it's not the only idea out there, but something's got to change. Nothing feels more awful than watching an influx of new excited players slowly stop logging in because they're being attacked constantly by ridiculous naked throwaway characters nobody can do anything about.