### PR TITLE
Alter Shadow Rift to only work in dark areas

### DIFF
--- a/kod/object/active/portal/necport.kod
+++ b/kod/object/active/portal/necport.kod
@@ -22,6 +22,8 @@ resources:
    NecropolisPortal_icon_rsc = teleport.bgf
 
    NecropolisPortal_closing = "The portal flickers and begins to draw imperceptibly in on itself."
+   NecropolisPortal_stabilized = "As the shadows deepen, the portal stops flickering and slowly grows stable."
+   NecropolisPortal_torch_failure = "The light of your torch causes the portal to dissipate around you!"
    NecropolisPortal_closed = "The portal disappears."
 
 classvars:
@@ -67,6 +69,19 @@ messages:
       % Don't allow monsters to escape through these portals
       if (NOT IsClass(what, &Player)) 
       {
+         return;
+      }
+
+      propagate;
+   }
+
+   TeleportSomething(what=$)
+   "Called when something walks on top of us."
+   {
+      if IsClass(what,&Player) AND Send(what,@FindUsing,#class=&Torch) <> $
+      {
+         Send(what,@MsgSendUser,#message_rsc=NecropolisPortal_torch_failure);
+         Send(self,@ClosePortal);
          return;
       }
 
@@ -140,6 +155,47 @@ messages:
       propagate;
    }
 
+   AmbientLightChanged()
+   {
+      local oPlayer;
+
+      if Send(poOwner,@GetRoomLight) > LIGHT_DARK
+      {
+         for oPlayer in send(poOwner,@GetHolderActive)
+         {
+            if isClass(first(oPlayer),&Player)
+            {
+               Send(first(oPlayer),@MsgSendUser,#message_rsc=NecropolisPortal_closing);
+            }
+         }
+
+         if ptClosePortal <> $
+         {
+            DeleteTimer(ptClosePortal);
+            ptClosePortal = $;
+         }
+
+         ptClosePortal = CreateTimer(self,@ClosePortal,NECROPORTAL_CLOSE_TIME);
+      }
+      else
+      {
+         if ptClosePortal <> $ AND Send(poOwner,@IsUserInRoom)
+         {
+            DeleteTimer(ptClosePortal);
+            ptClosePortal = $;
+
+            for oPlayer in send(poOwner,@GetHolderActive)
+            {
+               if IsClass(first(oPlayer),&Player)
+               {
+                  Send(first(oPlayer),@MsgSendUser,#message_rsc=NecropolisPortal_stabilized);
+               }
+            }
+         }
+
+      }
+      return;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/multicst/shadrift.kod
+++ b/kod/object/passive/spell/multicst/shadrift.kod
@@ -19,11 +19,11 @@ resources:
 
    DeathsDoor_name_rsc = "shadow rift"
    DeathsDoor_icon_rsc = ideadoor.bgf
-   DeathsDoor_desc_rsc = "Summons the darkest of magics to warp the fabic of space.  "
+   DeathsDoor_desc_rsc = "Summons the darkest of magics to warp the very shadows themselves.  "
                          "Forms a magical bond between a prism and the area in which it "
                          "is cast.  Subsequent castings with the same prism cause a mystical "
                          "portal to form which will transport all who enter it to the exact spot "
-                         "to which the prism was bound.  "
+                         "to which the prism was bound.  Such portals can only exist in dark locales."
                          "Requires the feathers of a dark angel and a prism. "
    
    DeathsDoor_sound = qdthdoor.wav
@@ -36,6 +36,7 @@ resources:
                           "to which it is bound."
    DeathsDoor_target_has_portal = "The prism briefly goes clear. Through it you see that "
                           "its target area already contains a portal."
+   DeathsDoor_not_dark_enough = "This area is not dark enough to create a shadow rift!"
 
    DeathsDoor_succeeded = "A shimmering portal springs into being!"
    DeathsDoor_succeeded2 = "The prism hums and shudders."
@@ -115,6 +116,15 @@ messages:
       {
          % Second cast: create a portal to the place where the first cast
 	      % occurred.
+
+          if Send(Send(oPrism,@GetOwner),@GetRoomLight) > LIGHT_DARK
+          {
+             for oCaster in lCasters
+             {
+                Send(oCaster,@MsgSendUser,#message_rsc=DeathsDoor_not_dark_enough);
+             }
+             return;
+          }
 
 	      % Where the portal leads
          lTargetLocation = send(oPrism,@GetTeleportLocation);  


### PR DESCRIPTION
To answer a few concerns with edge case Shadow Rift abuses, I added a thematic limitation to the spell. A portal cannot be created in areas brighter than LIGHT_DARK, and portals in an area that becomes brighter than LIGHT_DARK will start to close themselves according to the spell's existing closing procedures. This means that Shadow Rift portals are by and large temporary, as many areas are only dark enough at night, and when daylight comes, the portals will close of their own accord - even inside buildings, like inns, or private rooms. All these areas do in fact experience the day/night cycle of changing ambient light, often bringing it just dark enough at night, then too bright during the day. In many cases, players will need to cast Darkness to summon a portal at all, in which case the portal will only last as long as the Darkness spell left in your wake.

This also allows players to actively close any portals in public spaces by simply casting Light, or firewall, or lightning wall.

Towns and public areas are generally quite brightly lit, and this will basically make it impossible or pointless to open portals in Tos, Barloque, etc.

As a bit of extra theming that also doubles as edge case protection, if a player tries to go through while they have a torch equipped, the portal will instantly close and fail to teleport them. This will allow players to close problematic portals safely if someone puts portals in door landing spots or something similarly annoying where you might not actually get a chance to cast Light. It will also, in some cases, protect newbies - who are most likely to have torches equipped in dark places already.

I don't think that public space portal abuse was generally happening in any real capacity, as it's quite risky to try to open portals in public spaces - you're more liable to get your highly valuable prism stolen than anything else - however, it _has_ happened at times, so it's best to design out that silliness so admins don't have to manually handle it.