### PR TITLE
Remove ranged weapons' impact on berserker ring durability 

### DIFF
--- a/kod/object/item/passitem/ring/besring.kod
+++ b/kod/object/item/passitem/ring/besring.kod
@@ -110,8 +110,6 @@ messages:
             Send(poOwner,@MsgSendUser,#message_rsc=berserkerring_break_rsc); 
             Send(poOwner,@TryUnuseItem,#what=self);
             Send(self,@Delete);
-
-            return hit_roll;
          }
 
          return hit_roll - (Random(viHitrollReduceMin,viHitrollReduceMax) * viHitrollReduceMultiplier);

--- a/kod/object/item/passitem/ring/besring.kod
+++ b/kod/object/item/passitem/ring/besring.kod
@@ -90,17 +90,27 @@ messages:
 
    ModifyHitRoll(who = $, what = $, hit_roll = $)
    {
-      piHits = piHits - 1;
-      if piHits <= 0
-      {
-         Send(poOwner,@MsgSendUser,#message_rsc=berserkerring_break_rsc); 
-         Send(poOwner,@TryUnuseItem,#what=self);
-         Send(self,@Delete);
+      local oWeapon;
 
-         return hit_roll;
+      oWeapon = Send(who,@GetWeapon);
+
+      if oWeapon = $ OR NOT IsClass(oWeapon,&RangedWeapon)
+      {
+         piHits = piHits - 1;
+         if piHits <= 0
+         {
+            Send(poOwner,@MsgSendUser,#message_rsc=berserkerring_break_rsc); 
+            Send(poOwner,@TryUnuseItem,#what=self);
+            Send(self,@Delete);
+
+            return hit_roll;
+         }
+
+         return hit_roll - (Random(15,25) * 10);
       }
-      
-      return hit_roll - (Random(15,25) * 10);
+
+      Debug("No BerserkerRing hit");
+      return hit_roll;
    }
 
    ModifyDamage(who = $, what = $, damage = $)

--- a/kod/object/item/passitem/ring/besring.kod
+++ b/kod/object/item/passitem/ring/besring.kod
@@ -50,6 +50,13 @@ classvars:
    
    viValue_average = 200
 
+   viHitrollReduceMin = 15
+   viHitrollReduceMax = 25
+   viHitrollReduceMultiplier = 10
+
+   viDamageModMin = 1
+   viDamageModMax = 4
+
 properties:
 
 
@@ -97,6 +104,7 @@ messages:
       if oWeapon = $ OR NOT IsClass(oWeapon,&RangedWeapon)
       {
          piHits = piHits - 1;
+
          if piHits <= 0
          {
             Send(poOwner,@MsgSendUser,#message_rsc=berserkerring_break_rsc); 
@@ -106,10 +114,9 @@ messages:
             return hit_roll;
          }
 
-         return hit_roll - (Random(15,25) * 10);
+         return hit_roll - (Random(viHitrollReduceMin,viHitrollReduceMax) * viHitrollReduceMultiplier);
       }
 
-      Debug("No BerserkerRing hit");
       return hit_roll;
    }
 
@@ -121,7 +128,7 @@ messages:
 
       if oWeapon = $ OR NOT IsClass(oWeapon,&RangedWeapon)
       {
-         return damage + random(1,4);
+         return damage + random(viDamageModMin,viDamageModMax);
       }
 
       return damage;


### PR DESCRIPTION
This PR is an alternative to #658. Currently, when ranged weapons are used in tandem with a berserker ring, the ring's durability will decreases even though it's damage buff does not apply to ranged weapons. This will remove the invisible effect of ranged weapons on the ring's durability. It _also_ replaces some magic numbers. I can revert if preferred.