### PR TITLE
Fix for room key and room key copy errors on RecreateItemTemplates

### DIFF
--- a/kod/object/item/passitem/roomkeyc.kod
+++ b/kod/object/item/passitem/roomkeyc.kod
@@ -105,12 +105,17 @@ messages:
    GetMasterKey()
    "Attempts to look up the master key if one exists or $ if not."
    {
-      local oMaintenance, oRenter, oRoom;
+      local oMaintenance, oRenter, oRoom, oKey;
       oMaintenance = Send(SYS, @GetRentableRoomMaintenance);
       oRoom = Send(SYS, @FindRoomByNum, #num=piRID);
       oRenter = Send(self, @GetRenter);
+      oKey = $;
+      if (oRenter <> $ AND oRoom <> $)
+      {
+         oKey = Send(oMaintenance, @FindKeyByPlayer, #who=oRenter, #iLocation=Send(oRoom, @GetLocation));
+      }
 
-      return Send(oMaintenance, @FindKeyByPlayer, #who=oRenter, #iLocation=Send(oRoom, @GetLocation));
+      return oKey;
    }
 
    OriginalDeleted()
@@ -142,7 +147,7 @@ messages:
       oRoom = Send(SYS,@FindRoomByNum,#num=piRID);
       if (oRoom = $)
       {
-         Send(self,@Delete);
+         Post(self, @Delete);
          return;
       }
 
@@ -218,8 +223,13 @@ messages:
       local oRoom, oInn;
       
       oRoom = Send(SYS,@FindRoomByNum,#num=piRID);
-      oInn = Send(SYS,@FindRoomByNum,#num=send(oRoom,@GetLocation));
+      if (oRoom = $)
+      {
+         Post(self, @Delete);
+         return;
+      }
 
+      oInn = Send(SYS,@FindRoomByNum,#num=send(oRoom,@GetLocation));
       if send(what,@GetOwner) = oInn
          AND send(oInn,@EnterRentableRoom,#who=what)
       {

--- a/kod/util/rntmaint.kod
+++ b/kod/util/rntmaint.kod
@@ -462,6 +462,12 @@ messages:
       local oKey, oObj, lPassive;
 
       oKey = $;
+
+      if (who = $ OR iLocation = $)
+      {
+         return oKey;
+      }
+
       lPassive = Send(who, @GetHolderPassive);
 
       for oObj in lPassive


### PR DESCRIPTION
This cleans up a few bugs and error messages with room keys and their copies having null RIDs attached to them, most notably when template versions are created through the system function RecreateItemTemplates.

- Attempting to use such a key will delete it back into the void instead of triggering server error messages.
- Attempting to examine such a key will now correctly delete it back into the void.  Previously this wasn't working right.
- The GetMasterKey function on RoomKeyCopy and RoomKeySecureCopy now correctly returns null without generating error messages if either the renter or the room it connects to are null.
- FindKeyByPlayer on RentableRoomMaintenance now correctly returns null if either who or iLocation are null without generating server errors.