### PR TITLE
Make objects clickable in the hardware renderer

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -5493,11 +5493,6 @@ void D3DRenderBackgroundOverlays(d3d_render_pool_new* pPool, int angleHeading, i
 			int tempTop = (topLeft.y * -h / 2) + (h / 2);
 			int tempBottom = (bottomRight.y * -h / 2) + (h / 2);
 
-			tempLeft /= 2;
-			tempRight /= 2;
-			tempTop /= 2;
-			tempBottom /= 2;
-
 			int distX = bg_overlay_pos.x - player.x;
 			int distY = bg_overlay_pos.y - player.y;
 
@@ -7209,11 +7204,6 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 				tempTop    = (topLeft.y * -h / 2) + (h / 2);
 				tempBottom = (bottomRight.y * -h / 2) + (h / 2);
 
-				tempLeft /= 2;
-				tempRight /= 2;
-				tempTop /= 2;
-				tempBottom /= 2;
-
 				distX = pRNode->motion.x - player.x;
 				distY = pRNode->motion.y - player.y;
 
@@ -7884,11 +7874,6 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 							tempRight  = (bottomRight.x * w / 2) + (w / 2);
 							tempTop    = (topLeft.y * -h / 2) + (h / 2);
 							tempBottom = (bottomRight.y * -h / 2) + (h / 2);
-
-							tempLeft /= 2;
-							tempRight /= 2;
-							tempTop /= 2;
-							tempBottom /= 2;
 
 							distX = pRNode->motion.x - player.x;
 							distY = pRNode->motion.y - player.y;

--- a/clientd3d/graphics.c
+++ b/clientd3d/graphics.c
@@ -109,13 +109,21 @@ void ResizeAll(void)
  */
 Bool TranslateToRoom(int client_x, int client_y, int *x, int *y)
 {
-    // Calculate the scaling factor
-    float scale_x = static_cast<float>(main_viewport_width) / CLASSIC_WIDTH;
-    float scale_y = static_cast<float>(main_viewport_height) / CLASSIC_HEIGHT;
+    if(D3DRenderIsEnabled())
+    { 
+        *x = (client_x - view.x) / 2;
+        *y = (client_y - view.y) / 2;
+    }
+    else
+    {
+        // Calculate the scaling factor
+        float scale_x = static_cast<float>(main_viewport_width) / CLASSIC_WIDTH;
+        float scale_y = static_cast<float>(main_viewport_height) / CLASSIC_HEIGHT;
 
-    // Translate client coordinates to room coordinates, considering scaling
-    *x = static_cast<int>((client_x - view.x) / scale_x);
-    *y = static_cast<int>((client_y - view.y) / scale_y);
+        // Translate client coordinates to room coordinates, considering scaling
+        *x = static_cast<int>((client_x - view.x) / scale_x);
+        *y = static_cast<int>((client_y - view.y) / scale_y);
+    }
 
     if (*x < view.x || *x > view.x + view.cx ||
         *y < view.y || *y > view.y + view.cy)

--- a/clientd3d/graphics.c
+++ b/clientd3d/graphics.c
@@ -109,9 +109,9 @@ void ResizeAll(void)
  */
 Bool TranslateToRoom(int client_x, int client_y, int *x, int *y)
 {
-    // Default scale factors.
-    float scale_x = 2.0f;
-    float scale_y = 2.0f;
+    // Default scale factors for hardware renderer.
+    float scale_x = 1.0f;
+    float scale_y = 1.0f;
 
     if (!D3DRenderIsEnabled())
     { 

--- a/clientd3d/graphics.c
+++ b/clientd3d/graphics.c
@@ -109,22 +109,26 @@ void ResizeAll(void)
  */
 Bool TranslateToRoom(int client_x, int client_y, int *x, int *y)
 {
-    if(D3DRenderIsEnabled())
+    // Default scale factors assume no scaling required.
+    float scale_x = 2.0f;
+    float scale_y = 2.0f;
+
+    // Check if the D3D renderer is not enabled. 
+    // If not enabled, use classic client aspect ratio for scaling.
+    if (!D3DRenderIsEnabled())
     { 
-        *x = (client_x - view.x) / 2;
-        *y = (client_y - view.y) / 2;
-    }
-    else
-    {
-        // Calculate the scaling factor
-        float scale_x = static_cast<float>(main_viewport_width) / CLASSIC_WIDTH;
-        float scale_y = static_cast<float>(main_viewport_height) / CLASSIC_HEIGHT;
-
-        // Translate client coordinates to room coordinates, considering scaling
-        *x = static_cast<int>((client_x - view.x) / scale_x);
-        *y = static_cast<int>((client_y - view.y) / scale_y);
+        // The software renderer uses the classic client aspect ratio and stretches 
+        // the client area to fit the window. We calculate the scaling factors 
+        // based on the ratio of the current viewport size to the classic dimensions.
+        scale_x = static_cast<float>(main_viewport_width) / CLASSIC_WIDTH;
+        scale_y = static_cast<float>(main_viewport_height) / CLASSIC_HEIGHT;
     }
 
+    // Translate client coordinates to room coordinates, considering any scaling factors.
+    *x = static_cast<int>((client_x - view.x) / scale_x);
+    *y = static_cast<int>((client_y - view.y) / scale_y);
+
+    // Check if the translated coordinates are within the valid room bounds.
     if (*x < view.x || *x > view.x + view.cx ||
         *y < view.y || *y > view.y + view.cy)
         return False;

--- a/clientd3d/graphics.c
+++ b/clientd3d/graphics.c
@@ -109,12 +109,10 @@ void ResizeAll(void)
  */
 Bool TranslateToRoom(int client_x, int client_y, int *x, int *y)
 {
-    // Default scale factors assume no scaling required.
+    // Default scale factors.
     float scale_x = 2.0f;
     float scale_y = 2.0f;
 
-    // Check if the D3D renderer is not enabled. 
-    // If not enabled, use classic client aspect ratio for scaling.
     if (!D3DRenderIsEnabled())
     { 
         // The software renderer uses the classic client aspect ratio and stretches 


### PR DESCRIPTION
During https://github.com/Meridian59/Meridian59/pull/911 we assume all `TranslateToRoom`'s are being stretched from classic width/height. This is not the case for the hardware renderer, so we correct it for both cases.