### PR TITLE
Removes durability damage from robes, except Disciple Robe

### DIFF
--- a/kod/object/item/passitem/defmod/armor/robe.kod
+++ b/kod/object/item/passitem/defmod/armor/robe.kod
@@ -36,13 +36,6 @@ resources:
    robe_leftarm_female = bld.bgf
    robe_rightarm_female =brd.bgf
 
-   robe_condition_exc = " are in immaculate condition."
-   robe_condition_exc_mended = " are in excellent condition, but have been patched before."
-   robe_condition_good = " are scuffed and slightly worn."
-   robe_condition_med = " have a few unsightly rips."
-   robe_condition_poor = " are in tatters, and barely holding together."
-   robe_condition_broken = " are covered in filth and ripped beyond use."
-
 classvars:
 
    vrName = robe_name_rsc
@@ -80,13 +73,8 @@ classvars:
    vrLegs_female = robe_legs_female 
    
    vrPoss_article = object_article_cap_these_rsc
-
-   vrCondition_exc = robe_condition_exc 
-   vrCondition_exc_mended = robe_condition_exc_mended 
-   vrCondition_good = robe_condition_good 
-   vrCondition_med = robe_condition_med 
-   vrCondition_poor = robe_condition_poor 
-   vrCondition_broken = robe_condition_broken 
+   
+   vbShow_Condition = FALSE
 
 properties:   
 
@@ -188,6 +176,20 @@ messages:
       return;
    }
 
+   ReqRepair()
+   {
+      return FALSE;
+   }
+
+   CanMend()
+   {
+      return FALSE;
+   }
+
+   DefendingHit()
+   {
+      return;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/defmod/armor/robe/robedisc.kod
+++ b/kod/object/item/passitem/defmod/armor/robe/robedisc.kod
@@ -18,6 +18,9 @@ constants:
 
    include blakston.khd
 
+   % Percent chance that an item gets damaged when defending.
+   ARMOR_TAKE_DAMAGE_PCT = 75
+
 resources:
 
    RobeInsignia_name_rsc = "robes of the disciple"
@@ -25,6 +28,13 @@ resources:
    RobeInsignia_desc_rsc = \
    	"Heavy and warm, disciple robes typically denote a fervent (and some would say "
       "unhealthy) dedication to one school or another."
+
+   robe_condition_exc = " are in immaculate condition."
+   robe_condition_exc_mended = " are in excellent condition, but have been patched before."
+   robe_condition_good = " are scuffed and slightly worn."
+   robe_condition_med = " have a few unsightly rips."
+   robe_condition_poor = " are in tatters, and barely holding together."
+   robe_condition_broken = " are covered in filth and ripped beyond use."
 
    RobeInsignia_school_info1 = "  These robes bear the insignia of "
    RobeInsignia_school_info2 = " and will give bonuses to spells in that school."
@@ -56,6 +66,15 @@ classvars:
    viBulk = 160
    viWeight = 130
    viValue_average = 2000
+
+   vrCondition_exc = robe_condition_exc 
+   vrCondition_exc_mended = robe_condition_exc_mended 
+   vrCondition_good = robe_condition_good 
+   vrCondition_med = robe_condition_med 
+   vrCondition_poor = robe_condition_poor 
+   vrCondition_broken = robe_condition_broken 
+
+   vbShow_Condition = TRUE
 
 properties:   
 
@@ -429,6 +448,30 @@ messages:
       propagate;
    }
 
+   DefendingHit(who = $,what = $)
+   {
+      if random(1,100) < ARMOR_TAKE_DAMAGE_PCT   
+      {
+         piHits = piHits - 1;
+      }
+      
+      if piHits <= 0
+      {
+         Send(self,@ItemBrokenInBattle);
+      }
+      
+      return;
+   }
+
+   ReqRepair()
+   {
+      return TRUE;
+   }
+
+   CanMend()
+   {
+      return TRUE;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This PR follows the changes made in #544 by moving the durability handling from `Robe` to `DiscipleRobe` only, removing the need to mend the cosmetic general robes and light robes consistent with #544, while also maintaining the durability damage on Disciple Robes.

It seemed like my options where either make `Robe` consistent with the other apparel (no conditions, non-mendable, not `DefendingHit` handling) or keep it as is and override `DiscipleRobe`. I felt like consistency with other apparel classes was the right move, though I don't love that it meant copying `DefendingHit` from `Item`.