### PR TITLE
Denies Shadow Rift in `NO_COMBAT` rooms

### DIFF
--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3869,8 +3869,11 @@ messages:
    CanHavePlayerPortal()
    "Return whether it's permissible to have a player-created portal in this room. "
    {
-      % No portals into "historic" (i.e. inaccessible, dead) areas
-      if Send(self, @GetRegion) = RID_HISTORIC
+      % No portals in 
+      % - "historic" (i.e. inaccessible, dead) areas
+      % - "No combat" rooms like inns, adv halls, rented rooms, and others
+      if Send(self,@GetRegion) = RID_HISTORIC
+         OR Send(self,@CheckRoomFlag,#flag=ROOM_NO_COMBAT) 
       {
          return FALSE;
       }

--- a/kod/object/passive/spell/multicst/shadrift.kod
+++ b/kod/object/passive/spell/multicst/shadrift.kod
@@ -81,6 +81,15 @@ messages:
 
    CanPayCosts(who = $, lTargets = $, iSpellPower = 0)
    {
+      % Ask room if we're allowed to cast here.  For example, portals into 
+      % guild halls are a bad idea.
+      if (NOT Send(Send(who, @GetOwner), @CanHavePlayerPortal))
+      {
+         Send(who,@MsgSendUser,#message_rsc=spell_bad_location,#parm1=vrName);
+         
+         return FALSE;
+      }
+
       propagate;
    }
    
@@ -97,17 +106,6 @@ messages:
       if oPrism = $
       {
          DEBUG("PrismCast called with no prism.");
-         return;
-      }
-
-      % Ask room if we're allowed to cast here.  For example, portals into 
-      % guild halls are a bad idea.
-      if (NOT send(send(oPrism, @GetOwner), @CanHavePlayerPortal))
-      {
-         for oCaster in lCasters
-         {
-            Send(oCaster,@MsgSendUser,#message_rsc=spell_bad_location, #parm1=vrName);
-         }
          return;
       }
 


### PR DESCRIPTION
This commit adds `NO_COMBAT` rooms to the list of rooms excluded from shadow rift portals. Previously, only the `HISTORIC` rooms were excluded. This commit also moves the logic checking this to `CanPayCosts()`, so that the user gets immediate feedback that it cannot be cast.

`NO_COMBAT` rooms include:
- Inns
- Taverns
- Adventurer Halls
- Raza
- Many of the NPC/town rooms (blacksmiths, the vault, banks, etc)
- The Clearing of the Trading Post, Outside the Mad Scientist's Hut, The Remote Trading Post of Wulfgang zax'Ak, and a few others
- Rented Rooms