### PR TITLE
Adds folly broadcast to Riija bridge deaths

### DIFF
--- a/kod/object/active/holder/room/temprii.kod
+++ b/kod/object/active/holder/room/temprii.kod
@@ -45,6 +45,8 @@ resources:
    riijadeadmessage4 = "No, thats not it, you don't know what happened..."
    riijadeadmessage5 = "but.... you probably got very lucky."
 
+   user_killed_bridge_faith = "### %s just hurled %sself from the cliffs of Riija to find a watery grave."
+
 classvars:
 
    vrName = room_name_RiijaTemple
@@ -362,8 +364,13 @@ messages:
       row = send(what,@GetRow);
       col = send(what,@GetCol);
 
-      debug(send(what,@GetName),"Hurled self off cliffs");
-      
+      % Riija shames the user by sharing their folly far and wide
+      for i in Send(SYS,@GetUsersLoggedOn)
+      {
+         Send(i,@MsgSendUser,#message_rsc=user_killed_bridge_faith,
+              #parm1=Send(what,@GetTrueName),#parm2=Send(what,@GetHisHer));
+      }
+
       dropped = FALSE;
       for i in send(what,@GetPlayerUsing)
       {

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -52,9 +52,6 @@ resources:
    system_killed_self = "### %q was just slain by %s own folly."
    system_user_killed_room = \
       "### %s have laid claim to yet another poor soul, %q."
-   system_user_killed_bridge_faith = \
-      "### %q just hurled %sself from the cliffs of Riija to find a watery "
-      "grave."
    system_user_killed_token = "### %q lost a token to %s%q."
    system_user_killed_shield = "### %q was bested by faction rival %s%q."
    system_user_killed_guild = \
@@ -1507,16 +1504,8 @@ messages:
 
       if IsClass(killer,&Room)
       {
-         if IsClass(killer,&TempleRiija)
-         {
-            rMessage = system_user_killed_bridge_faith;
-            param2 = Send(what,@GetHisHer);
-         }
-         else
-         {
-            rMessage = system_user_killed_room;
-            param2 = Send(what,@GetTrueName);
-         }
+         rMessage = system_user_killed_room;
+         param2 = Send(what,@GetTrueName);
 
          % Eliminate param3 that was set by default
          param3 = $;


### PR DESCRIPTION
In response to #625, this PR adds a broadcast to all currently logged in users when a player unsuccessfully crosses the Riija bridge. It uses `GetTrueName`, so there's no hiding from the shaming.

> `### PlayerName just hurled hisself from the cliffs of Riija to find a watery grave.`

Closes #625 