### PR TITLE
Updated treasure tables of certain "messy" monsters

### DIFF
--- a/kod/object/passive/trestype/avart.kod
+++ b/kod/object/passive/trestype/avart.kod
@@ -27,19 +27,18 @@ messages:
    
    constructed()
    {
-      plTreasure = [ [ &RainbowFern, 20],
+      plTreasure = [ [ &RainbowFern, 30],
                      [ &Bread, 15],
                      [ &KriipaClaw, 15],
                      [ &Money, 14],
                      [ &WebMoss, 8],
-                     [ &NeruditeSword, 7],
-                     [ &NeruditeArmor, 7],
-                     [ &IvyCirclet, 5],
-                     [ &CurePoisonPotion, 2],
-                     [ &CureDiseasePotion, 2],
-                     [ &RemoveCursePotion, 2],
-                     [ &PurifyPotion, 2],
-                     [ &Yrxlsap, 1]
+                     [ &UncutSeraphym, 8],
+                     [ &TurkeyLeg, 5],
+                     [ &RemoveCursePotion, 1],
+                     [ &Yrxlsap, 1],
+                     [ &NeruditeSword, 1],
+                     [ &NeruditeArmor, 1],
+                     [ &IvyCirclet, 1]
 		             ];
 
       propagate;

--- a/kod/object/passive/trestype/skel2t.kod
+++ b/kod/object/passive/trestype/skel2t.kod
@@ -28,13 +28,17 @@ messages:
    
    Constructed()
    {
-      plTreasure = [ [ &MetalShield, 50 ],
-                     [ &Knightshield, 15 ],
+      plTreasure = [ [ &Mushroom, 25 ],
+                     [ &RedMushroom, 20 ],
+                     [ &Snack, 19 ],
                      [ &Money, 15 ],
-                     [ &Scimitar, 10 ],
                      [ &NeruditeArrow, 5 ],
+                     [ &Emerald, 5 ],
+                     [ &Sapphire, 4 ],
                      [ &InkyCap, 4 ],
-                     [ &DiscordScroll, 1 ]
+                     [ &KnightShield, 1 ],
+                     [ &DiscordScroll, 1 ],
+                     [ &IdentifyWand, 1 ]
                    ];
 
       propagate;

--- a/kod/object/passive/trestype/skel3t.kod
+++ b/kod/object/passive/trestype/skel3t.kod
@@ -29,17 +29,16 @@ messages:
    Constructed()
    {
       plTreasure = [ [ &NeruditeArrow, 15 ],
-                     [ &ShortSword, 15 ],
+                     [ &BlueMushroom, 15 ],
+                     [ &Snack, 14 ],
                      [ &InkyCap, 13 ],
                      [ &Money, 12 ],
-                     [ &Hammer, 10 ],
-                     [ &KnightShield, 8 ],
-                     [ &Scimitar, 8 ],
-                     [ &ScaleArmor, 5 ],
-                     [ &NodeburstPotion, 5 ],
-                     [ &LightScroll, 5 ],
-                     [ &EnfeebleWand, 2 ],
-                     [ &ForgetWand, 2 ]
+                     [ &Emerald, 10 ],
+                     [ &Sapphire, 10 ],
+                     [ &Diamond,  8 ],
+                     [ &ScaleArmor, 1 ],
+                     [ &Gauntlet, 1 ],
+                     [ &SimpleHelm, 1 ]
                    ];
 
       propagate;

--- a/kod/object/passive/trestype/skel4t.kod
+++ b/kod/object/passive/trestype/skel4t.kod
@@ -31,22 +31,20 @@ messages:
    
    constructed()
    {
-      plTreasure = [ [ &Scimitar, 20 ],
+      plTreasure = [ [ &BlueMushroom, 25 ],
                      [ &BlueDragonScale, 10 ],
                      [ &SilverArrow, 10 ],
                      [ &DarkAngelFeather, 10 ],
-                     [ &Circlet, 9 ],
+                     [ &Emerald, 10 ],
+                     [ &Sapphire, 10 ],
+                     [ &Diamond,  8 ],					 
                      [ &Money, 7 ],
-                     [ &Gauntlet, 5 ],
-                     [ &SimpleHelm, 5 ],
                      [ &InkyCap, 5 ],
-                     [ &KaraholsCursePotion, 5 ],
-                     [ &IdentifyWand, 5 ],
-                     [ &WindScroll, 2 ],
-                     [ &SummonPoisonFogScroll, 2 ],
-                     [ &KillingFieldScroll, 2 ],
-                     [ &LightScroll, 2 ],
-                     [ &DementWand, 1 ]
+                     [ &KillingFieldScroll, 1 ],
+                     [ &Circlet, 1 ],
+                     [ &DementWand, 1 ],
+                     [ &EnfeebleWand, 1 ],
+                     [ &ForgetWand, 1 ]					 
                   ];
 
       propagate;


### PR DESCRIPTION
This PR addresses an issue where certain monsters drop too many unstackable items.  As these items build up on the ground, graphical glitches such as flickering or vanishing/invisible objects occur after only a few minutes due to the number of unique objects on the screen.  The only current remedy is to leave the room and reset it every few minutes.

This addresses that issue by making the unstackable items much rarer, or removing them in some cases, then padding the table with stackable items that are typically of lesser value.

The drop rates of each monster's "valuable" stackable items is preserved, so I don't expect much of an economic impact.

Monsters affected:

Avar
- Added:  uncut seraphym, turkey leg
- Removed:  purify potion, cure poison potion, cure disease potion (all sold by lady aftyn)

Battered Skeleton**
- Added:   mushroom, red mushroom, edible mushroom (snack), emerald, sapphire, identify wand
- Removed:  scimitar (dropped by orcs, cave orcs), metal shield (sold by various blacksmiths)

Tusked Skeleton** (drops themed more around combat)
- Added:  blue mushroom, edible mushroom, emerald, sapphire, diamond, gauntlets, simple helm
- Removed:  short sword, hammer (buyable from several blacksmiths), scimitar (dropped by orcs/cave orcs), knight shield (dropped by various monsters), nodeburst potion (dropped by black spiders, certain quests), enfeeble wand, forget wand (moved to daemon skeleton), light scroll (dropped by several monsters - TID_MED_TOUGH)

Daemon Skeleton** (drops now themed more around magic)
- Added:  blue mushrooms, emeralds, sapphires, diamonds, enfeeble wand, forget wand
- Removed:  scimitar (dropped by orcs, cave orcs), gauntlet, simple helm (dropped by other monsters, including tusked skeletons now), karahol's curse potion, wind scroll, summon poison fog scroll, (not available anymore*), killing fields scroll (dropped by avar chieftains), light scroll (dropped by several other monsters)

\* Items no longer available as drops are all very low value and will be made available again by another PR at a later date.

\*\* Items added to the skeleton variants are based on the original skeleton's loot table.  It's also worth noting that all skeletons will still drop a varied-durability long sword 100% of the time, which is created independently of the drop tables.  This can be explored in another PR, as it seems outside this one's scope.

Edit:  As an added note, this will increase the rarity of the scimitar ever so slightly, which in my opinion is a good thing.