### PR TITLE
Single render pass for translucent overlays

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -7356,6 +7356,9 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 
 	anglePitch = PlayerGetHeightOffset();
 
+	// drawdata[] may contain more than one entry with the same id.
+	// We need to keep track of those we've already processed to avoid duplicates.
+	std::unordered_set<int> processedIds;
 	for (curObject = 0; curObject < nitems; curObject++)
 	{
 		list_type	list2;
@@ -7365,6 +7368,10 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 			continue;
 
 		pRNode = drawdata[curObject].u.object.object->draw.obj;
+
+		if (processedIds.find(pRNode->obj.id) != processedIds.end())
+			continue;
+		processedIds.insert(pRNode->obj.id);
 
 		if (pRNode == NULL)
 			continue;
@@ -7380,6 +7387,18 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 		else
 		{
 			if (GetDrawingEffect(pRNode->obj.flags) == OF_INVISIBLE)
+				continue;
+		}
+
+		// Check for translucent objects
+		bool objTranslucent = (pRNode->obj.flags & TRANSLUCENT_FLAGS) != 0;
+		if ((flags & TRANSLUCENT_FLAGS) != 0) {
+			if (!objTranslucent)
+				continue;
+		}
+		else
+		{
+			if (objTranslucent)
 				continue;
 		}
 

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -7357,7 +7357,9 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 	anglePitch = PlayerGetHeightOffset();
 
 	// drawdata[] may contain more than one entry with the same id.
-	// We need to keep track of those we've already processed to avoid duplicates.
+	// Rendering translucent objects multiple times can cause them to appear less translucent (more opaque).
+	// This happens because each rendering pass compounds the alpha blending, making the object appear more solid than intended.
+	// To prevent this, we need to keep track of those we've already processed to avoid rendering duplicates.
 	std::unordered_set<int> processedIds;
 	for (curObject = 0; curObject < nitems; curObject++)
 	{
@@ -7392,13 +7394,13 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 
 		// Check for translucent objects
 		bool objTranslucent = (pRNode->obj.flags & TRANSLUCENT_FLAGS) != 0;
-		if ((flags & TRANSLUCENT_FLAGS) != 0) {
-			if (!objTranslucent)
+		if ((flags & TRANSLUCENT_FLAGS) == 0) {
+			if (objTranslucent)
 				continue;
 		}
 		else
 		{
-			if (objTranslucent)
+			if (!objTranslucent)
 				continue;
 		}
 


### PR DESCRIPTION
We apply the same techniques for overlays as for regular objects (only render each object once and restrict translucent passes)
Logoff ghosts now look consistently translucent (previously overlays -- arms, legs etc were rendered twice and at certain distances were rendered multiple times due to duplication in drawdata) 

![image](https://github.com/user-attachments/assets/03c99933-e85a-43fd-b2fa-fdd9a9f1380d)
