### PR TITLE
Seduce: Verify conditions before continuing enchantment

### DIFF
--- a/kod/object/passive/spell/seduce.kod
+++ b/kod/object/passive/spell/seduce.kod
@@ -218,15 +218,24 @@ messages:
    
    EndEnchantment(who = $, report = TRUE, state = $)
    {
-      if send(state,@GetMana) >= (send(who,@getlevel) / 10)
+      % Verify the monster is still alive
+      if Send(who,@GetHealth) > 0
       {
-         Send(state,@LoseMana,#amount=send(who,@getlevel) / 10);
-         Post(who,@StartEnchantment,#what=self,#time=viDrainTime,#state=state);
-         return;
+         if Send(state,@GetMana) >= (Send(who,@getlevel) / 10)
+         {
+            Send(state,@LoseMana,#amount=Send(who,@getlevel) / 10);
+            Post(who,@StartEnchantment,#what=self,#time=viDrainTime,#state=state);
+
+            return;
+         }
+         
+         % Post because this must be done after the enchantment is gone from
+         % the monster's enchantment list
+         Post(who,@ResetBehaviorFlags);
+
+         Send(who,@SetMaster,#oMaster=$);
       }
-      post(who,@ResetBehaviorFlags);   %% this has to be done AFTER the enchantment 
-   				       %% is gone from the monster's ench list - post it    
-      send(who,@SetMaster,#oMaster=$);
+
       return;
    }
 

--- a/kod/object/passive/spell/seduce.kod
+++ b/kod/object/passive/spell/seduce.kod
@@ -218,23 +218,23 @@ messages:
    
    EndEnchantment(who = $, report = TRUE, state = $)
    {
-      % Verify the monster is still alive
-      if Send(who,@GetHealth) > 0
+      % Verify the conditions for continuing enchantment 
+      % - Monster (who) is alive
+      % - Player (state) is present
+      if Send(state,@IsLoggedOn) AND Send(who,@GetHealth) > 0 
+         AND Send(state,@GetOwner) = Send(who,@GetOwner)
+         AND Send(state,@GetMana) >= (Send(who,@getlevel) / 10)
       {
-         if Send(state,@GetMana) >= (Send(who,@getlevel) / 10)
-         {
-            Send(state,@LoseMana,#amount=Send(who,@getlevel) / 10);
-            Post(who,@StartEnchantment,#what=self,#time=viDrainTime,#state=state);
+         Send(state,@LoseMana,#amount=Send(who,@getlevel) / 10);
+         Post(who,@StartEnchantment,#what=self,#time=viDrainTime,#state=state);
 
-            return;
-         }
-         
-         % Post because this must be done after the enchantment is gone from
-         % the monster's enchantment list
-         Post(who,@ResetBehaviorFlags);
-
-         Send(who,@SetMaster,#oMaster=$);
+         return;
       }
+      
+      % Post because this must be done after the enchantment is gone from
+      % the monster's enchantment list
+      Post(who,@ResetBehaviorFlags);
+      Send(who,@SetMaster,#oMaster=$);
 
       return;
    }


### PR DESCRIPTION
This PR fixes #461 by verifying that the target monster is still alive during each iteration of Seduce's mana drain timer. Currently, if an affected mob is killed, `EndEnchantmentTimer` doesn't recognize this and the mana drain continues until the caster is out of mana. Additionally, it performs new checks to ensure the master (player) is present.

**About Seduce**: When cast on a monster, seduce will cause the monster to fight on your behalf for as long as your mana allows. If your mana runs out, the monster turns on you. Seduce can be cast on multiple monsters. If a monster is killed, the mana drain (from that monster) should stop.