### PR TITLE
Fixed small typo in class name reference (&necklace instead of &Necklace)

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -4185,7 +4185,7 @@ messages:
       if IsClass(what,&Armor)
          OR IsClass(what,&Helmet)
          OR IsClass(what,&Gauntlet)
-         OR IsClass(what,&necklace)
+         OR IsClass(what,&Necklace)
          OR IsClass(what,&Shield)
          OR IsClass(what,&Pants)
       {


### PR DESCRIPTION
I don't even know for sure if class names are case-sensitive like that in the kod files.  If not then I apologize for submitting the world's most unnecessary pull request lol