### PR TITLE
fix: mark of dishonor server error messages for monsters

### DIFF
--- a/kod/object/passive/spell/dishonor.kod
+++ b/kod/object/passive/spell/dishonor.kod
@@ -164,6 +164,9 @@ messages:
          Send(oTarget,@AddExertion,#amount=200000);
          Send(oTarget,@SetVigorRestThreshold,
                #amount=iVigorRestThreshold-iVigorRestThresholdChange);
+
+         % Ensure player HPs aren't over their natural maximum.
+         Post(oTarget,@NewHealth);
       }
 
       Send(oTarget,@StartEnchantment,#what=self,
@@ -172,9 +175,6 @@ messages:
       Send(oTarget,@MsgSendUser,#message_rsc=MarkOfDishonor_start);
       Send(who,@MsgSendUser,#message_rsc=MarkOfDishonor_success,
             #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
-
-      % Make sure hps aren't over maximum. Post this so enchantment is finished.
-      Post(oTarget,@NewHealth);
       
       % If being cast on a monster
       if isClass(who,&Monster)


### PR DESCRIPTION
# What
- This changes fixes a server error by modifying the Mark of Dishonor spell to only check if the target has exceeded their natural HP if the target is a player
- Fix for #727 

# Why
- The `@GetNewHealth` message call is passed as part of Mark of Dishonor to reduce the HP of a player to their natural maximum.
- The intent is to use this weapon offensively against morphed or otherwise HP-boosted players
  - However the logic needed to be adjusted so the `@GetNewHealth` call only occurs for players and not monthers
    - Monster classes do not have the `GetNewHealth` message so the server generates an error when it is called

# Changes
- Moved the `@GetNewHealth` message call to within an existing target check for class `Player`
- Slightly adjusted the comment to specify the check is related to player HP

# Notes
- No errors observed after this charge in testing when casting on monsters
- All other Mark of Dishonor spell behavior remains the same