### PR TITLE
Revises map marker sizing and color

### DIFF
--- a/clientd3d/map.c
+++ b/clientd3d/map.c
@@ -20,12 +20,14 @@
 #include "client.h"
 
 #define MAP_WALL_THICKNESS 1
-#define MAP_PLAYER_THICKNESS 2
+#define MAP_SELF_THICKNESS 2
+#define MAP_PLAYER_THICKNESS 5
 #define MAP_OBJECT_THICKNESS 3
 
 #define MAP_PLAYER_MARKER_SIZE 3
 
 #define MAP_WALL_COLOR          PALETTERGB(0, 0, 0)
+#define MAP_SELF_COLOR          PALETTERGB(0, 255, 255)
 #define MAP_PLAYER_COLOR        PALETTERGB(0, 0, 255)
 #define MAP_OBJECT_COLOR        PALETTERGB(255, 0, 0)
 
@@ -43,7 +45,7 @@
 #define MAP_OBJECT_DISTANCE (7 * FINENESS) // Draw all object closer than this to player
 
 static HBRUSH hObjectBrush, hPlayerBrush, hNullBrush;
-static HPEN hWallPen, hPlayerPen, hObjectPen;
+static HPEN hWallPen, hSelfPen, hPlayerPen, hObjectPen;
 static HPEN hFriendPen, hEnemyPen, hGuildmatePen;
 
 static float zoom;              // Factor to zoom in on map
@@ -128,6 +130,7 @@ void MapInitialize(void)
    logBrush.lbStyle = BS_HOLLOW;
 
    hWallPen = CreatePen(PS_SOLID, MAP_WALL_THICKNESS, MAP_WALL_COLOR);
+   hSelfPen = CreatePen(PS_SOLID, MAP_SELF_THICKNESS, MAP_SELF_COLOR);
    hPlayerPen = CreatePen(PS_SOLID, MAP_PLAYER_THICKNESS, MAP_PLAYER_COLOR);
    hObjectPen = CreatePen(PS_SOLID, MAP_OBJECT_THICKNESS, MAP_OBJECT_COLOR);
    hFriendPen = CreatePen(PS_SOLID, MAP_PLAYER_THICKNESS, MAP_FRIEND_COLOR);
@@ -476,7 +479,7 @@ void MapDrawPlayer(HDC hdc, int x, int y, float scale)
    RECT rc;
    int radius = player.width / 2;
 
-   hOldPen = (HPEN) SelectObject(hdc, hPlayerPen);
+   hOldPen = (HPEN) SelectObject(hdc, hSelfPen);
 
    FindOffsets(MAP_PLAYER_MARKER_SIZE * 3, player.angle, &dx, &dy);
    FindOffsets(MAP_PLAYER_MARKER_SIZE, player.angle+NUMDEGREES/4, &ldx, &ldy);

--- a/clientd3d/map.c
+++ b/clientd3d/map.c
@@ -27,7 +27,7 @@
 #define MAP_PLAYER_MARKER_SIZE 3
 
 #define MAP_WALL_COLOR          PALETTERGB(0, 0, 0)
-#define MAP_SELF_COLOR          PALETTERGB(0, 255, 255)
+#define MAP_SELF_COLOR          PALETTERGB(0, 0, 255)
 #define MAP_PLAYER_COLOR        PALETTERGB(0, 0, 255)
 #define MAP_OBJECT_COLOR        PALETTERGB(255, 0, 0)
 


### PR DESCRIPTION
This PR is meant to address some feedback heard on #809. Currently, other player's markers (blue dots) can sometimes be tiny in comparison to the player's marker and difficult to spot. This PR increases the size of them by introducing new pen so that _the_ player and other players can be styled differently. To help identity yourself against others, this PR also updates the player's marker to cyan.

I've also heard some concerns about situations where many players are in close proximity to one another. While there are situations and zoom levels where players dot will mash together, it would seem uncommon for those dots to remain static.

I created some representative examples of the current state vs what's proposed in this PR by screenshotting, copying, and pasting player markers. If there are more situations folks would like to see just drop a reply.

![image](https://github.com/user-attachments/assets/3fb97c95-83ed-4620-b3e3-53859137aa3c)