### PR TITLE
Stretch classic software renderer with classic original scale and fov

### DIFF
--- a/clientd3d/draw3d.c
+++ b/clientd3d/draw3d.c
@@ -86,10 +86,10 @@ BYTE light_rows[MAXY/2+1];      // Strength of light as function of screen row
 
 PDIB background;                      /* Pointer to background bitmap */
 
-static void Stretch(BYTE* src, BYTE* dest, int width, int height, int new_width, int new_height, int max_width);
-
 /* local function prototypes */
 static void StretchImage(void);
+static void Stretch(BYTE* src, BYTE* dest, int width, int height,
+    int new_width, int new_height, int max_width);
 /************************************************************************/
 /* return TRUE iff successful */
 Bool InitializeGraphics3D(void)
@@ -536,14 +536,20 @@ void StretchImage(void)
   Stretch(gBits, gBufferBits, area.cx, area.cy, main_viewport_width, main_viewport_height, MAXX);
 }
 /************************************************************************/
-void Stretch(BYTE* src, BYTE* dest, int width, int height, int new_width, int new_height, int max_width)
+/************************************************************************/
+/*
+ * Stretch: Function to stretch a source image to a new size while maintaining the aspect ratio.
+ * - src: Pointer to the source image data
+ * - dest: Pointer to the destination image buffer where the stretched image will be stored.
+ * - width: Width of the source image.
+ * - height: Height of the source image.
+ * - new_width: Desired width of the stretched image.
+ * - new_height: Desired height of the stretched image.
+ * - max_width: Maximum width of the destination buffer (used for row size calculations).
+ */
+void Stretch(BYTE* src, BYTE* dest, int width, int height, 
+    int new_width, int new_height, int max_width)
 {
-    // If the new size is exactly the same as the original, perform a direct copy
-    if (new_width == width && new_height == height) {
-        memcpy(dest, src, width * height * sizeof(BYTE));
-        return;
-    }
-
     // Calculate the scaling ratios
     int half_new_width = new_width / 2;
     int x_ratio = (width << 16) / half_new_width;

--- a/clientd3d/draw3d.c
+++ b/clientd3d/draw3d.c
@@ -539,39 +539,36 @@ void StretchImage(void)
 /************************************************************************/
 /*
  * Stretch: Function to stretch a source image to a new size while maintaining the aspect ratio.
- * - src: Pointer to the source image data
- * - dest: Pointer to the destination image buffer where the stretched image will be stored.
- * - width: Width of the source image.
- * - height: Height of the source image.
- * - new_width: Desired width of the stretched image.
- * - new_height: Desired height of the stretched image.
- * - max_width: Maximum width of the destination buffer (used for row size calculations).
+ * - src: Pointer to the source image data (bytes)
+ * - dest: Pointer to the destination image buffer where the stretched image will be stored (bytes).
+ * - width: Width of the source image in pixels.
+ * - height: Height of the source image in pixels.
+ * - new_width: Desired width of the stretched image in pixels.
+ * - new_height: Desired height of the stretched image in pixels.
+ * - row_stride: The row stride in bytes (used for row size calculations).
  */
 void Stretch(BYTE* src, BYTE* dest, int width, int height, 
-    int new_width, int new_height, int max_width)
+    int new_width, int new_height, int row_stride)
 {
     // Calculate the scaling ratios
     int half_new_width = new_width / 2;
     int x_ratio = (width << 16) / half_new_width;
     int y_ratio = (height << 16) / new_height;
 
-    int i, j, x, y;
-    BYTE* s, * d, * d2;
-
-    for (i = 0; i < new_height; i++)
+    for (int i = 0; i < new_height; i++)
     {
         // Calculate the y-coordinate in the source image
-        y = (i * y_ratio) >> 16;
-        s = src + y * max_width; // Set source pointer
+        int y = (i * y_ratio) >> 16;
+        BYTE* s = src + y * row_stride; // Set source pointer
 
         // Calculate the destination pointers for the current and next rows
-        d = dest + i * max_width * 2;
-        d2 = d + max_width;
+        BYTE* d = dest + i * row_stride * 2;
+        BYTE* d2 = d + row_stride;
 
-        for (j = 0; j < half_new_width; j++)
+        for (int j = 0; j < half_new_width; j++)
         {
             // Calculate the x-coordinate in the source image
-            x = (j * x_ratio) >> 16;
+            int x = (j * x_ratio) >> 16;
             BYTE b = *(s + x); // Fetch the pixel from the source
 
             // Write the pixel to the destination, expanding both horizontally and vertically

--- a/clientd3d/graphics.c
+++ b/clientd3d/graphics.c
@@ -109,7 +109,6 @@ void ResizeAll(void)
  */
 Bool TranslateToRoom(int client_x, int client_y, int *x, int *y)
 {
-
     // Calculate the scaling factor
     float scale_x = static_cast<float>(main_viewport_width) / CLASSIC_WIDTH;
     float scale_y = static_cast<float>(main_viewport_height) / CLASSIC_HEIGHT;
@@ -118,7 +117,11 @@ Bool TranslateToRoom(int client_x, int client_y, int *x, int *y)
     *x = static_cast<int>((client_x - view.x) / scale_x);
     *y = static_cast<int>((client_y - view.y) / scale_y);
 
-    return true;
+    if (*x < view.x || *x > view.x + view.cx ||
+        *y < view.y || *y > view.y + view.cy)
+        return False;
+
+    return True;
 }
 /************************************************************************/
 /*

--- a/clientd3d/graphics.c
+++ b/clientd3d/graphics.c
@@ -41,7 +41,6 @@ extern int border_index;
 
 int main_viewport_width;
 int main_viewport_height;
-extern float player_overlay_scaler;
 
 // Variables to store frame times and FPS
 static std::vector<double> fps_store;
@@ -111,14 +110,15 @@ void ResizeAll(void)
 Bool TranslateToRoom(int client_x, int client_y, int *x, int *y)
 {
 
-   if (client_x < view.x || client_x > view.x + view.cx ||
-       client_y < view.y || client_y > view.y + view.cy)
-      return False;
+    // Calculate the scaling factor
+    float scale_x = static_cast<float>(main_viewport_width) / CLASSIC_WIDTH;
+    float scale_y = static_cast<float>(main_viewport_height) / CLASSIC_HEIGHT;
 
-   *x = (client_x - view.x) / 2;
-   *y = (client_y - view.y) / 2;
+    // Translate client coordinates to room coordinates, considering scaling
+    *x = static_cast<int>((client_x - view.x) / scale_x);
+    *y = static_cast<int>((client_y - view.y) / scale_y);
 
-   return True;
+    return true;
 }
 /************************************************************************/
 /*
@@ -221,7 +221,6 @@ void GraphicsAreaResize(int xsize, int ysize)
    // update main viewport and classic scaler (required for FOV calculations and equipment scaling)
    main_viewport_width = view.cx;
    main_viewport_height = view.cy;
-   player_overlay_scaler = ((float)main_viewport_width) / CLASSIC_WIDTH;
 
    D3DRenderResizeDisplay(view.x, view.y, view.cx, view.cy);
 

--- a/clientd3d/overlay.c
+++ b/clientd3d/overlay.c
@@ -19,7 +19,6 @@ extern player_info player;
 // Main client windows current viewport area
 extern int main_viewport_width;
 extern int main_viewport_height;
-float player_overlay_scaler = 1;
 
 /* local function prototypes */
 Bool ComputePlayerOverlayArea(PDIB pdib, char hotspot, AREA *obj_area);
@@ -216,11 +215,10 @@ Bool ComputePlayerOverlayArea(PDIB pdib, char hotspot, AREA *obj_area)
       return False;
    }
 
-   float scaler = player_overlay_scaler * 0.5f;
-   int dib_width = DibWidth(pdib) * scaler;
-   int dib_height = DibHeight(pdib) * scaler;
-   int dib_x_offset = DibXOffset(pdib) * scaler;
-   int dib_y_offset = DibYOffset(pdib) * scaler;
+   int dib_width = DibWidth(pdib);
+   int dib_height = DibHeight(pdib);
+   int dib_x_offset = DibXOffset(pdib);
+   int dib_y_offset = DibYOffset(pdib);
 
    // Find x position
    switch (hotspot)


### PR DESCRIPTION
Full screen mode of the software renderer does not currently scale using the classic resolution and FOV. The FOV is calculated by the height and width defined within the draw room routine which we are setting with the height and width available. This is wrong as it also increases the view port and FOV significantly, above and beyond the original classic client view (and the hardware renderer). Instead we now improve the software renderer full screen implementation by scaling the classic view to the size of the available view port area -- importantly keeping the original scale and FOV.

Current full screen view:

![image](https://github.com/user-attachments/assets/f6fbaa38-1f64-4455-9960-9bb0be54f3b7)

With this new classic stretched implementation (this is large full screen max):

![image](https://github.com/user-attachments/assets/f9c68b1c-3dce-4f59-b9e4-b47b96a07cfa)

Scaled from original smaller ~classic view port size (this is a small view):

![image](https://github.com/user-attachments/assets/e4d8f05b-01c8-4e3b-8bcd-8dd66f9a5aee)