### PR TITLE
Prevent unwanted alpha blending of objects

### DIFF
--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -138,10 +138,13 @@ long D3DRenderObjects(
 	D3DRenderPoolReset(objectsRenderParams.renderPool, &D3DMaterialObjectPool);
 	D3DCacheSystemReset(objectsRenderParams.cacheSystem);
 
-	// Render world objects
+	// Render opaque objects
 	D3DRenderOverlaysDraw(objectsRenderParams, gameObjectDataParams, playerViewParams, lightAndTextureParams, 1, false);
 	D3DRenderObjectsDraw(objectsRenderParams, gameObjectDataParams, playerViewParams, lightAndTextureParams, false);
 	D3DRenderOverlaysDraw(objectsRenderParams, gameObjectDataParams, playerViewParams, lightAndTextureParams, 0, false);
+
+	D3DCacheFill(objectsRenderParams.cacheSystem, objectsRenderParams.renderPool, 1);
+	D3DCacheFlush(objectsRenderParams.cacheSystem, objectsRenderParams.renderPool, 1, D3DPT_TRIANGLESTRIP);
 
 	// Render translucent objects
 	D3DRenderOverlaysDraw(objectsRenderParams, gameObjectDataParams, playerViewParams, lightAndTextureParams, 1, TRANSLUCENT_FLAGS);


### PR DESCRIPTION
We remove unwanted alpha blending around world objects but filling and flushing the cache between opaque and transparent passes.

![image](https://github.com/user-attachments/assets/88bd3c94-4c68-42d7-990c-731fc3ebda8f)
![image](https://github.com/user-attachments/assets/d5f04798-cf7d-46f5-a713-9c3cb9f1d1e6)

Tested that transparency is still functioning correctly for monsters and overlays.
