### PR TITLE
Fix for karma-specific spellitems

### DIFF
--- a/kod/object/item/passitem/spelitem.kod
+++ b/kod/object/item/passitem/spelitem.kod
@@ -90,7 +90,7 @@ properties:
    pbDisabled = FALSE
 
    % If true, user has to pass spell's karma check.  Otherwise, can always cast.
-   pbCheckKarma = FALSE
+   pbCheckKarma = TRUE
 
 messages:
 
@@ -165,10 +165,27 @@ messages:
       return FALSE;
    }
 
+   GetRequiredKarma()
+   "Returns the karma value required to use the item, or 0 if there's no karma requirement."
+   {
+      local iKarma;
+
+      if (pbCheckKarma)
+      {
+         iKarma = Send(Send(SYS, @FindSpellByNum, #num=viSpellEffect), @GetRequiredKarma);
+      }
+      else
+      {
+         iKarma = 0;
+      }
+
+      return iKarma;
+   }
+
    AppendDesc()
    {
       % Tell player if this has karma restrictions
-      if pbCheckKarma
+      if (pbCheckKarma AND Send(self, @GetRequiredKarma) <> 0)
       {
          AppendTempString("\n\n");
          AppendTempString(vrKarmaDesc);

--- a/kod/object/item/passitem/spelitem/potion.kod
+++ b/kod/object/item/passitem/spelitem/potion.kod
@@ -78,6 +78,7 @@ properties:
 
    piMinSpellPower = 20
    piMaxSpellPower = 60
+   pbCheckKarma = FALSE
 
 messages:
 

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -455,29 +455,27 @@ messages:
    
    KarmaCheck(who=$)
    {
+      local iSpellKarma, iUserKarma;
+
       if Send(who,@PlayerIsImmortal)
       {
          return TRUE;
       }
-   
-      if viSchool = SS_SHALILLE
-      {
-         if Send(who,@GetKarma) < (10*viSpell_level)
-         {
-            return FALSE;
-         }
-      }
-      else
-      {
-         if viSchool = SS_QOR
-         {
-            if Send(who,@GetKarma) > -(10*viSpell_level)
-            {
-               return FALSE;
-            }
-         }
-      }
       
+      iSpellKarma = Send(self, @GetRequiredKarma);
+      % Spell has no karma requirement
+      if (iSpellKarma = 0)
+      {
+         return TRUE;
+      }
+
+      iUserKarma = Send(who, @GetKarma);
+      if ((iSpellKarma > 0 AND iUserKarma < iSpellKarma)
+         OR (iSpellKarma < 0 AND iUserKarma > iSpellKarma))
+      {
+         return FALSE;
+      }
+
       return TRUE;
    }
 

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -481,6 +481,24 @@ messages:
       return TRUE;
    }
 
+   GetRequiredKarma()
+   "Returns the karma value required to use the spell, or 0 if there's no karma requirement."
+   {
+      local iKarma;
+
+      iKarma = 0;
+      if (viSchool = SS_QOR)
+      {
+         iKarma = viSpell_level * -10;
+      }
+      if (viSchool = SS_SHALILLE)
+      {
+         iKarma = viSpell_level * 10;
+      }
+
+      return iKarma;
+   }
+
    IsRangedAttack()
    {
       return FALSE;


### PR DESCRIPTION
In a pervious PR intended to fix potions and karma restrictions, karma  restrictions for all spellitems was unintentionally disabled.   This PR:

- Re-enables karma restrictions for wands and scrolls.  (Potions have it disabled with the exception of the rescue potion)
- Will now properly show text in the description about the item being karma restricted if it is.
- Adds a function/message to spell.kod to query a given spell about its required karma--surprising that this didn't exist already.