### PR TITLE
Create a Frogman treasure table

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -1591,6 +1591,8 @@
    TID_DARK_ANGEL    = 51
    TID_MUMMY         = 52
    TID_THRASHER      = 53
+   
+   TID_FROGMAN      = 54
 
    %%% English articles
 

--- a/kod/object/active/holder/nomoveon/battler/monster/frogman.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/frogman.kod
@@ -42,7 +42,7 @@ classvars:
    vrDead_icon = frogman_dead_icon_rsc
    vrDead_name = frogman_dead_name_rsc
 
-   viTreasure_type = TID_MEDIUM_HUMAN
+   viTreasure_type = TID_FROGMAN
 
    viSpeed = SPEED_AVERAGE
    viAttack_type = ATCK_WEAP_PIERCE

--- a/kod/object/passive/trestype/frogmant.kod
+++ b/kod/object/passive/trestype/frogmant.kod
@@ -1,0 +1,50 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+FrogmanTreasure is TreasureType
+
+constants:
+   
+   include blakston.khd
+   
+classvars:
+
+
+properties:
+   
+   piTreasure_num = TID_FROGMAN
+   
+   %% frogman drops stuff good for qor and faren builders below 80 hp
+   % Compare to Skeletons - similar level/diff, opposite karma path
+   piDiff_seed = 5
+   piItem_att_chance = 8
+
+messages:
+   
+   constructed()
+   {
+      plTreasure = [ [ &EntrootBerry, 24 ],
+                     [ &PurpleMushroom, 24 ],
+                     [ &BlueMushroom, 15 ],
+                     [ &Mushroom, 10 ],
+                     [ &ElderBerry, 10 ],
+                     [ &InkyCap, 4],
+                     [ &FairyWing, 4 ],
+                     [ &DarkAngelFeather, 6 ],
+                     [ &ChainArmor,1 ],
+                     [ &MetalShield, 1],
+                     [ &MagicShieldPotion, 1 ]
+                   ];
+
+      propagate;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/trestype/makefile
+++ b/kod/object/passive/trestype/makefile
@@ -12,6 +12,7 @@ BOFS = wimptres.bof notres.bof spquent.bof med-tght.bof wmp-medt.bof \
 	caveorct.bof orcwizt.bof orcpitt.bof avart.bof avarsht.bof \
 	avarcht.bof lupkingt.bof dflyt.bof licht.bof \
 	dethspdt.bof skel2t.bof skel3t.bof skel4t.bof narthylt.bof \
-	wrmlarvt.bof wrmquent.bof dangelt.bof newbietrs.bof thrasht.bof
+	wrmlarvt.bof wrmquent.bof dangelt.bof newbietrs.bof thrasht.bof \
+	frogmant.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -3487,6 +3487,7 @@ messages:
 
       Create(&ThrasherTreasure);
 
+      Create(&FrogmanTreasure);
       return;
    }
 


### PR DESCRIPTION
Per https://github.com/Meridian59/Meridian59/issues/466

The treasure of Frogmen was the same as the Stone Troll, likely because the Frogmen were not actually placed in the world until recently, so it was just an ancient placeholder. This pull creates a treasure table based on some notes in the Ancient monster loot table. It's generally berries and mushrooms, with a tiny sprinkling of DAFs and useful equipment, to match Skeletons (the opposite karma path to this one) dropping BDS now and again.

The diff seed is also similar to Skeletons, but with an att chance similar to Shamans and other sentients, since Frogmen are intelligent beings who might seek out and wield special weapons. The special weapons they drop can only be the semi-useful intro stuff, like ceremonial. They cannot drop the powerful mods like Hold or Blind. I'm hoping this will help differentiate the karma paths and give a different feel for building as a Qor or Faren. Also, as I've posted in the Issues section, I believe the RNG for special weapons is overly punishing, so giving a few ways to get some drops is a good thing in and of itself.

I tried dragonfly eyes (per the issue suggestion) but they just didn't feel right when I was killing frogmen and looking at the drops. The general vibe for drops from this treasure table is intended to be 'dark' and 'natural', so it's mainly berries, mushrooms, etc, and wings and feathers the frogmen might have scavenged. I couldn't justify the eyes, because there are no dragonflies on the mainland. Plus, low level early builders don't really have a use for them.

There is also, super rarely, some equipment the frogmen themselves might hypothetically use. Chain armor is great against frogmen because they do pierce damage, and magic shield potions are something frogmen might have sorted in order to use themselves. Also a small shield, to help builders equip themselves.