### PR TITLE
Add missing word in Spiritual Hammer spell

### DIFF
--- a/kod/object/passive/spell/creasphm.kod
+++ b/kod/object/passive/spell/creasphm.kod
@@ -16,7 +16,7 @@ constants:
 resources:
 
    createspiritualhammer_cast_rsc = "A spiritual hammer appears."
-   createspiritualhammer_inv_full_rsc = "A spiritual appears in the air before you, "
+   createspiritualhammer_inv_full_rsc = "A spiritual hammer appears in the air before you, "
       "but before you can drop something and grab it, it vanishes."
 
    createspiritualhammer_name_rsc = "spiritual hammer"


### PR DESCRIPTION
Add the word hammer to the text that happens when you cannot hold a spiritual hammer.