### PR TITLE
Check unmodified base max health for faction soldier quest requirements

### DIFF
--- a/kod/object/passive/quest.kod
+++ b/kod/object/passive/quest.kod
@@ -411,7 +411,7 @@ CheckPlayerCriteria( quester_wannabe = $ )
          }
       }
       if first(iR2) = Q_R2_HAS_HEALTH_LEVEL {
-         if send(quester_wannabe,@GetMaxHealth) < nth(iR2, 2) {
+         if send(quester_wannabe,@GetBaseMaxHealth) < nth(iR2, 2) {
             if bDebug { debug("failed Q_R2_HAS_HEALTH_LEVEL."); }
             return FALSE;
          }


### PR DESCRIPTION
This PR updates the quest health requirement (`Q_R2_HAS_HEALTH_LEVEL`) to look at the player's unmodified base max health instead of their modified max health, which is affected by the likes of circlets and spells. These effects will no longer cause the faction leaders (the only uses of this requirement right now) to ignore players seeking the 'soldier' quest.

Fixes #739 