### PR TITLE
fix: make reveal and identify work on shrouded items (IA_SHROUD)

### DIFF
--- a/kod/object/passive/itematt/iashroud.kod
+++ b/kod/object/passive/itematt/iashroud.kod
@@ -80,11 +80,6 @@ messages:
 		return FALSE;
 	}
 
-	ItemCanIdentify()
-	{
-		return FALSE;
-	}
-  
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	%%
 	%%	Maintenance Routines


### PR DESCRIPTION
# What

- this change makes reveal and identify work on the `IA_SHROUD` item attribute

# Why

- when shroud is cast by a player, the `IA_SHROUD` item attribute is added as an identified attribute
- however, in some cases an admin can manually add the `IA_SHROUD` item attribute to an item as an unidentified attribute
    - with the new rarity grade system these items show up in the client as `UNIDENTIFIED`
- this change "fixes" the issue by allowing players to reveal and identify shrouded items
  - since `IA_SHROUD` does have a unique description string, it should be identifiable or reveal-able
    - > A cloak of magic surrounds it.

# Testing

- in limited testing I was able to reveal and identify items with the `IA_SHROUD` attribute that were applied before this change
- no errors seen in the server log

# Notes

- there is another change submitted to by default have item attributes be revealed when applied through the `dm create itematt` command #749 
- `IA_SHROUD` has a timer and should not last more than a day, even when applied by admins
  - the timer doesn't seem to work properly when applied by admins
    - players casting shroud seems to apply the timer correctly
  - should be addressed in another PR/Issue