### PR TITLE
Puts a cap on map object and annotation sizes

### DIFF
--- a/clientd3d/annotate.c
+++ b/clientd3d/annotate.c
@@ -98,11 +98,11 @@ void MapMoveAnnotations( MapAnnotation *annotations, int x, int y, float scale, 
        continue;
 
      // Set up tooltip for annotation
-     ti.rect.left = view.x + x + (int) ((annotations[i].x - MAP_ANNOTATION_RADIUS) * scale);
-     ti.rect.top  = view.y + y + (int) ((annotations[i].y - MAP_ANNOTATION_RADIUS) * scale);
+     ti.rect.left = view.x + x + (int) ((annotations[i].x - MAP_ANNOTATION_SIZE) * scale);
+     ti.rect.top  = view.y + y + (int) ((annotations[i].y - MAP_ANNOTATION_SIZE) * scale);
 
-     ti.rect.right  = ti.rect.left + (int) (MAP_ANNOTATION_RADIUS * 2 * scale);
-     ti.rect.bottom = ti.rect.top  + (int) (MAP_ANNOTATION_RADIUS * 2 * scale);
+     ti.rect.right  = ti.rect.left + (int) (MAP_ANNOTATION_SIZE * 2 * scale);
+     ti.rect.bottom = ti.rect.top  + (int) (MAP_ANNOTATION_SIZE * 2 * scale);
 
      // Clip tooltip rectangle to graphics view window
      ti.rect.left = max(ti.rect.left, view.x);
@@ -144,8 +144,8 @@ void MapAnnotationClick(int x, int y)
      if (a->text[0] == 0)
        continue;
 
-     if (a->x <= x + MAP_ANNOTATION_RADIUS && a->x >= x - MAP_ANNOTATION_RADIUS &&
-	 a->y <= y + MAP_ANNOTATION_RADIUS && a->y >= y - MAP_ANNOTATION_RADIUS)
+     if (a->x <= x + MAP_ANNOTATION_SIZE && a->x >= x - MAP_ANNOTATION_SIZE &&
+	 a->y <= y + MAP_ANNOTATION_SIZE && a->y >= y - MAP_ANNOTATION_SIZE)
        {
 	 existed = True;
 	 index = i;

--- a/clientd3d/annotate.c
+++ b/clientd3d/annotate.c
@@ -74,8 +74,16 @@ void MapAnnotationGetText(TOOLTIPTEXT *ttt)
 /*****************************************************************************/
 /*
  * MapMoveAnnotations:  Recompute tooltip rectangles for map annotations.
+ *
+ * Parameters:
+ *  annotations - An array of MapAnnotation objects containing annotation details
+ *  x           - X-offset to adjust the annotation position relative to the view
+ *  y           - Y-offset to adjust the annotation position relative to the view
+ *  scale       - Map scaling factor applied to annotation positions for zooming
+ *  bMiniMap    - True if minimap, false otherwise
+ *  size        - The full size of the square annotation, already adjusted by the zoom factor and clipped
  */
-void MapMoveAnnotations( MapAnnotation *annotations, int x, int y, float scale, Bool bMiniMap, int radius )
+void MapMoveAnnotations( MapAnnotation *annotations, int x, int y, float scale, Bool bMiniMap, int size )
 {
    int i;
    TOOLINFO ti;
@@ -97,11 +105,11 @@ void MapMoveAnnotations( MapAnnotation *annotations, int x, int y, float scale, 
      if (annotations[i].text[0] == 0)
        continue;
 
-     // Set up tooltip for annotation using zoomed radius  
-     ti.rect.left = view.x + x + (int) (annotations[i].x * scale) - radius;
-     ti.rect.top  = view.y + y + (int) (annotations[i].y * scale) - radius;
-     ti.rect.right  = ti.rect.left + (int) (radius * 2);
-     ti.rect.bottom = ti.rect.top  + (int) (radius * 2);
+     // Set up tooltip for annotation  
+     ti.rect.left = view.x + x + (int) (annotations[i].x * scale) - (size / 2);
+     ti.rect.top  = view.y + y + (int) (annotations[i].y * scale) - (size / 2);
+     ti.rect.right  = ti.rect.left + size;
+     ti.rect.bottom = ti.rect.top  + size;
 
      // Clip tooltip rectangle to graphics view window
      ti.rect.left = max(ti.rect.left, view.x);

--- a/clientd3d/annotate.c
+++ b/clientd3d/annotate.c
@@ -98,11 +98,11 @@ void MapMoveAnnotations( MapAnnotation *annotations, int x, int y, float scale, 
        continue;
 
      // Set up tooltip for annotation
-     ti.rect.left = view.x + x + (int) ((annotations[i].x - MAP_ANNOTATION_SIZE / 2) * scale);
-     ti.rect.top  = view.y + y + (int) ((annotations[i].y - MAP_ANNOTATION_SIZE / 2) * scale);
+     ti.rect.left = view.x + x + (int) ((annotations[i].x - MAP_ANNOTATION_RADIUS) * scale);
+     ti.rect.top  = view.y + y + (int) ((annotations[i].y - MAP_ANNOTATION_RADIUS) * scale);
 
-     ti.rect.right  = ti.rect.left + (int) (MAP_ANNOTATION_SIZE * scale);
-     ti.rect.bottom = ti.rect.top  + (int) (MAP_ANNOTATION_SIZE * scale);
+     ti.rect.right  = ti.rect.left + (int) (MAP_ANNOTATION_RADIUS * 2 * scale);
+     ti.rect.bottom = ti.rect.top  + (int) (MAP_ANNOTATION_RADIUS * 2 * scale);
 
      // Clip tooltip rectangle to graphics view window
      ti.rect.left = max(ti.rect.left, view.x);
@@ -144,8 +144,8 @@ void MapAnnotationClick(int x, int y)
      if (a->text[0] == 0)
        continue;
 
-     if (a->x <= x + MAP_ANNOTATION_SIZE / 2 && a->x >= x - MAP_ANNOTATION_SIZE / 2 &&
-	 a->y <= y + MAP_ANNOTATION_SIZE / 2 && a->y >= y - MAP_ANNOTATION_SIZE / 2)
+     if (a->x <= x + MAP_ANNOTATION_RADIUS && a->x >= x - MAP_ANNOTATION_RADIUS &&
+	 a->y <= y + MAP_ANNOTATION_RADIUS && a->y >= y - MAP_ANNOTATION_RADIUS)
        {
 	 existed = True;
 	 index = i;

--- a/clientd3d/annotate.c
+++ b/clientd3d/annotate.c
@@ -75,7 +75,7 @@ void MapAnnotationGetText(TOOLTIPTEXT *ttt)
 /*
  * MapMoveAnnotations:  Recompute tooltip rectangles for map annotations.
  */
-void MapMoveAnnotations( MapAnnotation *annotations, int x, int y, float scale, Bool bMiniMap )
+void MapMoveAnnotations( MapAnnotation *annotations, int x, int y, float scale, Bool bMiniMap, int radius )
 {
    int i;
    TOOLINFO ti;
@@ -97,12 +97,11 @@ void MapMoveAnnotations( MapAnnotation *annotations, int x, int y, float scale, 
      if (annotations[i].text[0] == 0)
        continue;
 
-     // Set up tooltip for annotation
-     ti.rect.left = view.x + x + (int) ((annotations[i].x - MAP_ANNOTATION_SIZE) * scale);
-     ti.rect.top  = view.y + y + (int) ((annotations[i].y - MAP_ANNOTATION_SIZE) * scale);
-
-     ti.rect.right  = ti.rect.left + (int) (MAP_ANNOTATION_SIZE * 2 * scale);
-     ti.rect.bottom = ti.rect.top  + (int) (MAP_ANNOTATION_SIZE * 2 * scale);
+     // Set up tooltip for annotation using zoomed radius  
+     ti.rect.left = view.x + x + (int) (annotations[i].x * scale) - radius;
+     ti.rect.top  = view.y + y + (int) (annotations[i].y * scale) - radius;
+     ti.rect.right  = ti.rect.left + (int) (radius * 2);
+     ti.rect.bottom = ti.rect.top  + (int) (radius * 2);
 
      // Clip tooltip rectangle to graphics view window
      ti.rect.left = max(ti.rect.left, view.x);

--- a/clientd3d/annotate.h
+++ b/clientd3d/annotate.h
@@ -14,7 +14,7 @@
 
 #define MAP_ANNOTATION_SIZE     (2 * FINENESS)    // Size of annotation indicator in FINENESS units
 #define MAP_ANNOTATION_MIN_SIZE 14                // Min size of drawn annotation in pixels
-
+#define MAP_ANNOTATION_MAX_SIZE 30
 #define MAX_ANNOTATIONS    20
 #define MAX_ANNOTATION_LEN 100
 

--- a/clientd3d/annotate.h
+++ b/clientd3d/annotate.h
@@ -25,7 +25,7 @@ typedef struct {
 
 void MapAnnotationsInitialize(void);
 void MapAnnotationGetText(TOOLTIPTEXT *ttt);
-void MapMoveAnnotations( MapAnnotation *annotations, int x, int y, float scale, Bool bMiniMap );
+void MapMoveAnnotations( MapAnnotation *annotations, int x, int y, float scale, Bool bMiniMap, int radius );
 void MapAnnotationClick(int x, int y);
 void AbortAnnotateDialog(void);
 

--- a/clientd3d/annotate.h
+++ b/clientd3d/annotate.h
@@ -12,7 +12,7 @@
 #ifndef _ANNOTATE_H
 #define _ANNOTATE_H
 
-#define MAP_ANNOTATION_RADIUS     FINENESS          // Radius of annotation indicator in FINENESS units
+#define MAP_ANNOTATION_SIZE       FINENESS          // Size of annotation graphic in FINENESS units
 #define MAP_ANNOTATION_MIN_RADIUS 7                 // Min radius of drawn annotation in pixels
 #define MAP_ANNOTATION_MAX_RADIUS 15                // Max radius
 #define MAX_ANNOTATIONS    20

--- a/clientd3d/annotate.h
+++ b/clientd3d/annotate.h
@@ -12,9 +12,9 @@
 #ifndef _ANNOTATE_H
 #define _ANNOTATE_H
 
-#define MAP_ANNOTATION_SIZE     (2 * FINENESS)    // Size of annotation indicator in FINENESS units
-#define MAP_ANNOTATION_MIN_SIZE 14                // Min size of drawn annotation in pixels
-#define MAP_ANNOTATION_MAX_SIZE 30
+#define MAP_ANNOTATION_RADIUS     FINENESS          // Radius of annotation indicator in FINENESS units
+#define MAP_ANNOTATION_MIN_RADIUS 7                 // Min radius of drawn annotation in pixels
+#define MAP_ANNOTATION_MAX_RADIUS 15                // Max radius
 #define MAX_ANNOTATIONS    20
 #define MAX_ANNOTATION_LEN 100
 

--- a/clientd3d/annotate.h
+++ b/clientd3d/annotate.h
@@ -12,9 +12,9 @@
 #ifndef _ANNOTATE_H
 #define _ANNOTATE_H
 
-#define MAP_ANNOTATION_SIZE       FINENESS          // Size of annotation graphic in FINENESS units
-#define MAP_ANNOTATION_MIN_RADIUS 7                 // Min radius of drawn annotation in pixels
-#define MAP_ANNOTATION_MAX_RADIUS 15                // Max radius
+#define MAP_ANNOTATION_SIZE     (2 * FINENESS)  // Size of annotation graphic in FINENESS units
+#define MAP_ANNOTATION_MIN_SIZE 14              // Min size of drawn annotation in pixels
+#define MAP_ANNOTATION_MAX_SIZE 30              // Max size
 #define MAX_ANNOTATIONS    20
 #define MAX_ANNOTATION_LEN 100
 
@@ -25,7 +25,7 @@ typedef struct {
 
 void MapAnnotationsInitialize(void);
 void MapAnnotationGetText(TOOLTIPTEXT *ttt);
-void MapMoveAnnotations( MapAnnotation *annotations, int x, int y, float scale, Bool bMiniMap, int radius );
+void MapMoveAnnotations( MapAnnotation *annotations, int x, int y, float scale, Bool bMiniMap, int size );
 void MapAnnotationClick(int x, int y);
 void AbortAnnotateDialog(void);
 

--- a/clientd3d/map.c
+++ b/clientd3d/map.c
@@ -529,7 +529,7 @@ void MapDrawAnnotations( HDC hdc, MapAnnotation *annotations, int x, int y, floa
 		new_y =	y + (int) (annotations[i].y * scaleToUse);
 
       // Scale annotation, capping it between the minimum and maximum limits
-      capped_scaled_size = min(MAP_ANNOTATION_RADIUS * scaleToUse, MAP_ANNOTATION_MAX_RADIUS);
+      capped_scaled_size = min(MAP_ANNOTATION_SIZE * scaleToUse, MAP_ANNOTATION_MAX_RADIUS);
       radius = max(MAP_ANNOTATION_MIN_RADIUS, capped_scaled_size);
 
 		if (annotation.bits != NULL)

--- a/clientd3d/map.c
+++ b/clientd3d/map.c
@@ -36,7 +36,7 @@
 #define MAP_GUILDMATE_COLOR     PALETTERGB(255, 255, 0)
 
 #define MAP_OBJECT_RADIUS (FINENESS / 6)  // Radius of circle drawn for an object
-#define MAP_OBJECT_MAX_SIZE 4             // Maximum size for objects on map
+#define MAP_OBJECT_MAX_RADIUS 4           // Maximum radius for objects on map
 
 #define MAP_ZOOM_INCREMENT 0.1       // Amount to change zoom factor per user command
 #define MAP_ZOOM_DELAY     100       // # of milliseconds between zooming in by INCREMENT
@@ -383,8 +383,8 @@ void MapDrawObjects(HDC hdc, list_type objects, int x, int y, float scale)
    int dx, dy;
    static int mapObjectDistanceShiftAndSquare = (MAP_OBJECT_DISTANCE >> 4) * (MAP_OBJECT_DISTANCE >> 4);
 
-   // Scale radius, clamping between a minimum of 1 and MAP_OBJECT_MAX_SIZE
-   radius = min(max(1, MAP_OBJECT_RADIUS * scale), MAP_OBJECT_MAX_SIZE);
+   // Scale radius, clamping between a minimum of 1 and the defined maximum
+   radius = min(max(1, MAP_OBJECT_RADIUS * scale), MAP_OBJECT_MAX_RADIUS);
 
    for (l = objects; l != NULL; l = l->next)
    {
@@ -529,8 +529,8 @@ void MapDrawAnnotations( HDC hdc, MapAnnotation *annotations, int x, int y, floa
 		new_y =	y + (int) (annotations[i].y * scaleToUse);
 
       // Scale annotation, capping it between the minimum and maximum limits
-      capped_scaled_size = min(MAP_ANNOTATION_SIZE * scaleToUse, MAP_ANNOTATION_MAX_SIZE);
-      radius = max(MAP_ANNOTATION_MIN_SIZE, capped_scaled_size) / 2;
+      capped_scaled_size = min(MAP_ANNOTATION_RADIUS * scaleToUse, MAP_ANNOTATION_MAX_RADIUS);
+      radius = max(MAP_ANNOTATION_MIN_RADIUS, capped_scaled_size);
 
 		if (annotation.bits != NULL)
 		{

--- a/clientd3d/map.c
+++ b/clientd3d/map.c
@@ -36,6 +36,7 @@
 #define MAP_GUILDMATE_COLOR     PALETTERGB(255, 255, 0)
 
 #define MAP_OBJECT_RADIUS (FINENESS / 6)  // Radius of circle drawn for an object
+#define MAP_OBJECT_MAX_SIZE 4             // Maximum size for objects on map
 
 #define MAP_ZOOM_INCREMENT 0.1       // Amount to change zoom factor per user command
 #define MAP_ZOOM_DELAY     100       // # of milliseconds between zooming in by INCREMENT
@@ -382,7 +383,8 @@ void MapDrawObjects(HDC hdc, list_type objects, int x, int y, float scale)
    int dx, dy;
    static int mapObjectDistanceShiftAndSquare = (MAP_OBJECT_DISTANCE >> 4) * (MAP_OBJECT_DISTANCE >> 4);
 
-   radius = max(1, MAP_OBJECT_RADIUS * scale);
+   // Scale radius, clamping between a minimum of 1 and MAP_OBJECT_MAX_SIZE
+   radius = min(max(1, MAP_OBJECT_RADIUS * scale), MAP_OBJECT_MAX_SIZE);
 
    for (l = objects; l != NULL; l = l->next)
    {
@@ -514,7 +516,7 @@ void MapDrawPlayer(HDC hdc, int x, int y, float scale)
  */
 void MapDrawAnnotations( HDC hdc, MapAnnotation *annotations, int x, int y, float scaleToUse, Bool bMiniMap )
 {
-	int i, radius, new_x, new_y;
+	int i, radius, capped_scaled_size, new_x, new_y;
 
 	MapMoveAnnotations( annotations, x, y, scaleToUse, bMiniMap );
 
@@ -526,7 +528,9 @@ void MapDrawAnnotations( HDC hdc, MapAnnotation *annotations, int x, int y, floa
 		new_x = x + (int) (annotations[i].x * scaleToUse);
 		new_y =	y + (int) (annotations[i].y * scaleToUse);
 
-		radius = max(MAP_ANNOTATION_MIN_SIZE / 2, (int) (MAP_ANNOTATION_SIZE * scaleToUse / 2));
+      // Scale annotation, capping it between the minimum and maximum limits
+      capped_scaled_size = min(MAP_ANNOTATION_SIZE * scaleToUse, MAP_ANNOTATION_MAX_SIZE);
+      radius = max(MAP_ANNOTATION_MIN_SIZE, capped_scaled_size) / 2;
 
 		if (annotation.bits != NULL)
 		{

--- a/clientd3d/map.c
+++ b/clientd3d/map.c
@@ -516,13 +516,13 @@ void MapDrawPlayer(HDC hdc, int x, int y, float scale)
  */
 void MapDrawAnnotations( HDC hdc, MapAnnotation *annotations, int x, int y, float scaleToUse, Bool bMiniMap )
 {
-	int i, radius, scaled_radius, new_x, new_y;
+	int i, adjusted_size, new_x, new_y;
 
    // Scale annotation, capping it between the minimum and maximum limits
-   scaled_radius = min(MAP_ANNOTATION_SIZE * scaleToUse, MAP_ANNOTATION_MAX_RADIUS);
-   radius = max(MAP_ANNOTATION_MIN_RADIUS, scaled_radius);
+   adjusted_size = min(MAP_ANNOTATION_SIZE * scaleToUse, MAP_ANNOTATION_MAX_SIZE);
+   adjusted_size = max(MAP_ANNOTATION_MIN_SIZE, adjusted_size);
 
-	MapMoveAnnotations( annotations, x, y, scaleToUse, bMiniMap, scaled_radius );
+	MapMoveAnnotations( annotations, x, y, scaleToUse, bMiniMap, adjusted_size );
 
 	for (i=0; i < MAX_ANNOTATIONS; i++)
 	{
@@ -534,10 +534,10 @@ void MapDrawAnnotations( HDC hdc, MapAnnotation *annotations, int x, int y, floa
 
 		if (annotation.bits != NULL)
 		{
-			OffscreenWindowBackground(NULL, new_x - radius, new_y - radius, 
+			OffscreenWindowBackground(NULL, new_x - (adjusted_size / 2), new_y - (adjusted_size / 2), 
 									    annotation.width, annotation.height);
-			OffscreenStretchBlt(hdc, (int) (new_x - radius), (int) (new_y - radius), 
-								  2 * radius, 2 * radius,
+			OffscreenStretchBlt(hdc, (int) (new_x - (adjusted_size / 2)), (int) (new_y - (adjusted_size / 2)), 
+								  adjusted_size, adjusted_size,
 								  annotation.bits, 0, 0, 
 								  annotation.width, annotation.height,
 								  OBB_COPY | OBB_FLIP);

--- a/clientd3d/map.c
+++ b/clientd3d/map.c
@@ -19,12 +19,12 @@
 
 #include "client.h"
 
-#define MAP_WALL_THICKNESS 1
-#define MAP_SELF_THICKNESS 2
-#define MAP_PLAYER_THICKNESS 5
-#define MAP_OBJECT_THICKNESS 3
+#define MAP_WALL_THICKNESS 1        // Thickness of wall lines
+#define MAP_SELF_THICKNESS 2        // Stroke thickness of player arrow marker
+#define MAP_PLAYER_THICKNESS 3      // Stroke thickness of other players
+#define MAP_OBJECT_THICKNESS 3      // Stroke thickness of objects
 
-#define MAP_PLAYER_MARKER_SIZE 3
+#define MAP_PLAYER_MARKER_SIZE 3    // Size of player arrow marker
 
 #define MAP_WALL_COLOR          PALETTERGB(0, 0, 0)
 #define MAP_SELF_COLOR          PALETTERGB(0, 0, 255)
@@ -35,8 +35,8 @@
 #define MAP_ENEMY_COLOR         PALETTERGB(255, 0, 0)
 #define MAP_GUILDMATE_COLOR     PALETTERGB(255, 255, 0)
 
-#define MAP_OBJECT_RADIUS (FINENESS / 6)  // Radius of circle drawn for an object
-#define MAP_OBJECT_MAX_RADIUS 4           // Maximum radius for objects on map
+#define MAP_OBJECT_SIZE (FINENESS / 2)  // Size of ellipse drawn for an object
+#define MAP_OBJECT_MAX_SIZE 8           // Maximum size of object ellipses
 
 #define MAP_ZOOM_INCREMENT 0.1       // Amount to change zoom factor per user command
 #define MAP_ZOOM_DELAY     100       // # of milliseconds between zooming in by INCREMENT
@@ -384,7 +384,7 @@ void MapDrawObjects(HDC hdc, list_type objects, int x, int y, float scale)
    static int mapObjectDistanceShiftAndSquare = (MAP_OBJECT_DISTANCE >> 4) * (MAP_OBJECT_DISTANCE >> 4);
 
    // Scale radius, clamping between a minimum of 1 and the defined maximum
-   radius = min(max(1, MAP_OBJECT_RADIUS * scale), MAP_OBJECT_MAX_RADIUS);
+   radius = min(max(1, (MAP_OBJECT_SIZE * scale)), MAP_OBJECT_MAX_SIZE) / 2;
 
    for (l = objects; l != NULL; l = l->next)
    {

--- a/clientd3d/map.c
+++ b/clientd3d/map.c
@@ -516,9 +516,13 @@ void MapDrawPlayer(HDC hdc, int x, int y, float scale)
  */
 void MapDrawAnnotations( HDC hdc, MapAnnotation *annotations, int x, int y, float scaleToUse, Bool bMiniMap )
 {
-	int i, radius, capped_scaled_size, new_x, new_y;
+	int i, radius, scaled_radius, new_x, new_y;
 
-	MapMoveAnnotations( annotations, x, y, scaleToUse, bMiniMap );
+   // Scale annotation, capping it between the minimum and maximum limits
+   scaled_radius = min(MAP_ANNOTATION_SIZE * scaleToUse, MAP_ANNOTATION_MAX_RADIUS);
+   radius = max(MAP_ANNOTATION_MIN_RADIUS, scaled_radius);
+
+	MapMoveAnnotations( annotations, x, y, scaleToUse, bMiniMap, scaled_radius );
 
 	for (i=0; i < MAX_ANNOTATIONS; i++)
 	{
@@ -527,10 +531,6 @@ void MapDrawAnnotations( HDC hdc, MapAnnotation *annotations, int x, int y, floa
 
 		new_x = x + (int) (annotations[i].x * scaleToUse);
 		new_y =	y + (int) (annotations[i].y * scaleToUse);
-
-      // Scale annotation, capping it between the minimum and maximum limits
-      capped_scaled_size = min(MAP_ANNOTATION_SIZE * scaleToUse, MAP_ANNOTATION_MAX_RADIUS);
-      radius = max(MAP_ANNOTATION_MIN_RADIUS, capped_scaled_size);
 
 		if (annotation.bits != NULL)
 		{


### PR DESCRIPTION
This PR introduces improvements to how map objects and annotations are scaled during zoom operations. The changes are meant to ensure that both objects and annotations are constrained in a way that offers proper visibility and prevents scaling issues at various zoom levels and in the various room sizes.

### Demos

https://github.com/user-attachments/assets/d48e6432-91b7-4861-a56c-d57237c719ec

https://github.com/user-attachments/assets/3d9f08ee-ac6d-4611-aeab-52cc52a7ebc9

https://github.com/user-attachments/assets/ac849105-be9a-4077-a2e8-492d72df7ffd

