### PR TITLE
Adds two new monster generator locations to Avar Village (`ke4`)

### DIFF
--- a/kod/object/active/holder/room/monsroom/kcforest/ke4.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/ke4.kod
@@ -117,7 +117,7 @@ messages:
    {
       plMonsters = [ [&Avar, 40], [&AvarChieftain, 35], [&Avarshaman,25] ];  
       plGenerators = [ [13,54], [20,39], [34,39], [44,37], [53,46],
-                       [53,56], [46,66], [33,71], [22,67] ];
+                       [53,56], [46,66], [33,71], [22,67], [70,20], [14,25] ];
 
       % Create the node.
       poNode = Create(&AvarNode,#node_num=NODE_AVAR,#iRoomNum=piRoom_num);


### PR DESCRIPTION
Per @jrotunda's suggestion in #471, this PR adds two new monster generator locations along the ridge often used by players to grind while avoiding monster engagement. This PR codifies a change already in place on 101.

### New generator locations
![Screenshot 2024-08-18 082654](https://github.com/user-attachments/assets/73366399-9bba-43dc-8a25-63f936de091b)

Closes #471