### PR TITLE
Remove karma from reflection and evil twin

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -340,16 +340,6 @@ messages:
       return Send(poOriginal,@GetDamage,#what=what,#stroke_obj=oStroke);
    }
 
-   GetKarma(detect=FALSE)
-   {
-      if detect
-      {
-         return send(poOriginal,@GetKarma);
-      }
-      
-      propagate;
-   }
-
    SomethingChanged(what=$)
    {
       if what = poOriginal

--- a/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
@@ -360,11 +360,6 @@ messages:
       return 1;
    }
 
-   GetKarma(detect=FALSE)
-   {
-      return Send(poOriginal,@GetKarma);
-   }
-
    GetOffense(what = $, stroke_obj=$)
    {
       return Send(poOriginal,@GetOffense,#what=what,#stroke_obj=stroke_obj);


### PR DESCRIPTION
This PR sets the karma of reflections and evil twins to 0, rather than the caster's karma. This came about from a discussion in Discord, where it was felt that killing illusions should not impact player karma.

This was also the subject of #535.