### PR TITLE
Improve rendering order

### DIFF
--- a/clientd3d/d3drender_world.h
+++ b/clientd3d/d3drender_world.h
@@ -14,8 +14,7 @@
 #ifndef _D3DRENDERWORLD_H
 #define _D3DRENDERWORLD_H
 
+void D3DRenderGeometry(room_type* room, Bool gD3DRedrawAll);
 void D3DRenderWorld(room_type* room, Draw3DParams* params, room_contents_node* pRNode);
-void D3DGeometryBuildNew(room_type* room, d3d_render_pool_new* pPool, bool transparent_pass);
-void GeometryUpdate(d3d_render_pool_new* pPool, d3d_render_cache_system* pCacheSystem);
 
 #endif	/* #ifndef _D3DRENDERWORLD_H */


### PR DESCRIPTION
We correct the render order to be more logical: Skybox, Background overlays, World, Static world, Particles and finally Objects.
We also move the static world geometry to d3drender_world with a second round of deconstruction of that file coming soon.