### PR TITLE
Fixes erroring faction service timer deletion

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -10972,6 +10972,8 @@ messages:
    {
       local iHistory;
 
+      ptFactionTimer = $;
+
       if piFaction = FACTION_NEUTRAL
       {
          return;
@@ -11175,7 +11177,6 @@ messages:
          factliege = Send(Send(SYS,@GetParliament),@GetLiege,#faction=piFaction);
       }
                           
-      ptFactionTimer = $;
       Send(Self,@FactionServiceRoutine);
       Send(Send(SYS,@GetParliament),@MoveToFaction,#who=self,#faction=piFaction);
       Send(Send(SYS,@GetParliament),@UpdateEffects,#who=self);

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1807,7 +1807,7 @@ messages:
             AND (not Send(Send(SYS,@GetParliament),@IsShutdown))
          {
             piFactionTimeUpdated=GetTime();
-            Send(self,@FactionServiceTimer);
+            Send(self,@FactionServiceRoutine);
          }
 
          if Send(self,@PlayerIsIntriguing)
@@ -1884,7 +1884,7 @@ messages:
 
       if piFaction <> FACTION_NEUTRAL
       {
-         Send(self,@factionServiceRoutine,#renew=FALSE);
+         Send(self,@FactionServiceRoutine,#renew=FALSE);
       }
 
       % Stop health and mana timers.
@@ -10971,13 +10971,7 @@ messages:
    FactionServiceTimer(renew=TRUE)
    {
       local iHistory;
-      
-      if ptFactionTimer <> $
-      {
-         DeleteTimer(ptFactionTimer);
-         ptFactionTimer = $;
-      }
-      
+
       if piFaction = FACTION_NEUTRAL
       {
          return;
@@ -11182,7 +11176,7 @@ messages:
       }
                           
       ptFactionTimer = $;
-      Send(Self,@FactionServiceTimer);
+      Send(Self,@FactionServiceRoutine);
       Send(Send(SYS,@GetParliament),@MoveToFaction,#who=self,#faction=piFaction);
       Send(Send(SYS,@GetParliament),@UpdateEffects,#who=self);
       Send(self,@MsgSendUser,#message_rsc=player_join_faction,


### PR DESCRIPTION
When a player joins a faction, `FactionServiceTimer()` creates a timer callback to itself to determine faction status and if good, create another timer to do the same in the future. The problem seen in the logs, is that when control returns to this method, the reference to the timer remains but the timer has since been deleted. The result is a `DeleteTimer()` error.

I'm unable to pinpoint a point in the code where an inadvertent deletion of this timer exists and am kind of assuming that when the timer expires and the call to `FactionServiceTimer()` is made, the timer has been cleaned up and the reference via `ptFactionTimer` remains.

To fix this, I've removed any timer deletion code from `FactionServiceTimer()` and have given that responsibility to `FactionServiceRoutine()`.

### Testing
Testing this is made much easier by tuning `FACTION_RESIGN_TIME` and `FACTION_UPDATE_TIME` way down to create rapid faction service cycles.