### PR TITLE
fix: adjust rarity grade logic to sum (vs bound) and change magic grade to uncommon

### DIFF
--- a/clientd3d/client.rc
+++ b/clientd3d/client.rc
@@ -1787,7 +1787,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_RARITY_GRADE_MAGIC         "magic"
+    IDS_RARITY_GRADE_UNCOMMON      "uncommon"
     IDS_RARITY_GRADE_RARE          "rare"
     IDS_RARITY_GRADE_LEGENDARY     "legendary"
     IDS_RARITY_GRADE_UNIDENTIFIED  "unidentified"

--- a/clientd3d/color.c
+++ b/clientd3d/color.c
@@ -56,7 +56,7 @@ static char colorinfo[][15] = {
 	{ "255,255,255"},   /* COLOR_BAR4 */
 	{ "192,192,192"},   /* COLOR_INVNUMFGD */
 	{ "0,0,0"},         /* COLOR_INVNUMBGD */
-	{ "141,242,242"},	/* COLOR_ITEM_TEXT_MAGIC        - cyan   */
+	{ "141,242,242"},	/* COLOR_ITEM_TEXT_UNCOMMON     - cyan   */
 	{ "0,255,0"},	    /* COLOR_ITEM_TEXT_RARE         - lime   */
 	{ "255,0,255"},     /* COLOR_ITEM_TEXT_LEGENDARY    - purple */
 	{ "252,128,0"},	    /* COLOR_ITEM_TEXT_UNIDENTIFIED - orange */
@@ -416,8 +416,8 @@ WORD GetItemListColor(HWND hwnd, int type, item_rarity_grade text_color_value)
 	{
 		switch (text_color_value)
 		{
-			case ITEM_RARITY_GRADE_MAGIC:
-				return COLOR_ITEM_TEXT_MAGIC;
+			case ITEM_RARITY_GRADE_UNCOMMON:
+				return COLOR_ITEM_TEXT_UNCOMMON;
 			case ITEM_RARITY_GRADE_RARE:
 				return COLOR_ITEM_TEXT_RARE;
 			case ITEM_RARITY_GRADE_LEGENDARY:

--- a/clientd3d/color.h
+++ b/clientd3d/color.h
@@ -38,7 +38,7 @@ enum {
    COLOR_BAR4,            /* Bar graph color #4 (numbers in graphs) */
    COLOR_INVNUMFGD,       /* Inventory number foreground */
    COLOR_INVNUMBGD,       /* Inventory number background */
-   COLOR_ITEM_TEXT_MAGIC,
+   COLOR_ITEM_TEXT_UNCOMMON,
    COLOR_ITEM_TEXT_RARE,
    COLOR_ITEM_TEXT_LEGENDARY,
    COLOR_ITEM_TEXT_UNIDENTIFIED,

--- a/clientd3d/dialog.c
+++ b/clientd3d/dialog.c
@@ -682,8 +682,8 @@ std::string GetRaritySuffix(item_rarity_grade rarity)
 	{
         case ITEM_RARITY_GRADE_NORMAL:
             return "";
-        case ITEM_RARITY_GRADE_MAGIC:
-            stringID = IDS_RARITY_GRADE_MAGIC;
+        case ITEM_RARITY_GRADE_UNCOMMON:
+            stringID = IDS_RARITY_GRADE_UNCOMMON;
 			break;
         case ITEM_RARITY_GRADE_RARE:
             stringID = IDS_RARITY_GRADE_RARE;

--- a/clientd3d/resource.h
+++ b/clientd3d/resource.h
@@ -232,7 +232,7 @@
 #define IDS_RESENDAPI                   203
 #define IDS_SIGNUPMSG                   204
 #define IDS_CANTATTACKSELF              205
-#define IDS_RARITY_GRADE_MAGIC          206
+#define IDS_RARITY_GRADE_UNCOMMON       206
 #define IDS_RARITY_GRADE_RARE           207
 #define IDS_RARITY_GRADE_LEGENDARY      208
 #define IDS_RARITY_GRADE_UNIDENTIFIED   209

--- a/include/proto.h
+++ b/include/proto.h
@@ -496,9 +496,9 @@ typedef enum {
    ITEM_RARITY_GRADE_NORMAL       = 0,
    ITEM_RARITY_GRADE_MAGIC        = 1,
    ITEM_RARITY_GRADE_RARE         = 2,
-   ITEM_RARITY_GRADE_LEGENDARY    = 3,
-   ITEM_RARITY_GRADE_UNIDENTIFIED = 4,
-   ITEM_RARITY_GRADE_CURSED       = 5,
+   ITEM_RARITY_GRADE_LEGENDARY    = 4,
+   ITEM_RARITY_GRADE_UNIDENTIFIED = 100,
+   ITEM_RARITY_GRADE_CURSED       = 200,
 } item_rarity_grade;
 
 /* Size in bytes of numbers in protocol */

--- a/include/proto.h
+++ b/include/proto.h
@@ -494,7 +494,7 @@ enum {
 /* Item rarity designations used for different object presentations */
 typedef enum {
    ITEM_RARITY_GRADE_NORMAL       = 0,
-   ITEM_RARITY_GRADE_MAGIC        = 1,
+   ITEM_RARITY_GRADE_UNCOMMON     = 1,
    ITEM_RARITY_GRADE_RARE         = 2,
    ITEM_RARITY_GRADE_LEGENDARY    = 4,
    ITEM_RARITY_GRADE_UNIDENTIFIED = 100,

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -42,11 +42,11 @@
 
    %%% Item rarity constants used for presentation in client
    ITEM_RARITY_GRADE_NORMAL        = 0
-   ITEM_RARITY_GRADE_MAGIC         = 1
+   ITEM_RARITY_GRADE_UNCOMMON      = 1
    ITEM_RARITY_GRADE_RARE          = 2
-   ITEM_RARITY_GRADE_LEGENDARY     = 3
-   ITEM_RARITY_GRADE_UNIDENTIFIED  = 4
-   ITEM_RARITY_GRADE_CURSED        = 5
+   ITEM_RARITY_GRADE_LEGENDARY     = 4
+   ITEM_RARITY_GRADE_UNIDENTIFIED  = 100
+   ITEM_RARITY_GRADE_CURSED        = 200
 
    %%% Object flags for client
 

--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -642,7 +642,7 @@ messages:
 
       if count = 1
       {
-         return ITEM_RARITY_GRADE_MAGIC;
+         return ITEM_RARITY_GRADE_UNCOMMON;
       }
 
       if count = 2
@@ -702,9 +702,8 @@ messages:
    GetRarityGradeCount()
    "Checks plItem_attributes with GetRarityCountModifier().  "
    "Adds each attribute's rarity count to the total.  "
-   "Return either viRarity or count, whichever is larger.  "
-   "This ensures the higher rarity is chosen if in the case "
-   "of competing rarities for an item."
+   "Returns a rarity grade based on the sum of the total and the "
+   "item's class-based viRarity value."
    {
 
       local i, iNum, oItemAtt, count;
@@ -720,7 +719,7 @@ messages:
          }
       }
 
-      return Bound(count, viRarity, $);
+      return (count + viRarity);
    }
 
    GetRarityCountModifier()

--- a/kod/object/item/passitem/weapon/goldswrd.kod
+++ b/kod/object/item/passitem/weapon/goldswrd.kod
@@ -51,7 +51,7 @@ classvars:
    viMin_damage = 2
    viMax_damage = 5
 
-   viRarity = ITEM_RARITY_GRADE_MAGIC
+   viRarity = ITEM_RARITY_GRADE_RARE
 
 properties:
 

--- a/kod/object/item/passitem/weapon/ranged/bow/magicbow.kod
+++ b/kod/object/item/passitem/weapon/ranged/bow/magicbow.kod
@@ -29,7 +29,7 @@ classvars:
    viBulk = 70
    viWeight = 70
 
-   viRarity = ITEM_RARITY_GRADE_MAGIC
+   viRarity = ITEM_RARITY_GRADE_RARE
 
 properties:
 

--- a/kod/object/item/passitem/weapon/ranged/bow/nerubow.kod
+++ b/kod/object/item/passitem/weapon/ranged/bow/nerubow.kod
@@ -50,7 +50,7 @@ classvars:
    % What's the basic color of the bow?
    viBaseXLAT = XLAT_TO_GREEN
 
-   viRarity = ITEM_RARITY_GRADE_MAGIC
+   viRarity = ITEM_RARITY_GRADE_RARE
 
 properties:
 

--- a/kod/object/item/passitem/weapon/riijaswd.kod
+++ b/kod/object/item/passitem/weapon/riijaswd.kod
@@ -57,8 +57,6 @@ classvars:
    viInventory_group = 3
    viBroken_group = 2
 
-   viRarity = ITEM_RARITY_GRADE_MAGIC
-
 properties:
 
    piAttack_type = ATCK_WEAP_MAGIC+ATCK_WEAP_SLASH


### PR DESCRIPTION
# What
- several changes based on feedback to calibrate the rarity grade system

# Changes
- changed MAGIC rarity grade to be UNCOMMON both on server and client
- changed rarity grade logic to add class based rarity `viRarity` and item attributes
  - formerly picked the higher value of the two
- changed `viRarity` class based assignment for several items
  - removed MAGIC/UNCOMMON from Riija Sword (now is NORMAL)
  - moved the following to RARE
    - nerudite bow
    - magic bow
    - gold sword
- changed `item_rarity_grade` enums to be a little more spaced out
  - changed LEGENDARY to 4 from 3 so the values line up better with the rarity calculation (mostly just so things are consistent and easier to understand) 
  - UNIDENTIFIED is now 100
  - CURSED is now 200

# Logic Diagram
``` mermaid
flowchart TD
    I(Class Rarity
     default = 0)  -->|viRarity| C
    J(Item Att Count
    default = 0) --> C
    C(Sum of viRarity + Item Att Count) -->D
    D(NORMAL = 0
    UNCOMMON = 1
    RARE = 2
    LEGENDARY = 4+)
    style D text-align:right
 ```

# Reference documentation
Below are tables for class rarity assignments and item attributes that contribute to the rarity calculation of an item.  These are mostly unchanged by this PR and are here for reference.

## Class Rarity Assignments `viRarity`
All items have a default class rarity or `viRarity` of NORMAL.  Below are the exceptions.

| Name                      | Item Class    | viRarity Assignment |
| --- | --- | ---|
| Magic Spirit Helmet (MSH) | Helm          | Rare |
| Brass Medallion           | FarenCharm    | Rare                |
| Steel Torc                | KraananCharm  | Rare                |
| Monacle                   | QorCharm      | Rare                |
| Feathered Choker          | RiijaCharm    | Rare                |
| Diamond Pendant           | ShalilleCharm | Rare                |
| Gold Sword                | GoldSword     | Rare                |
| Magic Bow                 | MagicBow      | Rare                |
| Nerudite Bow              | NeruditeBow   | Rare                |

## Item and Weapon Attribute Modifiers
These are the item attributes that contribute to a higher rarity grade.  They are added together along with the class based rarity `viRarity` to determine the rarity grade for a revealed or identified item.

| Name | Attribute | Rarity Modifier | DM word | Description and Notes|
| --- | --- | --- | --- | --- |
| Bonded | IA_BONDED | +1 | N/A | This Item Attribute bonds an item to a specific player. Not sure if it is in use.                                                                                                     |
| Bonded | IA_TRANSCENDANT | +1 | transcendant | It glows with a soft, white light. This is what is commonly known as "bonded" where the item will remain in your inventory when you die.|
| Durable | IA_DURABLE             | +1 | durable  | The craftsmanship of this X is admirable, obviously the result of hundreds of hours of work by expert hands.  Default modifier is 300% bonus to durability.|
| Artifice                 | IA_MISDIRECTION        | +1 | N/A | An illusion has been cast on this item, hiding it's true abilities. This is used by the Riija spell Artifice to make an item appear to have attributes that it does not have, and (according to the description) hide true attributes the item has.|
| Engraved Item | IA_ENGRAVED | + 1 | use dm engrave spell | The words x are delicately engraved on the edge.|
| Blind Weapon             | WA_BLINDER             | +1 | blinder | Q's insignia is emblazoned on the metal of the weapon.|
| Bonk Weapon              | WA_BONK                | +1 | bonker | Mocker's signature flamboyantly emblazons the pommel.|
| Arena Weapon             | WA_CEREMONIAL          | +1 | ceremonial | Beautiful and ornate, this weapon is obviously  unsuitable for blood combat, though it might provide X edge in games and tourneys. |
| Expert Weapon            | WA_EXPERT              | +1 | expert | Colhorr's signature is engraved on the handle of this weapon. This "weapon looks to provide X advantage - in the right hands. |
| Faction Weapon           | WA_FACTION | +1 | duke, princess, rebel ||
| Guildhall Weapon         | WA_GUILD_HALL_DEFENDER | +1 | guild hall defender | The crest of X is inscribed on the hilt of the weapon, suggesting Y bonus in the defense of that hall. |
| Hold Weapon              | WA_Paralyzer | +1 | Paralyzer | A glow that can only be described as Zjiriaesqe surrounds the weapon. |
| Justice Weapon           | WA_PUNISHER | +1 | punisher | The emblem of a fist holding an ankh rests in the pommel of this weapon, promising X advantage in the fight for justice. |
| Purge Weapon             | WA_PURGER | +1 | purger | The sign of Psychochild is engraved on the weapon.|
| Spellcasting Weapon      | WA_SPELLCASTER | +1 | spellcaster | Mystical energy flits about this weapon.                                                                                               Possible spells<br>[SID_DEMENT, 12], [SID_ENFEEBLE, 13], [SID_VERTIGO, 13], [SID_SWAP, 12], [SID_INVISIBILITY, 12], [SID_FORGET, 13], [SID_EVIL_TWIN, 12],[SID_MARK_OF_DISHONOR, 13] |
| Attack spell type Weapon | WA_ATTACKSPELLTYPE     | +1 | fire, cold, shock, holy, unholy, acid | This weapon attribute merely flags a weapon as having the spell attack type that corresponds with it. It also has a timer, which, when it expires, flips the Attack type back.      |
| Twisting Weapon          | WA_TWISTER | +1 | twister | A swirling green 'GMT' is stamped into the pommel.|
| Vampiric Weapon          | WA_Vamper | +1 | Vamper | An unholy glow seems to suck all life from the air around the weapon.|