### PR TITLE
Add background objects following a system save 

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2182,6 +2182,8 @@ messages:
 
       Send(self,@SendUserAllWindowOverlays);
 
+      Send(self,@SendBackgroundObjects);
+
       return;
    }
 
@@ -2216,18 +2218,25 @@ messages:
 
    UserLogonHook()
    {
-      local i;
-      
-      for i in Send(SYS,@GetBackgroundObjects)
-      {
-         Send(i,@AddBackgroundObject,#who=self);
-      }
+      Send(self,@SendBackgroundObjects);
 
       Send(self,@LoadMailNews);
 
       % Count right now as the last time we moved.
       piLastMoveUpdateTime = GetTime();
       piMovesCounter = 0;
+
+      propagate;
+   }
+
+   SendBackgroundObjects()
+   {
+      local i;
+
+      for i in Send(SYS,@GetBackgroundObjects)
+      {
+         Send(i,@AddBackgroundObject,#who=self);
+      }
 
       propagate;
    }

--- a/kod/object/passive/moon.kod
+++ b/kod/object/passive/moon.kod
@@ -114,7 +114,7 @@ messages:
    }
 
    AddBackgroundObject(who = $)
-   "Called by user upon logon and after system save"
+   "Sends the background overlay to the client specified by the 'who' parameter."
    {
       Send(who,@ToCliAddBackgroundOverlay,#what=self);
       return;

--- a/kod/object/passive/moon.kod
+++ b/kod/object/passive/moon.kod
@@ -114,7 +114,7 @@ messages:
    }
 
    AddBackgroundObject(who = $)
-   "Called by user upon logon"
+   "Called by user upon logon and after system save"
    {
       Send(who,@ToCliAddBackgroundOverlay,#what=self);
       return;

--- a/kod/object/passive/sun.kod
+++ b/kod/object/passive/sun.kod
@@ -72,7 +72,7 @@ messages:
    }
 
    AddBackgroundObject(who = $)
-   "Called by user upon logon and after system save"
+   "Sends the background overlay to the client specified by the 'who' parameter."
    {
       Send(who,@ToCliAddBackgroundOverlay,#what=self);
       return;

--- a/kod/object/passive/sun.kod
+++ b/kod/object/passive/sun.kod
@@ -72,7 +72,7 @@ messages:
    }
 
    AddBackgroundObject(who = $)
-   "Called by user upon logon"
+   "Called by user upon logon and after system save"
    {
       Send(who,@ToCliAddBackgroundOverlay,#what=self);
       return;


### PR DESCRIPTION
Currently, background objects are only sent to players on login. When a system save takes place they disappear from the room overlays and are therefore not rendered (in both hardware/software renderer). This could have never worked or been supported by the game until now.

<img src="https://github.com/user-attachments/assets/bdd5825a-d947-4e56-86ab-fd582080234d" alt="drawing" width="200"/>

This change adds them again following a system save as well as on login.

fixes https://github.com/Meridian59/Meridian59/issues/990