### PR TITLE
Flip negative bludgeon resistance on SimpleHelm

### DIFF
--- a/kod/object/item/passitem/defmod/helmet/simphelm.kod
+++ b/kod/object/item/passitem/defmod/helmet/simphelm.kod
@@ -66,7 +66,7 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_BLUDGEON,-10]
+      return [ [ATCK_WEAP_BLUDGEON,10]
              ];
    }
 


### PR DESCRIPTION
Helmets make you take more damage from bludgeon. Judging by other extremely old resistances being incorrect in the same way, I'm guessing this was a mistake. Flipped it to a positive resistance in this commit.