### PR TITLE
Adds a cooldown timer to prevent rapid toggling of the Rest/Stand toolbar button

### DIFF
--- a/clientd3d/toolbar.c
+++ b/clientd3d/toolbar.c
@@ -25,7 +25,7 @@
 
 #define MAX_BUTTONS 30
 // Define cooldown period in milliseconds (e.g., 1000 ms = 1 second)
-#define BUTTON_COOLDOWN_PERIOD 250
+#define BUTTON_TOGGLE_COOLDOWN_PERIOD 250
 
 static Button buttons[MAX_BUTTONS];
 static int    num_buttons;           // Number of buttons currently created
@@ -276,7 +276,7 @@ Bool ToolbarSetButtonState(int action, void *action_data, Bool state)
    EnableWindow(b->hwnd, FALSE);
 
    // Start a timer for the cooldown period
-   SetTimer(hMain, (UINT_PTR)b->hwnd, BUTTON_COOLDOWN_PERIOD, (TIMERPROC)ReenableButton);
+   SetTimer(hMain, (UINT_PTR)b->hwnd, BUTTON_TOGGLE_COOLDOWN_PERIOD, (TIMERPROC)ReenableButton);
 
   Button_SetState(b->hwnd, state);
   // Redraw if necessary

--- a/clientd3d/toolbar.c
+++ b/clientd3d/toolbar.c
@@ -25,7 +25,7 @@
 
 #define MAX_BUTTONS 30
 // Define cooldown period in milliseconds (e.g., 1000 ms = 1 second)
-#define BUTTON_COOLDOWN_PERIOD 500
+#define BUTTON_COOLDOWN_PERIOD 250
 
 static Button buttons[MAX_BUTTONS];
 static int    num_buttons;           // Number of buttons currently created


### PR DESCRIPTION
This PR implements `SetTimer` to disable the rest/stand toggle button temporarily and re-enable it after a cooldown period. This prevents the rapid toggling seen in #969 and provides time for the client and server to sync up. I believe this could be resolved by faster polling/communication between the client and server, but that's obviously much larger discussion.

I'm okay if this doesn't see the light of day, but I wanted to at least offer up this potential solution.

Fixes #969 