### PR TITLE
Redraw all in hardware renderer as blind wears off

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -650,8 +650,21 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	timeOverall = timeGetTime();
 	timeSetup = timeGetTime();
 
-	// If blind, don't draw anything
-	Bool can_see = !effects.blind;
+	// Static variable to track the player's previous ability to see. Initialize it only once.
+	static Bool can_see = !effects.blind;
+
+	// Determine the current ability to see.
+	Bool new_can_see = !effects.blind;
+
+	// Trigger a redraw only if the player was blind, but now can see.
+	if (!can_see && new_can_see) {
+		gD3DRedrawAll |= D3DRENDER_REDRAW_ALL;
+	}
+
+	// Update the can_see state for the next frame.
+	can_see = new_can_see;
+
+	// If blind (!can_see), don't draw anything
 	Bool draw_sky = can_see;
 	Bool draw_world = can_see;
 	Bool draw_objects = can_see;

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -650,21 +650,8 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	timeOverall = timeGetTime();
 	timeSetup = timeGetTime();
 
-	// Static variable to track the player's previous ability to see. Initialize it only once.
-	static Bool can_see = !effects.blind;
-
-	// Determine the current ability to see.
-	Bool new_can_see = !effects.blind;
-
-	// Trigger a redraw only if the player was blind, but now can see.
-	if (!can_see && new_can_see) {
-		gD3DRedrawAll |= D3DRENDER_REDRAW_ALL;
-	}
-
-	// Update the can_see state for the next frame.
-	can_see = new_can_see;
-
-	// If blind (!can_see), don't draw anything
+	// If blind, don't draw anything
+	Bool can_see = !effects.blind;
 	Bool draw_sky = can_see;
 	Bool draw_world = can_see;
 	Bool draw_objects = can_see;

--- a/clientd3d/server.c
+++ b/clientd3d/server.c
@@ -787,7 +787,7 @@ Bool HandleChange(char *ptr, long len)
    ChangeObject(&object, translation, effect, &a, overlays);
 
    // something changed, so we probably need to rebuild static lists
-//   gD3DRedrawAll |= D3DRENDER_REDRAW_UPDATE;
+   gD3DRedrawAll |= D3DRENDER_REDRAW_UPDATE;
    
    return True;
 }


### PR DESCRIPTION
If a player is blinded and something changes in the scene (for example a monster is killed) then later when blind wears off the geometry hasn't been updated and we see missing textures. We reinstate the trigger to redraw all from `HandleChange`. Please see PR commit history for an[ alternative solution within 3d3render only](https://github.com/Meridian59/Meridian59/pull/907/commits/1c51b578f3211345dda5adf5bba7ec7aeeb64923).

![image](https://github.com/user-attachments/assets/96c14a29-5dc8-49ee-a35d-e0cfd8f90a7b)

Issue:
https://github.com/user-attachments/assets/fa4208d5-0852-4461-899c-deb6f6784869

with changes:
https://github.com/user-attachments/assets/3e3cdaed-644b-4ac4-a883-c41723a7a64d

Fixes #908 