### PR TITLE
Add IsLegalMove check to rooms, use it to fix guild hall security checks

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3083,6 +3083,21 @@ messages:
          }
       }
 
+      % Manual move checks in some rooms 
+      if NOT Send(poOwner,@IsLegalMove,#who=self,
+               #old_row=piRow,#old_col=piCol,
+               #new_row=new_row,#new_col=new_col)
+      {
+         % Illegal move! Reset position.
+         Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
+               #new_row=piRow,
+               #new_col=piCol,
+               #fine_row=piFine_Row,
+               #fine_col=piFine_Col);
+
+         return;
+      }
+      
       % Update this value for both speedhack detection AND movement detection.
       piLastMoveUpdateTime = GetTime();
 

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3938,5 +3938,10 @@ messages:
       return;
    }
 
+   IsLegalMove()
+   "Some rooms have special checks to prevent illegal movement"
+   {
+      return TRUE;
+   }
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/room/ghall.kod
+++ b/kod/object/active/holder/room/ghall.kod
@@ -1452,14 +1452,26 @@ messages:
       }
 
       if Send(self,@InFoyer,#who=what) <> Send(self,@InFoyer,#who=victim)
+         AND GetTime() > piLastDoorOpen + viSeconds_til_close + 1
       {
-         if GetTime() > piLastDoorOpen + viSeconds_til_close + 1
+         if Send(self,@InVulnerableZone,#who=victim)
+         {
+            propagate;
+         }
+         else
          {
             return FALSE;
          }
       }
 
       propagate;
+   }
+   
+   InVulnerableZone(who=$)
+   {
+      % Is the player still attackable even with the door closed?
+      % Some guild halls allow this on purpose.
+      return FALSE;
    }
 
    CanHavePlayerPortal()

--- a/kod/object/active/holder/room/ghall.kod
+++ b/kod/object/active/holder/room/ghall.kod
@@ -240,6 +240,33 @@ messages:
       propagate;
    }
 
+   IsLegalMove(who=$,old_row=1,old_col=1,new_row=1,new_col=1)
+   {
+      % Hardcoded movement check, prevent hacking into hall.
+      % No crossing out of foyer unless door is open.
+      if GetTime() > piLastDoorOpen + viSeconds_til_close + 1
+      {
+         if Send(self,@InFoyer,#who=who)
+         {
+            % We're in the foyer. Check if we're trying to move into the hall.
+            if NOT Send(self,@InFoyer,#test_row=new_row,#test_col=new_col)
+            {
+               % Bad player! Fail the attempt.
+               Debug("ALERT!",Send(who,@GetTrueName),who,
+                     "tried to move through closed Guild Hall door ",
+                     Send(self,@GetName)," from ",old_row,old_col,
+                     " to ", new_row, new_col,". Last door opening was ",
+                     GetTime() - piLastDoorOpen,
+                     " seconds ago.");
+
+               return FALSE;
+            }
+         }
+      }
+
+      return TRUE;
+   }
+
    CreateStandardObjects()
    "Two objects that all guild halls have:  newsball and lever."
    {
@@ -314,6 +341,11 @@ messages:
       piLastDoorOpen = GetTime();
 
       return;
+   }
+   
+   GetDoorTimeStamp()
+   {
+      return piLastDoorOpen;
    }
 
    EnteredInTimeWindow()
@@ -893,20 +925,24 @@ messages:
       return;
    }
 
-   InFoyer(who=$)
+   InFoyer(who=$,test_row=0,test_col=0)
    "This returns TRUE if the player is in the foyer area, and FALSE if the "
    "player is in the guild hall proper.  Note that the declared silence area "
    "must now be perfectly rectangular."
    {
       local iRow, iCol;
 
-      if Send(who,@GetOwner) <> self
+      if who = $
       {
-         return FALSE;
+         % Hypothetical coordinates a player wants to step to
+         iRow = test_row;
+         iCol = test_col;
       }
-
-      iRow = Send(who,@GetRow);
-      iCol = Send(who,@GetCol);
+      else
+      {
+         iRow = Send(who,@GetRow);
+         iCol = Send(who,@GetCol);
+      }
 
       if iRow >= viFoyer_north AND iRow <= viFoyer_South
          AND iCol <= viFoyer_east AND iCol >= viFoyer_west

--- a/kod/object/active/holder/room/ghall.kod
+++ b/kod/object/active/holder/room/ghall.kod
@@ -1404,6 +1404,12 @@ messages:
          % These players can always log into their own guild
          return TRUE;
       }
+      
+      if NOT Send(self,@InFoyer,#who=who)
+      {
+         % Anyone who got inside must be legal
+         return TRUE;
+      }
 
       for i in plLegal_entry
       {
@@ -1427,15 +1433,33 @@ messages:
  
    ReqTakeFromGuildChest(what=$,taker=$)
    {
-      if Send(self,@ReqLegalEntry,#who=taker)
+      if Send(self,@InFoyer,#who=taker)
       {
-         return TRUE;
+         Debug("Player",Send(taker,@GetTrueName),"stealing items from chest in",
+            Send(self,@GetName),"illegally.");
+         return FALSE;
       }
 
-      Debug("Player",Send(taker,@GetTrueName),"stealing items from chest in",
-            Send(self,@GetName),"illegally.");
+      return TRUE;
+   }
 
-      return FALSE;
+   ReqSomethingAttack(what = $,victim = $,use_weapon = $,stroke_obj = $)
+   "No one may attack through the door if it's closed."
+   {
+      if (what = $) or (victim = $)
+      {
+         propagate;
+      }
+
+      if Send(self,@InFoyer,#who=what) <> Send(self,@InFoyer,#who=victim)
+      {
+         if GetTime() > piLastDoorOpen + viSeconds_til_close + 1
+         {
+            return FALSE;
+         }
+      }
+
+      propagate;
    }
 
    CanHavePlayerPortal()

--- a/kod/object/active/holder/room/ghall/guildh10.kod
+++ b/kod/object/active/holder/room/ghall/guildh10.kod
@@ -115,12 +115,21 @@ messages:
    }
 
 
-     InFoyer(who=$)
-     {
-       local iRow, iCol;
-
-       iRow = send(who,@getrow);
-       iCol = send(who,@getcol);
+   InFoyer(who=$,test_row=0,test_col=0)
+   {
+      local iRow, iCol;
+ 
+      if who = $
+      {
+         % Hypothetical coordinates a player wants to step to
+         iRow = test_row;
+         iCol = test_col;
+      }
+      else
+      {
+         iRow = Send(who,@GetRow);
+         iCol = Send(who,@GetCol);
+      }
 
        if iRow > 16 or iCol < 4 or iCol > 18
          {

--- a/kod/object/active/holder/room/ghall/guildh10.kod
+++ b/kod/object/active/holder/room/ghall/guildh10.kod
@@ -51,6 +51,20 @@ classvars:
    viFoyer_south = 33
    viFoyer_east = 23
    viFoyer_west = 13
+   
+   % Switch maze area
+   viVulnerableZoneOneWest = 8
+   viVulnerableZoneOneSouth = 7
+   viVulnerableZoneOneEast = 13
+   
+   % Hallways adjacent to windows
+   viVulnerableZoneTwoSouth = 4
+   
+   % If the inner door to switch area is open
+   % it can be seen through
+   viVulnerableZoneThreeWest = 8
+   viVulnerableZoneThreeSouth = 10
+   viVulnerableZoneThreeEast = 13
 
    viLever_row = 2
    viLever_col = 14
@@ -393,6 +407,38 @@ messages:
       return;
    }
 
+   InVulnerableZone(who=$)
+   {
+      local iRow, iCol;
+
+      % Jaarba's Abode has windows into the switch room
+      % that can be attacked through
+
+      iRow = Send(who,@GetRow);
+      iCol = Send(who,@GetCol);
+
+      if iRow <= viVulnerableZoneOneSouth
+         AND iCol >= viVulnerableZoneOneWest
+         AND iCol <= viVulnerableZoneOneEast
+      {
+         return TRUE;
+      }
+
+      if iRow <= viVulnerableZoneTwoSouth
+      {
+         return TRUE;
+      }
+
+      if iRow <= viVulnerableZoneThreeSouth
+         AND iCol >= viVulnerableZoneThreeWest
+         AND iCol <= viVulnerableZoneThreeEast
+         AND ptNorthDoor <> $
+      {
+         return TRUE;
+      }
+      
+      return FALSE;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/room/ghall/guildh12.kod
+++ b/kod/object/active/holder/room/ghall/guildh12.kod
@@ -38,8 +38,10 @@ resources:
    guildh12_sealed4 = "Access to the upper wall is denied to non-military personnel."
    guildh12_sealed5 = "All access to the upper levels of the west tower is blocked by an iron "
       "gate.  It would not be wise to violate a lease with the Ko'catan army."
+   guildh12_sealed6 = "The secondary security door has been locked."
 
    guildh12_gong = gong.wav
+   security_door_locked_sound = doorlck.wav
 
    guildh12_lift_up_sound = stoneup2.wav
    guildh12_lift_down_sound = stonedn2.wav
@@ -159,6 +161,23 @@ messages:
            send(self,@OpenEntranceDoor);
            
            return TRUE;
+         }
+      }
+      
+      if (row = 40 OR row = 41) AND col = 9
+      {
+         % The secondary door needs a check, it's technically in the foyer.
+         % This door would teleport wallhackers past the foyer security.
+         % So, to allow for some potential fighting, we give intruders
+         % 20 seconds extra to try get through.
+         % If the InFoyer calculation is ever refined for this hall,
+         % this becomes unnecessary.
+         if GetTime() > Send(self,@GetDoorTimeStamp) + viSeconds_til_close + 21
+            AND NOT Send(self,@CanEnter,#who=what)
+         {
+            Send(what,@MsgSendUser,#message_rsc=guildh12_sealed6);
+            Send(what,@WaveSendUser,#wave_rsc=security_door_locked_sound);
+            return TRUE;
          }
       }
       

--- a/kod/object/active/holder/room/ghall/guildh13.kod
+++ b/kod/object/active/holder/room/ghall/guildh13.kod
@@ -216,19 +216,23 @@ messages:
       return;
    }
 
-   InFoyer(who=$)
+   InFoyer(who=$,test_row=0,test_col=0)
    "This returns TRUE if the player is in the foyer area, and FALSE if the "
    "player is in the guild hall proper."
    {
       local iRow, iCol;
-
-      if send(who,@GetOwner) <> self
+ 
+      if who = $
       {
-         return FALSE;
+         % Hypothetical coordinates a player wants to step to
+         iRow = test_row;
+         iCol = test_col;
       }
-
-      iRow = send(who,@GetRow);
-      iCol = send(who,@GetCol);
+      else
+      {
+         iRow = Send(who,@GetRow);
+         iCol = Send(who,@GetCol);
+      }
 
       if iRow >= viFoyer_north AND iRow <= viFoyer_south
          AND iCol <= viFoyer_east AND iCol >= viFoyer_west

--- a/kod/object/active/holder/room/ghall/guildh14.kod
+++ b/kod/object/active/holder/room/ghall/guildh14.kod
@@ -146,6 +146,19 @@ classvars:
    viFoyer_south = 3
    viFoyer_west = 26
    viFoyer_east = 39
+   
+   % Foyer and ticket booth   
+   viVulnerableZoneOneSouth = 3
+   viVulnerableZoneOneWest = 20
+   
+   % Behind the bar (still barely visible)
+   viVulnerableZoneTwoSouth = 7
+   viVulnerableZoneTwoWest = 18
+   viVulnerableZoneTwoEast = 24
+
+   % Hallway behind ticket booth, only when door is open
+   viVulnerableZoneThreeSouth = 5
+   viVulnerableZoneThreeEast = 21
 
    viLever_row = 11
    viLever_col = 16
@@ -614,6 +627,37 @@ messages:
       return GUILDH14_ZONE_MAIN;
    }
 
+   InVulnerableZone(who=$)
+   {
+      local iRow, iCol;
+
+      % Bookmaker's has a visible ticket booth area
+
+      iRow = Send(who,@GetRow);
+      iCol = Send(who,@GetCol);
+
+      if iRow <= viVulnerableZoneOneSouth
+         AND iCol >= viVulnerableZoneOneWest
+      {
+         return TRUE;
+      }
+
+      if iRow <= viVulnerableZoneTwoSouth
+         AND iCol >= viVulnerableZoneTwoWest
+         AND iCol <= viVulnerableZoneTwoEast
+      {
+         return TRUE;
+      }
+
+      if iRow <= viVulnerableZoneThreeSouth
+         AND iCol <= viVulnerableZoneThreeEast
+         AND ptCounterDoor <> $
+      {
+         return TRUE;
+      }
+      
+      return FALSE;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/room/ghall/guildh15.kod
+++ b/kod/object/active/holder/room/ghall/guildh15.kod
@@ -365,27 +365,6 @@ messages:
       propagate;
    }
 
-   ReqSomethingAttack(what = $,victim = $,use_weapon = $,stroke_obj = $)
-   "No one may attack through the door if it's closed."
-   {
-      if (what = $) or (victim = $)
-      {
-         propagate;
-      }
-      if send(self,@InFoyer,#who=what) <> send(self,@InFoyer,#who=victim)
-      {
-         if ptEntrance = $      % if the door was closed recently - note that this treats the door as closed the instant it starts closing - oh well.
-         {
-            if isClass(what,&player)
-            {
-               send(what,@SendAttackOutOfRangeMessage,#what=victim,#use_weapon=use_weapon,#stroke_obj=stroke_obj);
-            }
-            return FALSE;
-         }
-      }
-      propagate;
-   }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/room/ghall/guildh5.kod
+++ b/kod/object/active/holder/room/ghall/guildh5.kod
@@ -44,6 +44,8 @@ classvars:
    viFoyer_south = 33
    viFoyer_east = 23
    viFoyer_west = 13
+   
+   viVulnerableZone_north = 24
 
    viLever_row = 27
    viLever_col = 11
@@ -452,6 +454,17 @@ messages:
       }
 
       return;
+   }
+   
+   InVulnerableZone(who=$)
+   {
+      % This hall has ledges that can be fought from
+      if Send(who,@GetRow) > viVulnerableZone_north
+      {
+         return TRUE;
+      }
+      
+      return FALSE;
    }
 
 

--- a/kod/object/active/holder/room/ghall/guildh7.kod
+++ b/kod/object/active/holder/room/ghall/guildh7.kod
@@ -86,14 +86,23 @@ messages:
       propagate;
    }
 
-   InFoyer(who=$)
+   InFoyer(who=$,test_row=0,test_col=0)
    "Due to the multiple foyers in this guild hall, we return which foyer 'who' "
    "is currently in.  Returns FALSE if not in foyer, a positive integer otherwise."
    {
       local iRow, iCol;
 
-      iRow = Send(who,@GetRow);
-      iCol = Send(who,@GetCol);
+      if who = $
+      {
+         % Hypothetical coordinates a player wants to step to
+         iRow = test_row;
+         iCol = test_col;
+      }
+      else
+      {
+         iRow = Send(who,@GetRow);
+         iCol = Send(who,@GetCol);
+      }
 
       if (iRow > 15) AND (iRow < 22) AND (iCol < 9)
       {

--- a/kod/object/active/holder/room/ghall/guildh8.kod
+++ b/kod/object/active/holder/room/ghall/guildh8.kod
@@ -62,6 +62,18 @@ classvars:
    viFoyer_west = 8
    viFoyer_south = 31
    viFoyer_east = 10
+   
+   % Chest room
+   viNonVulnerableZoneOneSouth = 17
+   viNonVulnerableZoneOneWest = 24
+   
+   % Switch room
+   viNonVulnerableZoneTwoSouth = 8
+   viNonVulnerableZoneTwoWest = 17
+   
+   % Top left corner in upper river
+   viNonVulnerableZoneThreeSouth = 3
+   viNonVulnerableZoneThreeEast = 13
 
    viInner_teleport_row = 3
    viInner_teleport_col = 14
@@ -339,7 +351,37 @@ messages:
 
       return;
    }
+   
+   InVulnerableZone(who=$)
+   {
+      local iRow, iCol;
 
+      % Sewer Hideout is almost entirely attackable from outside
+      % with the exception of a few hideaways
+
+      iRow = Send(who,@GetRow);
+      iCol = Send(who,@GetCol);
+
+      if iRow <= viNonVulnerableZoneOneSouth
+         AND iCol >= viNonVulnerableZoneOneWest
+      {
+         return FALSE;
+      }
+
+      if iRow <= viNonVulnerableZoneTwoSouth
+         AND iCol >= viNonVulnerableZoneTwoWest
+      {
+         return FALSE;
+      }
+
+      if iRow <= viNonVulnerableZoneThreeSouth
+         AND iCol <= viNonVulnerableZoneThreeEast
+      {
+         return FALSE;
+      }
+      
+      return TRUE;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/room/ghall/guildh9.kod
+++ b/kod/object/active/holder/room/ghall/guildh9.kod
@@ -40,6 +40,11 @@ classvars:
    viFoyer_south = 11
    viFoyer_west = 15
    viFoyer_east = 24
+   
+   viVulnerableZoneOneSouth = 11
+   
+   viVulnerableZoneTwoSouth = 16
+   viVulnerableZoneTwoEast = 15
 
    viLever_row = 16
    viLever_col = 10
@@ -188,6 +193,29 @@ messages:
       return;
    }
 
+   InVulnerableZone(who=$)
+   {
+      local iRow, iCol;
+
+      % Abandoned Warehouse has highly unfortunate windows
+      % that enemies can fire through... and vice versa
+
+      iRow = Send(who,@GetRow);
+      iCol = Send(who,@GetCol);
+
+      if iRow <= viVulnerableZoneOneSouth
+      {
+         return TRUE;
+      }
+
+      if iRow <= viVulnerableZoneTwoSouth
+         AND iCol <= viVulnerableZoneTwoEast
+      {
+         return TRUE;
+      }
+      
+      return FALSE;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
I saw recently that there might be a patch soon, but this is a pressing issue with a fairly simple solution, so I'm really hoping we can get this in.

Guild hall security checks are completely broken. In testing, both on 101 live and local, I have not been able to get any non-guild member into a hall and have it properly registered as legal. This goes for allies as well, who can open the door, then be unable to open it from the inside or even blink to escape, creating traps that can be inescapable without help. Admins can attest to this - I've seen them having to assist people who were stuck and broadcasting for aid. As for enemies, guild hall raids don't work _at all_. 

This pull request has commits from a system I came up with a long time ago, and has had 10 years of live testing to attest to its effectiveness. Counter to the complex hot plate system, it's very straightforward: the server simply rejects illegal moves and bounces the player back. Then, we use where the server believes the player is as its own 'validity check' with respect to objects and players, without the need for complex tracking. This can be used for many places where wallhack offers an advantage, like the yeti node or forest shrine.

For guild halls specifically, we use this to prevent any and all movement out of the foyer if the door is not open. Then, we add a few checks to prevent illegal attacks, taking from the hall chest, or flipping the switch if the server believes the player is in the foyer. That way, it doesn't matter what hacking shenanigans you do on your local client. The server says no. This **also** finally provides actual security inside a guild hall - I myself have been killed in the distant past inside my own hall by wallhackers that came right through the wall and were allowed to attack me, because the code only protects the halls and switches. There's no debug or cheat tracking for this as far as I know, so members of guilds on 101 are vulnerable at this very moment without realizing it.

For halls that have intentional foyer <-> internal combat, special vulnerability zones have been added, allowing attacks if the victim is in one of them. These are simple bounding boxes, and include the foyer, so that defenders can attack out as well.