### PR TITLE
Consuming a mana crystal breaks the user's trance

### DIFF
--- a/kod/object/item/passitem/manacrys.kod
+++ b/kod/object/item/passitem/manacrys.kod
@@ -117,6 +117,8 @@ messages:
 
       Send(poOwner,@GainMana,#amount=piStoredMana);
       Post(self,@Delete);
+      % Always break a trance when using a mana crystal for balance reasons.
+      Send(poOwner,@BreakTrance,#event=EVENT_STEER);
 
       return;
    }

--- a/kod/object/item/passitem/manacrys.kod
+++ b/kod/object/item/passitem/manacrys.kod
@@ -118,6 +118,7 @@ messages:
       Send(poOwner,@GainMana,#amount=piStoredMana);
       Post(self,@Delete);
       % Always break a trance when using a mana crystal for balance reasons.
+      % Event_Steer is used to ensure the trance is broken.
       Send(poOwner,@BreakTrance,#event=EVENT_STEER);
 
       return;


### PR DESCRIPTION
This PR prevents a Jala singer who is using a Jala necklace from looping Crystallize mana songs.  Now the use of the Crystal will break the singer's trance and end the Crystallize mana song.

EVENT_STEER is used for this purpose to avoid the oddities of EVENT_USE or other events.  This convention is used in other places in the database for ensuring a trance is broken.  A comment to this effect is included in the change.

To test:  Use a Jala Necklace and cast Crystallize mana.  Prior to this change you could consume the mana crystal, leaving the song up.  A new crystal would appear and get filled with the mana that you generated from the first crystal.

After applying this change: Using the crystal breaks the caster's trance and ends the song.  The need for this change was introduced by the changes included in PR #606.