### PR TITLE
Make world object invisible checks consistent

### DIFF
--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -578,6 +578,7 @@ void D3DRenderOverlaysDraw(
 		if (pRNode->obj.id == player->id)
 			continue;
 
+		// Check for invisible objects
 		bool objInvisible = IsInvisibleEffect(pRNode->obj.flags);
 		if ((flags & OF_INVISIBLE) == OF_INVISIBLE)
 		{

--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -68,7 +68,7 @@ static bool D3DComputePlayerOverlayArea(PDIB pdib, char hotspot, AREA* obj_area,
 
 // Functions
 
-bool IsInvisibleEffect(int flags) {
+static bool IsInvisibleEffect(int flags) {
 	return (flags & (OF_INVISIBLE | OF_DITHERINVIS)) == OF_INVISIBLE;
 }
 
@@ -1657,7 +1657,8 @@ void D3DRenderObjectsDraw(
 		}
 
 		if (pRNode->obj.id != INVALID_ID 
-			&& pRNode->obj.id == GetUserTargetID())
+			&& pRNode->obj.id == GetUserTargetID()
+			&& !IsInvisibleEffect(pRNode->obj.flags))
 		{
 			pPacket = D3DRenderPacketFindMatch(objectsRenderParams.renderPool, NULL, pDib, xLat0, xLat1,
 				GetDrawingEffect(pRNode->obj.flags));

--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -1905,16 +1905,8 @@ void D3DRenderPlayerOverlaysDraw(
 	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_PROJECTION, &mat);
 
 	// Get player's object flags for special drawing effects
-<<<<<<< HEAD
-	pRNode = GetRoomObjectById(playerViewParams.player->id);
-=======
 	const auto* player = GetPlayerInfo();
 	pRNode = GetRoomObjectById(player->id);
-	if (pRNode == NULL)
-		flags = 0;
-	else
-		flags = pRNode->obj.flags;
->>>>>>> master
 
 	for (i = 0; i < NUM_PLAYER_OVERLAYS; i++)
 	{

--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -69,6 +69,9 @@ static bool D3DComputePlayerOverlayArea(PDIB pdib, char hotspot, AREA* obj_area,
 // Functions
 
 static bool IsInvisibleEffect(int flags) {
+	// OF_DITHERINVIS is not treated as invisible in the hardware renderer, instead
+	// it is treated as grey scale and translucent (such as logoff ghosts). 
+	// Without using OF_DITHERINVIS below it would be incorrectly treated as invisible.
 	return (flags & (OF_INVISIBLE | OF_DITHERINVIS)) == OF_INVISIBLE;
 }
 


### PR DESCRIPTION
Reports that being invisible while a translucent monster (such as a slime) caused the player is not be visible at all.
Translucent, invisible morphed players will now be visible.