### PR TITLE
fix: sanitize target URLs in client before using

### DIFF
--- a/clientd3d/web.c
+++ b/clientd3d/web.c
@@ -42,7 +42,7 @@ void WebLaunchBrowser(const char *url)
         urlStr = "https://" + urlStr;
     }
 
-    HINSTANCE result = ShellExecute(NULL, "open", urlStr.c_str(), NULL, NULL, SW_SHOWNORMAL);
+    ShellExecute(NULL, "open", urlStr.c_str(), NULL, NULL, SW_SHOWNORMAL);
 }
 
 // convert c string to wstring

--- a/clientd3d/web.c
+++ b/clientd3d/web.c
@@ -19,9 +19,34 @@ using namespace std;
 /*
  * WebLaunchBrowser:  Attempt to run browser on given URL.
  */
-void WebLaunchBrowser(char *url)
+void WebLaunchBrowser(const char *url)
 {
-  ShellExecute(NULL, "open", url, NULL, NULL, SW_SHOWNORMAL);
+    if (url == nullptr || strlen(url) == 0) {
+        debug(("URL string empty\n"));
+        return;
+    }
+
+    std::string urlStr(url);
+
+    if (ContainsSpaces(urlStr)) {
+        debug(("URL contains spaces\n"));
+        return;
+    }
+
+    if (urlStr.find("https://") != 0 && urlStr.find("https://") != 0) {
+        urlStr = "https://" + urlStr;
+    }
+
+    HINSTANCE result = ShellExecute(NULL, "open", urlStr.c_str(), NULL, NULL, SW_SHOWNORMAL);
+    if ((INT_PTR)result <= 32) {
+        debug(("Failed to open URL\n"));
+        return;
+    }
+}
+
+bool ContainsSpaces(const std::string& str)
+{
+    return str.find(' ') != std::string::npos;
 }
 
 // convert c string to wstring

--- a/clientd3d/web.c
+++ b/clientd3d/web.c
@@ -15,6 +15,11 @@
 
 using namespace std;
 
+static bool ContainsSpaces(const std::string& str)
+{
+    return str.find(' ') != std::string::npos;
+}
+
 /************************************************************************/
 /*
  * WebLaunchBrowser:  Attempt to run browser on given URL.
@@ -33,20 +38,11 @@ void WebLaunchBrowser(const char *url)
         return;
     }
 
-    if (urlStr.find("https://") != 0 && urlStr.find("https://") != 0) {
+    if (urlStr.find("http://") != 0 && urlStr.find("https://") != 0) {
         urlStr = "https://" + urlStr;
     }
 
     HINSTANCE result = ShellExecute(NULL, "open", urlStr.c_str(), NULL, NULL, SW_SHOWNORMAL);
-    if ((INT_PTR)result <= 32) {
-        debug(("Failed to open URL\n"));
-        return;
-    }
-}
-
-bool ContainsSpaces(const std::string& str)
-{
-    return str.find(' ') != std::string::npos;
 }
 
 // convert c string to wstring

--- a/clientd3d/web.h
+++ b/clientd3d/web.h
@@ -39,7 +39,8 @@ enum AccountStatusWebResponse
     FAILURE = 1 << 2
 };
 
-void WebLaunchBrowser(char *url);
+void WebLaunchBrowser(const char *url);
+bool ContainsSpaces(const std::string& str);
 
 // Send a HTTPS request to a given domain and resource.
 bool SendHttpsRequest(HWND hDlg, const std::string& domain, const std::string& resource, const std::string& requestBody, std::wstring& response);

--- a/clientd3d/web.h
+++ b/clientd3d/web.h
@@ -40,7 +40,6 @@ enum AccountStatusWebResponse
 };
 
 void WebLaunchBrowser(const char *url);
-bool ContainsSpaces(const std::string& str);
 
 // Send a HTTPS request to a given domain and resource.
 bool SendHttpsRequest(HWND hDlg, const std::string& domain, const std::string& resource, const std::string& requestBody, std::wstring& response);


### PR DESCRIPTION
# What

- checks and sanitizes URL strings before opening them from the client with a browser

# Changes

- checks for
  - empty URL string
    - returns if so
  - spaces in the URL
    - returns if so
  - lack of `HTTP/HTTPS` prefix
    - adds `HTTPS://` if there is no prefix
- adds relevant debug messages in client
