### PR TITLE
Fix for DM-added attributes not being revealed

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user/dm/admin.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm/admin.kod
@@ -32,6 +32,7 @@ resources:
    admin_currently_in = "The ROO for `b%s`n is `k`B%s`n."
 
    admin_create_itematt_command = "create item attribute"
+   admin_create_unrevealed_itematt_command = "create unrevealed itematt"
    admin_anonymous_command = "anonymous"
    admin_shadow_command = "shadow"
    admin_relic_command = "relic"
@@ -138,11 +139,12 @@ messages:
 
    UserSay(string = $,type = $)
    {
-      local oWeapon, i, oObject;
+      local oWeapon, i, oObject, lItemAttributes, lAttribute;
 
       if type = SAY_DM
          AND (StringContain(string,admin_create_itematt_command)
-              OR StringContain(string,"create itematt"))
+              OR StringContain(string,"create itematt")
+              OR StringContain(string, admin_create_unrevealed_itematt_command))
       {
          %% Only works on weapons for now.
          oWeapon = Send(self,@LookupPlayerWeapon);
@@ -159,6 +161,17 @@ messages:
             if Send(i,@DMCreateItemAtt,#who=self,#string=string,
                     #oWeapon=oWeapon)
             {
+               % Identify the newly-added attribute
+               if (NOT StringContain(string, admin_create_unrevealed_itematt_command))
+               {
+                  lItemAttributes = Send(oWeapon, @GetItemAttributes);
+                  lAttribute = First(lItemAttributes);
+                  if (lAttribute <> $ AND First(lAttribute) mod 2 = 0)
+                  {
+                     SetNth(lAttribute, 1, First(lAttribute) + 1);
+                  }
+               }
+
                if NOT pbStealth
                {
                   Send(poOwner,@SomeoneSaid,#what=self,#type=SAY_MESSAGE,

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm/admin.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm/admin.kod
@@ -139,13 +139,15 @@ messages:
 
    UserSay(string = $,type = $)
    {
-      local oWeapon, i, oObject, lItemAttributes, lAttribute;
+      local oWeapon, i, oObject, lItemAttributes, lAttribute, bShouldRevealAttribute;
 
       if type = SAY_DM
          AND (StringContain(string,admin_create_itematt_command)
               OR StringContain(string,"create itematt")
               OR StringContain(string, admin_create_unrevealed_itematt_command))
       {
+         bShouldRevealAttribute = NOT StringContain(string, admin_create_unrevealed_itematt_command);
+
          %% Only works on weapons for now.
          oWeapon = Send(self,@LookupPlayerWeapon);
          
@@ -162,12 +164,20 @@ messages:
                     #oWeapon=oWeapon)
             {
                % Identify the newly-added attribute
-               if (NOT StringContain(string, admin_create_unrevealed_itematt_command))
+               if (bShouldRevealAttribute)
                {
                   lItemAttributes = Send(oWeapon, @GetItemAttributes);
+
+                  % The first attribute in the list of item attributes is the
+                  % most recently-added attribute.
                   lAttribute = First(lItemAttributes);
+
+                  % The first value in an attribute list is a compound value,
+                  % where the ones digit represents revealed (odd) or 
+                  % unrevealed (even).
                   if (lAttribute <> $ AND First(lAttribute) mod 2 = 0)
                   {
+                     % This sets an unrevealed attribute's status to revealed.
                      SetNth(lAttribute, 1, First(lAttribute) + 1);
                   }
                }

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm/admin.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm/admin.kod
@@ -141,62 +141,69 @@ messages:
    {
       local oWeapon, i, oObject, lItemAttributes, lAttribute, bShouldRevealAttribute;
 
-      if type = SAY_DM
-         AND (StringContain(string,admin_create_itematt_command)
-              OR StringContain(string,"create itematt")
-              OR StringContain(string, admin_create_unrevealed_itematt_command))
+
+
+      if (type = SAY_DM)
       {
          bShouldRevealAttribute = NOT StringContain(string, admin_create_unrevealed_itematt_command);
-
-         %% Only works on weapons for now.
-         oWeapon = Send(self,@LookupPlayerWeapon);
-         
-         if oWeapon= $
-         {   
-            Send(self,@MsgSendUser,#message_rsc=admin_need_weapon);   
-
-            return;  
-         }
-	 
-         for i in Send(SYS,@GetItemAtts)
+      
+         % if bShouldRevealAttribute ends up FALSE, we've already passed the 
+         % dialog check for an attempt to create an item attribute.  Otherwise,
+         % check the dialog for the standard item attribute creation strings 
+         if (NOT bShouldRevealAttribute
+            OR StringContain(string,admin_create_itematt_command)
+            OR StringContain(string,"create itematt"))
          {
-            if Send(i,@DMCreateItemAtt,#who=self,#string=string,
-                    #oWeapon=oWeapon)
-            {
-               % Identify the newly-added attribute
-               if (bShouldRevealAttribute)
-               {
-                  lItemAttributes = Send(oWeapon, @GetItemAttributes);
-
-                  % The first attribute in the list of item attributes is the
-                  % most recently-added attribute.
-                  lAttribute = First(lItemAttributes);
-
-                  % The first value in an attribute list is a compound value,
-                  % where the ones digit represents revealed (odd) or 
-                  % unrevealed (even).
-                  if (lAttribute <> $ AND First(lAttribute) mod 2 = 0)
-                  {
-                     % This sets an unrevealed attribute's status to revealed.
-                     SetNth(lAttribute, 1, First(lAttribute) + 1);
-                  }
-               }
-
-               if NOT pbStealth
-               {
-                  Send(poOwner,@SomeoneSaid,#what=self,#type=SAY_MESSAGE,
-                       #string=admin_made_itematt,#parm1=Send(self,@GetName),
-                       #parm2=Send(oWeapon,@GetDef),
-                       #parm3=Send(oWeapon,@GetName));
-               }
-
-               return;
-            }
-         }
+            %% Only works on weapons for now.
+            oWeapon = Send(self,@LookupPlayerWeapon);
          
-         Send(self,@MsgSendUser,#message_rsc=admin_cant_create_itematt);   
+            if oWeapon= $
+            {   
+               Send(self,@MsgSendUser,#message_rsc=admin_need_weapon);   
 
-         return;
+               return;  
+            }
+
+            for i in Send(SYS,@GetItemAtts)
+            {
+               if Send(i,@DMCreateItemAtt,#who=self,#string=string,
+                       #oWeapon=oWeapon)
+            {
+                  % Identify the newly-added attribute
+                  if (bShouldRevealAttribute)
+                  {
+                     lItemAttributes = Send(oWeapon, @GetItemAttributes);
+
+                     % The first attribute in the list of item attributes is the
+                     % most recently-added attribute.
+                     lAttribute = First(lItemAttributes);
+
+                     % The first value in an attribute list is a compound value,
+                     % where the ones digit represents revealed (odd) or 
+                     % unrevealed (even).
+                     if (lAttribute <> $ AND First(lAttribute) mod 2 = 0)
+                     {
+                        % This sets an unrevealed attribute's status to revealed.
+                        SetNth(lAttribute, 1, First(lAttribute) + 1);
+                     }
+                  }
+   
+                  if NOT pbStealth
+                  {
+                     Send(poOwner,@SomeoneSaid,#what=self,#type=SAY_MESSAGE,
+                          #string=admin_made_itematt,#parm1=Send(self,@GetName),
+                          #parm2=Send(oWeapon,@GetDef),
+                          #parm3=Send(oWeapon,@GetName));
+                  }
+
+                  return;
+               }
+            }
+         
+            Send(self,@MsgSendUser,#message_rsc=admin_cant_create_itematt);   
+
+            return;
+         }
       }
 
       if (StringContain(string,admin_relic_command)

--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -354,6 +354,11 @@ messages:
       return iFinal;
    }
 
+   GetItemAttributes()
+   {
+      return plItem_Attributes;
+   }
+
    GetMaxHits()
    {
       return piHits_init;


### PR DESCRIPTION
This PR causes item attributes added through the "dm create itematt <attribute>" command to always be revealed.  Previously, an admin using this command would have to use the reveal spell, which is problematic if one of the added attributes was shroud.

If the old behavior of adding an unrevealed attribute is preferred, the command "dm create unrevealed itematt <attribute>" has been added.