### PR TITLE
Fix:  Instrument's BreakTrance() message causing server errors with Morph

### DIFF
--- a/kod/object/item/passitem/instrum.kod
+++ b/kod/object/item/passitem/instrum.kod
@@ -47,8 +47,21 @@ messages:
 
    NewUnused()
    {
+      local oRoom;
+
       Send(poOwner,@RemoveOverlay,#what=self);
-      Send(poOwner,@BreakTrance,#event=EVENT_USE,#usewhat=self);
+
+      % The following code ensures that any Jala song ends regardless
+      %   when an instrument is unequipped
+      %   regardless of how the instrument was removed.
+      % We send the message to the room and not to the player
+      %   because Room.kod will loop over plEnchantments and direct
+      %   the break trance message to the correct spell.
+      % This prevents server errors in the event the caster is singing
+      %   and has a second trance going such as for morph or elusion.
+
+      oRoom = Send(poOwner,@GetOwner);
+      Send(oRoom,@BreakTrance,#who=poOwner,#event=EVENT_USE,#usewhat=self);
       propagate;
    }
 

--- a/kod/object/item/passitem/instrum.kod
+++ b/kod/object/item/passitem/instrum.kod
@@ -51,9 +51,9 @@ messages:
 
       Send(poOwner,@RemoveOverlay,#what=self);
 
-      % The following code ensures that any Jala song ends regardless
+      % The following code ensures that any Jala song ends
       %   when an instrument is unequipped
-      %   regardless of how the instrument was removed.
+      %   regardless of how or why the instrument was removed.
       % We send the message to the room and not to the player
       %   because Room.kod will loop over plEnchantments and direct
       %   the break trance message to the correct spell.


### PR DESCRIPTION
PR #606 allowed the user to equip a weapon or change robes or armor while singing a song if they are using a Jala Necklace.

In the testing for that change it was noted that a user could cast the spell with a Jala Necklace equiped, and then equip a god gift necklace.  Doing so removes the Jala Necklace without calling UserUseItem() or UserApply().  The result was that the player would be able to cast the Jala spell and then put on a different necklace and continue singing.

To fix this potential problem a BreakTrance message was added to NewUnused() in Instrument.  The idea was that every time an instrument is unequipped for any reason the BreakTrance message will trigger the Jala song to end.

In testing prior to having the updates from PR606 going live, it was discovered that a user singing a Jala song and then having the instrument removed by a spell which itself has a focus timer and which calls BreakTrance as part of the effect of the spell causes two server errors:
[player.bof (2984)] DeleteTimer can't find timer 10654
[player.bof (2666)] DelListElem can't find elem 3,0 in list id 79600

These errors were caused by sending two BreakTrance messages in rapid succession.  The first one cleared the two trance spells and deleted the timer and removed the spell from plEnchantments.  The second one fails to find the timer that we send in and is unable to remove the item from plEnchantments.  Both problems print an error to the server.

The fix for this is simple: We don't need to send the BreakTrance() message to the player - instead we need to send the BreakTrance() message to the room.  Room.kod loops over plEnchantments, determines what type of room enchantment is present, and sends a BreakTrance message only to the spells that it finds in the room.  The result is that only the Jala spell trance is broken by the message in Instrument and the Morph (or other spell) related trance is broken by Player.kod.

To recreate error:  Load a current build of the game prior to this update.  Equip a Jala Necklace.  Cast a Jala song spell.  Cast morph and wait for the timer to expire.  You will see the two error messages above.  Next, build the game from this PR branch and do the same and note that there are no errors.

Testing history:  I tested Morph, Jig (with a second player), Gnarled Staff (with 2nd while first had two trances active), Feign Death, and Elusion and found no errors related to interrupting Jala spells or dropping or unequipping instruments.