### PR TITLE
Adds `bItemCast=TRUE` flag to Hold weapatt spell cast

### DIFF
--- a/kod/object/passive/itematt/weapatt/waparal.kod
+++ b/kod/object/passive/itematt/weapatt/waparal.kod
@@ -61,14 +61,14 @@ messages:
 
       if random(1,100) <= piEffect_percent
       {
-         oSpell = send(SYS,@FindSpellByNum,#num=SID_HOLD);
+         oSpell = Send(SYS,@FindSpellByNum,#num=SID_HOLD);
 	 
          %% no duplicates
-         if not Send(target,@IsEnchanted,#what=oSpell)
+         if NOT Send(target,@IsEnchanted,#what=oSpell)
          {	          
-            send(oSpell,@CastSpell,#who=self,#ltargets=[target],#ispellpower=99);
-            send(wielder,@MsgSendUser,#message_rsc=holder_worked,
-                 #parm1=send(target,@GetCapDef),#parm2=send(target,@GetName));
+            Send(oSpell,@CastSpell,#who=self,#lTargets=[target],#iSpellPower=99,#bItemCast=TRUE);
+            Send(wielder,@MsgSendUser,#message_rsc=holder_worked,
+                 #parm1=Send(target,@GetCapDef),#parm2=Send(target,@GetName));
          }
       }
 
@@ -78,10 +78,10 @@ messages:
    ItemReqUse(oItem=$,oPlayer=$)
    {
       % A person needs 50% in the weapon's proficiency to use
-      if send(oItem,@GetProf,#who=oPlayer) < 50      
+      if Send(oItem,@GetProf,#who=oPlayer) < 50      
       {
-         send(oPlayer, @MsgSendUser, #message_rsc = paralyzer_fail_use,
-            #parm1=send(oItem,@getdef),#parm2=send(oItem,@GetName));
+         Send(oPlayer,@MsgSendUser,#message_rsc=paralyzer_fail_use,
+            #parm1=Send(oItem,@getdef),#parm2=Send(oItem,@GetName));
 
          return FALSE;      
       }


### PR DESCRIPTION
This further avoids traditional spell cast logic by flagging this weapatt's spell cast as an item cast via `bItemCast`. Doing so avoids a few bits of traditional spell casting code in Spell's `CastSpell()`. 

In Discord, I had suggested that without this flag the player might be improving off a weapon attribute. However, an instance of `self` (the weapon attribute) is being passed to `CastSpell()`, standing in as the caster, and causes `ImproveAbility()` to return immediately.

