### PR TITLE
Updates mouse x-button assignment to use predefined constants

### DIFF
--- a/keybind/Assignkey.cpp
+++ b/keybind/Assignkey.cpp
@@ -107,15 +107,15 @@ INT_PTR CAssignkey::DoModal()
         bGetbind=FALSE;
         strcpy(TCNewkey,"mouse2");
         break;
-      case 0x20b:
+      case WM_XBUTTONDOWN:
         bSkip=TRUE;
         switch(pMsg.wParam)
         {
-        case 0x10020:
+        case XBUTTON1:
           bGetbind=FALSE;
           strcpy(TCNewkey,"mouse3");
           break;
-        case 0x20040:
+        case XBUTTON2:
           bGetbind=FALSE;
           strcpy(TCNewkey,"mouse4");
           break;


### PR DESCRIPTION
This commit is pretty straightforward. I was looking at the mouse config and noticed that these values could be converted to their predefined constants.