### PR TITLE
Reformats `mailread.c` and `newsread.c` classes

### DIFF
--- a/module/mailnews/mailread.c
+++ b/module/mailnews/mailread.c
@@ -15,12 +15,12 @@
 extern HWND hReadMailDlg; /* Non-NULL if Read Mail dialog is up */
 extern HWND hSendMailDlg; /* Non-NULL if Send Mail dialog is up */
 
-static RECT  dlg_rect;        // Screen position of dialog
+static RECT dlg_rect; // Screen position of dialog
 
 static ChildPlacement mailread_controls[] = {
-{ IDC_MAILLIST,  RDI_TOP | RDI_LEFT | RDI_RIGHT },
-{ IDC_MAILEDIT,  RDI_ALL },
-{ 0,             0 },   // Must end this way
+    {IDC_MAILLIST, RDI_TOP | RDI_LEFT | RDI_RIGHT},
+    {IDC_MAILEDIT, RDI_ALL},
+    {0, 0}, // Must end this way
 };
 
 /* local function prototypes */
@@ -37,23 +37,22 @@ void UserReadMail(void)
    {
       // Don't ask for new mail; might need to wait for user list
       if (CreateDialog(hInst, MAKEINTRESOURCE(IDD_MAILREAD), NULL, ReadMailDialogProc) == NULL)
-	 debug(("CreateDialog failed for read mail dialog\n"));
+         debug(("CreateDialog failed for read mail dialog\n"));
    }
    else
    {
       ShowWindow(hReadMailDlg, SW_SHOWNORMAL);
       SetFocus(hReadMailDlg);
-      
+
       // Ask server for new mail
       RequestReadMail();
    }
-
 }
 /****************************************************************************/
 INT_PTR CALLBACK ReadMailDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 {
    static HWND hEdit, hList;
-   static int mail_index;  /* Number of currently displayed message, -1 if none */
+   static int mail_index; /* Number of currently displayed message, -1 if none */
    MailHeader *header;
    int index, msg_num, count;
    char str[MAX_HEADERLINE], msg[MAXMAIL];
@@ -82,16 +81,16 @@ INT_PTR CALLBACK ReadMailDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
       // Add column headings
       lvcol.mask = LVCF_TEXT | LVCF_WIDTH;
       lvcol.pszText = GetString(hInst, IDS_MHEADER1);
-      lvcol.cx      = 25;
+      lvcol.cx = 25;
       ListView_InsertColumn(hList, 0, &lvcol);
       lvcol.pszText = GetString(hInst, IDS_MHEADER2);
-      lvcol.cx      = 80;
+      lvcol.cx = 80;
       ListView_InsertColumn(hList, 1, &lvcol);
       lvcol.pszText = GetString(hInst, IDS_MHEADER3);
-      lvcol.cx      = 150;
+      lvcol.cx = 150;
       ListView_InsertColumn(hList, 2, &lvcol);
       lvcol.pszText = GetString(hInst, IDS_MHEADER4);
-      lvcol.cx      = 135;
+      lvcol.cx = 135;
       ListView_InsertColumn(hList, 3, &lvcol);
 
       mail_index = -1;
@@ -104,25 +103,26 @@ INT_PTR CALLBACK ReadMailDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
 
    case WM_SIZE:
       ResizeDialog(hDlg, &dlg_rect, mailread_controls);
-      return TRUE;      
+      return TRUE;
 
    case WM_GETMINMAXINFO:
-      lpmmi = (MINMAXINFO *) lParam;
+      lpmmi = (MINMAXINFO *)lParam;
       lpmmi->ptMinTrackSize.x = 200;
       lpmmi->ptMinTrackSize.y = 300;
       return 0;
 
    case WM_ACTIVATE:
       if (wParam == 0)
-	 *cinfo->hCurrentDlg = NULL;
-      else *cinfo->hCurrentDlg = hDlg;
+         *cinfo->hCurrentDlg = NULL;
+      else
+         *cinfo->hCurrentDlg = hDlg;
       return TRUE;
-      
+
    case BK_SETDLGFONTS:
       SetWindowFont(hEdit, GetFont(FONT_MAIL), TRUE);
       SetWindowFont(hList, GetFont(FONT_MAIL), TRUE);
       return TRUE;
-      
+
    case BK_SETDLGCOLORS:
       ListView_SetTextColor(hList, GetColor(COLOR_LISTFGD));
       ListView_SetBkColor(hList, GetColor(COLOR_LISTBGD));
@@ -133,10 +133,10 @@ INT_PTR CALLBACK ReadMailDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
       /* By default, whole message becomes selected for some reason */
       Edit_SetSel(hEdit, -1, 0);
       break;
-      
+
    case BK_NEWMAIL: /* wParam = message number, lParam = message header string */
       msg_num = wParam;
-      header = (MailHeader *) lParam;
+      header = (MailHeader *)lParam;
 
       // Add message to list view
       if (!IsNameInIgnoreList(header->sender))
@@ -165,7 +165,7 @@ INT_PTR CALLBACK ReadMailDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
       // Erase message in status area
       SetDlgItemText(hDlg, IDC_MAILINFO, "");
       return TRUE;
-   
+
    case BK_NONEWMAIL:
       SetDlgItemText(hDlg, IDC_MAILINFO, GetString(hInst, IDS_NONEWMAIL));
       return TRUE;
@@ -176,7 +176,7 @@ INT_PTR CALLBACK ReadMailDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
       HANDLE_MSG(hDlg, WM_CTLCOLORDLG, MailCtlColor);
 
       HANDLE_MSG(hDlg, WM_INITMENUPOPUP, InitMenuPopupHandler);
-      
+
    case WM_CLOSE:
       SendMessage(hDlg, WM_COMMAND, IDCANCEL, 0);
       return TRUE;
@@ -184,105 +184,105 @@ INT_PTR CALLBACK ReadMailDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
    case WM_DESTROY:
       hReadMailDlg = NULL;
       if (exiting)
-	 PostMessage(cinfo->hMain, BK_MODULEUNLOAD, 0, MODULE_ID);
+         PostMessage(cinfo->hMain, BK_MODULEUNLOAD, 0, MODULE_ID);
       return TRUE;
 
    case WM_NOTIFY:
       if (wParam != IDC_MAILLIST)
-	 return TRUE;
+         return TRUE;
 
-      nm = (NM_LISTVIEW *) lParam;
+      nm = (NM_LISTVIEW *)lParam;
 
       switch (nm->hdr.code)
       {
       case NM_CLICK:
-	 // If you click on an item, select it--why doesn't control work this way by default?
-	 GetCursorPos(&lvhit.pt);
-	 ScreenToClient(hList, &lvhit.pt);
-	 lvhit.pt.x = 10;
-	 index = ListView_HitTest(hList, &lvhit);
+         // If you click on an item, select it--why doesn't control work this way by default?
+         GetCursorPos(&lvhit.pt);
+         ScreenToClient(hList, &lvhit.pt);
+         lvhit.pt.x = 10;
+         index = ListView_HitTest(hList, &lvhit);
 
-	 if (index == -1)
-	    break;
+         if (index == -1)
+            break;
 
-	 ListView_SetItemState(hList, index, 
-			       LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
-	 break;
+         ListView_SetItemState(hList, index,
+                               LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
+         break;
 
       case LVN_ITEMCHANGED:
-	 // New item selected; get its message number
-	 lvitem.mask = LVIF_STATE | LVIF_PARAM;
-	 lvitem.stateMask = LVIS_SELECTED;
-	 lvitem.iItem = nm->iItem;
-	 lvitem.iSubItem = 0;
-	 ListView_GetItem(hList, &lvitem);
+         // New item selected; get its message number
+         lvitem.mask = LVIF_STATE | LVIF_PARAM;
+         lvitem.stateMask = LVIS_SELECTED;
+         lvitem.iItem = nm->iItem;
+         lvitem.iSubItem = 0;
+         ListView_GetItem(hList, &lvitem);
 
-	 if (!(lvitem.state & LVIS_SELECTED))
-	    break;
+         if (!(lvitem.state & LVIS_SELECTED))
+            break;
 
-	 msg_num = lvitem.lParam;
-	 if (msg_num == mail_index)
-	    break;
-	 
-	 if (MailLoadMessage(msg_num, MAXMAIL, msg) == False)
-	 {
-	    ClientError(hInst, hReadMailDlg, IDS_CANTLOADMSG);
-	    break;
-	 }
+         msg_num = lvitem.lParam;
+         if (msg_num == mail_index)
+            break;
 
-	 mail_index = msg_num;
-	 Edit_SetText(hEdit, msg);
-	 break;
+         if (MailLoadMessage(msg_num, MAXMAIL, msg) == False)
+         {
+            ClientError(hInst, hReadMailDlg, IDS_CANTLOADMSG);
+            break;
+         }
+
+         mail_index = msg_num;
+         Edit_SetText(hEdit, msg);
+         break;
       }
       return TRUE;
 
    case WM_COMMAND:
       UserDidSomething();
 
-      switch(GET_WM_COMMAND_ID(wParam, lParam))
+      switch (GET_WM_COMMAND_ID(wParam, lParam))
       {
       case IDC_DELETEMSG:
-	 if (!ListViewGetCurrentData(hList, &index, &msg_num))
-	    return TRUE;
-	 
-	 if (MailDeleteMessage(msg_num) == True)
-	 {
-	    /* Display new current message, if any */
-	    Edit_SetText(hEdit, "");
-	    ListView_DeleteItem(hList, index);
+         if (!ListViewGetCurrentData(hList, &index, &msg_num))
+            return TRUE;
 
-	    count = ListView_GetItemCount(hList);
-	    if (count == 0)
-	       return TRUE;
+         if (MailDeleteMessage(msg_num) == True)
+         {
+            /* Display new current message, if any */
+            Edit_SetText(hEdit, "");
+            ListView_DeleteItem(hList, index);
 
-	    index = min(index, count - 1);  // in case last message deleted
-	    ListView_SetItemState(hList, index, LVIS_SELECTED, LVIS_SELECTED);
-	 }
-	 return TRUE;
+            count = ListView_GetItemCount(hList);
+            if (count == 0)
+               return TRUE;
+
+            index = min(index, count - 1); // in case last message deleted
+            ListView_SetItemState(hList, index, LVIS_SELECTED, LVIS_SELECTED);
+         }
+         return TRUE;
 
       case IDC_RESCAN:
-	 SetDlgItemText(hDlg, IDC_MAILINFO, GetString(hInst, IDS_GETTINGMSGS));
-	 RequestReadMail();
-	 return TRUE;
+         SetDlgItemText(hDlg, IDC_MAILINFO, GetString(hInst, IDS_GETTINGMSGS));
+         RequestReadMail();
+         return TRUE;
 
       case IDC_SEND:
-	 UserSendMail();
-	 return TRUE;
+         UserSendMail();
+         return TRUE;
 
       case IDC_REPLY:
       case IDC_REPLYALL:
-	 /* Find message number for currently selected message */
-	 if (!ListViewGetCurrentData(hList, &index, &msg_num))
-	    return TRUE;
+         /* Find message number for currently selected message */
+         if (!ListViewGetCurrentData(hList, &index, &msg_num))
+            return TRUE;
 
-	 UserMailReply(msg_num, (Bool) (GET_WM_COMMAND_ID(wParam, lParam) == IDC_REPLYALL));
-	 return TRUE;
+         UserMailReply(msg_num, (Bool)(GET_WM_COMMAND_ID(wParam, lParam) == IDC_REPLYALL));
+         return TRUE;
 
       case IDCANCEL:
-	 /* Note:  This code is also used by the WM_CLOSE message */
-	 MailDeleteMessageList();
-	 DestroyWindow(hDlg);
-	 return TRUE;
+         /* Note:  This code is also used by the WM_CLOSE message */
+         MailDeleteMessageList();
+         DestroyWindow(hDlg);
+         return TRUE;
       }
       break;
    }
@@ -290,7 +290,7 @@ INT_PTR CALLBACK ReadMailDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
 }
 /****************************************************************************/
 /*
- * ListViewGetCurrentData:  Set index to index of currently selected item 
+ * ListViewGetCurrentData:  Set index to index of currently selected item
  *   in given list view control, and data to its lParam value.
  * Return True if a selected item is found, False otherwise.
  */
@@ -304,16 +304,16 @@ Bool ListViewGetCurrentData(HWND hList, int *index, int *data)
    lvitem.mask = LVIF_STATE | LVIF_PARAM;
    lvitem.iSubItem = 0;
    lvitem.stateMask = LVIS_SELECTED;
-   for (i=0; i < num; i++)
+   for (i = 0; i < num; i++)
    {
       lvitem.iItem = i;
       ListView_GetItem(hList, &lvitem);
-      
+
       if (lvitem.state & LVIS_SELECTED)
       {
-	 *index = i;
-	 *data = lvitem.lParam;
-	 return True;
+         *index = i;
+         *data = lvitem.lParam;
+         return True;
       }
    }
    return False;
@@ -327,7 +327,7 @@ void UserMailReply(int msg_num, Bool reply_all)
 {
    MailInfo *reply;
 
-   reply = (MailInfo *) SafeMalloc(sizeof(MailInfo));  // Freed when reply dialog ends
+   reply = (MailInfo *)SafeMalloc(sizeof(MailInfo)); // Freed when reply dialog ends
 
    MailParseMessage(msg_num, reply);
 
@@ -335,10 +335,10 @@ void UserMailReply(int msg_num, Bool reply_all)
    {
       if (reply->num_recipients >= MAX_RECIPIENTS)
       {
-	 // If user wants to go ahead anyway, just truncate recipients
-	 if (!AreYouSure(hInst, hReadMailDlg, NO_BUTTON, IDS_TOOMANYRECIPIENTS, MAX_RECIPIENTS))
-	    return;
-	 reply->num_recipients--;  // Add sender below
+         // If user wants to go ahead anyway, just truncate recipients
+         if (!AreYouSure(hInst, hReadMailDlg, NO_BUTTON, IDS_TOOMANYRECIPIENTS, MAX_RECIPIENTS))
+            return;
+         reply->num_recipients--; // Add sender below
       }
 
       strcpy(reply->recipients[reply->num_recipients], reply->sender);

--- a/module/mailnews/newsread.c
+++ b/module/mailnews/newsread.c
@@ -23,21 +23,22 @@ static HBITMAP hbmUpArrow = NULL;
 static HBITMAP hbmDownArrow = NULL;
 
 /* Stuff for making raw times into human-readable times */
-static int months[] = 
-{IDS_JANUARY, IDS_FEBRUARY, IDS_MARCH, IDS_APRIL, IDS_MAY, IDS_JUNE, IDS_JULY,
-    IDS_AUGUST, IDS_SEPTEMBER, IDS_OCTOBER, IDS_NOVEMBER, IDS_DECEMBER};
-static int weekdays[] = 
-{IDS_SUNDAY, IDS_MONDAY, IDS_TUESDAY, IDS_WEDNESDAY, IDS_THURSDAY, IDS_FRIDAY, IDS_SATURDAY};
+static int months[] =
+    {IDS_JANUARY, IDS_FEBRUARY, IDS_MARCH, IDS_APRIL, IDS_MAY, IDS_JUNE, IDS_JULY,
+     IDS_AUGUST, IDS_SEPTEMBER, IDS_OCTOBER, IDS_NOVEMBER, IDS_DECEMBER};
+static int weekdays[] =
+    {IDS_SUNDAY, IDS_MONDAY, IDS_TUESDAY, IDS_WEDNESDAY, IDS_THURSDAY, IDS_FRIDAY, IDS_SATURDAY};
 
-static list_type new_articles = NULL;   /* Build up new articles arriving from server */
+static list_type new_articles = NULL; /* Build up new articles arriving from server */
 
-static RECT  dlg_rect;        // Screen position of dialog
+static RECT dlg_rect; // Screen position of dialog
 
 // Constants for news dialog columns
-typedef enum {
-    COL_TITLE = 0,
-    COL_POSTER = 1,
-    COL_TIME = 2
+typedef enum
+{
+   COL_TITLE = 0,
+   COL_POSTER = 1,
+   COL_TIME = 2
 } NewsColumns;
 
 // Constants used to track sorted column
@@ -45,9 +46,9 @@ static int currentSortColumn = -1;
 static bool currentSortAscending = TRUE;
 
 static ChildPlacement newsread_controls[] = {
-{ IDC_NEWSEDIT,   RDI_ALL },
-{ IDC_NEWSLIST,   RDI_RIGHT | RDI_LEFT | RDI_TOP },
-{ 0,              0 },   // Must end this way
+    {IDC_NEWSEDIT, RDI_ALL},
+    {IDC_NEWSLIST, RDI_RIGHT | RDI_LEFT | RDI_TOP},
+    {0, 0}, // Must end this way
 };
 
 /* local function prototypes */
@@ -73,13 +74,13 @@ void UserReadNews(object_node *obj, char *desc, WORD newsgroup, BYTE permissions
    if (hReadNewsDialog != NULL)
       return;
 
-   s.newsgroup      = newsgroup;
+   s.newsgroup = newsgroup;
    s.group_name_rsc = obj->name_res;
-   s.permissions    = permissions;
-   s.desc           = desc;
+   s.permissions = permissions;
+   s.desc = desc;
 
    DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_NEWSREAD), cinfo->hMain,
-		  ReadNewsDialogProc, (LPARAM) &s);
+                  ReadNewsDialogProc, (LPARAM)&s);
 }
 /****************************************************************************/
 /*
@@ -89,7 +90,7 @@ void UserReadNews(object_node *obj, char *desc, WORD newsgroup, BYTE permissions
  */
 void ReceiveArticles(WORD newsgroup, BYTE part, BYTE max_part, list_type articles)
 {
-   static int last_part = 0;           /* Last part we received */
+   static int last_part = 0; /* Last part we received */
 
    // Make sure that parts are arriving in order
    if (hReadNewsDialog == NULL || part != last_part + 1)
@@ -108,7 +109,7 @@ void ReceiveArticles(WORD newsgroup, BYTE part, BYTE max_part, list_type article
 
    if (part == max_part)
    {
-      SendMessage(hReadNewsDialog, BK_ARTICLES, 0, (LPARAM) new_articles);
+      SendMessage(hReadNewsDialog, BK_ARTICLES, 0, (LPARAM)new_articles);
       last_part = 0;
    }
 }
@@ -121,12 +122,12 @@ void UserReadArticle(char *article)
    if (hReadNewsDialog == NULL)
       return;
 
-   SendMessage(hReadNewsDialog, BK_ARTICLE, 0, (LPARAM) article);
+   SendMessage(hReadNewsDialog, BK_ARTICLE, 0, (LPARAM)article);
 }
 /****************************************************************************/
 INT_PTR CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 {
-   static ReadNewsDialogStruct* info = NULL;
+   static ReadNewsDialogStruct *info = NULL;
    static HWND hEdit = NULL;
    static HWND hList = NULL;
    static int article_index = -1;
@@ -140,14 +141,14 @@ INT_PTR CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
    LV_ITEM lvitem;
    LV_HITTESTINFO lvhit;
    NM_LISTVIEW *nm;
-   
+
    char date[MAXDATE], title[MAX_SUBJECT + MAXDATE + MAXNAME + 10];
 
    switch (message)
    {
    case WM_INITDIALOG:
       CenterWindow(hDlg, cinfo->hMain);
-      info = (ReadNewsDialogStruct *) lParam;
+      info = (ReadNewsDialogStruct *)lParam;
 
       hList = GetDlgItem(hDlg, IDC_NEWSLIST);
       hEdit = GetDlgItem(hDlg, IDC_NEWSEDIT);
@@ -163,23 +164,23 @@ INT_PTR CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
 
       // Set newsgroup description and window title
       SetWindowText(GetDlgItem(hDlg, IDC_NEWSDESC), info->desc);
-      GetWindowText(hDlg, title, MAXNAME);  // Append group name to window title
+      GetWindowText(hDlg, title, MAXNAME); // Append group name to window title
       strncat(title, LookupNameRsc(info->group_name_rsc), MAX_SUBJECT);
       SetWindowText(hDlg, title);
-      
+
       EnableWindow(GetDlgItem(hDlg, IDC_REPLY), FALSE);
       EnableWindow(GetDlgItem(hDlg, IDC_REPLYMAIL), FALSE);
 
       // Add column headings
       lvcol.mask = LVCF_TEXT | LVCF_WIDTH;
       lvcol.pszText = GetString(hInst, IDS_NHEADER1);
-      lvcol.cx      = 190;
+      lvcol.cx = 190;
       ListView_InsertColumn(hList, 0, &lvcol);
       lvcol.pszText = GetString(hInst, IDS_NHEADER2);
-      lvcol.cx      = 80;
+      lvcol.cx = 80;
       ListView_InsertColumn(hList, 1, &lvcol);
       lvcol.pszText = GetString(hInst, IDS_NHEADER3);
-      lvcol.cx      = 135;
+      lvcol.cx = 135;
       ListView_InsertColumn(hList, 2, &lvcol);
 
       article_index = -1;
@@ -187,35 +188,35 @@ INT_PTR CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
 
       // Ask for articles if we have read permission
       if (info->permissions & NEWS_READ)
-	 RequestArticles(info->newsgroup);
+         RequestArticles(info->newsgroup);
       else
-	 EnableWindow(GetDlgItem(hDlg, IDC_RESCAN), FALSE);
+         EnableWindow(GetDlgItem(hDlg, IDC_RESCAN), FALSE);
 
       // Disable post button if we don't have permission
       if (!(info->permissions & NEWS_POST))
-	 EnableWindow(GetDlgItem(hDlg, IDC_NEWSPOST), FALSE);
+         EnableWindow(GetDlgItem(hDlg, IDC_NEWSPOST), FALSE);
 
       SetTimer(hDlg, 1, 100, NULL);
 
       hReadNewsDialog = hDlg;
 
       // Load sort arrow bitmaps
-      hbmUpArrow = (HBITMAP)LoadImage(hInst, 
-         MAKEINTRESOURCE(IDB_UPARROW), IMAGE_BITMAP, 0, 0, 
-         LR_LOADTRANSPARENT | LR_LOADMAP3DCOLORS);
+      hbmUpArrow = (HBITMAP)LoadImage(hInst,
+                                      MAKEINTRESOURCE(IDB_UPARROW), IMAGE_BITMAP, 0, 0,
+                                      LR_LOADTRANSPARENT | LR_LOADMAP3DCOLORS);
 
-      hbmDownArrow = (HBITMAP)LoadImage(hInst, 
-         MAKEINTRESOURCE(IDB_DOWNARROW), IMAGE_BITMAP, 0, 0, 
-         LR_LOADTRANSPARENT | LR_LOADMAP3DCOLORS);
-         
+      hbmDownArrow = (HBITMAP)LoadImage(hInst,
+                                        MAKEINTRESOURCE(IDB_DOWNARROW), IMAGE_BITMAP, 0, 0,
+                                        LR_LOADTRANSPARENT | LR_LOADMAP3DCOLORS);
+
       return TRUE;
 
    case WM_SIZE:
       ResizeDialog(hDlg, &dlg_rect, newsread_controls);
-      return TRUE;      
+      return TRUE;
 
    case WM_GETMINMAXINFO:
-      lpmmi = (MINMAXINFO *) lParam;
+      lpmmi = (MINMAXINFO *)lParam;
       lpmmi->ptMinTrackSize.x = 200;
       lpmmi->ptMinTrackSize.y = 300;
       return 0;
@@ -224,19 +225,19 @@ INT_PTR CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
       /* Get rid of old index, if any */
       if (info->articles != NULL)
          list_destroy(info->articles);
-      
-      info->articles = (list_type) lParam;
-      
+
+      info->articles = (list_type)lParam;
+
       /* Put article title lines in list box; save old position if appropriate */
       index = -1;
       if (ListView_GetItemCount(hList) > 0)
-         if (!ListViewGetCurrentData(hList, &index, (int *) &article))
+         if (!ListViewGetCurrentData(hList, &index, (int *)&article))
             index = -1;
       ListView_DeleteAllItems(hList);
       for (l = info->articles; l != NULL; l = l->next)
       {
-         article = (NewsArticle *) (l->data);
-         
+         article = (NewsArticle *)(l->data);
+
          // Add article to list view
          if (!IsNameInIgnoreList(article->poster))
          {
@@ -244,28 +245,28 @@ INT_PTR CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
             lvitem.iItem = ListView_GetItemCount(hList);
             lvitem.iSubItem = 0;
             lvitem.pszText = article->title;
-            lvitem.lParam = (LPARAM) article;
+            lvitem.lParam = (LPARAM)article;
             ListView_InsertItem(hList, &lvitem);
-         
+
             // Add subitems
             lvitem.mask = LVIF_TEXT;
             lvitem.iSubItem = 1;
             lvitem.pszText = article->poster;
             ListView_SetItem(hList, &lvitem);
-         
+
             DateFromSeconds(article->time, date);
             lvitem.iSubItem = 2;
             lvitem.pszText = date;
             ListView_SetItem(hList, &lvitem);
          }
       }
-      
+
       /* Get first article by faking select message */
       if (index == -1)
       {
          ListView_SetItemState(hList, 0, LVIS_SELECTED, LVIS_SELECTED);
       }
-      else 
+      else
       {
          ListView_SetItemState(hList, index, LVIS_SELECTED, LVIS_SELECTED);
          ListView_EnsureVisible(hList, index, FALSE);
@@ -277,9 +278,9 @@ INT_PTR CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
 
    case BK_ARTICLE:
       /* Display article's text */
-      SetWindowText(hEdit, (char *) lParam);
+      SetWindowText(hEdit, (char *)lParam);
       if (info->permissions & NEWS_POST)
-	 EnableWindow(GetDlgItem(hDlg, IDC_REPLY), TRUE);
+         EnableWindow(GetDlgItem(hDlg, IDC_REPLY), TRUE);
       EnableWindow(GetDlgItem(hDlg, IDC_REPLYMAIL), TRUE);
       SetTimer(hDlg, 1, 1000, NULL);
       return TRUE;
@@ -288,58 +289,58 @@ INT_PTR CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
       HANDLE_MSG(hDlg, WM_CTLCOLORLISTBOX, MailCtlColor);
       HANDLE_MSG(hDlg, WM_CTLCOLORSTATIC, MailCtlColor);
       HANDLE_MSG(hDlg, WM_CTLCOLORDLG, MailCtlColor);
-      
+
    case WM_NOTIFY:
-      if ((((LPNMHDR) lParam)->idFrom == IDC_NEWSLIST) &&
-          (((LPNMHDR) lParam)->code == LVN_COLUMNCLICK))
-         OnColumnClick((LPNMLISTVIEW) lParam);
+      if ((((LPNMHDR)lParam)->idFrom == IDC_NEWSLIST) &&
+          (((LPNMHDR)lParam)->code == LVN_COLUMNCLICK))
+         OnColumnClick((LPNMLISTVIEW)lParam);
 
       if (wParam != IDC_NEWSLIST)
-	 return TRUE;
+         return TRUE;
 
-      nm = (NM_LISTVIEW *) lParam;
+      nm = (NM_LISTVIEW *)lParam;
 
       switch (nm->hdr.code)
       {
       case NM_CLICK:
-	 // If you click on an item, select it--why doesn't control work this way by default?
-	 GetCursorPos(&lvhit.pt);
-	 ScreenToClient(hList, &lvhit.pt);
-	 lvhit.pt.x = 10;
-	 index = ListView_HitTest(hList, &lvhit);
-	 if (index == -1)
-	    break;
+         // If you click on an item, select it--why doesn't control work this way by default?
+         GetCursorPos(&lvhit.pt);
+         ScreenToClient(hList, &lvhit.pt);
+         lvhit.pt.x = 10;
+         index = ListView_HitTest(hList, &lvhit);
+         if (index == -1)
+            break;
 
-	 ListView_SetItemState(hList, index, 
-			       LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
-	 break;
+         ListView_SetItemState(hList, index,
+                               LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
+         break;
 
       case LVN_ITEMCHANGED:
-	 // New item selected; get its message number
-	 lvitem.mask = LVIF_STATE | LVIF_PARAM;
-	 lvitem.stateMask = LVIS_SELECTED;
-	 lvitem.iItem = nm->iItem;
-	 lvitem.iSubItem = 0;
-	 ListView_GetItem(hList, &lvitem);
+         // New item selected; get its message number
+         lvitem.mask = LVIF_STATE | LVIF_PARAM;
+         lvitem.stateMask = LVIS_SELECTED;
+         lvitem.iItem = nm->iItem;
+         lvitem.iSubItem = 0;
+         ListView_GetItem(hList, &lvitem);
 
-	 if (!(lvitem.state & LVIS_SELECTED))
-	    break;
+         if (!(lvitem.state & LVIS_SELECTED))
+            break;
 
-	 article = (NewsArticle *) lvitem.lParam;
-	 if (article->num == article_index)
-	    break;
+         article = (NewsArticle *)lvitem.lParam;
+         if (article->num == article_index)
+            break;
 
-	 lastRequestedIndex = article->num;
+         lastRequestedIndex = article->num;
 
-	 break;
+         break;
       }
       return TRUE;
 
    case WM_TIMER:
       if (article_index != lastRequestedIndex)
       {
-	 article_index = lastRequestedIndex;
-	 RequestArticle(info->newsgroup, article_index);
+         article_index = lastRequestedIndex;
+         RequestArticle(info->newsgroup, article_index);
       }
       SetTimer(hDlg, 1, 100, NULL);
       break;
@@ -348,51 +349,51 @@ INT_PTR CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPAR
       hReadNewsDialog = NULL;
       KillTimer(hDlg, 1);
       if (exiting)
-	 PostMessage(cinfo->hMain, BK_MODULEUNLOAD, 0, MODULE_ID);
+         PostMessage(cinfo->hMain, BK_MODULEUNLOAD, 0, MODULE_ID);
       return TRUE;
 
    case WM_COMMAND:
       UserDidSomething();
 
-      switch(GET_WM_COMMAND_ID(wParam, lParam))
+      switch (GET_WM_COMMAND_ID(wParam, lParam))
       {
       case IDC_REPLY:
-	 if (!ListViewGetCurrentData(hList, &index, (int *) &article))
-	    break;
+         if (!ListViewGetCurrentData(hList, &index, (int *)&article))
+            break;
 
-	 /* If user posts article, rescan so that it will show up */
-	 if (UserPostArticle(hDlg, info->newsgroup, info->group_name_rsc, article->title))
-	    RequestArticles(info->newsgroup);
-	 SetFocus(hList);
-	 return TRUE;
+         /* If user posts article, rescan so that it will show up */
+         if (UserPostArticle(hDlg, info->newsgroup, info->group_name_rsc, article->title))
+            RequestArticles(info->newsgroup);
+         SetFocus(hList);
+         return TRUE;
 
       case IDC_REPLYMAIL:
-	 if (!ListViewGetCurrentData(hList, &index, (int *) &article))
-	    break;
+         if (!ListViewGetCurrentData(hList, &index, (int *)&article))
+            break;
 
-	 UserReplyNewsMail(article);
-	 return TRUE;
+         UserReplyNewsMail(article);
+         return TRUE;
 
       case IDC_NEWSPOST:
-	 /* If user posts article, rescan so that it will show up */
-	 if (UserPostArticle(hDlg, info->newsgroup, info->group_name_rsc, NULL))
-	    RequestArticles(info->newsgroup);
-   ResetListSort(hList);
-	 SetFocus(hList);
-	 return TRUE;
+         /* If user posts article, rescan so that it will show up */
+         if (UserPostArticle(hDlg, info->newsgroup, info->group_name_rsc, NULL))
+            RequestArticles(info->newsgroup);
+         ResetListSort(hList);
+         SetFocus(hList);
+         return TRUE;
 
       case IDC_RESCAN:
-	 RequestArticles(info->newsgroup);
-   ResetListSort(hList);
-	 SetFocus(hList);
-	 return TRUE;
+         RequestArticles(info->newsgroup);
+         ResetListSort(hList);
+         SetFocus(hList);
+         return TRUE;
 
       case IDOK:
       case IDCANCEL:
-	 info->articles = list_destroy(info->articles);
-         new_articles   = NULL;
-	 EndDialog(hDlg, 0);
-	 return TRUE;
+         info->articles = list_destroy(info->articles);
+         new_articles = NULL;
+         EndDialog(hDlg, 0);
+         return TRUE;
       }
    }
    return FALSE;
@@ -405,7 +406,7 @@ void UserReplyNewsMail(NewsArticle *article)
 {
    MailInfo *reply;
 
-   reply = (MailInfo *) SafeMalloc(sizeof(MailInfo));  // Freed when reply dialog ends
+   reply = (MailInfo *)SafeMalloc(sizeof(MailInfo)); // Freed when reply dialog ends
 
    reply->num_recipients = 1;
    strcpy(reply->recipients[0], article->poster);
@@ -415,7 +416,7 @@ void UserReplyNewsMail(NewsArticle *article)
 }
 /****************************************************************************/
 /*
- * DateFromSeconds:  Given a time in minutes since midnight, Jan. 1, 1996 UT, 
+ * DateFromSeconds:  Given a time in minutes since midnight, Jan. 1, 1996 UT,
  *   fill in str to contain a string describing the date and time, such as
  *   "Dec 25, 1994 18:00".
  *   str must have length at least MAXDATE.
@@ -426,49 +427,49 @@ Bool DateFromSeconds(long seconds, char *str)
    struct tm *t;
    time_t local_time = seconds;
 
-   local_time += 1534000000L;    // Offset to sometime in mid-2018
+   local_time += 1534000000L; // Offset to sometime in mid-2018
    t = localtime(&local_time);
 
    if (t == NULL)
       return False;
 
-   snprintf(str, MAXDATE, "%s %s %.2ld, %.4ld %.2ld:%.2ld", 
-	   GetString(hInst, weekdays[t->tm_wday]), GetString(hInst, months[t->tm_mon]), 
-	   t->tm_mday, t->tm_year + 1900, t->tm_hour, t->tm_min);
+   snprintf(str, MAXDATE, "%s %s %.2ld, %.4ld %.2ld:%.2ld",
+            GetString(hInst, weekdays[t->tm_wday]), GetString(hInst, months[t->tm_mon]),
+            t->tm_mday, t->tm_year + 1900, t->tm_hour, t->tm_min);
    return True;
 }
 
 void OnColumnClick(LPNMLISTVIEW pLVInfo)
 {
-    int nSortColumn = pLVInfo->iSubItem;
-    bool bSortAscending = TRUE;
+   int nSortColumn = pLVInfo->iSubItem;
+   bool bSortAscending = TRUE;
 
-    if (nSortColumn == currentSortColumn) 
-    {
-        // Toggle sort direction if the same column is clicked again
-        currentSortAscending = !currentSortAscending;
-    } 
-    else 
-    {
-        // Set ascending order for new column
-        currentSortColumn = nSortColumn;
-        currentSortAscending = TRUE;
-    }
+   if (nSortColumn == currentSortColumn)
+   {
+      // Toggle sort direction if the same column is clicked again
+      currentSortAscending = !currentSortAscending;
+   }
+   else
+   {
+      // Set ascending order for new column
+      currentSortColumn = nSortColumn;
+      currentSortAscending = TRUE;
+   }
 
-    LPARAM lParamSort = (currentSortAscending ? 1 : -1) * (currentSortColumn + 1);
+   LPARAM lParamSort = (currentSortAscending ? 1 : -1) * (currentSortColumn + 1);
 
-    if (hbmUpArrow != NULL && hbmDownArrow != NULL)
-    {
-       ListView_SetHeaderSortImage(pLVInfo->hdr.hwndFrom, currentSortColumn, currentSortAscending);
-    }
-    
-    // Sort list
-    ListView_SortItems(pLVInfo->hdr.hwndFrom, CompareListItems, lParamSort);
+   if (hbmUpArrow != NULL && hbmDownArrow != NULL)
+   {
+      ListView_SetHeaderSortImage(pLVInfo->hdr.hwndFrom, currentSortColumn, currentSortAscending);
+   }
+
+   // Sort list
+   ListView_SortItems(pLVInfo->hdr.hwndFrom, CompareListItems, lParamSort);
 }
 
 /****************************************************************************/
 /*
- * CompareListItems: Comparison function for sorting items in the news dialog 
+ * CompareListItems: Comparison function for sorting items in the news dialog
  * list view.
  */
 int CALLBACK CompareListItems(LPARAM lParam1, LPARAM lParam2, LPARAM lParamSort)
@@ -509,7 +510,7 @@ void ListView_SetHeaderSortImage(HWND hListView, int sortedColumn, BOOL sortAsce
    // Get the handle to the header control associated with the list view
    HWND hHeader = ListView_GetHeader(hListView);
    if (!hHeader)
-       return;
+      return;
 
    int columnCount = Header_GetItemCount(hHeader);
 
@@ -517,7 +518,7 @@ void ListView_SetHeaderSortImage(HWND hListView, int sortedColumn, BOOL sortAsce
    {
       HDITEM hdi = {0};
       hdi.mask = HDI_FORMAT | HDI_BITMAP;
-      
+
       // Get the current format of the header item
       Header_GetItem(hHeader, i, &hdi);
 
@@ -538,8 +539,8 @@ void ListView_SetHeaderSortImage(HWND hListView, int sortedColumn, BOOL sortAsce
 }
 
 /*
-* Resets the news list to its default sort: by time, descending
-*/
+ * Resets the news list to its default sort: by time, descending
+ */
 void ResetListSort(HWND hListView)
 {
    // 1-based column


### PR DESCRIPTION
This PR reformats `mailread.c` and `newsread.c` using `clang-format`'s default Visual Studio formatting style. This is partly to tidy up, but also to make working with them easier as I look to apply the sorting logic from news to mail.