### PR TITLE
Remove hidden admin imp audio cue

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -7162,8 +7162,12 @@ messages:
       {
          oRoom = Send(self, @GetOwner);
          Post(self,@MsgSendUser,#message_rsc=player_improved,#parm1=skillName);
-         Send(oRoom, @SomethingWaveRoom, #what=self, 
-              #wave_rsc=player_improved_wav_rsc);
+
+         if NOT (isClass(self,&Admin) AND Send(self,@IsHidden))
+         {
+            Send(oRoom, @SomethingWaveRoom, #what=self, 
+               #wave_rsc=player_improved_wav_rsc);
+         }
       }
       
       if iChange > 0 

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -7163,7 +7163,7 @@ messages:
          oRoom = Send(self, @GetOwner);
          Post(self,@MsgSendUser,#message_rsc=player_improved,#parm1=skillName);
 
-         if NOT (isClass(self,&Admin) AND Send(self,@IsHidden))
+         if NOT (isClass(self,&DM) AND Send(self,@IsHidden))
          {
             Send(oRoom, @SomethingWaveRoom, #what=self, 
                #wave_rsc=player_improved_wav_rsc);

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -6588,9 +6588,13 @@ messages:
       if report AND iChange > 0
       {
          oRoom = Send(self, @GetOwner);
-         Post(self,@MsgSendUser,#message_rsc=player_improved,#parm1=spellName);
-         Send(oRoom, @SomethingWaveRoom, #what=self, 
-              #wave_rsc=player_improved_wav_rsc);
+         Post(self,@MsgSendUser,#message_rsc=player_improved,#parm1=spellName);   
+         
+         if NOT (isClass(self,&Admin) AND Send(self,@IsHidden))
+         {
+            Send(oRoom, @SomethingWaveRoom, #what=self, 
+               #wave_rsc=player_improved_wav_rsc);
+         }
       }
       
       if iChange > 0 

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1409,8 +1409,7 @@ messages:
 
       if oRoom <> $
       {
-         if isClass(who,&Admin)
-            AND Send(who, @IsHidden)
+         if isClass(who,&DM) AND Send(who, @IsHidden)
          {
              if oTarget = $
              {

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1413,11 +1413,11 @@ messages:
          {
              if oTarget = $
              {
-                 Debug("ADMIN:",Send(who,@GetTrueName),"cast",Send(Self,@GetName),"while hidden.");
+                 Debug("DM:",Send(who,@GetTrueName),"cast",Send(Self,@GetName),"while hidden.");
              }               
              else
              {
-                 Debug("ADMIN:",Send(who,@GetTrueName),"cast ",Send(self,@GetName),"on",Send(oTarget,@GetTrueName),"while hidden.");
+                 Debug("DM:",Send(who,@GetTrueName),"cast ",Send(self,@GetName),"on",Send(oTarget,@GetTrueName),"while hidden.");
              }
               
             return;

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1409,7 +1409,7 @@ messages:
 
       if oRoom <> $
       {
-         if isClass(who,&DM) AND Send(who, @IsHidden)
+         if isClass(who,&DM) AND Send(who,@IsHidden)
          {
              if oTarget = $
              {


### PR DESCRIPTION
This PR adds logic to skip skill and spell improvement room audio cues (added some time ago) when the improving player is a hidden admin.

This is in response to and fixes #819