### PR TITLE
Fix: User compares an integer to a value from an optional argument

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3678,7 +3678,7 @@ messages:
                }
                if Send(what,@ReqNewOwner,#what=oSplit)
                {
-                  if iCan_hold < number
+                  if iCan_hold < iNumber
                   {
                      Send(self,@MsgSendUser,#message_rsc=user_got_some,
                         #parm1=Send(what,@GetName));


### PR DESCRIPTION
This PR fixes a bug which throws errors to the server when we try to compare an integer to an argument that can be NULL.

The bug had no gameplay effect but is likely spamming the server with these error messages.  The functionality worked prior to this fix because oSplit is already defined before the error is made.

Testing: Use a mortal with a nearly full inventory.  Attempt to pick up a stack of number items.  Note the server error log.  Then incorporate this change and repeat the testing to show that it is fixed.

Additional testing: This logic is also used when withdrawing items from boxes.  I tested with a Mortal withdrawing items that don't fit, where only some fit, and withdrawing items with no weight like shillings.  Everything seems to work.

