### PR TITLE
Make logoff ghost overlays visible

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -11878,7 +11878,7 @@ messages:
    % Facial overlays such as face masks and helmets are displayed by statues 
    % and logoff ghosts. Such overlays (helms/mummy masks) may may also require a 
    % players hair, nose and/or mouth to be hidden to look right.
-   GetFacialOverlayRsc()
+   GetFacialOverlay()
    {
       local overlay;
       

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8488,6 +8488,11 @@ messages:
       return;
    }
 
+   GetOverlays()
+   {
+      return plOverlays;
+   }
+
    RemoveOverlayObject(what = $)
    "Removes <what> from plOverlays if it's in there."
    {
@@ -8504,6 +8509,11 @@ messages:
       }
 
       return;
+   }
+
+   GetHairRemoved()
+   {
+      return poHair_remove;
    }
 
    RemoveHair(what = $)

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -11875,8 +11875,8 @@ messages:
       return piAction;
    }
 
-   % Facial overlays such as face masks and helmets are used by statues and 
-   % logoff ghosts. Such overlays (helms/mummy masks) may may also require a 
+   % Facial overlays such as face masks and helmets are displayed by statues 
+   % and logoff ghosts. Such overlays (helms/mummy masks) may may also require a 
    % players hair, nose and/or mouth to be hidden to look right.
    GetFacialOverlayRsc()
    {

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8490,12 +8490,7 @@ messages:
 
    IsHairVisible()
    {
-      if poHair_remove = $
-      {
-         return TRUE;
-      }
-
-      return FALSE;
+      return poHairRemove = $;
    }
 
    RemoveOverlayObject(what = $)
@@ -11880,7 +11875,10 @@ messages:
       return piAction;
    }
 
-   GetMaskOrHelmRsc()
+   % Facial overlays such as face masks and helmets are used by statues and 
+   % logoff ghosts. Such overlays (helms/mummy masks) may may also require a 
+   % players hair, nose and/or mouth to be hidden to look right.
+   GetFacialOverlayRsc()
    {
       local overlay;
       

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8490,7 +8490,7 @@ messages:
 
    IsHairVisible()
    {
-      return poHairRemove = $;
+      return poHair_remove = $;
    }
 
    RemoveOverlayObject(what = $)

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8488,9 +8488,14 @@ messages:
       return;
    }
 
-   GetOverlays()
+   IsHairVisible()
    {
-      return plOverlays;
+      if poHair_remove = $
+      {
+         return TRUE;
+      }
+
+      return FALSE;
    }
 
    RemoveOverlayObject(what = $)
@@ -8509,11 +8514,6 @@ messages:
       }
 
       return;
-   }
-
-   GetHairRemoved()
-   {
-      return poHair_remove;
    }
 
    RemoveHair(what = $)
@@ -11878,6 +11878,21 @@ messages:
    GetExpression()
    {
       return piAction;
+   }
+
+   GetMaskOrHelmRsc()
+   {
+      local overlay;
+      
+      for overlay in plOverlays
+      {
+         if IsClass(overlay,&FaceMask) or IsClass(overlay,&Helmet)
+         {
+            return overlay;
+         }
+      }
+
+      return $;
    }
 
    GetShieldRsc()

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -11876,7 +11876,7 @@ messages:
    }
 
    % Facial overlays such as face masks and helmets are displayed by statues 
-   % and logoff ghosts. Such overlays (helms/mummy masks) may may also require a 
+   % and logoff ghosts. Such overlays (helms/mummy masks) may also require a 
    % players hair, nose and/or mouth to be hidden to look right.
    GetFacialOverlay()
    {

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -104,7 +104,7 @@ properties:
    prLeft_arm = LogoffGhost_default_larm
    prLegs = LogoffGhost_default_legs
    pbIsHairVisible = $
-   prMaskOrHelm = $
+   prFacialOverlay = $
 
    prWeapon = LogoffGhost_default_sword
    prShield = LogoffGhost_default_shield
@@ -573,7 +573,7 @@ messages:
          piOverlays = piOverlays + 1;
       }
 
-      if prMaskOrHelm <> $
+      if prFacialOverlay <> $
       {
          piOverlays = piOverlays + 1;
       }
@@ -634,7 +634,7 @@ messages:
       piShield_translation = Send(poGhostedPlayer,@GetShieldTranslation);
       oWeapon = Send(poGhostedPlayer,@LookUpPlayerWeapon);
 
-      prMaskOrHelm = Send(poGhostedPlayer,@GetMaskOrHelmRsc);
+      prFacialOverlay = Send(poGhostedPlayer,@GetFacialOverlayRsc);
       pbIsHairVisible = Send(poGhostedPlayer,@IsHairVisible);
 
       piWeapon_translation = 0;
@@ -764,9 +764,9 @@ messages:
          AddPacket(1,ANIMATE_NONE, 2,piWeapon_frame);
       }
 
-      if prMaskOrHelm <> $
+      if prFacialOverlay <> $
       {
-         Send(prMaskOrHelm,@SendOverlayInformation,#iAnimation = $);
+         Send(prFacialOverlay,@SendOverlayInformation,#iAnimation = $);
       }
 
       return;

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -103,8 +103,8 @@ properties:
    prRight_arm = LogoffGhost_default_rarm
    prLeft_arm = LogoffGhost_default_larm
    prLegs = LogoffGhost_default_legs
-   prHairRemoved = $
-   plOverlays = $
+   pbIsHairVisible = $
+   prMaskOrHelm = $
 
    prWeapon = LogoffGhost_default_sword
    prShield = LogoffGhost_default_shield
@@ -542,7 +542,6 @@ messages:
 
    ResetFrames()
    {
-      local overlay; 
       piIcon_frame = 1;
       piLeft_frame = 1;
       piRight_frame = 1;
@@ -574,9 +573,12 @@ messages:
          piOverlays = piOverlays + 1;
       }
 
-      piOverlays = piOverlays + length(plOverlays);
+      if prMaskOrHelm <> $
+      {
+         piOverlays = piOverlays + 1;
+      }
 
-      if prHairRemoved = $
+      if pbIsHairVisible
       {    
          piOverlays = piOverlays + 1;
       }
@@ -632,8 +634,8 @@ messages:
       piShield_translation = Send(poGhostedPlayer,@GetShieldTranslation);
       oWeapon = Send(poGhostedPlayer,@LookUpPlayerWeapon);
 
-      plOverlays = Send(poGhostedPlayer,@GetOverlays);
-      prHairRemoved = Send(poGhostedPlayer,@GetHairRemoved);
+      prMaskOrHelm = Send(poGhostedPlayer,@GetMaskOrHelmRsc);
+      pbIsHairVisible = Send(poGhostedPlayer,@IsHairVisible);
 
       piWeapon_translation = 0;
       prBowTop = $;
@@ -676,7 +678,7 @@ messages:
 
    SendOverlays()
    {
-      local iSkin_xlat, overlay;
+      local iSkin_xlat;
 
       % Send overlay bitmap info to user.
 
@@ -724,7 +726,7 @@ messages:
       AddPacket(4,prNose, 1,HS_NOSE, 1,ANIMATE_TRANSLATION, 1,iSkin_xlat,
                 1,ANIMATE_NONE, 2,1);
   
-      if prHairRemoved = $
+      if pbIsHairVisible
       { 
          AddPacket(4,prToupee, 1,HS_TOUPEE, 1,ANIMATE_TRANSLATION,
                   1,piHair_translation, 1,ANIMATE_NONE, 2,1);
@@ -762,9 +764,9 @@ messages:
          AddPacket(1,ANIMATE_NONE, 2,piWeapon_frame);
       }
 
-      for overlay in plOverlays
+      if prMaskOrHelm <> $
       {
-         Send(overlay,@SendOverlayInformation,#iAnimation = $);
+         Send(prMaskOrHelm,@SendOverlayInformation,#iAnimation = $);
       }
 
       return;

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -103,6 +103,8 @@ properties:
    prRight_arm = LogoffGhost_default_rarm
    prLeft_arm = LogoffGhost_default_larm
    prLegs = LogoffGhost_default_legs
+   prOverlays = $
+   prHairRemoved = $
 
    prWeapon = LogoffGhost_default_sword
    prShield = LogoffGhost_default_shield
@@ -540,11 +542,14 @@ messages:
 
    ResetFrames()
    {
+      local overlay; 
       piIcon_frame = 1;
       piLeft_frame = 1;
       piRight_frame = 1;
       piLegs_frame = 1;
-      piOverlays = 8;
+      % Player has 7 standard overlays:
+      %  right arm, left arm, legs, head, eyes, mouth, nose
+      piOverlays = 7;
 
       if prShield <> $
       {
@@ -566,6 +571,16 @@ messages:
             piRight_frame = 17;
          }
 
+         piOverlays = piOverlays + 1;
+      }
+
+      for overlay in prOverlays
+      {
+         piOverlays = piOverlays + 1;
+      }
+
+      if prHairRemoved = $
+      {    
          piOverlays = piOverlays + 1;
       }
 
@@ -620,6 +635,9 @@ messages:
       piShield_translation = Send(poGhostedPlayer,@GetShieldTranslation);
       oWeapon = Send(poGhostedPlayer,@LookUpPlayerWeapon);
 
+      prOverlays = Send(poGhostedPlayer,@GetOverlays);
+      prHairRemoved = Send(poGhostedPlayer,@GetHairRemoved);
+
       piWeapon_translation = 0;
       prBowTop = $;
 
@@ -661,7 +679,7 @@ messages:
 
    SendOverlays()
    {
-      local iSkin_xlat;
+      local iSkin_xlat, overlay;
 
       % Send overlay bitmap info to user.
 
@@ -708,8 +726,12 @@ messages:
                 1,ANIMATE_NONE, 2,piExpression);
       AddPacket(4,prNose, 1,HS_NOSE, 1,ANIMATE_TRANSLATION, 1,iSkin_xlat,
                 1,ANIMATE_NONE, 2,1);
-      AddPacket(4,prToupee, 1,HS_TOUPEE, 1,ANIMATE_TRANSLATION,
-                1,piHair_translation, 1,ANIMATE_NONE, 2,1);
+  
+      if prHairRemoved = $
+      { 
+         AddPacket(4,prToupee, 1,HS_TOUPEE, 1,ANIMATE_TRANSLATION,
+                  1,piHair_translation, 1,ANIMATE_NONE, 2,1);
+      }
 
       if prShield <> $
       {
@@ -741,6 +763,11 @@ messages:
          }
 
          AddPacket(1,ANIMATE_NONE, 2,piWeapon_frame);
+      }
+
+      for overlay in prOverlays
+      {
+         Send(overlay,@SendOverlayInformation,#iAnimation = $);
       }
 
       return;

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -634,7 +634,7 @@ messages:
       piShield_translation = Send(poGhostedPlayer,@GetShieldTranslation);
       oWeapon = Send(poGhostedPlayer,@LookUpPlayerWeapon);
 
-      prFacialOverlay = Send(poGhostedPlayer,@GetFacialOverlayRsc);
+      prFacialOverlay = Send(poGhostedPlayer,@GetFacialOverlay);
       pbIsHairVisible = Send(poGhostedPlayer,@IsHairVisible);
 
       piWeapon_translation = 0;

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -103,8 +103,8 @@ properties:
    prRight_arm = LogoffGhost_default_rarm
    prLeft_arm = LogoffGhost_default_larm
    prLegs = LogoffGhost_default_legs
-   prOverlays = $
    prHairRemoved = $
+   plOverlays = $
 
    prWeapon = LogoffGhost_default_sword
    prShield = LogoffGhost_default_shield
@@ -574,10 +574,7 @@ messages:
          piOverlays = piOverlays + 1;
       }
 
-      for overlay in prOverlays
-      {
-         piOverlays = piOverlays + 1;
-      }
+      piOverlays = piOverlays + length(plOverlays);
 
       if prHairRemoved = $
       {    
@@ -635,7 +632,7 @@ messages:
       piShield_translation = Send(poGhostedPlayer,@GetShieldTranslation);
       oWeapon = Send(poGhostedPlayer,@LookUpPlayerWeapon);
 
-      prOverlays = Send(poGhostedPlayer,@GetOverlays);
+      plOverlays = Send(poGhostedPlayer,@GetOverlays);
       prHairRemoved = Send(poGhostedPlayer,@GetHairRemoved);
 
       piWeapon_translation = 0;
@@ -765,7 +762,7 @@ messages:
          AddPacket(1,ANIMATE_NONE, 2,piWeapon_frame);
       }
 
-      for overlay in prOverlays
+      for overlay in plOverlays
       {
          Send(overlay,@SendOverlayInformation,#iAnimation = $);
       }


### PR DESCRIPTION
Logoff ghosts currently do not display overlays (such as masks or helms) - we add that functionality.

![image](https://github.com/user-attachments/assets/5cc23f5b-9ea5-44d6-b495-26f5bab94a75)

![image](https://github.com/user-attachments/assets/46748217-2a40-4ba1-8d52-a2da6a663328)

![image](https://github.com/user-attachments/assets/1c4373c0-4afd-4e02-9dbc-7cb629d6979d)

![image](https://github.com/user-attachments/assets/eb0b5f4f-dabc-429f-879f-a908da2c8cef)
