### PR TITLE
Adds purge audio to purge weapon hits

### DIFF
--- a/kod/object/passive/itematt/weapatt/wapurge.kod
+++ b/kod/object/passive/itematt/weapatt/wapurge.kod
@@ -49,7 +49,7 @@ properties:
   
    piValue_modifier = 200   %% modify the object's price by 100%
    piValue_power_modifier = 10
-   piEffect_percent = 15
+   piEffect_percent = 50
 
 messages:
 
@@ -71,28 +71,32 @@ messages:
    %%% Effect Functions
       
    ModifyDamage(damage = 0, target = $, wielder = $, lData= $)
-   "Wielder has a 1% chance of blinding target with any hit."
+   "Wielder has a percent chance of purging target with any hit."
    {
-      local oSpell;
+      local oSpell, oRoom;
 
       if random(1,100) < piEffect_percent
       {
-         oSpell = send(SYS,@FindSpellByNum,#num=SID_PURGE);
+         oSpell = Send(SYS,@FindSpellByNum,#num=SID_PURGE);
          
          %% Gotta have something to try to remove....
          if Send(target,@IsEnchanted)
          {
-            % Try to purge off random(25,75)% of the enchantments.
-            if send(oSpell,@DoPurge,#who=target,#iChance=random(25,75))
+            oRoom = Send(wielder,@GetOwner);
+
+            % Try to purge off random number of the enchantments
+            % Only tell our victim if they lost enchantments
+            if Send(oSpell,@DoPurge,#who=target,#iChance=random(25,75))
             {
-               % Only tell our victim if they lost enchantments.
-               send(target,@MsgSendUser,#message_rsc=purger_worked_target,
-                    #parm1=send(wielder,@GetCapDef),#parm2=send(wielder,@GetName));
+               Send(oSpell,@PlaySpellSound,#room_obj=oRoom,#what=wielder);
+
+               Send(target,@MsgSendUser,#message_rsc=purger_worked_target,
+                    #parm1=Send(wielder,@GetCapDef),#parm2=Send(wielder,@GetName));
             }
 
-            % Tell the wielder every time we fired so they think it's cool.
-            send(wielder,@MsgSendUser,#message_rsc=purger_worked_user,
-                 #parm1=send(target,@GetCapDef),#parm2=send(target,@GetName));
+            % Tell the wielder every time we fired so they think it's cool
+            Send(wielder,@MsgSendUser,#message_rsc=purger_worked_user,
+                 #parm1=Send(target,@GetCapDef),#parm2=Send(target,@GetName));
          }
       }
 

--- a/kod/object/passive/itematt/weapatt/wapurge.kod
+++ b/kod/object/passive/itematt/weapatt/wapurge.kod
@@ -84,10 +84,10 @@ messages:
          {
             Send(target,@MsgSendUser,#message_rsc=purger_worked_target,
                #parm1=Send(wielder,@GetCapDef),#parm2=Send(wielder,@GetName));
-`
+
             % Try to purge off random number of the enchantments
             % Only tell our victim if they lost enchantments
-            Send(oSpell,@CastSpell,#who=self,#lTargets=[target],#iSpellPower=random(25,75));
+            Send(oSpell,@CastSpell,#who=self,#lTargets=[target],#iSpellPower=random(25,75),#bItemCast=TRUE);
          }
 
          % Tell the wielder every time we fired so they think it's cool

--- a/kod/object/passive/itematt/weapatt/wapurge.kod
+++ b/kod/object/passive/itematt/weapatt/wapurge.kod
@@ -49,7 +49,7 @@ properties:
   
    piValue_modifier = 200   %% modify the object's price by 100%
    piValue_power_modifier = 10
-   piEffect_percent = 50
+   piEffect_percent = 15
 
 messages:
 

--- a/kod/object/passive/itematt/weapatt/wapurge.kod
+++ b/kod/object/passive/itematt/weapatt/wapurge.kod
@@ -73,7 +73,7 @@ messages:
    ModifyDamage(damage = 0, target = $, wielder = $, lData= $)
    "Wielder has a percent chance of purging target with any hit."
    {
-      local oSpell;
+      local oSpell, oRoom;
 
       if random(1,100) < piEffect_percent
       {
@@ -82,17 +82,22 @@ messages:
          %% Gotta have something to try to remove....
          if Send(target,@IsEnchanted)
          {
-            Send(target,@MsgSendUser,#message_rsc=purger_worked_target,
-               #parm1=Send(wielder,@GetCapDef),#parm2=Send(wielder,@GetName));
-`
+            oRoom = Send(wielder,@GetOwner);
+
             % Try to purge off random number of the enchantments
             % Only tell our victim if they lost enchantments
-            Send(oSpell,@CastSpell,#who=self,#lTargets=[target],#iSpellPower=random(25,75));
-         }
+            if Send(oSpell,@DoPurge,#who=target,#iChance=random(25,75))
+            {
+               Send(oSpell,@PlaySpellSound,#room_obj=oRoom,#what=wielder);
 
-         % Tell the wielder every time we fired so they think it's cool
-         Send(wielder,@MsgSendUser,#message_rsc=purger_worked_user,
-            #parm1=Send(target,@GetCapDef),#parm2=Send(target,@GetName));
+               Send(target,@MsgSendUser,#message_rsc=purger_worked_target,
+                    #parm1=Send(wielder,@GetCapDef),#parm2=Send(wielder,@GetName));
+            }
+
+            % Tell the wielder every time we fired so they think it's cool
+            Send(wielder,@MsgSendUser,#message_rsc=purger_worked_user,
+                 #parm1=Send(target,@GetCapDef),#parm2=Send(target,@GetName));
+         }
       }
 
       return damage;

--- a/kod/object/passive/itematt/weapatt/wapurge.kod
+++ b/kod/object/passive/itematt/weapatt/wapurge.kod
@@ -88,11 +88,11 @@ messages:
             % Try to purge off random number of the enchantments
             % Only tell our victim if they lost enchantments
             Send(oSpell,@CastSpell,#who=self,#lTargets=[target],#iSpellPower=random(25,75),#bItemCast=TRUE);
-         }
 
-         % Tell the wielder every time we fired so they think it's cool
-         Send(wielder,@MsgSendUser,#message_rsc=purger_worked_user,
-            #parm1=Send(target,@GetCapDef),#parm2=Send(target,@GetName));
+            % Tell the wielder every time we fired so they think it's cool
+            Send(wielder,@MsgSendUser,#message_rsc=purger_worked_user,
+               #parm1=Send(target,@GetCapDef),#parm2=Send(target,@GetName));
+         }
       }
 
       return damage;

--- a/kod/object/passive/itematt/weapatt/wapurge.kod
+++ b/kod/object/passive/itematt/weapatt/wapurge.kod
@@ -73,7 +73,7 @@ messages:
    ModifyDamage(damage = 0, target = $, wielder = $, lData= $)
    "Wielder has a percent chance of purging target with any hit."
    {
-      local oSpell, oRoom;
+      local oSpell;
 
       if random(1,100) < piEffect_percent
       {
@@ -82,22 +82,17 @@ messages:
          %% Gotta have something to try to remove....
          if Send(target,@IsEnchanted)
          {
-            oRoom = Send(wielder,@GetOwner);
-
+            Send(target,@MsgSendUser,#message_rsc=purger_worked_target,
+               #parm1=Send(wielder,@GetCapDef),#parm2=Send(wielder,@GetName));
+`
             % Try to purge off random number of the enchantments
             % Only tell our victim if they lost enchantments
-            if Send(oSpell,@DoPurge,#who=target,#iChance=random(25,75))
-            {
-               Send(oSpell,@PlaySpellSound,#room_obj=oRoom,#what=wielder);
-
-               Send(target,@MsgSendUser,#message_rsc=purger_worked_target,
-                    #parm1=Send(wielder,@GetCapDef),#parm2=Send(wielder,@GetName));
-            }
-
-            % Tell the wielder every time we fired so they think it's cool
-            Send(wielder,@MsgSendUser,#message_rsc=purger_worked_user,
-                 #parm1=Send(target,@GetCapDef),#parm2=Send(target,@GetName));
+            Send(oSpell,@CastSpell,#who=self,#lTargets=[target],#iSpellPower=random(25,75));
          }
+
+         % Tell the wielder every time we fired so they think it's cool
+         Send(wielder,@MsgSendUser,#message_rsc=purger_worked_user,
+            #parm1=Send(target,@GetCapDef),#parm2=Send(target,@GetName));
       }
 
       return damage;

--- a/kod/object/passive/spell/purge.kod
+++ b/kod/object/passive/spell/purge.kod
@@ -130,19 +130,22 @@ messages:
       propagate;
    }
 
-   CastSpell(who = $, lTargets = $, iSpellPower = 0)
+   CastSpell(who = $, lTargets = $, iSpellPower = 0, bItemCast = FALSE)
    {
       local oTarget;
       
       oTarget = First(lTargets);
-      if oTarget <> who
+      if NOT bItemCast
       {
-         Send(who,@MsgSendUser,#message_rsc=spell_cast_on_target,
-              #parm1=Send(self,@GetName),#parm2=Send(oTarget,@GetDef),
-              #parm3=Send(oTarget,@GetName));
-      }
+         if oTarget <> who
+         {
+            Send(who,@MsgSendUser,#message_rsc=spell_cast_on_target,
+               #parm1=Send(self,@GetName),#parm2=Send(oTarget,@GetDef),
+               #parm3=Send(oTarget,@GetName));
+         }
       
-      Send(oTarget,@MsgSendUser,#message_rsc=Purge_on);
+         Send(oTarget,@MsgSendUser,#message_rsc=Purge_on);
+      }
 
       % keep tabs on guides/bards, but not admins.
       if IsClass(who, &DM)


### PR DESCRIPTION
This PR plays the purge spell audio cue on successful hits. It does so by going through `CastSpell`, as `waparal.kod` does.

### What the attacker sees:
```
Your weapon tears at the magic surrounding Test3.
Your axe slashes Test3.
```

### What the target sees:
```
Test1's weapon tears at the magic surrounding you!
The spirit of battle has left you.
Test1 slashes you with his axe.
```

In my testing, purge often failed to remove a single PE because of the randomness of it. However, I only wanted to address the audio and not get into the probability of its effectiveness.

Fixes #820 