### PR TITLE
Increase server update rate & incoming packet allowance

### DIFF
--- a/clientd3d/move.c
+++ b/clientd3d/move.c
@@ -54,8 +54,8 @@
 
 #define MAX_STEP_HEIGHT (HeightKodToClient(24)) // Max vertical step size (FINENESS units)
 
-#define MOVE_INTERVAL  1000            // Inform server at most once per this many milliseconds
-#define MOVE_THRESHOLD (FINENESS / 4)  // Inform server only of moves at least this large
+#define MOVE_INTERVAL  250            // Inform server at most once per this many milliseconds
+#define MOVE_THRESHOLD (FINENESS / 8)  // Inform server only of moves at least this large
 #define MOVE_THRESHOLD2 (MOVE_THRESHOLD * MOVE_THRESHOLD)
 #define TIME_THRESHOLD 1000
 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -47,7 +47,7 @@ constants:
    USER_RUNNING_SPEED = 36
 
    % How many packets incoming per second do we allow?
-   INCOMING_PACKET_THROTTLE = 25
+   INCOMING_PACKET_THROTTLE = 20
 
    % What's the lower threshold for being able to run?  Below this, we can't
    %  run.
@@ -2909,7 +2909,7 @@ messages:
       % NEW Speedhack detection!
       % How this works:
       %   Speedhack works by sending a LOT of little moves very, very quickly.
-      %   Normal players only send 1 movement packet per second, but 
+      %   Normal players only send 4 movement packets per second (MOVE_INTERVAL), but 
       %   speedhackers send more.  Even at low levels, speedhackers will send
       %   more packets per second.  So, we keep track of the number of packets
       %   sent and the number of seconds that happen.  Every movement packet
@@ -2923,9 +2923,11 @@ messages:
       %   allowed over the duration due to rounding errors, etc.
 
       % Check the delta since the last time we moved.  Keep an upper bound on
-      %  the delta, since people could just be moving from rest.
+      % the delta, since people could just be moving from rest.
+      % We divide the piLastMoveUpdateTime by four, since movement 
+      % is being updated 4 times per second (MOVE_INTERVAL) while people are actively moving.
       iCurrentTime = GetTime();
-      iDelta = iCurrentTime - piLastMoveUpdateTime;
+      iDelta = iCurrentTime - (piLastMoveUpdateTime / 4);
 
       %  Make sure this person is not lagging; increment our counter since we
       %  got a move packet, then adjust for last movement time.

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -47,7 +47,7 @@ constants:
    USER_RUNNING_SPEED = 36
 
    % How many packets incoming per second do we allow?
-   INCOMING_PACKET_THROTTLE = 5
+   INCOMING_PACKET_THROTTLE = 25
 
    % What's the lower threshold for being able to run?  Below this, we can't
    %  run.


### PR DESCRIPTION
The purpose of these changes is simple, to allow for more 'real time' server/client location updates.  In summary:

1. Decreased the movement interval in which the server is informed of changes
2. Decreased the minimum amount of distance travel distance to where the server should be informed
3. Increased the packet throttle to support the above changes

I chose the values for MOVE_INTERVAL and INCOMING_PACKET_THROTTLE based on values from other open-source forks that have been used 'in the wild' for many years.

**I tested these changes with the following results:**

- I am able to stop on a dime and channel a spell, without a non-moving fizzle
- My attack range (and defense range) is now far more predictable. I no longer need to 'predict' where a target is heading in order to swing in melee combat; nor do monsters hit me as I'm already well out of their range from the client's perspective.
- Entering and exiting through doors is now snappy, and doesn't require delay for consistency

As a disclaimer, I am by no means an expert.  I made these changes through research and testing - any feedback or suggestions are welcome.