### PR TITLE
Allows for Defile to be cast upon the corpses of good monsters

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -3062,7 +3062,8 @@ messages:
       {
          oBody = Create(&DeadBody,#icon=vrDead_icon,#name=vrDead_name,
                         #mob=TRUE,#playername=Send(killer,@GetTrueName),
-                        #monstername=vrName,#drawfx=viDead_drawfx);       
+                        #good=(Send(self,@GetKarma) > 0),#monstername=vrName,
+                        #drawfx=viDead_drawfx);       
       }
 
       return oBody;                 

--- a/kod/object/passive/body.kod
+++ b/kod/object/passive/body.kod
@@ -73,7 +73,7 @@ messages:
       pbMob = mob;
       piDrawfx = drawfx;
       prPlayer_name = playername;
-      pbWas_good_player = good; 
+      pbWas_good_player = good;           % Used to track monster karma as well
       pbAssassinated = assassinated;
       prPlayerBodyOverlay = PlayerBodyOverlay;
       piBodyTrans = BodyTranslation;
@@ -184,7 +184,7 @@ messages:
       return;
    }
 
-   WasGoodPlayer()
+   WasGood()
    {
       return pbWas_good_player;
    }
@@ -196,11 +196,6 @@ messages:
 
    GetObjectFlags()
    {
-      if pbMob
-      {
-         return LOOK_NO | piDrawfx;
-      }
-      
       return viObject_flags | piDrawfx;
    }
    

--- a/kod/object/passive/spell/defile.kod
+++ b/kod/object/passive/spell/defile.kod
@@ -105,7 +105,7 @@ messages:
 	      return FALSE;
       }
 
-      if NOT Send(target,@WasGoodPlayer)
+      if NOT Send(target,@WasGood)
       {
 	      Send(who,@MsgSendUser,#message_rsc=defile_not_good);           
 


### PR DESCRIPTION
This PR makes it possible to Defile the corpses of good monsters, in addition to good player corpses. This is in response to discussion in Discord arguing that it's a very challenging spell to improve without the use of mules.

It borrows a player-based flag in `body` to make this possible and sets this `pbWas_good_player` flag to true when generating the corpse in `monster`. On submission, I realized that corpses are completely ephemeral and we're unlikely to have any problems if I rename `pbWas_good_player` to `pbWas_good_battler` along with this change. I can make that change if my thinking is valid.

As far as gameplay balance is concerned, should this come at a higher reagent cost if we're increasing the target pool?