### PR TITLE
fix: make hotkey aliases refresh without restarting client 

### DIFF
--- a/module/merintr/alias.c
+++ b/module/merintr/alias.c
@@ -81,24 +81,9 @@ static HWND hAliasDialog2 = NULL;
 
 static INT_PTR CALLBACK AliasDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);
 static INT_PTR CALLBACK VerbAliasDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);
-
+static void UpdateKeyTables(int key, WORD command, char *text);
 extern Bool	gbClassicKeys;
 extern player_info *GetPlayer(void);
-
-/****************************************************************************/
-/*
- * UpdateKeyTables:  Update either the classic or custom keys interfaces table
- * depending on the client configuration, then also update the inventory key
- * table so that the hotkey aliases work when the user is in that child window
- */
-static void UpdateKeyTables(int key, WORD command, char *text)
-{
-   if (gbClassicKeys) 
-      AliasSetKey(interface_key_table, key, KEY_NONE, command, text);
-   else
-      AliasSetKey(gCustomKeys, key, KEY_NONE, command, text);
-   AliasSetKey(inventory_key_table, key, KEY_NONE, command, text);
-}
 
 /****************************************************************************/
 /*
@@ -972,4 +957,19 @@ INT_PTR CALLBACK VerbAliasDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPA
    }
    
    return FALSE;
+}
+
+/****************************************************************************/
+/*
+ * UpdateKeyTables:  Update either the classic or custom keys interfaces table
+ * depending on the client configuration, then also update the inventory key
+ * table so that the hotkey aliases work when the user is in that child window
+ */
+static void UpdateKeyTables(int key, WORD command, char *text)
+{
+   if (gbClassicKeys) 
+      AliasSetKey(interface_key_table, key, KEY_NONE, command, text);
+   else
+      AliasSetKey(gCustomKeys, key, KEY_NONE, command, text);
+   AliasSetKey(inventory_key_table, key, KEY_NONE, command, text);
 }

--- a/module/merintr/alias.c
+++ b/module/merintr/alias.c
@@ -162,7 +162,7 @@ void AliasInit(void)
 	 aliases[i].cr = True;
       }
 
-   UpdateKeyTables(aliases[i].key, command, aliases[i].text);
+      UpdateKeyTables(aliases[i].key, command, aliases[i].text);
    }
 }
 
@@ -274,7 +274,7 @@ void AliasSave(void)
       }
       WritePrivateProfileString(fullSection, temp, text, cinfo->ini_file);
 
-   UpdateKeyTables(aliases[i].key, command, aliases[i].text);
+      UpdateKeyTables(aliases[i].key, command, aliases[i].text);
    }
 
    strcpy(fullSection, command_section);


### PR DESCRIPTION
# What

- this change reloads the hotkey aliases into memory after they are saved

# Why

- currently players must reload their client for changes in the hotkey aliases "automatic enter" to take effect
  - example: players change f1 from `help` to `tg <guild banner>` and uncheck automatic enter
    - when they close the hotkey aliases edit screen, it will still automatically enter
    - the only workaround is to restart the client
- it's a small quality of life change but I think will be welcomed by players
  - today while on 101 someone was complaining about this issue after telling a guildmate to log on and off for their aliases to be updated properly

# Changes

- created new function `UpdateKeyTables` to update saved in-memory key configuration
  - used by both `AliasInit` and `AliasSave`

