### PR TITLE
feature: make heal wand use more obvious

### DIFF
--- a/kod/object/item/passitem/specwand/healwand.kod
+++ b/kod/object/item/passitem/specwand/healwand.kod
@@ -21,7 +21,7 @@ resources:
    healWand_desc_rsc = "This wand is almost comically decorated by obviously fake gems.  "
        "Still, the wand hums nearly inaudibly, and when you put your hand on it, it is "
        "warm to the touch."
-   healWand_success_wav_rsc = shalille.wav
+   healWand_success_wav_rsc = healwand.wav
    healed_rsc = "You feel better."
    wand_used_rsc = "The wand pulses once in your hand."
    wand_fail_snd = spelfail.wav

--- a/kod/object/item/passitem/specwand/healwand.kod
+++ b/kod/object/item/passitem/specwand/healwand.kod
@@ -18,10 +18,10 @@ resources:
 
    healWand_name_rsc = "wand of healing"
    healWand_icon_rsc = healwand.bgf
-   healWand_desc_rsc = "This wand is almost comically decorated by obviously fake gems.   "
+   healWand_desc_rsc = "This wand is almost comically decorated by obviously fake gems.  "
        "Still, the wand hums nearly inaudibly, and when you put your hand on it, it is "
        "warm to the touch."
-   healWand_success_wav_rsc = healwand.wav
+   healWand_success_wav_rsc = shalille.wav
    healed_rsc = "You feel better."
    wand_used_rsc = "The wand pulses once in your hand."
    wand_fail_snd = spelfail.wav
@@ -101,7 +101,13 @@ messages:
       oRoom = Send(poOwner, @GetOwner);
       Send(oRoom, @SomethingWaveRoom, #what = poOwner, 
            #wave_rsc = healWand_success_wav_rsc);
-      
+
+      if apply_on <> $
+         AND IsClass(apply_on,&User)
+      {
+         Send(apply_on,@GoodSpellFlashEffect);
+      }
+
       return;
    }
 


### PR DESCRIPTION
# What

- this change adds several queues to make heal wand use more obvious to the recipient and 3rd parties in the same room

# Why

- changes requested in #705 
- gives a more obvious feedback to the recipient that they are being healed


# Changes

- adds a "good spell" flash to the recipient's screen
- adds a projectile upon using a heal wand from the user to the target (if user != target)
- adds a third person message so others in the room know that a heal wand is being used by person X on person Y
- makes the user of the wand "point"

### Example of `GoodSpellFlashEffect` on successful heal wand cast
![meridian_odjuPvcsUL](https://github.com/Meridian59/Meridian59/assets/4023541/9b330b62-2fa7-41e6-997e-20e8c0fa370e)

# Notes

- also removed a third space in the heal wand description (normal seems to be 2 spaces)
