### PR TITLE
Adjust the viewing height of ViewpointGlobe's so as not to be affected by ceilings

### DIFF
--- a/clientd3d/game.c
+++ b/clientd3d/game.c
@@ -230,7 +230,7 @@ void SetPlayerRemoteView(ID objID, int flags, int height, BYTE light)
       if (flags & REMOTE_VIEW_VALID_HEIGHT)
 	 player.viewHeight = floor + height;
       else if (flags & REMOTE_VIEW_TOP)
-	 player.viewHeight = viewObject->motion.z - 10;
+	 player.viewHeight = viewObject->motion.z + objHeight;
       else if (flags & REMOTE_VIEW_BOTTOM)
 	 player.viewHeight = viewObject->motion.z;
       else if (flags & REMOTE_VIEW_MID)

--- a/clientd3d/game.c
+++ b/clientd3d/game.c
@@ -230,7 +230,7 @@ void SetPlayerRemoteView(ID objID, int flags, int height, BYTE light)
       if (flags & REMOTE_VIEW_VALID_HEIGHT)
 	 player.viewHeight = floor + height;
       else if (flags & REMOTE_VIEW_TOP)
-	 player.viewHeight = viewObject->motion.z + objHeight;
+	 player.viewHeight = viewObject->motion.z - 10;
       else if (flags & REMOTE_VIEW_BOTTOM)
 	 player.viewHeight = viewObject->motion.z;
       else if (flags & REMOTE_VIEW_MID)

--- a/kod/object/passive/viewglbe.kod
+++ b/kod/object/passive/viewglbe.kod
@@ -60,7 +60,7 @@ messages:
 
       Send(who,@MsgSendUser,#message_rsc=ViewPointGlobe_used);
       send(who,@SetPlayerView,#what=poTargetGlobe,
-            #iFlags=(REMOTE_VIEW_TURN | REMOTE_VIEW_TILT | REMOTE_VIEW_CONTROL | REMOTE_VIEW_TOP));
+            #iFlags=(REMOTE_VIEW_TURN | REMOTE_VIEW_TILT | REMOTE_VIEW_CONTROL | REMOTE_VIEW_BOTTOM));
       
       return True;
    }


### PR DESCRIPTION
This PR seeks to resolve an issue seen in the Lich maze (`lichmaze`) when using the globes/cameras. When a player uses a globe their viewpoint becomes the top of the globe and is above the height of the ceiling, causing a visual bug. This PR uses `REMOTE_VIEW_BOTTOM` instead of `REMOTE_VIEW_BOTTOM` to set their viewpoint to the bottom of the globe, rather than the top.

### Before
![image](https://github.com/Meridian59/Meridian59/assets/467443/0d5062c6-5051-44a3-ae4e-73f15bb93558)

### After
![image](https://github.com/Meridian59/Meridian59/assets/467443/f5f228ef-de66-45e9-9de8-41fcf09e9ca7)


### Before
https://github.com/Meridian59/Meridian59/assets/467443/5266cb8c-55e2-4f49-9ed1-e8b044b67a03

### After
https://github.com/Meridian59/Meridian59/assets/467443/e6db9d5e-0510-4c0c-a728-5c964b18f043

