### PR TITLE
Adds 'hello' response for Rodric d'Stane

### DIFF
--- a/kod/util/library.kod
+++ b/kod/util/library.kod
@@ -92,6 +92,7 @@ resources:
    LM_Haz_entroot_response = "The mummies use the magic of the entroot to keep the magic that animates them sustained.  Perhaps one of them carries entroot."
    LM_haz_smith_buy = "If you happen to come across a stray weapon or armor, I could probably scrounge enough to take it off your hands."
    LM_haz_smith_sell = "I've got a few weapons behind the counter I can show you.  Type BUY."
+   LM_haz_elder_greeting = "Ah, greetings, adventurer!  May your journey be filled with fortune and glory."
    LM_haz_elder_buy = "I have no need of worldly goods."
    LM_haz_elder_sell = "Do I look like a common peddler?  Nay!"
    LM_haz_apoth_buy = "I'm running low on just about everything.  Should you find reagents, I'll happily take them off your hands."
@@ -1268,7 +1269,8 @@ messages:
         [[LT_eric],0,[LIBACT_SAY,LM_haz_eric]],      
        [[LT_ravi],0,[LIBACT_SAY,LM_haz_ravi]],
        [[LT_marcus],0,[LIBACT_SAY,LM_haz_marcus]],      
-       [[LT_tomas],0,[LIBACT_SAY,LM_haz_tomas]]      
+       [[LT_tomas],0,[LIBACT_SAY,LM_haz_tomas]],
+      [[LT_hello],0, [LIBACT_SAY,LM_haz_elder_greeting]]  
     ]],plSpeechLib);
      plSpeechLib = Cons(
     [&hazarApothecary,[


### PR DESCRIPTION
Rodric is the first NPC's new player's encounter and is accompanied by a tutorial sign directing the user to say "HELLO" to get a reaction. The only problem is, Rodric doesn't have a trigger or response for this command. This adds a simple greeting in response to a player saying "hello".

> Ah, greetings, adventurer!  May your journey be filled with fortune and glory.

![Screenshot 2024-07-13 195832](https://github.com/user-attachments/assets/e9119a5b-758e-4615-8aef-6fab7d7cd451)

### Deployment notes:
- A recreate() call on Library is needed to rebuild the library with this new response.

This PR closes #610.