### PR TITLE
Sorting enhancements for newsglobes

### DIFF
--- a/module/mailnews/newsread.c
+++ b/module/mailnews/newsread.c
@@ -538,7 +538,7 @@ void ListView_SetHeaderSortImage(HWND hListView, int sortedColumn, BOOL sortAsce
 }
 
 /*
-* Resets the news list to it's default sort: by time, descending
+* Resets the news list to its default sort: by time, descending
 */
 void ResetListSort(HWND hListView)
 {

--- a/module/mailnews/newsread.c
+++ b/module/mailnews/newsread.c
@@ -538,13 +538,10 @@ void ListView_SetHeaderSortImage(HWND hListView, int sortedColumn, BOOL sortAsce
 }
 
 /*
-* Resets the news list to its default sort: date descending
+* Resets the news list to it's default sort: date descending
 */
 void ResetListSort(HWND hListView)
 {
-   // 1-based column
-   ListView_SortItems(hListView, CompareListItems, -(COL_TITLE + 1));
-   
-   // 0-based column
-   ListView_SetHeaderSortImage(hListView, COL_TITLE, FALSE);
+   ListView_SortItems(hListView, CompareListItems, -3); // 1-based column
+   ListView_SetHeaderSortImage(hListView, 2, FALSE); // 0-based column
 }

--- a/module/mailnews/newsread.c
+++ b/module/mailnews/newsread.c
@@ -271,7 +271,7 @@ INT_PTR CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
          ListView_EnsureVisible(hList, index, FALSE);
       }
 
-      ListView_SetHeaderSortImage(hList, 2, FALSE);
+      ListView_SetHeaderSortImage(hList, COL_TIME, FALSE);
 
       return TRUE;
 
@@ -538,10 +538,12 @@ void ListView_SetHeaderSortImage(HWND hListView, int sortedColumn, BOOL sortAsce
 }
 
 /*
-* Resets the news list to it's default sort: date descending
+* Resets the news list to it's default sort: by time, descending
 */
 void ResetListSort(HWND hListView)
 {
-   ListView_SortItems(hListView, CompareListItems, -3); // 1-based column
-   ListView_SetHeaderSortImage(hListView, 2, FALSE); // 0-based column
+   // 1-based column
+   ListView_SortItems(hListView, CompareListItems, -(COL_TIME + 1));
+   // 0-based column
+   ListView_SetHeaderSortImage(hListView, COL_TIME, FALSE);
 }

--- a/module/mailnews/newsread.c
+++ b/module/mailnews/newsread.c
@@ -56,6 +56,7 @@ static void UserReplyNewsMail(NewsArticle *article);
 static void OnColumnClick(LPNMLISTVIEW pLVInfo);
 static int CALLBACK CompareListItems(LPARAM lParam1, LPARAM lParam2, LPARAM lParamSort);
 static void ListView_SetHeaderSortImage(HWND hListView, int sortedColumn, BOOL sortAscending);
+static void ResetListSort(HWND hListView);
 
 /****************************************************************************/
 /*
@@ -109,11 +110,6 @@ void ReceiveArticles(WORD newsgroup, BYTE part, BYTE max_part, list_type article
    {
       SendMessage(hReadNewsDialog, BK_ARTICLES, 0, (LPARAM) new_articles);
       last_part = 0;
-      
-      // Set default sort to date column
-      HWND hListView = GetDlgItem(hReadNewsDialog, IDC_NEWSLIST);
-      ListView_SortItems(hListView, CompareListItems, -3);
-      ListView_SetHeaderSortImage(hListView, 2, FALSE);
    }
 }
 /****************************************************************************/
@@ -274,6 +270,9 @@ INT_PTR CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
          ListView_SetItemState(hList, index, LVIS_SELECTED, LVIS_SELECTED);
          ListView_EnsureVisible(hList, index, FALSE);
       }
+
+      ListView_SetHeaderSortImage(hList, 2, FALSE);
+
       return TRUE;
 
    case BK_ARTICLE:
@@ -378,11 +377,13 @@ INT_PTR CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
 	 /* If user posts article, rescan so that it will show up */
 	 if (UserPostArticle(hDlg, info->newsgroup, info->group_name_rsc, NULL))
 	    RequestArticles(info->newsgroup);
+   ResetListSort(hList);
 	 SetFocus(hList);
 	 return TRUE;
 
       case IDC_RESCAN:
 	 RequestArticles(info->newsgroup);
+   ResetListSort(hList);
 	 SetFocus(hList);
 	 return TRUE;
 
@@ -534,4 +535,13 @@ void ListView_SetHeaderSortImage(HWND hListView, int sortedColumn, BOOL sortAsce
       // Set the header item at the current index with the updated details
       Header_SetItem(hHeader, i, &hdi);
    }
+}
+
+/*
+* Resets the news list to it's default sort: date descending
+*/
+void ResetListSort(HWND hListView)
+{
+   ListView_SortItems(hListView, CompareListItems, -3); // 1-based column
+   ListView_SetHeaderSortImage(hListView, 2, FALSE); // 0-based column
 }

--- a/module/mailnews/newsread.c
+++ b/module/mailnews/newsread.c
@@ -538,10 +538,13 @@ void ListView_SetHeaderSortImage(HWND hListView, int sortedColumn, BOOL sortAsce
 }
 
 /*
-* Resets the news list to it's default sort: date descending
+* Resets the news list to its default sort: date descending
 */
 void ResetListSort(HWND hListView)
 {
-   ListView_SortItems(hListView, CompareListItems, -3); // 1-based column
-   ListView_SetHeaderSortImage(hListView, 2, FALSE); // 0-based column
+   // 1-based column
+   ListView_SortItems(hListView, CompareListItems, -(COL_TITLE + 1));
+   
+   // 0-based column
+   ListView_SetHeaderSortImage(hListView, COL_TITLE, FALSE);
 }

--- a/module/mailnews/newsread.c
+++ b/module/mailnews/newsread.c
@@ -109,6 +109,11 @@ void ReceiveArticles(WORD newsgroup, BYTE part, BYTE max_part, list_type article
    {
       SendMessage(hReadNewsDialog, BK_ARTICLES, 0, (LPARAM) new_articles);
       last_part = 0;
+      
+      // Set default sort to date column
+      HWND hListView = GetDlgItem(hReadNewsDialog, IDC_NEWSLIST);
+      ListView_SortItems(hListView, CompareListItems, -3);
+      ListView_SetHeaderSortImage(hListView, 2, FALSE);
    }
 }
 /****************************************************************************/


### PR DESCRIPTION
This PR came about from some comments in #798:
> It might be a good idea to show a down arrow on the Date column when the dialog loads, to indicate the default sort order. Also, if you initially click on the Date column, nothing happens, You have to click twice.

While addressing that feedback, I realized that rescanning and posting new messages introduce new, unsorted items to the list. This PR addresses all of these things by sorting by descending date when articles are first presented, rescanned, and when new articles are posted.