### PR TITLE
Adjust FOV for hardware renderer to match classic software renderer

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -24,11 +24,12 @@ extern int main_viewport_height;
 // Define field of views with magic numbers for tuning
 inline float FovHorizontal(long width)
 {
-	return width / (float)(main_viewport_width) * (-PI / 3.6f);
+	return width / (float)(main_viewport_width) * (-PI / 3.78f);
 }
+
 inline float FovVertical(long height)
 {
-	return height / (float)(main_viewport_height) * (PI / 5.6f);
+	return height / (float)(main_viewport_height) * (PI / 5.88f);
 }
 
 static const auto TRANSLUCENT_FLAGS = OF_TRANSLUCENT25 | OF_TRANSLUCENT50 | OF_TRANSLUCENT75 | OF_DITHERTRANS;

--- a/clientd3d/draw3d.c
+++ b/clientd3d/draw3d.c
@@ -385,10 +385,10 @@ void UpdateRoom3D(room_type *room, Draw3DParams *params)
    long t1,t2,t3;
    static int count = 0;
 
-   // Size of offscreen bitmap.
+   // View area of the player (as per software renderer view/fov)
    area.x = area.y = 0;
-   area.cx = main_viewport_width;
-   area.cy = main_viewport_height;
+   area.cx = CLASSIC_WIDTH;
+   area.cy = CLASSIC_HEIGHT;
 
    // Force size to be even.
    area.cy = area.cy & ~1;


### PR DESCRIPTION
In busier rooms (number of items/lights/walls) and at higher resolutions the number of draw items may exceed the maximum allowed. On further investigation the greater the resolution, the greater the number of items being identified as visible in the world - which is wrong. This spawns from the original implementation of the full screen for software renderer: https://github.com/Meridian59/Meridian59/pull/911

When this happens out of memory messages would appear in the debug logs as the `drawdata` was full and as a result objects were missing and not rendered in the 3d world.

As the world is being built from the bsp tree using a static world size and the width is given as a parameter - regardless of the screen resolution the same objects in the world should be visible. This width of the players view as provided to the bsp walk functions directly impact the bounds of the viewing frustum - it should be independent of the actual size of the viewport on the screen.

With this change the number of items in `drawdata` remains static regardless of the resolution of the viewport and the out of memory debug messages no longer appear. Overall this will be an optimization for all resolutions using the hardware renderer.

This is how the issue manifests:
https://github.com/user-attachments/assets/994abf14-f54a-4c87-8ebd-4b3f66986e45

To mitigate this issue we adjust FOV (manually compared and tuned) to be as close as possible to the software renderer to ensure the visible objects determined from the bsp walk match the players view. We also use a static height / width for the purposes of traversing the bsp - just like for the classic software renderer.

The original implementation for the hardware renderer includes magic numbers for FOVs which we have adjusted over the years. As per this original implementation and further research there doesn't appear to be an obvious way to calculate this exactly and hence this tuning is required.

The views now compare as follows (manually setup and tuned for your pleasure).
software
![image](https://github.com/user-attachments/assets/4b8baf52-44ac-42ad-a829-c5d7110535f0)
hardware
![image](https://github.com/user-attachments/assets/b083058a-e45f-49aa-98bb-3518caa42f97)
