### PR TITLE
feature: extend BGF format to support 24-bit color

### DIFF
--- a/makebgf/dibutil.c
+++ b/makebgf/dibutil.c
@@ -187,7 +187,8 @@ PDIB DibReadBitmapInfo(int fh)
 
     if (nNumColors != NUM_COLORS)
     {
-       printf("Expecting %d color bitmap; found %d colors\n", NUM_COLORS, nNumColors);
+       printf("Expecting %llu color bitmap; found %d colors\n",
+          (unsigned long long)NUM_COLORS, nNumColors);
        return NULL;
     }
        

--- a/makebgf/makebgf.c
+++ b/makebgf/makebgf.c
@@ -366,15 +366,15 @@ int main(int argc, char **argv)
 	 Usage();
 	 exit(0);
 
-      case 'b': // used for 8 bit or 32 bit color depth
+      case 'b': // used for 8 bit or 24 bit color depth
       arg++;
       if (arg >= argc) {
          printf("Missing color depth argument\n");
          break;
       }
       options.color_depth = atoi(argv[arg]);
-      if (options.color_depth != 8 && options.color_depth != 32) {
-         printf("Invalid color depth specified. Use 8 or 32\n");
+      if (options.color_depth != 8 && options.color_depth != 24) {
+         printf("Invalid color depth specified. Use 8 or 24\n");
          break;
       }
       break;

--- a/makebgf/makebgf.c
+++ b/makebgf/makebgf.c
@@ -289,6 +289,8 @@ int main(int argc, char **argv)
    options.compress = True;
    memset(&b.name, 0, MAX_BITMAPNAME);
 
+   options.color_depth = 0;
+
    /* Parse options */
    for (arg = 1; arg < argc; arg++)
    {
@@ -370,12 +372,11 @@ int main(int argc, char **argv)
          printf("Missing color depth argument\n");
          break;
       }
-      int color_depth = atoi(argv[arg]);
-      if (color_depth != 8 && color_depth != 32) {
+      options.color_depth = atoi(argv[arg]);
+      if (options.color_depth != 8 && options.color_depth != 32) {
          printf("Invalid color depth specified. Use 8 or 32\n");
          break;
       }
-      options.color_depth = color_depth;
       break;
 
       default:
@@ -395,7 +396,7 @@ int main(int argc, char **argv)
    if (!VerifyArguments(&b, &options))
       exit(1);
 
-   if (!WriteBGFFile(&b, &options, output_filename))
+   if (!WriteBGFFile(&b, &options, output_filename, options.color_depth))
       Error("Error writing output file");
 
    return 0;

--- a/makebgf/makebgf.c
+++ b/makebgf/makebgf.c
@@ -364,6 +364,20 @@ int main(int argc, char **argv)
 	 Usage();
 	 exit(0);
 
+      case 'b': // used for 8 bit or 32 bit color depth
+      arg++;
+      if (arg >= argc) {
+         printf("Missing color depth argument\n");
+         break;
+      }
+      int color_depth = atoi(argv[arg]);
+      if (color_depth != 8 && color_depth != 32) {
+         printf("Invalid color depth specified. Use 8 or 32\n");
+         break;
+      }
+      options.color_depth = color_depth;
+      break;
+
       default:
 	 printf("Ignoring unknown option %c\n", argv[arg][1]);
       }

--- a/makebgf/makebgf.c
+++ b/makebgf/makebgf.c
@@ -287,9 +287,9 @@ int main(int argc, char **argv)
    options.shrink = 1;
    options.rotate = False;
    options.compress = True;
+   options.color_depth = 8; // Set default color depth to 8-bit
    memset(&b.name, 0, MAX_BITMAPNAME);
 
-   options.color_depth = 0;
 
    /* Parse options */
    for (arg = 1; arg < argc; arg++)

--- a/makebgf/makebgf.h
+++ b/makebgf/makebgf.h
@@ -27,7 +27,8 @@ enum {False = 0, True = 1};
 
 #define MAX_BITMAPNAME 32
 
-#define NUM_COLORS 4294967296  // 32-bit color depth
+//#define NUM_COLORS 4294967296  // 24-bit color depth
+#define NUM_COLORS 256  // build error when changed need to fix later
 
 typedef struct {
    int   num_indices;   // Number of bitmaps in this group
@@ -55,7 +56,7 @@ typedef struct {
    int  shrink;
    Bool rotate;
    Bool compress;
-   int  color_depth;       // Color depth (8 or 32 bit)
+   int  color_depth;       // Color depth (8 or 24 bit)
 } Options;
 
 void Error(char *fmt,...);

--- a/makebgf/makebgf.h
+++ b/makebgf/makebgf.h
@@ -27,7 +27,7 @@ enum {False = 0, True = 1};
 
 #define MAX_BITMAPNAME 32
 
-#define NUM_COLORS 256  // Require bitmaps to have exactly this many colors
+#define NUM_COLORS 4294967296  // 32-bit color depth
 
 typedef struct {
    int   num_indices;   // Number of bitmaps in this group
@@ -55,6 +55,7 @@ typedef struct {
    int  shrink;
    Bool rotate;
    Bool compress;
+   int  color_depth;       // Color depth (8 or 32 bit)
 } Options;
 
 void Error(char *fmt,...);

--- a/makebgf/writebgf.c
+++ b/makebgf/writebgf.c
@@ -31,7 +31,7 @@ static void MappedFileClose(file_node *f);
 
 static int EstimateBGFFileSize(Bitmaps *b);
 static BOOL WriteBitmap(file_node *f, PDIB pdib, Options *options);
-static BOOL WriteBitmap32(file_node *f, PDIB pdib, Options *options);
+static BOOL WriteBitmap24(file_node *f, PDIB pdib, Options *options);
 /**************************************************************************/
 /*
  * WriteBGFFile:  Write Bitmaps and Options structures out to given filename.
@@ -116,9 +116,9 @@ BOOL WriteBGFFile(Bitmaps *b, Options *opts, char *filename, int color_depth)
       {
         if (!WriteBitmap(&f, pdib, opts)) return FALSE;
       } 
-      else if (color_depth == 32)
+      else if (color_depth == 24)
       {
-        if (!WriteBitmap32(&f, pdib, opts)) return FALSE;
+        if (!WriteBitmap24(&f, pdib, opts)) return FALSE;
       }
       else 
       {
@@ -222,10 +222,10 @@ BOOL WriteBitmap(file_node *f, PDIB pdib, Options *options)
 
 /***************************************************************************/
 /*
- * WriteBitmap32: Write bytes of given 32-bit PDIB out to the given file.
+ * WriteBitmap24: Write bytes of given 24-bit PDIB out to the given file.
  *   Return FALSE on error.
  */
-BOOL WriteBitmap32(file_node *f, PDIB pdib, Options *options)
+BOOL WriteBitmap24(file_node *f, PDIB pdib, Options *options)
 {
     int width, height, row, col, len, temp;
     BYTE *bits;
@@ -234,7 +234,7 @@ BOOL WriteBitmap32(file_node *f, PDIB pdib, Options *options)
     width = DibWidth(pdib);
     height = DibHeight(pdib);
 
-    buf = (BYTE *)malloc(4 * width * height); // Allocate memory for 32-bit bitmap
+    buf = (BYTE *)malloc(4 * width * height); // Allocate memory for 24-bit bitmap
     bufptr = buf;
 
     for (row = 0; row < height; row++)
@@ -250,7 +250,7 @@ BOOL WriteBitmap32(file_node *f, PDIB pdib, Options *options)
         }
     }
 
-    len = 4 * width * height; // Length of the 32-bit bitmap
+    len = 4 * width * height; // Length of the 24-bit bitmap
 
     // Write the bitmap size
     if (MappedFileWrite(f, &len, 4) < 0)

--- a/makebgf/writebgf.h
+++ b/makebgf/writebgf.h
@@ -12,7 +12,7 @@
 #ifndef _WRITEBGF_H
 #define _WRITEBGF_H
 
-int WriteBGFFile(Bitmaps *bitmaps, Options *opts, char *filename);
+int WriteBGFFile(Bitmaps *bitmaps, Options *opts, char *filename, int color_depth);
 
 #endif /* #ifndef _WRITEBGF_H */
 


### PR DESCRIPTION
🚧 Warning: Draft PR 🚧 

# What

- This change extends the BGF format to support 24-bit color.
- A command line argument is added to `makebgf.exe` with a `-b` to specify 8-bit or 32-bit color

# Why
- Currently all bitmaps that go through the makebgf process are reduced in color depth to Meridian 59's 256 color palette.
- Extending the palette could make the game look a lot better and artists could make use of AI upscaling tools on existing bitmaps

# Changes

- Added a new command line argument `-b`
- Added a new function `WriteBitmap32` which is called if the command line argument for `-b` is `32`

# Notes

- This is still in draft