### PR TITLE
Fixes territory game recreate by skipping post-processing on flag claims

### DIFF
--- a/kod/object/active/flag.kod
+++ b/kod/object/active/flag.kod
@@ -695,8 +695,8 @@ messages:
       return poClaimer;
    }
 
-   SetFaction(faction=FACTION_NEUTRAL,processClaim=TRUE)
-   "Sets the flag's faction and process the claim through the territory game."
+   SetFaction(faction=FACTION_NEUTRAL,processClaim=FALSE)
+   "Updates the flag's faction. By default, this updates the faction only, which is needed when the territory game is recreated. Pass `processClaim=TRUE` to notify the territory game of the change."
    {
       piFaction = faction;
       if poOwner <> $

--- a/kod/object/active/flag.kod
+++ b/kod/object/active/flag.kod
@@ -695,8 +695,8 @@ messages:
       return poClaimer;
    }
 
-   SetFaction(faction=FACTION_NEUTRAL,processClaim=FALSE)
-   "Updates the flag's faction. If just updating the flag's ownership and nothing else--such as during a recreate--leave the `processClaim` flag as `FALSE`. However, if changing the flag as part of an action in an ongoing territory game, set `processClaim=TRUE` so that the territory game can recount flags and persist state changes."
+   SetFaction(faction=FACTION_NEUTRAL)
+   "Admins use `AdminSetFaction` when forcing a faction change to ensure the territory game updates flag counts and persists state changes."
    {
       piFaction = faction;
       if poOwner <> $
@@ -707,11 +707,6 @@ messages:
          {
             ptGenerateTroops = createtimer(self,@GenerateTroops,piGen_time);
          }
-      }
-
-      if (send(SYS,@GetTerritoryGame) <> $) AND processClaim
-      {
-         send(send(SYS,@GetTerritoryGame),@FlagClaimed,#flag=self);
       }
 
       return;
@@ -880,5 +875,18 @@ messages:
       propagate;
    }
 
+   AdminSetFaction(faction=FACTION_NEUTRAL)
+   "Admin supported.\n"
+   "Sets flag's faction and forces the territory game to recount flags and persist state changes."
+   {
+      Send(self,@SetFaction,#faction=faction);
+
+      if (Send(SYS,@GetTerritoryGame) <> $)
+      {
+         Send(Send(SYS,@GetTerritoryGame),@FlagClaimed,#flag=self);
+      }
+      
+      return;
+   }
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/flag.kod
+++ b/kod/object/active/flag.kod
@@ -695,8 +695,8 @@ messages:
       return poClaimer;
    }
 
-   SetFaction(faction=FACTION_NEUTRAL)
-   "for admin use"
+   SetFaction(faction=FACTION_NEUTRAL,processClaim=TRUE)
+   "Sets the flag's faction and process the claim through the territory game."
    {
       piFaction = faction;
       if poOwner <> $
@@ -709,7 +709,7 @@ messages:
          }
       }
 
-      if (send(SYS,@GetTerritoryGame) <> $)
+      if (send(SYS,@GetTerritoryGame) <> $) AND processClaim
       {
          send(send(SYS,@GetTerritoryGame),@FlagClaimed,#flag=self);
       }

--- a/kod/object/active/flag.kod
+++ b/kod/object/active/flag.kod
@@ -696,7 +696,7 @@ messages:
    }
 
    SetFaction(faction=FACTION_NEUTRAL,processClaim=FALSE)
-   "Updates the flag's faction. By default, this updates the faction only, which is needed when the territory game is recreated. Pass `processClaim=TRUE` to notify the territory game of the change."
+   "Updates the flag's faction. If just updating the flag's ownership and nothing else--such as during a recreate--leave the `processClaim` flag as `FALSE`. However, if you're changing the flag as part of an action in an ongoing territory game, set `processClaim=TRUE` so that the territory game can recount flags and persist state changes."
    {
       piFaction = faction;
       if poOwner <> $

--- a/kod/object/active/flag.kod
+++ b/kod/object/active/flag.kod
@@ -696,7 +696,7 @@ messages:
    }
 
    SetFaction(faction=FACTION_NEUTRAL,processClaim=FALSE)
-   "Updates the flag's faction. If just updating the flag's ownership and nothing else--such as during a recreate--leave the `processClaim` flag as `FALSE`. However, if you're changing the flag as part of an action in an ongoing territory game, set `processClaim=TRUE` so that the territory game can recount flags and persist state changes."
+   "Updates the flag's faction. If just updating the flag's ownership and nothing else--such as during a recreate--leave the `processClaim` flag as `FALSE`. However, if changing the flag as part of an action in an ongoing territory game, set `processClaim=TRUE` so that the territory game can recount flags and persist state changes."
    {
       piFaction = faction;
       if poOwner <> $

--- a/kod/util/factgame/territry.kod
+++ b/kod/util/factgame/territry.kod
@@ -254,23 +254,23 @@ messages:
 
             if (lRIDs = plTosRIDs) or (lRIDs = plMarionRIDs)
             {
-               send(oFlag,@SetFaction,#faction=FACTION_DUKE);
+               send(oFlag,@SetFaction,#faction=FACTION_DUKE,#processClaim=FALSE);
             }
 
             if (lRIDs = plCorNothRIDs) or (lRIDs = plBarloqueRIDs)
             {
-               send(oFlag,@SetFaction,#faction=FACTION_PRINCESS);
+               send(oFlag,@SetFaction,#faction=FACTION_PRINCESS,#processClaim=FALSE);
             }
 
             if (lRIDs = plJasperRIDs)
             {
                if (random(0,1) = 0)
                {
-                  send(oFlag,@SetFaction,#faction=FACTION_PRINCESS);
+                  send(oFlag,@SetFaction,#faction=FACTION_PRINCESS,#processClaim=FALSE);
                }
                else
                {
-                  send(oFlag,@SetFaction,#faction=FACTION_DUKE);
+                  send(oFlag,@SetFaction,#faction=FACTION_DUKE,#processClaim=FALSE);
                }
             }
 
@@ -313,7 +313,7 @@ messages:
          iLocation = FindListElem(plTosRIDs,iRID);
          if iLocation
          {
-            send(oFlag,@SetFaction,#faction=FACTION_DUKE);
+            send(oFlag,@SetFaction,#faction=FACTION_DUKE,#processClaim=FALSE);
             if iLocation = 1
             {
                % town flag
@@ -324,7 +324,7 @@ messages:
          iLocation = FindListElem(plBarloqueRIDs,iRID);
          if iLocation
          {
-            send(oFlag,@SetFaction,#faction=FACTION_PRINCESS);
+            send(oFlag,@SetFaction,#faction=FACTION_PRINCESS,#processClaim=FALSE);
             if iLocation = 1
             {
                % town flag
@@ -335,7 +335,7 @@ messages:
          iLocation = FindListElem(plJasperRIDs,iRID);
          if iLocation
          {
-            send(oFlag,@SetFaction,#faction=FACTION_REBEL);
+            send(oFlag,@SetFaction,#faction=FACTION_REBEL,#processClaim=FALSE);
             if iLocation = 1
             {
                % town flag
@@ -346,7 +346,7 @@ messages:
          iLocation = FindListElem(plMarionRIDs,iRID);
          if iLocation
          {
-            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL);
+            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL,#processClaim=FALSE);
             if iLocation = 1
             {
                % town flag
@@ -357,7 +357,7 @@ messages:
          iLocation = FindListElem(plCorNothRIDs,iRID);
          if iLocation
          {
-            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL);
+            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL,#processClaim=FALSE);
             if iLocation = 1
             {
                % town flag
@@ -425,7 +425,7 @@ messages:
             DEBUG("ReloadSavedFlagStates:: got nil flag in",send(oRoom,@GetName));
             continue;
          }
-         send(oFlag,@SetFaction,#faction=nth(plFlagStates,(i+1)));
+         send(oFlag,@SetFaction,#faction=nth(plFlagStates,(i+1)),#processClaim=FALSE);
       }
 
       return;
@@ -564,7 +564,7 @@ messages:
                oFlagpole = send(oRoom,@FindHoldingActive,#class=&FlagPole);
                if send(oFlagPole,@GetFaction) <> (iFaction-1)
                {
-                  send(oFlagPole,@SetFaction,#faction=(iFaction-1));
+                  send(oFlagPole,@SetFaction,#faction=(iFaction-1),#processClaim=TRUE);
                   if report
                   {
                      send(self,@SendBonusTownMessage,#faction=(iFaction-1),#town=lRIDs);
@@ -797,7 +797,7 @@ messages:
             if iRID = first(lRIDs) { continue; }
             oRoom = send(SYS,@FindRoomByNum,#num=iRID);
             oFlag = send(oRoom,@FindHoldingActive,#class=&Flagpole);
-            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL);
+            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL,#processClaim=FALSE);
          }
       }
 
@@ -811,7 +811,7 @@ messages:
                if iRID = first(lRIDs) { continue; }
                oRoom = send(SYS,@FindRoomByNum,#num=iRID);
                oFlag = send(oRoom,@FindHoldingActive,#class=&Flagpole);
-               send(oFlag,@SetFaction,#faction=FACTION_DUKE);
+               send(oFlag,@SetFaction,#faction=FACTION_DUKE,#processClaim=FALSE);
                iDukeFlags = iDukeFlags - 1;
             }
          }
@@ -827,7 +827,7 @@ messages:
                if iRID = first(lRIDs) { continue; }
                oRoom = send(SYS,@FindRoomByNum,#num=iRID);
                oFlag = send(oRoom,@FindHoldingActive,#class=&Flagpole);
-               send(oFlag,@SetFaction,#faction=FACTION_PRINCESS);
+               send(oFlag,@SetFaction,#faction=FACTION_PRINCESS,#processClaim=FALSE);
                iPrincessFlags = iPrincessFlags - 1;
             }
          }

--- a/kod/util/factgame/territry.kod
+++ b/kod/util/factgame/territry.kod
@@ -564,10 +564,13 @@ messages:
                oFlagpole = send(oRoom,@FindHoldingActive,#class=&FlagPole);
                if send(oFlagPole,@GetFaction) <> (iFaction-1)
                {
-                  % We pass `processClaim=TRUE` to fully process the faction 
-                  % change by notifying the territory game of the change; not 
-                  % simply flip the faction type of the flag.
-                  send(oFlagPole,@SetFaction,#faction=(iFaction-1),#processClaim=TRUE);
+                  Send(oFlagPole,@SetFaction,#faction=(iFaction-1));
+
+                  if (Send(SYS,@GetTerritoryGame) <> $)
+                  {
+                     Send(self,@FlagClaimed,#flag=oFlagPole);
+                  }
+
                   if report
                   {
                      send(self,@SendBonusTownMessage,#faction=(iFaction-1),#town=lRIDs);

--- a/kod/util/factgame/territry.kod
+++ b/kod/util/factgame/territry.kod
@@ -254,23 +254,23 @@ messages:
 
             if (lRIDs = plTosRIDs) or (lRIDs = plMarionRIDs)
             {
-               send(oFlag,@SetFaction,#faction=FACTION_DUKE,#processClaim=FALSE);
+               send(oFlag,@SetFaction,#faction=FACTION_DUKE);
             }
 
             if (lRIDs = plCorNothRIDs) or (lRIDs = plBarloqueRIDs)
             {
-               send(oFlag,@SetFaction,#faction=FACTION_PRINCESS,#processClaim=FALSE);
+               send(oFlag,@SetFaction,#faction=FACTION_PRINCESS);
             }
 
             if (lRIDs = plJasperRIDs)
             {
                if (random(0,1) = 0)
                {
-                  send(oFlag,@SetFaction,#faction=FACTION_PRINCESS,#processClaim=FALSE);
+                  send(oFlag,@SetFaction,#faction=FACTION_PRINCESS);
                }
                else
                {
-                  send(oFlag,@SetFaction,#faction=FACTION_DUKE,#processClaim=FALSE);
+                  send(oFlag,@SetFaction,#faction=FACTION_DUKE);
                }
             }
 
@@ -313,7 +313,7 @@ messages:
          iLocation = FindListElem(plTosRIDs,iRID);
          if iLocation
          {
-            send(oFlag,@SetFaction,#faction=FACTION_DUKE,#processClaim=FALSE);
+            send(oFlag,@SetFaction,#faction=FACTION_DUKE);
             if iLocation = 1
             {
                % town flag
@@ -324,7 +324,7 @@ messages:
          iLocation = FindListElem(plBarloqueRIDs,iRID);
          if iLocation
          {
-            send(oFlag,@SetFaction,#faction=FACTION_PRINCESS,#processClaim=FALSE);
+            send(oFlag,@SetFaction,#faction=FACTION_PRINCESS);
             if iLocation = 1
             {
                % town flag
@@ -335,7 +335,7 @@ messages:
          iLocation = FindListElem(plJasperRIDs,iRID);
          if iLocation
          {
-            send(oFlag,@SetFaction,#faction=FACTION_REBEL,#processClaim=FALSE);
+            send(oFlag,@SetFaction,#faction=FACTION_REBEL);
             if iLocation = 1
             {
                % town flag
@@ -346,7 +346,7 @@ messages:
          iLocation = FindListElem(plMarionRIDs,iRID);
          if iLocation
          {
-            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL,#processClaim=FALSE);
+            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL);
             if iLocation = 1
             {
                % town flag
@@ -357,7 +357,7 @@ messages:
          iLocation = FindListElem(plCorNothRIDs,iRID);
          if iLocation
          {
-            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL,#processClaim=FALSE);
+            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL);
             if iLocation = 1
             {
                % town flag
@@ -425,7 +425,7 @@ messages:
             DEBUG("ReloadSavedFlagStates:: got nil flag in",send(oRoom,@GetName));
             continue;
          }
-         send(oFlag,@SetFaction,#faction=nth(plFlagStates,(i+1)),#processClaim=FALSE);
+         send(oFlag,@SetFaction,#faction=nth(plFlagStates,(i+1)));
       }
 
       return;
@@ -564,6 +564,9 @@ messages:
                oFlagpole = send(oRoom,@FindHoldingActive,#class=&FlagPole);
                if send(oFlagPole,@GetFaction) <> (iFaction-1)
                {
+                  % We pass `processClaim=TRUE` to fully process the faction 
+                  % change by notifying the territory game of the change; not 
+                  % simply flip the faction type of the flag.
                   send(oFlagPole,@SetFaction,#faction=(iFaction-1),#processClaim=TRUE);
                   if report
                   {
@@ -797,7 +800,7 @@ messages:
             if iRID = first(lRIDs) { continue; }
             oRoom = send(SYS,@FindRoomByNum,#num=iRID);
             oFlag = send(oRoom,@FindHoldingActive,#class=&Flagpole);
-            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL,#processClaim=FALSE);
+            send(oFlag,@SetFaction,#faction=FACTION_NEUTRAL);
          }
       }
 
@@ -811,7 +814,7 @@ messages:
                if iRID = first(lRIDs) { continue; }
                oRoom = send(SYS,@FindRoomByNum,#num=iRID);
                oFlag = send(oRoom,@FindHoldingActive,#class=&Flagpole);
-               send(oFlag,@SetFaction,#faction=FACTION_DUKE,#processClaim=FALSE);
+               send(oFlag,@SetFaction,#faction=FACTION_DUKE);
                iDukeFlags = iDukeFlags - 1;
             }
          }
@@ -827,7 +830,7 @@ messages:
                if iRID = first(lRIDs) { continue; }
                oRoom = send(SYS,@FindRoomByNum,#num=iRID);
                oFlag = send(oRoom,@FindHoldingActive,#class=&Flagpole);
-               send(oFlag,@SetFaction,#faction=FACTION_PRINCESS,#processClaim=FALSE);
+               send(oFlag,@SetFaction,#faction=FACTION_PRINCESS);
                iPrincessFlags = iPrincessFlags - 1;
             }
          }


### PR DESCRIPTION
This PR modifies the `SetFaction` function to only change the flag's faction without performing post-processing steps. Specifically, the flag claim process and other related actions will no longer occur when only the faction is updated. This is needed to properly recreate the territory game and specifically, the full version of the territory game.

## Testing
* I manually converted flags to another faction when testing. Using `send o <TerritoryGame> GetFlagCounts` to verify the counts were the expected values.
* Tested existing functionality to ensure no side effects or unintended behaviors were introduced when recreating the territory game and when performing a system `RecreateAll`.

## Notes:
* This has been attempted and discussed before in #450 
* This attempts to address the issue with the least change possible, so it doesn't address some [desires in the original issue](https://github.com/Meridian59/Meridian59/issues/29#issuecomment-1478850125). I can address those in this or we can leave that for a follow-up.

Fixes #29 (at least what I understand to be the remaining issue)