### PR TITLE
Correctly select skybox assets

### DIFF
--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -288,9 +288,13 @@ void D3DRenderBackgroundSet(ID background)
 	if (!filename) return;
 
 	static const std::unordered_map<std::string, int> backgroundMap = {
+		{"1skya.bgf", 0},
 		{"2skya.bgf", 0},
+		{"1skyb.bgf", 1},
 		{"2skyb.bgf", 1},
+		{"1skyc.bgf", 2},
 		{"2skyc.bgf", 2},
+		{"1skyd.bgf", 3},
 		{"2skyd.bgf", 3},
 		{"redsky.bgf", 4}
 	};

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -288,11 +288,11 @@ void D3DRenderBackgroundSet(ID background)
 	if (!filename) return;
 
 	static const std::unordered_map<std::string, int> backgroundMap = {
-		{"skya.bgf", 0},
-		{"skyb.bgf", 1},
-		{"skyc.bgf", 2},
-		{"skyd.bgf", 3},
-		{"redsky.bgf", 4}
+		{"2skya.bgf", 0},
+		{"2skyb.bgf", 1},
+		{"2skyc.bgf", 2},
+		{"2skyd.bgf", 3},
+		{"2redsky.bgf", 4}
 	};
 
 	auto it = backgroundMap.find(filename);

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -288,13 +288,16 @@ void D3DRenderBackgroundSet(ID background)
 	if (!filename) return;
 
 	static const std::unordered_map<std::string, int> backgroundMap = {
-		{"2skya.bgf", 0},
-		{"2skyb.bgf", 1},
-		{"2skyc.bgf", 2},
-		{"2skyd.bgf", 3},
-		{"2redsky.bgf", 4}
+		{"skya.bgf", 0},
+		{"skyb.bgf", 1},
+		{"skyc.bgf", 2},
+		{"skyd.bgf", 3},
+		{"redsky.bgf", 4}
 	};
 
+	// filenames are prefixed with a number, so we need to skip that to match
+	// with an item in our map.
+	filename = filename + 1;
 	auto it = backgroundMap.find(filename);
 	if (it != backgroundMap.end())
 	{

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -288,16 +288,13 @@ void D3DRenderBackgroundSet(ID background)
 	if (!filename) return;
 
 	static const std::unordered_map<std::string, int> backgroundMap = {
-		{"skya.bgf", 0},
-		{"skyb.bgf", 1},
-		{"skyc.bgf", 2},
-		{"skyd.bgf", 3},
+		{"2skya.bgf", 0},
+		{"2skyb.bgf", 1},
+		{"2skyc.bgf", 2},
+		{"2skyd.bgf", 3},
 		{"redsky.bgf", 4}
 	};
 
-	// filenames are prefixed with a number, so we need to skip that to match
-	// with an item in our map.
-	filename = filename + 1;
 	auto it = backgroundMap.find(filename);
 	if (it != backgroundMap.end())
 	{


### PR DESCRIPTION
During deconstruction of the skybox we did a small refactor for `D3DRenderBackgroundSet` https://github.com/Meridian59/Meridian59/pull/928. This wasn't correct as the previous code uses a `strstr` We update the code to cater for this. 

Tested by switching successfully through times of the day `send o 0 sethour num int 21`.
After prompting also tested with a frenzy `send object 0 StartChaosNight` successfully with hard coded asset names.

