### PR TITLE
Adds vscode settings file with encoding settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
-  "files.encoding": "windows1252",
   "[rc]": {
     "files.encoding": "windows1252"
+  },
+  "[kod]": {
+    "files.encoding": "utf8"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,4 @@
   "[rc]": {
     "files.encoding": "windows1252"
   },
-  "[kod]": {
-    "files.encoding": "utf8"
-  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
-  "[rc]": {
-    "files.encoding": "windows1252"
+  "files.associations": {
+    "*.rc": "resource_files"
   },
+  "[resource_files]": {
+    "files.encoding": "windows1252"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "files.encoding": "windows1252",
+  "[rc]": {
+    "files.encoding": "windows1252"
+  }
+}


### PR DESCRIPTION
This PR adds a Visual Studio Code settings file to the project that enforces `windows1252` encoding for `rc` files.

Currently, contributors must manually reopen `rc` files with the correct encoding before saving to avoid introducing unwanted characters, especially in files containing translations. This settings file automates the process, ensuring `rc` files always use the proper encoding, preventing encoding errors and preserving file integrity.

Windows-1252 supports ISO-8859-1 plus full support for the following ligature forms (for English):

* German
* Portuguese
* Spanish
* French
* and [more](https://en.wikipedia.org/wiki/Windows-1252)
