### PR TITLE
Adds window capture of mouse wheel to zoom map

### DIFF
--- a/clientd3d/client.c
+++ b/clientd3d/client.c
@@ -105,6 +105,18 @@ LRESULT CALLBACK WndProc (HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 
 	switch (message)
 	{
+		case WM_MOUSEWHEEL:
+		{
+				if (state == STATE_GAME)
+				{
+						int zDelta = GET_WHEEL_DELTA_WPARAM(wParam);
+						int direction = (zDelta > 0) ? 1 : -1; // Scroll up is positive, scroll down is negative
+						MapZoom(direction);
+						return 0;
+				}
+				break;
+		}
+
 		HANDLE_MSG(hwnd, WM_CREATE, MainInit);
 		HANDLE_MSG(hwnd, WM_PAINT, MainExpose);
 		HANDLE_MSG(hwnd, WM_DESTROY, MainQuit);
@@ -129,6 +141,7 @@ LRESULT CALLBACK WndProc (HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 		HANDLE_MSG(hwnd, WM_MBUTTONDOWN, MainMouseMButtonDown);
 		HANDLE_MSG(hwnd, WM_LBUTTONDBLCLK, MainMouseLButtonDown);
 		HANDLE_MSG(hwnd, WM_LBUTTONUP, MainMouseLButtonUp);
+
 		HANDLE_MSG(hwnd, WM_MOUSEMOVE, MainMouseMove);
 		HANDLE_MSG(hwnd, WM_VSCROLL,MainVScroll);
 


### PR DESCRIPTION
This PR introduces mouse wheel support for zooming in and out of the map, making navigation a bit more intuitive and user-friendly. Users can now use their mouse to zoom both the map view and minimap.

https://github.com/user-attachments/assets/da80de59-45ea-4aee-961a-cf898f2738e5