### PR TITLE
Adds ignore for temporary roomedit files (`room.roo~`) to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ bin/rscprint.exe
 bin/waveplay.dll
 install/meridian59-installer.exe
 roomedit/windeu32.log
+resource/rooms/*~
 
 # Include runtime scripts
 !run/scripts


### PR DESCRIPTION
This PR adds a new ignore for the temporary `filename.roo~` files created by room edit.