### PR TITLE
Adds additional Identify functionality around hidden attributes

### DIFF
--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -1255,9 +1255,19 @@ messages:
 
    HideHiddenAttributes()
    {
-      % TODO: Reverse RevealHiddenAttributes()
+      local i, bDone;
 
-      return;
+      bDone = FALSE;
+      for i in plItem_Attributes
+      {
+         if NOT Send(self,@GetIDStatusFromCompound,#compound=First(i))
+         {
+            setNth(i,1,(First(i)-1));
+            bDone = TRUE;
+         }
+      }
+      
+      return bDone;
    }
 
    AddAttributeSpecifics(litemAtt=$)

--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -1253,6 +1253,13 @@ messages:
       return bDone;
    }
 
+   HideHiddenAttributes()
+   {
+      % TODO: Reverse RevealHiddenAttributes()
+
+      return;
+   }
+
    AddAttributeSpecifics(litemAtt=$)
    "Don't call this directly!  Call this from itematt.kod!"
    {
@@ -1792,6 +1799,19 @@ messages:
          AND Send(self,@GetPaletteTranslation) = (viUnrevealedColor & ITEM_PALETTE_MASK)
       {
          Send(self,@SetPaletteTranslation,#translation=viRevealedColor);
+         return TRUE;
+      }
+      return FALSE;
+   }
+
+   HideHiddenColor()
+   "Hides the item's true color."
+   {
+      if viUnrevealedColor <> 0
+         AND viRevealedColor <> 0
+         AND Send(self,@GetPaletteTranslation) = (viRevealedColor & ITEM_PALETTE_MASK)
+      {
+         Send(self,@SetPaletteTranslation,#translation=viUnrevealedColor);
          return TRUE;
       }
       return FALSE;

--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -1237,6 +1237,7 @@ messages:
    }
 
    RevealHiddenAttributes()
+   "Reveals the item's attributes, returning TRUE if any were hidden."
    {
       local i, bDone;
 
@@ -1254,20 +1255,19 @@ messages:
    }
 
    HideHiddenAttributes()
+   "Hides the item's hidden attributes."
    {
-      local i, bDone;
+      local i;
 
-      bDone = FALSE;
       for i in plItem_Attributes
       {
          if NOT Send(self,@GetIDStatusFromCompound,#compound=First(i))
          {
             setNth(i,1,(First(i)-1));
-            bDone = TRUE;
          }
       }
-      
-      return bDone;
+
+      return;
    }
 
    AddAttributeSpecifics(litemAtt=$)
@@ -1809,9 +1809,9 @@ messages:
          AND Send(self,@GetPaletteTranslation) = (viUnrevealedColor & ITEM_PALETTE_MASK)
       {
          Send(self,@SetPaletteTranslation,#translation=viRevealedColor);
-         return TRUE;
       }
-      return FALSE;
+
+      return;
    }
 
    HideHiddenColor()
@@ -1822,9 +1822,9 @@ messages:
          AND Send(self,@GetPaletteTranslation) = (viRevealedColor & ITEM_PALETTE_MASK)
       {
          Send(self,@SetPaletteTranslation,#translation=viUnrevealedColor);
-         return TRUE;
       }
-      return FALSE;
+
+      return;
    }
 
 end

--- a/kod/object/item/passitem/ring.kod
+++ b/kod/object/item/passitem/ring.kod
@@ -99,7 +99,19 @@ messages:
          bDone = TRUE;
       }
       
+      Send(self,@RevealHiddenColor);      
+      
       return bDone;
+   }
+
+   HideHiddenAttributes()
+   {      
+      vrName = ring_unidentified_name_rsc;
+      vrDesc = ring_unidentified_description_rsc;
+
+      Send(self,@HideHiddenColor);
+
+      propagate;
    }
 
    GetTrueName()

--- a/kod/object/item/passitem/ring/lethring.kod
+++ b/kod/object/item/passitem/ring/lethring.kod
@@ -118,7 +118,6 @@ messages:
       % at this point, it's pretty obvious it's not helping them.
       if Send(self, @RevealHiddenAttributes)
       {
-         Send(self, @RevealHiddenColor);
          Send(poOwner, @SomethingChanged, #what=self);
       }
 

--- a/kod/object/item/passitem/spelitem/wand.kod
+++ b/kod/object/item/passitem/spelitem/wand.kod
@@ -95,6 +95,11 @@ messages:
       return;
    }
 
+   HideHiddenAttributes()
+   {
+      vrName = Wand_name_rsc;
 
+      propagate;
+   }
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/identify.kod
+++ b/kod/object/passive/spell/identify.kod
@@ -66,7 +66,7 @@ messages:
       oTarget = First(lTargets);
 
       % Check that target is a weapon or armor
-      if NOT (IsClass(oTarget,&Item) AND send(oTarget,@CanIdentify))
+      if NOT (IsClass(oTarget,&Item) AND Send(oTarget,@CanIdentify))
       {
          if NOT bItemCast
          {
@@ -87,21 +87,29 @@ messages:
 
    CastSpell(who = $, lTargets = $)
    {
-      local oTarget;
+      local oTarget, bKeepRevealed;
       
+      bKeepRevealed = FALSE;
       oTarget = First(lTargets);
       
       Send(who,@MsgSendUser,#message_rsc=identify_working, 
            #parm1=send(oTarget,@GetDef),#parm2=send(oTarget,@GetName));
 
-      % Temporarily reveal the item's attributes for display   
+      % If the item has already been identified, don't hide its properties later
+      if Send(oTarget,@IsIdentified)
+      {  
+         bKeepRevealed = TRUE;
+      } 
+
       Send(oTarget,@RevealHiddenAttributes);
 
       Send(who,@SendLook,#what=oTarget,#bShow_All=TRUE);
       
       % Remove attributes if not *fully* revealed yet
-      Send(oTarget,@HideHiddenAttributes);
-
+      if NOT bKeepRevealed
+      {
+         Send(oTarget,@HideHiddenAttributes);
+      }
       propagate;
    }
  

--- a/kod/object/passive/spell/identify.kod
+++ b/kod/object/passive/spell/identify.kod
@@ -90,13 +90,20 @@ messages:
       local oTarget;
       
       oTarget = First(lTargets);
+      
       Send(who,@MsgSendUser,#message_rsc=identify_working, 
            #parm1=send(oTarget,@GetDef),#parm2=send(oTarget,@GetName));
+
+      % Temporarily reveal the item's attributes for display   
+      Send(oTarget,@RevealHiddenAttributes);
+
       Send(who,@SendLook,#what=oTarget,#bShow_All=TRUE);
       
+      % Remove attributes if not *fully* revealed yet
+      Send(oTarget,@HideHiddenAttributes);
+
       propagate;
    }
-
-
+ 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/identify.kod
+++ b/kod/object/passive/spell/identify.kod
@@ -87,29 +87,26 @@ messages:
 
    CastSpell(who = $, lTargets = $)
    {
-      local oTarget, bKeepRevealed;
+      local oTarget;
       
-      bKeepRevealed = FALSE;
       oTarget = First(lTargets);
       
       Send(who,@MsgSendUser,#message_rsc=identify_working, 
            #parm1=send(oTarget,@GetDef),#parm2=send(oTarget,@GetName));
 
-      % If the item has already been identified, don't hide its properties later
+      % If the item has already been identified, simply show it
+      % Otherwise, reveal the hidden attributes, show the item, then hide the attributes
       if Send(oTarget,@IsIdentified)
       {  
-         bKeepRevealed = TRUE;
+         Send(who,@SendLook,#what=oTarget,#bShow_All=TRUE);
       } 
-
-      Send(oTarget,@RevealHiddenAttributes);
-
-      Send(who,@SendLook,#what=oTarget,#bShow_All=TRUE);
-      
-      % Remove attributes if not *fully* revealed yet
-      if NOT bKeepRevealed
+      else
       {
+         Send(oTarget,@RevealHiddenAttributes);
+         Send(who,@SendLook,#what=oTarget,#bShow_All=TRUE);
          Send(oTarget,@HideHiddenAttributes);
       }
+      
       propagate;
    }
  

--- a/kod/object/passive/spell/reveal.kod
+++ b/kod/object/passive/spell/reveal.kod
@@ -119,10 +119,9 @@ messages:
       %% on something with no hope of revealing anything.
       piAdvance = send(oTarget,@RevealHiddenAttributes);
       
-      % Show newly revealed color
+      % Show newly revealed attributes
       if piAdvance
       {      
-         Send(oTarget,@RevealHiddenColor);
          Send(Send(oTarget,@GetOwner),@SomethingChanged,#what=oTarget);
       }
       Send(who,@SendLook,#what=oTarget,#bShow_All=TRUE);


### PR DESCRIPTION
This PR addresses issue #702, where Identify wasn’t revealing item name and description as expected. To address this, I added code to Identify that will temporarily reveal an items hidden attributes, then hide them once again. I took this a step further by also revealing and hidden an items hidden color, if it has one. Examples of this include many of the magical rings.

With this fix, Identify now works as intended _and_ will (temporarily) reveal an item's hidden color.

1. Screenshot of an item with hidden attributes, including color:
![image](https://github.com/user-attachments/assets/f3abae49-d32a-45f5-ab8d-c998641c4779)

2. The same item when Identify is cast upon it, revealing it's true name, true description, and hidden color, but only temporarily in the dialog:
![image](https://github.com/user-attachments/assets/e14c9268-0d53-4f41-bb89-34cf74908c1e)

3. If the user inspects the item again, any attributes that were hidden will be hidden once again:
![image](https://github.com/user-attachments/assets/5a3f66bf-6ba0-495f-a2f6-4490adec7583)

4. And if a user casts Reveal, these changes become permanent:
![image](https://github.com/user-attachments/assets/7a934967-b4b8-414e-92d3-af2579a1328c)

This fixes #702 