### PR TITLE
Update to innkeeper room cost command

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqinnk.kod
@@ -35,9 +35,11 @@ resources:
       "our rooms to be most well-appointed.  Enjoyest thine stay!"
 
    BarloqueInnkeeper_cost = \
-      "The rooms here are the finest.  I needeth %i shillings when thou ~Irent~neth a "
-      "~Iroom~n for for 85 days.  After that, I requireth %i per day up front.  Key copies "
-      "costeth %i shillings if thou wishest to share thine room with a special someone."
+      "The rooms here are the finest.  I needeth %i shillings when thou ~I~Urent~neth a "
+      "~I~Uroom~n for for 85 days.  After that, I requireth %i per day up front.  A ~I~Ucopy~n "
+      "of your ~I~Ukey~n, which may be ~I~Usecure~nth shoudst thou be proneth to losing them, costeth "
+      "%i shillings if thou wishest to share thine room with a special someone.  If thou loseth "
+      "one of thine copies, just let me knoweth and I can ~I~Uchange locks~n free of chargeth!"
 
    BarloqueInnkeeper_days_left = "I thanketh thee.  Thou hast %i days left at my luxurious inn."
    BarloqueInnkeeper_too_long = "It pleaseth me that ye liketh thine room, but thou hast paid enough in rent already!  I canst not accept more from you right now."

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqinnk.kod
@@ -35,11 +35,11 @@ resources:
       "our rooms to be most well-appointed.  Enjoyest thine stay!"
 
    BarloqueInnkeeper_cost = \
-      "The rooms here are the finest.  I needeth %i shillings when thou ~I~Urent~neth a "
-      "~I~Uroom~n for for 85 days.  After that, I requireth %i per day up front.  A ~I~Ucopy~n "
-      "of your ~I~Ukey~n, which may be ~I~Usecure~nth shoudst thou be proneth to losing them, costeth "
+      "The rooms here are the finest.  I needeth %i shillings when thou ~Irent~neth a "
+      "~Iroom~n for for 85 days.  After that, I requireth %i per day up front.  A ~Icopy~n "
+      "of your ~Ikey~n, which may be ~Isecure~nth shoudst thou be proneth to losing them, costeth "
       "%i shillings if thou wishest to share thine room with a special someone.  If thou loseth "
-      "one of thine copies, just let me knoweth and I can ~I~Uchange locks~n free of chargeth!"
+      "one of thine copies, just let me knoweth and I can ~Ichange locks~n free of chargeth!"
 
    BarloqueInnkeeper_days_left = "I thanketh thee.  Thou hast %i days left at my luxurious inn."
    BarloqueInnkeeper_too_long = "It pleaseth me that ye liketh thine room, but thou hast paid enough in rent already!  I canst not accept more from you right now."

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcinnk.kod
@@ -39,11 +39,13 @@ resources:
 
    KocatanInnkeeper_cost = \
       "You'll not find a better deal on the island!  It costs %i shillings to "
-      "~Irent~n a ~Iroom~n at my fine establishment for 85 days.  If you "
+      "~I~Urent~n a ~I~Uroom~n at my fine establishment for 85 days.  If you "
       "want to stay longer, that'll be %i shillings per day, paid in advance.  "
       "For a very modest fee of %i shillings, I can even provide you "
-      "with a copy of your room key.  Act now, because this offer won't last "
-      "long!  Space is very limited and my rooms are first-come, first-serve!"
+      "with an optionally ~I~Usecure~n ~I~Ucopy~n of your room ~I~Ukey~n.  I'll "
+      "even ~I~Uchange locks~n for you if necessary, free of charge!  Act "
+      "now, because this offer won't last long!  Space is very limited and my "
+      "rooms are first-come, first-serve!"
 
    KocatanInnkeeper_days_left = \
       "Thank you, my friend!  I'll have triple this amount for you after "

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcinnk.kod
@@ -39,11 +39,11 @@ resources:
 
    KocatanInnkeeper_cost = \
       "You'll not find a better deal on the island!  It costs %i shillings to "
-      "~I~Urent~n a ~I~Uroom~n at my fine establishment for 85 days.  If you "
+      "~Irent~n a ~Iroom~n at my fine establishment for 85 days.  If you "
       "want to stay longer, that'll be %i shillings per day, paid in advance.  "
       "For a very modest fee of %i shillings, I can even provide you "
-      "with an optionally ~I~Usecure~n ~I~Ucopy~n of your room ~I~Ukey~n.  I'll "
-      "even ~I~Uchange locks~n for you if necessary, free of charge!  Act "
+      "with an optionally ~Isecure~n ~Icopy~n of your room ~Ikey~n.  I'll "
+      "even ~Ichange locks~n for you if necessary, free of charge!  Act "
       "now, because this offer won't last long!  Space is very limited and my "
       "rooms are first-come, first-serve!"
 

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/marntwn/mrinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/marntwn/mrinnk.kod
@@ -29,12 +29,12 @@ resources:
       "Here ya go then.  Hope you enjoy your stay, if you have any problems Tova "
       "will be glad to help you."
    MarionInnkeeper_cost = \
-      "Oh, good, you should rest.  Let me see....  I charge %i shillings to ~I~Urent~n "
-      "a nice ~I~Uroom~n here for 85 days.  If you wish to stay longer, I charge %i "
-      "per day if you pre-pay.  Need a ~I~Ucopy~n of your room ~I~Ukey~n?  Uh, key "
-      "copies....  Oh, they cost %i shillings to make, and can even be ~I~Usecure~n "
+      "Oh, good, you should rest.  Let me see....  I charge %i shillings to ~Irent~n "
+      "a nice ~Iroom~n here for 85 days.  If you wish to stay longer, I charge %i "
+      "per day if you pre-pay.  Need a ~Icopy~n of your room ~Ikey~n?  Uh, key "
+      "copies....  Oh, they cost %i shillings to make, and can even be ~Isecure~n "
       "if you want to lower the risk of accidentally losing it.  There was one more "
-      "thing...oh right!  If you lose one of your copied keys, ask me to ~I~Uchange "
+      "thing...oh right!  If you lose one of your copied keys, ask me to ~Ichange "
       "locks~n and I will happily see that it is take care of.  I know you'll like "
       "your room."
    MarionInnkeeper_days_left = \

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/marntwn/mrinnk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/marntwn/mrinnk.kod
@@ -29,10 +29,14 @@ resources:
       "Here ya go then.  Hope you enjoy your stay, if you have any problems Tova "
       "will be glad to help you."
    MarionInnkeeper_cost = \
-      "Oh, good, you should rest.  Let me see....  I charge %i shillings to ~Irent~n "
-      "a nice ~Iroom~n here for 85 days.  If you wish to stay longer, I charge %i "
-      "per day if you pre-pay.  Key copies, uh, key copies....  Oh, they cost %i "
-      "shillings to make.  I know you'll like your room."
+      "Oh, good, you should rest.  Let me see....  I charge %i shillings to ~I~Urent~n "
+      "a nice ~I~Uroom~n here for 85 days.  If you wish to stay longer, I charge %i "
+      "per day if you pre-pay.  Need a ~I~Ucopy~n of your room ~I~Ukey~n?  Uh, key "
+      "copies....  Oh, they cost %i shillings to make, and can even be ~I~Usecure~n "
+      "if you want to lower the risk of accidentally losing it.  There was one more "
+      "thing...oh right!  If you lose one of your copied keys, ask me to ~I~Uchange "
+      "locks~n and I will happily see that it is take care of.  I know you'll like "
+      "your room."
    MarionInnkeeper_days_left = \
       "You like it here, I see.  There are %i days until you should pay me again."
    MarionInnkeeper_too_long = \

--- a/kod/util/rntmaint.kod
+++ b/kod/util/rntmaint.kod
@@ -33,6 +33,7 @@ resources:
    RoomMaintenance_command_room = "room"
    RoomMaintenance_command_rent = "rent"
    RoomMaintenance_command_cost = "cost"
+   RoomMaintenance_command_help = "help"
    RoomMaintenance_command_copy_key = "copy key"
    RoomMaintenance_command_secure = "secure"
    RoomMaintenance_command_change_lock = "change lock"
@@ -175,7 +176,9 @@ messages:
       }
 
       % Command: Room Cost
-      if StringContain(speech, RoomMaintenance_command_room) AND StringContain(speech, RoomMaintenance_command_cost)
+      if StringContain(speech, RoomMaintenance_command_room) 
+         AND (StringContain(speech, RoomMaintenance_command_cost)
+         OR StringContain(speech, RoomMaintenance_command_help))
       {
          Post(Send(who, @GetOwner), @SomeoneSaid, #type=SAY_RESOURCE, #what=who,
             #string=rscRoomCost, 


### PR DESCRIPTION
This PR adds the following improvements to the "room cost" command and its functionality:

- Adds an underline to the various room rental keywords to make them pop better.
- Adds text for the newer commands: "secure" keyword for copying keys, as well as the "change lock" command.
- Added an alternative command to reach the "room cost" dialog:  "room help" which seems like something a player is more likely to say when they want to know the commands and such.

![image](https://github.com/user-attachments/assets/48432171-8b3c-460b-96fb-8f10e7d23d5a)
