### PR TITLE
Restore logoff ghosts visuals

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -6879,7 +6879,7 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 		processedIds.insert(pRNode->obj.id);
 
 		// Check for invisible objects
-		bool objInvisible = (pRNode->obj.flags & OF_INVISIBLE) == OF_INVISIBLE;
+		bool objInvisible = (pRNode->obj.flags & (OF_INVISIBLE | OF_DITHERINVIS)) == OF_INVISIBLE;
 		if((flags & OF_INVISIBLE) == OF_INVISIBLE)
 		{
 			if (!objInvisible)


### PR DESCRIPTION
Logoff ghosts were being rendered as if they were invisible - this small change prevents that.
![image](https://github.com/Meridian59/Meridian59/assets/7548210/ee496555-77cb-4ede-8dfd-48fa8705147c)
