### PR TITLE
Adjust alpha test threshold to prevent unwanted blending

### DIFF
--- a/clientd3d/d3drender_world.c
+++ b/clientd3d/d3drender_world.c
@@ -40,11 +40,10 @@ extern int gNumObjects;
 extern Vector3D sun_vect;
 extern D3DMATRIX view;
 
-// The alpha_test_threshold value of 200 was chosen based on tuning through experimentation.
-// This value provided the best visual results for our specific textures and scenes, helping to 
-// prevent unwanted alpha blending between static geometry and the skybox, as well as eliminating 
-// lines that appeared between doorways. It balances visual quality and performance while minimizing
-// transparency issues.
+// Lower values (e.g., 128) resulted in too many semi-transparent pixels being rendered, 
+// causing blending artifacts, especially between the skybox and other static transparent geometry. 
+// Higher values (e.g., 210 or above) resulted in too much transparency being discarded, creating sharp, 
+// noticeable edges where smooth transparency should occur, such as between door archways.
 static const auto alpha_test_threshold = 200;
 
 extern Bool gWireframe;


### PR DESCRIPTION
We have some unwanted blending taking place between static world geometry and the skybox. This issue is most obvious at certain times of the day when the sky is bright on screens such as the outskirts of Barloque or the Flatlands.

Before:
![image](https://github.com/user-attachments/assets/7053a7b3-7cf6-4c7b-baa4-984eb4c8f80e)
![image](https://github.com/user-attachments/assets/3874dde7-5aed-483d-9d5c-f9b65d8095c0)

After:
![image](https://github.com/user-attachments/assets/74a79a97-7686-46be-9f8a-cea23be1ebe3)
![image](https://github.com/user-attachments/assets/6242408f-0e29-47f6-95c4-4071ebf5a25d)
