### PR TITLE
balance: Updates rebel quests with more accessible cargo

### DIFF
--- a/kod/util/questengine.kod
+++ b/kod/util/questengine.kod
@@ -5659,13 +5659,13 @@ RecreateQuestNodes()
    if send( self, @AddQuestNodeTemplate,\
             #NPC_modifier = QN_NPCMOD_SAME,\
             #questnode_type = QN_TYPE_ITEMFINDCLASS,\
-            #cargolist = [ [ QN_PRIZETYPE_ITEMCLASS, &SimpleHelm, 1 ],\
+            #cargolist = [ [ QN_PRIZETYPE_ITEMCLASS, &GoldShield, 1 ],\
 		           [ QN_PRIZETYPE_ITEMCLASS, &Knightshield, 1 ],\
 		           [ QN_PRIZETYPE_ITEMCLASS, &Gauntlet, 1 ],\
 		           [ QN_PRIZETYPE_ITEMCLASS, &LongSword, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &MysticSword, 1 ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &Hammer, 1 ],\
 		           [ QN_PRIZETYPE_ITEMCLASS, &Scimitar, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &NeruditeSword, 1 ] ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &Axe, 1 ] ],\
             #prizelist = [ [ QN_PRIZETYPE_FACTION, QN_PRIZE_FACTION_UPDATE ],
                           [ QN_PRIZETYPE_SCHEDULE_QUEST, QST_ID_REBEL_SERVICE ] ],
             #penaltylist = [ [ [ QN_PRIZETYPE_FACTION, QN_PRIZE_FACTION_NEUTRAL ] ] ],
@@ -5695,13 +5695,13 @@ RecreateQuestNodes()
    if send( self, @AddQuestNodeTemplate,\
             #NPC_modifier = QN_NPCMOD_SAME,\
             #questnode_type = QN_TYPE_ITEMFINDCLASS,\
-            #cargolist = [ [ QN_PRIZETYPE_ITEMCLASS, &PlateArmor, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &SimpleHelm, 1 ],\
+            #cargolist = [ [ QN_PRIZETYPE_ITEMCLASS, &ScaleArmor, 1 ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &GoldShield, 1 ],\
 		           [ QN_PRIZETYPE_ITEMCLASS, &Knightshield, 1 ],\
 		           [ QN_PRIZETYPE_ITEMCLASS, &Gauntlet, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &MysticSword, 1 ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &Hammer, 1 ],\
 		           [ QN_PRIZETYPE_ITEMCLASS, &Scimitar, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &Scimitar, 1 ] ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &Axe, 1 ] ],\
             #prizelist = [ [ QN_PRIZETYPE_FACTION, QN_PRIZE_FACTION_REBEL ] ],
             #timelimit = 3600 )
    {

--- a/kod/util/questengine.kod
+++ b/kod/util/questengine.kod
@@ -5666,9 +5666,7 @@ RecreateQuestNodes()
                [ QN_PRIZETYPE_ITEMCLASS, &GoldShield, 1 ],\
                [ QN_PRIZETYPE_ITEMCLASS, &ScaleArmor, 1 ],\
                [ QN_PRIZETYPE_ITEMCLASS, &Axe, 1 ],\
-               [ QN_PRIZETYPE_ITEMCLASS, &LongSword, 1 ],\
-               [ QN_PRIZETYPE_ITEMCLASS, &PlateArmor, 1 ],\
-               [ QN_PRIZETYPE_ITEMCLASS, &MysticSword, 1 ] ],\
+               [ QN_PRIZETYPE_ITEMCLASS, &LongSword, 1 ] ],\
             #prizelist = [ [ QN_PRIZETYPE_FACTION, QN_PRIZE_FACTION_UPDATE ],
                           [ QN_PRIZETYPE_SCHEDULE_QUEST, QST_ID_REBEL_SERVICE ] ],
             #penaltylist = [ [ [ QN_PRIZETYPE_FACTION, QN_PRIZE_FACTION_NEUTRAL ] ] ],
@@ -5706,10 +5704,7 @@ RecreateQuestNodes()
                [ QN_PRIZETYPE_ITEMCLASS, &Bread, 50 ],\
                [ QN_PRIZETYPE_ITEMCLASS, &Apple, 50 ],\
 		         [ QN_PRIZETYPE_ITEMCLASS, &Snack, 50 ],\
-		         [ QN_PRIZETYPE_ITEMCLASS, &Meatpie, 50 ],\
-               [ QN_PRIZETYPE_ITEMCLASS, &Knightshield, 1 ],\
-               [ QN_PRIZETYPE_ITEMCLASS, &Scimitar, 1 ],\
-               [ QN_PRIZETYPE_ITEMCLASS, &Gauntlet, 1 ] ],\
+		         [ QN_PRIZETYPE_ITEMCLASS, &Meatpie, 50 ] ],\
             #prizelist = [ [ QN_PRIZETYPE_FACTION, QN_PRIZE_FACTION_REBEL ] ],
             #timelimit = 3600 )
    {

--- a/kod/util/questengine.kod
+++ b/kod/util/questengine.kod
@@ -5659,13 +5659,14 @@ RecreateQuestNodes()
    if send( self, @AddQuestNodeTemplate,\
             #NPC_modifier = QN_NPCMOD_SAME,\
             #questnode_type = QN_TYPE_ITEMFINDCLASS,\
-            #cargolist = [ [ QN_PRIZETYPE_ITEMCLASS, &SimpleHelm, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &Knightshield, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &Gauntlet, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &LongSword, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &MysticSword, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &Scimitar, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &NeruditeSword, 1 ] ],\
+            #cargolist = [ 
+               [ QN_PRIZETYPE_ITEMCLASS, &Money, 2000 ],\
+               [ QN_PRIZETYPE_ITEMCLASS, &Money, 3000 ],\
+               [ QN_PRIZETYPE_ITEMCLASS, &Money, 4000 ],\
+               [ QN_PRIZETYPE_ITEMCLASS, &GoldShield, 1 ],\
+               [ QN_PRIZETYPE_ITEMCLASS, &ScaleArmor, 1 ],\
+               [ QN_PRIZETYPE_ITEMCLASS, &Axe, 1 ],\
+               [ QN_PRIZETYPE_ITEMCLASS, &LongSword, 1 ] ],\
             #prizelist = [ [ QN_PRIZETYPE_FACTION, QN_PRIZE_FACTION_UPDATE ],
                           [ QN_PRIZETYPE_SCHEDULE_QUEST, QST_ID_REBEL_SERVICE ] ],
             #penaltylist = [ [ [ QN_PRIZETYPE_FACTION, QN_PRIZE_FACTION_NEUTRAL ] ] ],
@@ -5695,13 +5696,15 @@ RecreateQuestNodes()
    if send( self, @AddQuestNodeTemplate,\
             #NPC_modifier = QN_NPCMOD_SAME,\
             #questnode_type = QN_TYPE_ITEMFINDCLASS,\
-            #cargolist = [ [ QN_PRIZETYPE_ITEMCLASS, &PlateArmor, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &SimpleHelm, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &Knightshield, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &Gauntlet, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &MysticSword, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &Scimitar, 1 ],\
-		           [ QN_PRIZETYPE_ITEMCLASS, &Scimitar, 1 ] ],\
+            #cargolist = [ 
+               [ QN_PRIZETYPE_ITEMCLASS, &Mug, 40 ],\
+		         [ QN_PRIZETYPE_ITEMCLASS, &Goblet, 40 ],\
+		         [ QN_PRIZETYPE_ITEMCLASS, &Waterskin, 40 ],\
+		         [ QN_PRIZETYPE_ITEMCLASS, &Cheese, 50 ],\
+               [ QN_PRIZETYPE_ITEMCLASS, &Bread, 50 ],\
+               [ QN_PRIZETYPE_ITEMCLASS, &Apple, 50 ],\
+		         [ QN_PRIZETYPE_ITEMCLASS, &Snack, 50 ],\
+		         [ QN_PRIZETYPE_ITEMCLASS, &Meatpie, 50 ] ],\
             #prizelist = [ [ QN_PRIZETYPE_FACTION, QN_PRIZE_FACTION_REBEL ] ],
             #timelimit = 3600 )
    {

--- a/kod/util/questengine.kod
+++ b/kod/util/questengine.kod
@@ -5659,14 +5659,13 @@ RecreateQuestNodes()
    if send( self, @AddQuestNodeTemplate,\
             #NPC_modifier = QN_NPCMOD_SAME,\
             #questnode_type = QN_TYPE_ITEMFINDCLASS,\
-            #cargolist = [ 
-               [ QN_PRIZETYPE_ITEMCLASS, &Money, 2000 ],\
-               [ QN_PRIZETYPE_ITEMCLASS, &Money, 3000 ],\
-               [ QN_PRIZETYPE_ITEMCLASS, &Money, 4000 ],\
-               [ QN_PRIZETYPE_ITEMCLASS, &GoldShield, 1 ],\
-               [ QN_PRIZETYPE_ITEMCLASS, &ScaleArmor, 1 ],\
-               [ QN_PRIZETYPE_ITEMCLASS, &Axe, 1 ],\
-               [ QN_PRIZETYPE_ITEMCLASS, &LongSword, 1 ] ],\
+            #cargolist = [ [ QN_PRIZETYPE_ITEMCLASS, &SimpleHelm, 1 ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &Knightshield, 1 ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &Gauntlet, 1 ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &LongSword, 1 ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &MysticSword, 1 ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &Scimitar, 1 ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &NeruditeSword, 1 ] ],\
             #prizelist = [ [ QN_PRIZETYPE_FACTION, QN_PRIZE_FACTION_UPDATE ],
                           [ QN_PRIZETYPE_SCHEDULE_QUEST, QST_ID_REBEL_SERVICE ] ],
             #penaltylist = [ [ [ QN_PRIZETYPE_FACTION, QN_PRIZE_FACTION_NEUTRAL ] ] ],
@@ -5696,15 +5695,13 @@ RecreateQuestNodes()
    if send( self, @AddQuestNodeTemplate,\
             #NPC_modifier = QN_NPCMOD_SAME,\
             #questnode_type = QN_TYPE_ITEMFINDCLASS,\
-            #cargolist = [ 
-               [ QN_PRIZETYPE_ITEMCLASS, &Mug, 40 ],\
-		         [ QN_PRIZETYPE_ITEMCLASS, &Goblet, 40 ],\
-		         [ QN_PRIZETYPE_ITEMCLASS, &Waterskin, 40 ],\
-		         [ QN_PRIZETYPE_ITEMCLASS, &Cheese, 50 ],\
-               [ QN_PRIZETYPE_ITEMCLASS, &Bread, 50 ],\
-               [ QN_PRIZETYPE_ITEMCLASS, &Apple, 50 ],\
-		         [ QN_PRIZETYPE_ITEMCLASS, &Snack, 50 ],\
-		         [ QN_PRIZETYPE_ITEMCLASS, &Meatpie, 50 ] ],\
+            #cargolist = [ [ QN_PRIZETYPE_ITEMCLASS, &PlateArmor, 1 ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &SimpleHelm, 1 ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &Knightshield, 1 ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &Gauntlet, 1 ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &MysticSword, 1 ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &Scimitar, 1 ],\
+		           [ QN_PRIZETYPE_ITEMCLASS, &Scimitar, 1 ] ],\
             #prizelist = [ [ QN_PRIZETYPE_FACTION, QN_PRIZE_FACTION_REBEL ] ],
             #timelimit = 3600 )
    {

--- a/kod/util/questengine.kod
+++ b/kod/util/questengine.kod
@@ -5666,7 +5666,9 @@ RecreateQuestNodes()
                [ QN_PRIZETYPE_ITEMCLASS, &GoldShield, 1 ],\
                [ QN_PRIZETYPE_ITEMCLASS, &ScaleArmor, 1 ],\
                [ QN_PRIZETYPE_ITEMCLASS, &Axe, 1 ],\
-               [ QN_PRIZETYPE_ITEMCLASS, &LongSword, 1 ] ],\
+               [ QN_PRIZETYPE_ITEMCLASS, &LongSword, 1 ],\
+               [ QN_PRIZETYPE_ITEMCLASS, &PlateArmor, 1 ],\
+               [ QN_PRIZETYPE_ITEMCLASS, &MysticSword, 1 ] ],\
             #prizelist = [ [ QN_PRIZETYPE_FACTION, QN_PRIZE_FACTION_UPDATE ],
                           [ QN_PRIZETYPE_SCHEDULE_QUEST, QST_ID_REBEL_SERVICE ] ],
             #penaltylist = [ [ [ QN_PRIZETYPE_FACTION, QN_PRIZE_FACTION_NEUTRAL ] ] ],
@@ -5704,7 +5706,10 @@ RecreateQuestNodes()
                [ QN_PRIZETYPE_ITEMCLASS, &Bread, 50 ],\
                [ QN_PRIZETYPE_ITEMCLASS, &Apple, 50 ],\
 		         [ QN_PRIZETYPE_ITEMCLASS, &Snack, 50 ],\
-		         [ QN_PRIZETYPE_ITEMCLASS, &Meatpie, 50 ] ],\
+		         [ QN_PRIZETYPE_ITEMCLASS, &Meatpie, 50 ],\
+               [ QN_PRIZETYPE_ITEMCLASS, &Knightshield, 1 ],\
+               [ QN_PRIZETYPE_ITEMCLASS, &Scimitar, 1 ],\
+               [ QN_PRIZETYPE_ITEMCLASS, &Gauntlet, 1 ] ],\
             #prizelist = [ [ QN_PRIZETYPE_FACTION, QN_PRIZE_FACTION_REBEL ] ],
             #timelimit = 3600 )
    {


### PR DESCRIPTION
This PR updates the Rebel faction's "join" and "loyalty" cargo lists to better align with the balance of similar requests from other factions. The changes replace items that were disproportionately difficult to obtain—such as those requiring trips to the orc caves or battles with high-difficulty monsters—with alternatives that the average player can reasonably acquire without outside assistance. This ensures a fair and rewarding experience while maintaining balance across factions.

Per @Aesica 's suggestion in the comments:

* Helm → Gold Shield
* Mystic Sword → Hammer
* Nerudite Sword→ Axe
* Plate Armor → Scale Armor

Closes #602