### PR TITLE
Reinstate animation sleep to lower CPU load while in background

### DIFF
--- a/clientd3d/config.c
+++ b/clientd3d/config.c
@@ -275,7 +275,7 @@ void ConfigLoad(void)
    config.showUnseenWalls = GetConfigInt(special_section, INIShowUnseenWalls, 0, ini_file);
    config.showUnseenMonsters = GetConfigInt(special_section, INIShowUnseenMonsters, 0, ini_file);
    config.avoidDownloadAskDialog = GetConfigInt(special_section, INIAvoidDownloadAskDialog, 0, ini_file);
-   config.maxFPS = GetConfigInt(special_section, INIMaxFPS, 140, ini_file);
+   config.maxFPS = GetConfigInt(special_section, INIMaxFPS, 120, ini_file);
    config.clearCache = GetConfigInt(special_section, INIClearCache, False, ini_file);
    //config.quickstart = GetConfigInt(special_section, INIQuickStart, 0, ini_file);
 #else

--- a/clientd3d/statgame.c
+++ b/clientd3d/statgame.c
@@ -27,6 +27,8 @@ static int window_width = 0;
 
 static POINT previous_mouse_position;
 
+#define ANIMATE_BACKGROUND_SLEEP_MS 50
+
 /****************************************************************************/
 void GameInit(void)
 {
@@ -358,6 +360,11 @@ void GameCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify)
    }
 }
 /****************************************************************************/
+void AnimationSleep(void)
+{
+    Sleep(ANIMATE_BACKGROUND_SLEEP_MS);
+}
+/****************************************************************************/
 void GameTimer(HWND hwnd, UINT id)
 {
    switch (id)
@@ -377,6 +384,12 @@ void GameIdle(void)
 
    // Are we the active foreground application?
    AnimationTimerAbort();
+
+   // If we're in the background, sleep to lower CPU load
+   if (GetWindowLong(GetActiveWindow(), GWL_HINSTANCE) != (LONG)hInst)
+   {
+       AnimationSleep();
+   }
 }
 /****************************************************************************/
 void GameEnterIdle(HWND hwnd, UINT source, HWND hwndSource)


### PR DESCRIPTION
This change reintroduces the original sleep used to lower CPU load while the game is running in the background which was previously [removed](https://github.com/Meridian59/Meridian59/pull/452).

In addition to this change we now also improve app background detection for sleeping, reduce maximum frame rate of 120 FPS and finally prevent the animation timer triggering on non game screens (was happening on at least the character selection window).

A background sleep of 1ms quickly produces a 0% cpu when the game is in the background without significant game activity (such as numerous hostile monsters animating). Using a value of 0ms does not achieve 0% cpu and actually *significantly* raised background CPU usage due returning immediately (https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleep).
