### PR TITLE
Fit Qor primary spellpower bonus to accurately match day/night

### DIFF
--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -2130,7 +2130,7 @@ messages:
       if viSchool = SS_QOR
       {
          % Qor strength determined by day or night.
-         iPrimaryBonus =  (2 + Send(SYS,@GetHour));
+         iPrimaryBonus = 2 + (abs(Send(SYS,@GetHour)-12) * 2);
          % Secondary bonus comes from Karma.
          iSecondaryBonus = abs(Send(who,@GetKarma)/10);
 


### PR DESCRIPTION
Currently, Qor's 'day and night' primary spellpower bonus calculation does not at all fit the intended theme. It gives the lowest power at midnight, climbing throughout the day (so Qor power is actually really strong mid afternoon) and then peaks at 11 pm, when it then crashes back to minimum at midnight.

This new equation shifts it so that the Qor primary spellpower bonus is strongest at midnight, and weakest at noon. This more accurately ties Qor to 'night time.'

New results:
Midnight - 26 power (maximum)
1 AM - 24 power
2 AM - 22 power
3 AM - 20 power
4 AM - 18 power
5 AM - 16 power
6 AM - 14 power - Dawn
7 AM - 12 power
8 AM - 10 power
9 AM - 8 power
10 AM - 6 power
11 AM - 4 power
12 - high noon 2 power (minimum)
1 PM - 4 power
2 PM - 6 power
3 PM - 8 power
4 PM - 10 power
5 PM - 12 power
6 PM - 14 power - Nightfall
7 PM - 16 power
8 PM - 18 power
9 PM - 20 power
10 PM - 22 power
11 PM - 24 power