### PR TITLE
fix: make colored listbox text more robust in client

### DIFF
--- a/clientd3d/msgfiltr.c
+++ b/clientd3d/msgfiltr.c
@@ -127,11 +127,16 @@ INT_PTR CALLBACK WhoDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lP
        debug(("WHOM_UPDATE NULL user\n"));
        return FALSE;
      }
+     if (!hList)
+     { 
+       debug(("Failed to get handle for IDC_USERLIST\n"));
+       return FALSE;
+     }
      debug(("WHOM_UPDATE, %s user %i\n", (LPCTSTR)(bAdded?"adding":"removing"), pUser->id));
      if (bAdded)
      {
        i = ItemListAddItem(hList, pUser, -1, False);
-       if (!IsUserInIgnoreList(pUser->name_res))
+       if (i != LB_ERR && !IsUserInIgnoreList(pUser->name_res))
 	       ListBox_SetSel(hList, TRUE, i);
      }
      else

--- a/clientd3d/msgfiltr.c
+++ b/clientd3d/msgfiltr.c
@@ -127,11 +127,6 @@ INT_PTR CALLBACK WhoDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lP
        debug(("WHOM_UPDATE NULL user\n"));
        return FALSE;
      }
-     if (!hList)
-     { 
-       debug(("Failed to get handle for IDC_USERLIST\n"));
-       return FALSE;
-     }
      debug(("WHOM_UPDATE, %s user %i\n", (LPCTSTR)(bAdded?"adding":"removing"), pUser->id));
      if (bAdded)
      {

--- a/clientd3d/ownerdrw.c
+++ b/clientd3d/ownerdrw.c
@@ -374,8 +374,7 @@ void DrawOwnerListItem(const DRAWITEMSTRUCT *lpdis, Bool selected, Bool combo)
    SetBkMode(lpdis->hDC, TRANSPARENT);
 
    if (style & (OD_DRAWOBJ | OD_DRAWICON) && obj != NULL)
-      if (IsValidRarity(obj->rarity)) 
-         item_rarity_value = (item_rarity_grade)obj->rarity;
+      item_rarity_value = (item_rarity_grade)obj->rarity;
 
       crColorText = GetColor(
                         GetItemListColor(
@@ -484,23 +483,5 @@ void DrawOwnerListItem(const DRAWITEMSTRUCT *lpdis, Bool selected, Bool combo)
        (SendMessage(lpdis->hwndItem, LB_GETCARETINDEX, 0, 0L) == (LRESULT)lpdis->itemID))
    {
       DrawFocusRect(lpdis->hDC, &lpdis->rcItem);
-   }
-}
-/*****************************************************************************/
-/* 
- * IsValidRarity:  checks whether a given rarity value is valid
- */
-int IsValidRarity(int rarity) {
-   switch (rarity) {
-      case ITEM_RARITY_GRADE_NORMAL:
-      case ITEM_RARITY_GRADE_UNCOMMON:
-      case ITEM_RARITY_GRADE_RARE:
-      case ITEM_RARITY_GRADE_LEGENDARY:
-      case ITEM_RARITY_GRADE_UNIDENTIFIED:
-      case ITEM_RARITY_GRADE_CURSED:
-         return 1;
-      default:
-         debug(("Invalid rarity: %d\n", rarity));
-         return 0;
    }
 }

--- a/clientd3d/ownerdrw.c
+++ b/clientd3d/ownerdrw.c
@@ -356,6 +356,9 @@ void DrawOwnerListItem(const DRAWITEMSTRUCT *lpdis, Bool selected, Bool combo)
    SetBkMode(lpdis->hDC, OPAQUE);
    obj = (object_node*)lpdis->itemData;
 
+   if obj = NULL
+      return;
+
    hColorBg = GetBrush(
                GetItemListColor(
                   lpdis->hwndItem,

--- a/clientd3d/ownerdrw.c
+++ b/clientd3d/ownerdrw.c
@@ -356,9 +356,6 @@ void DrawOwnerListItem(const DRAWITEMSTRUCT *lpdis, Bool selected, Bool combo)
    SetBkMode(lpdis->hDC, OPAQUE);
    obj = (object_node*)lpdis->itemData;
 
-   if (obj == NULL)
-      return;
-
    hColorBg = GetBrush(
                GetItemListColor(
                   lpdis->hwndItem,
@@ -377,6 +374,7 @@ void DrawOwnerListItem(const DRAWITEMSTRUCT *lpdis, Bool selected, Bool combo)
    SetBkMode(lpdis->hDC, TRANSPARENT);
 
    if (style & (OD_DRAWOBJ | OD_DRAWICON) && obj != NULL)
+      if (IsValidRarity(obj->rarity)) 
          item_rarity_value = (item_rarity_grade)obj->rarity;
 
       crColorText = GetColor(
@@ -486,5 +484,23 @@ void DrawOwnerListItem(const DRAWITEMSTRUCT *lpdis, Bool selected, Bool combo)
        (SendMessage(lpdis->hwndItem, LB_GETCARETINDEX, 0, 0L) == (LRESULT)lpdis->itemID))
    {
       DrawFocusRect(lpdis->hDC, &lpdis->rcItem);
+   }
+}
+/*****************************************************************************/
+/* 
+ * IsValidRarity:  checks whether a given rarity value is valid
+ */
+int IsValidRarity(int rarity) {
+   switch (rarity) {
+      case ITEM_RARITY_GRADE_NORMAL:
+      case ITEM_RARITY_GRADE_UNCOMMON:
+      case ITEM_RARITY_GRADE_RARE:
+      case ITEM_RARITY_GRADE_LEGENDARY:
+      case ITEM_RARITY_GRADE_UNIDENTIFIED:
+      case ITEM_RARITY_GRADE_CURSED:
+         return 1; // Valid rarity
+      default:
+         debug("Invalid rarity: %d\n", rarity);
+         return 0; // Invalid rarity
    }
 }

--- a/clientd3d/ownerdrw.c
+++ b/clientd3d/ownerdrw.c
@@ -498,9 +498,9 @@ int IsValidRarity(int rarity) {
       case ITEM_RARITY_GRADE_LEGENDARY:
       case ITEM_RARITY_GRADE_UNIDENTIFIED:
       case ITEM_RARITY_GRADE_CURSED:
-         return 1; // Valid rarity
+         return 1;
       default:
          debug(("Invalid rarity: %d\n", rarity));
-         return 0; // Invalid rarity
+         return 0;
    }
 }

--- a/clientd3d/ownerdrw.c
+++ b/clientd3d/ownerdrw.c
@@ -356,7 +356,7 @@ void DrawOwnerListItem(const DRAWITEMSTRUCT *lpdis, Bool selected, Bool combo)
    SetBkMode(lpdis->hDC, OPAQUE);
    obj = (object_node*)lpdis->itemData;
 
-   if obj == NULL
+   if (obj == NULL)
       return;
 
    hColorBg = GetBrush(

--- a/clientd3d/ownerdrw.c
+++ b/clientd3d/ownerdrw.c
@@ -458,7 +458,15 @@ void DrawOwnerListItem(const DRAWITEMSTRUCT *lpdis, Bool selected, Bool combo)
    if (style & OD_COLORTEXT)
    {
      // get the color we'd prefer for this particular obj
-     crColorText = GetPlayerNameColor(obj->flags,NULL);
+     if (obj != NULL) 
+     {
+        crColorText = GetPlayerNameColor(obj->flags,NULL);
+     }
+     else
+     {
+        crColorText = NAME_COLOR_NORMAL_FG;
+        debug(("Null pointer detected for obj in DrawOwnerListItem\n"));
+     }
      
      // draw a black halo around the text just to ensure it is visible
      SetTextColor(lpdis->hDC, RGB(0, 0, 0));

--- a/clientd3d/ownerdrw.c
+++ b/clientd3d/ownerdrw.c
@@ -500,7 +500,7 @@ int IsValidRarity(int rarity) {
       case ITEM_RARITY_GRADE_CURSED:
          return 1; // Valid rarity
       default:
-         debug("Invalid rarity: %d\n", rarity);
+         debug(("Invalid rarity: %d\n", rarity));
          return 0; // Invalid rarity
    }
 }

--- a/clientd3d/ownerdrw.c
+++ b/clientd3d/ownerdrw.c
@@ -458,14 +458,14 @@ void DrawOwnerListItem(const DRAWITEMSTRUCT *lpdis, Bool selected, Bool combo)
    if (style & OD_COLORTEXT)
    {
      // get the color we'd prefer for this particular obj
-     if (obj != NULL) 
-     {
-        crColorText = GetPlayerNameColor(obj->flags, NULL);
-     }
-     else
+     if (obj == NULL) 
      {
         crColorText = PALETTERGB(255, 255, 255);
         debug(("Null pointer detected for obj in DrawOwnerListItem\n"));
+     }
+     else
+     {
+        crColorText = GetPlayerNameColor(obj->flags, NULL);
      }
      
      // draw a black halo around the text just to ensure it is visible

--- a/clientd3d/ownerdrw.c
+++ b/clientd3d/ownerdrw.c
@@ -356,7 +356,7 @@ void DrawOwnerListItem(const DRAWITEMSTRUCT *lpdis, Bool selected, Bool combo)
    SetBkMode(lpdis->hDC, OPAQUE);
    obj = (object_node*)lpdis->itemData;
 
-   if obj = NULL
+   if obj == NULL
       return;
 
    hColorBg = GetBrush(

--- a/clientd3d/ownerdrw.c
+++ b/clientd3d/ownerdrw.c
@@ -464,7 +464,7 @@ void DrawOwnerListItem(const DRAWITEMSTRUCT *lpdis, Bool selected, Bool combo)
      }
      else
      {
-        crColorText = NAME_COLOR_NORMAL_FG;
+        crColorText = PALETTERGB(255, 255, 255);
         debug(("Null pointer detected for obj in DrawOwnerListItem\n"));
      }
      

--- a/clientd3d/ownerdrw.c
+++ b/clientd3d/ownerdrw.c
@@ -460,7 +460,7 @@ void DrawOwnerListItem(const DRAWITEMSTRUCT *lpdis, Bool selected, Bool combo)
      // get the color we'd prefer for this particular obj
      if (obj != NULL) 
      {
-        crColorText = GetPlayerNameColor(obj->flags,NULL);
+        crColorText = GetPlayerNameColor(obj->flags, NULL);
      }
      else
      {

--- a/clientd3d/ownerdrw.h
+++ b/clientd3d/ownerdrw.h
@@ -64,7 +64,6 @@ M59EXPORT int OwnerListCompareItem(HWND hwnd, const COMPAREITEMSTRUCT *lpcis, Bo
 M59EXPORT void OwnerListMeasureItem(HWND hwnd, MEASUREITEMSTRUCT *lpMeasureItem, Bool combo);
 M59EXPORT BOOL OwnerListDrawItem(HWND hwnd, const DRAWITEMSTRUCT *lpDrawItem, Bool combo);
 M59EXPORT BOOL OwnerListDrawItemNoSelect(HWND hwnd, const DRAWITEMSTRUCT *lpdis, Bool combo);
-M59EXPORT int IsValidRarity(int rarity);
 
 
 #endif /* #ifndef _OWNERDRW_H */

--- a/clientd3d/ownerdrw.h
+++ b/clientd3d/ownerdrw.h
@@ -64,6 +64,7 @@ M59EXPORT int OwnerListCompareItem(HWND hwnd, const COMPAREITEMSTRUCT *lpcis, Bo
 M59EXPORT void OwnerListMeasureItem(HWND hwnd, MEASUREITEMSTRUCT *lpMeasureItem, Bool combo);
 M59EXPORT BOOL OwnerListDrawItem(HWND hwnd, const DRAWITEMSTRUCT *lpDrawItem, Bool combo);
 M59EXPORT BOOL OwnerListDrawItemNoSelect(HWND hwnd, const DRAWITEMSTRUCT *lpdis, Bool combo);
+M59EXPORT int IsValidRarity(int rarity);
 
 
 #endif /* #ifndef _OWNERDRW_H */


### PR DESCRIPTION
# What

- this change attempts to make wholist handling more robust to reduce client crashes related to `DrawOwnerListItem`
 
| function | line | filename|
| - | - | - |
`meridian!DrawOwnerListItem` | 377 | ownerdrw.c
`meridian!OwnerListDrawItem`  | 288 | ownerdrw.c
`meridian!WhoDialogProc` | 153 | msgfiltr.c

# Why

- there are several bug reports on different dates related to a crash in `DrawOwnerListItem` on this line
```
if (style & (OD_DRAWOBJ | OD_DRAWICON) && obj != NULL)
   item_rarity_value = (item_rarity_grade)obj->rarity;
```
- It is suspected that the compiler might be reordering things within the `DrawOwnerListItem` function
  - if so, this line could be the culprit (as pointed out to me)
  - [Meridian59/clientd3d/ownerdrw.c](https://github.com/Meridian59/Meridian59/blob/bf65a1a5677e277379662456ca42f96106045b5b/clientd3d/ownerdrw.c#L461)
    - `crColorText = GetPlayerNameColor(obj->flags,NULL);` in this line if the obj is null then there could be a crash

# Changes
- added a check in `clientd3d/ownerdrw.c` `DrawOwnerListItem`
  - check for a null pointer and if it is, then use default black text for the obj
- added a check in `clientd3d/msgfiltr.c` within the `WHOM_UPDATE` case
  - validate the `i = ItemListAddItem(hList, pUser, -1, False);` call so that i does not return an error code
    - added check that adding the list item does not return `LB_ERR` which is the `WinUser.h` listbox error value return (`-1`)
