### PR TITLE
Zero bound on Princess Soldier Shield mana cost reduction

### DIFF
--- a/kod/object/item/passitem/defmod/shield/soldshld/prinshld.kod
+++ b/kod/object/item/passitem/defmod/shield/soldshld/prinshld.kod
@@ -153,7 +153,7 @@ messages:
    {
       local iReduction;
 
-      iReduction = ((piFactionRank/3) - 1);
+      iReduction = Bound(((piFactionRank/3) - 1),0,$);
 
       return iReduction;
    }


### PR DESCRIPTION
At low Faction Rank levels, the Princess Soldier Shield is actually *increasing* mana costs by 1. Given that nothing else related to Soldier Shields is ever a negative, this must be an oversight. In this PR, I put a zero bound on it so it will no longer actually make you perform worse.