### PR TITLE
Statically size the player map marker

### DIFF
--- a/clientd3d/map.c
+++ b/clientd3d/map.c
@@ -21,11 +21,12 @@
 
 #define MAP_WALL_THICKNESS 1
 #define MAP_PLAYER_THICKNESS 2
-#define MAP_OBJECT_THICKNESS 2
+#define MAP_OBJECT_THICKNESS 3
+
+#define MAP_PLAYER_MARKER_SIZE 3
 
 #define MAP_WALL_COLOR          PALETTERGB(0, 0, 0)
 #define MAP_PLAYER_COLOR        PALETTERGB(0, 0, 255)
-#define MAP_PLAYER_FRONT_COLOR  PALETTERGB(0, 0, 0)   // Pixel at front of player
 #define MAP_OBJECT_COLOR        PALETTERGB(255, 0, 0)
 
 #define MAP_FRIEND_COLOR        PALETTERGB(0, 255, 0)
@@ -477,9 +478,9 @@ void MapDrawPlayer(HDC hdc, int x, int y, float scale)
 
    hOldPen = (HPEN) SelectObject(hdc, hPlayerPen);
 
-   FindOffsets(player.width * 3 / 4, player.angle, &dx, &dy);
-   FindOffsets(player.width / 4, player.angle+NUMDEGREES/4, &ldx, &ldy);
-   FindOffsets(player.width / 4, player.angle-NUMDEGREES/4, &rdx, &rdy);
+   FindOffsets(MAP_PLAYER_MARKER_SIZE * 3, player.angle, &dx, &dy);
+   FindOffsets(MAP_PLAYER_MARKER_SIZE, player.angle+NUMDEGREES/4, &ldx, &ldy);
+   FindOffsets(MAP_PLAYER_MARKER_SIZE, player.angle-NUMDEGREES/4, &rdx, &rdy);
 
    if (config.showMapBlocking)
    {
@@ -491,22 +492,15 @@ void MapDrawPlayer(HDC hdc, int x, int y, float scale)
       Ellipse(hdc, rc.left, rc.top, rc.right+1, rc.bottom+1);
       SelectObject(hdc, hOldBrush);
    }
+   
    x += (int) (player.x * scale);
    y += (int) (player.y * scale);
-   dx = (int) (dx * scale);
-   dy = (int) (dy * scale);
-   ldx = (int) (ldx * scale);
-   ldy = (int) (ldy * scale);
-   rdx = (int) (rdx * scale);
-   rdy = (int) (rdy * scale);
+
    MoveToEx(hdc, x - dx, y - dy, NULL);
    LineTo(hdc, x + dx, y + dy);
    LineTo(hdc, x + ldx, y + ldy);
    LineTo(hdc, x + rdx, y + rdy);
    LineTo(hdc, x + dx, y + dy);
-
-   // Indicate front of player
-   //SetPixel(hdc, x + dx, y + dy, MAP_PLAYER_FRONT_COLOR);
 
    SelectObject(hdc, hOldPen);
 }


### PR DESCRIPTION
This PR makes two changes to the map:

1. It makes the player map marker static in size rather than based on the player width, which causes the current player marker to scale with map zoom. Today's map marker and player direction are almost indistinguishable when zoomed out or when the player zones into larger rooms. This PR uses a new `MAP_PLAYER_MARKER_SIZE` macro to draw and maintain a statically sized marker.
2. Map objects like monsters and other players are static, but perhaps a tad too small. This PR increases the thickness of these markers/dots by 1.

Here are screenshots showing 3 levels of zoom with these changes in effect:
![Screenshot 2024-07-20 140307](https://github.com/user-attachments/assets/98636ae5-c09c-4c96-894e-72321b513515)
![Screenshot 2024-07-20 140249](https://github.com/user-attachments/assets/a8c18acf-55bb-4c92-bcf2-25a339f0db71)
![Screenshot 2024-07-20 140227](https://github.com/user-attachments/assets/aa5ba004-c756-4285-ad8d-386a21adeb96)

I believe this PR closes #744 

Note: I removed the unused `MAP_PLAYER_FRONT_COLOR` macro and commented out use of it.