### PR TITLE
Quality of Life: Auto-delete depleted wands and Froz

### DIFF
--- a/kod/object/item/passitem/attmod/frozjewl.kod
+++ b/kod/object/item/passitem/attmod/frozjewl.kod
@@ -28,7 +28,7 @@ resources:
 
    frozjewel_desc_broken_rsc = "The jewel seems ordinary and dull."
 
-   frozjewel_broken = "The Jewel of Froz now seems quite ordinary."
+   frozjewel_broken = "Having expended its power, the Jewel of Froz crumbles to crimson dust."
 
 classvars:
 
@@ -62,7 +62,7 @@ messages:
          Send(poOwner,@MsgSendUser,#message_rsc=frozjewel_broken,
 	           #parm1=Send(self,@GetCapDef),#parm2=vrName);
          Send(poOwner,@TryUnuseItem,#what=self);
-         vrDesc = frozjewel_desc_broken_rsc;
+         Send(self,@Delete);
       
          return hit_roll;
       }

--- a/kod/object/item/passitem/attmod/frozjewl.kod
+++ b/kod/object/item/passitem/attmod/frozjewl.kod
@@ -26,8 +26,6 @@ resources:
       "aggression, using raw mana to boost elemental touch spells.  "
       "Your hand tingles when you hold it."
 
-   frozjewel_desc_broken_rsc = "The jewel seems ordinary and dull."
-
    frozjewel_broken = "Having expended its power, the Jewel of Froz crumbles to crimson dust."
 
 classvars:

--- a/kod/object/item/passitem/specwand.kod
+++ b/kod/object/item/passitem/specwand.kod
@@ -70,7 +70,7 @@ messages:
       {
          Send(poOwner,@MsgSendUser,#message_rsc=SpecialWand_broken,
            #parm1=send(self,@getcapdef),#parm2=send(self,@getname));
-         vrDesc = SpecialWand_desc_broken_rsc;
+         Send(self,@Delete);
       }
       
       return;

--- a/kod/object/item/passitem/specwand.kod
+++ b/kod/object/item/passitem/specwand.kod
@@ -38,8 +38,6 @@ classvars:
 
 properties:
 
-   vrDesc = SpecialWand_desc_rsc
-
 messages:
 
    %the subclass should define what the wand can apply itself to


### PR DESCRIPTION
This PR serves two purposes - to remove the clutter that inevitably clogs inventories when using wands, or Jewels of Froz; and bringing consistency to the way that consumable combat items are disposed of.

Both wands and Froz remove delete themselves after depletion, like Berserker Rings.  The "shatters" message for wands already makes perfect sense, but the Froz depletion message was updated to be more accurate and lore friendly.