### PR TITLE
feature: modify heal wand sound and add heal flash on recipient

### DIFF
--- a/kod/object/item/passitem/specwand/healwand.kod
+++ b/kod/object/item/passitem/specwand/healwand.kod
@@ -18,10 +18,10 @@ resources:
 
    healWand_name_rsc = "wand of healing"
    healWand_icon_rsc = healwand.bgf
-   healWand_desc_rsc = "This wand is almost comically decorated by obviously fake gems.   "
+   healWand_desc_rsc = "This wand is almost comically decorated by obviously fake gems.  "
        "Still, the wand hums nearly inaudibly, and when you put your hand on it, it is "
        "warm to the touch."
-   healWand_success_wav_rsc = healwand.wav
+   healWand_success_wav_rsc = shalille.wav
    healed_rsc = "You feel better."
    wand_used_rsc = "The wand pulses once in your hand."
    wand_fail_snd = spelfail.wav
@@ -101,7 +101,13 @@ messages:
       oRoom = Send(poOwner, @GetOwner);
       Send(oRoom, @SomethingWaveRoom, #what = poOwner, 
            #wave_rsc = healWand_success_wav_rsc);
-      
+
+      if apply_on <> $
+         AND IsClass(apply_on,&User)
+      {
+         Send(apply_on,@GoodSpellFlashEffect);
+      }
+
       return;
    }
 


### PR DESCRIPTION
# What

- changes heal wand sound to the default Shal'ille sound
  - the sound is public and heard by others in the room
  - the sound originates from the user of the wand
- adds a "good spell" flash to the recipient's screen

# Why

- changes requested in #705 
- does perhaps make more sense to have the well known heal sound play for a healing action
- gives a little bit more obvious feedback to the recipient that they are being healed

# Notes

- removed a third space in the description (normal seems to be 2 spaces)