### PR TITLE
Fix heat scrolls by updating of target retrieval logic

### DIFF
--- a/kod/object/item/passitem/spelitem.kod
+++ b/kod/object/item/passitem/spelitem.kod
@@ -216,8 +216,16 @@ messages:
       oSpell = Send(SYS,@FindSpellByNum,#num=viSpellEffect);
 
       % Get proper targets according to spell, assume that apply_on is our basic target.
-      lTargets = Send(oSpell,@GetTargets,#who=what,#lTargets=[apply_on]);
 
+      if IsClass(self,&Scroll)
+      {
+         lTargets = Send(oSpell,@GetTargets,#who=what);
+      }
+      else
+      {
+         lTargets = Send(oSpell,@GetTargets,#who=what,#lTargets=[apply_on]);
+      }
+      
       if Send(oSpell,@IsHarmful)
          AND IsClass(apply_on,&Monster)
          AND NOT Send(apply_on,@CanMonsterFight,#who=poOwner,#oStroke=self)

--- a/kod/object/item/passitem/spelitem.kod
+++ b/kod/object/item/passitem/spelitem.kod
@@ -217,14 +217,7 @@ messages:
 
       % Get proper targets according to spell, assume that apply_on is our basic target.
 
-      if IsClass(self,&Scroll)
-      {
-         lTargets = Send(oSpell,@GetTargets,#who=what);
-      }
-      else
-      {
-         lTargets = Send(oSpell,@GetTargets,#who=what,#lTargets=[apply_on]);
-      }
+      lTargets = Send(self,@GetTargetsBySpell,#oSpell=oSpell,#who=what,#lTargets=[apply_on]);
       
       if Send(oSpell,@IsHarmful)
          AND IsClass(apply_on,&Monster)
@@ -470,6 +463,11 @@ messages:
    IsIdentified()
    {
       return Send(self, @IsLabelled);
+   }
+
+   GetTargetsBySpell(oSpell = $,who = $,lTargets = $)
+   {
+      return Send(oSpell,@GetTargets,#who=who,#lTargets=lTargets);
    }
 
 end

--- a/kod/object/item/passitem/spelitem/scroll.kod
+++ b/kod/object/item/passitem/spelitem/scroll.kod
@@ -83,7 +83,12 @@ messages:
 
       return;
    }
-
+   
+   GetTargetsBySpell(oSpell = $,who = $)
+   {
+      % Scrolls do not have targets, so override to ignore SpellItem targeting
+      return Send(oSpell,@GetTargets,#who=who);
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
In the game currently are two harmful scrolls: heat and earthquake. Earthquake is disabled and heat is enabled, but fails to cast. The issue as I understand it, is that as a `SpellItem`, scrolls expect a target. This seems to work fine for most scrolls, but _harmful_ scrolls/spells like heat and EQ run through additional logic that fails the spell because the target is the player themselves.

This PR adds a small bit of logic to spell item casts that says, ignore any "apply_on" target if this is a scroll. It does makes a bold assumption that no future scroll will be a targeted spell, which makes me wonder if I should be checking for a room enchantment spell rather than a scroll. I'm curious to hear thoughts on that as I'm leaning towards enchantment.

### The issue
When used, the scroll fails and says:
> There are no proper targets for heat.

https://github.com/user-attachments/assets/bc73ceea-be27-4024-ae6a-25bdce37d1db

### The fix in action

https://github.com/user-attachments/assets/41bf2a6e-c6bd-41c5-85b6-dee700ad2281


Closes #728 