### PR TITLE
Fix: Summoned monsters getting the last kill in arena causes server error.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/tostwn/tswatch.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/tostwn/tswatch.kod
@@ -1125,7 +1125,7 @@ messages:
                      if IsClass(j,&Monster)
                         AND NOT (Send(j,@GetBehavior) & AI_NPC)
                      {
-                        Send(j,@Delete);
+                        Post(j,@Delete);
                      }
                   }
                }
@@ -1987,7 +1987,7 @@ messages:
             if IsClass(j,&Monster)
                AND (NOT (Send(j,@GetBehavior) & AI_NPC))
             {
-               Send(j,@Delete);
+               Post(j,@Delete);
             }
 
             % Yuckily, this is the easiest way to deal with this.


### PR DESCRIPTION
When a summoned monster gets the final hit in an arena battle we were generating the following error message on the server:

monster.bof (1066)] C_SendMessage OBJECT 6996 CLASS Reflection can't send MESSAGE PostAttackTimer (13444) to non-object 0,0

The monster was finishing its attack logic and then trying to start up its new attack sequence.  Before being able to do so the Tos Watcher was deleting the monsters because the battle was over.  The result is we try to call a message to a nonexistent object.

Converting the two possible delete messages to a Post message prevents this timing error.