### PR TITLE
Add z-depth adjustments for all objects at the same location

### DIFF
--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -1443,17 +1443,13 @@ void D3DRenderObjectsDraw(
 		// For everything else we start with the deault z bias which positions them behind these more complex arrangements.
 		pChunk->zBias = (pRNode->obj.flags & OF_PLAYER) || (pRNode->boundingHeightAdjust != 0) ? ZBIAS_BASE : ZBIAS_DEFAULT;
 
-		if (pRNode->obj.flags & OF_GETTABLE)
-		{
-			// Typical items such as reagents, keys, etc. are drawn at the default depth
-			// offset by the number of items already drawn at this location.
 
-			// Combine objects x and y position into a single int64 for the map key.
-			int64 key = ((int64)pRNode->motion.x << 32) | (int)(pRNode->motion.y & 0xFFFFFFFF);
+		// All objects are drawn at the default depth offset by the number of items already drawn at this location.
+		// Combine objects x and y position into a single int64 for the map key.
+		int64 key = ((int64)pRNode->motion.x << 32) | (int)(pRNode->motion.y & 0xFFFFFFFF);
 
-			// Increment the counter at the appropriate bin and assign the appropriate zBias.
-			pChunk->zBias += (BYTE)depth_adjustment_map[key]++;
-		}
+		// Increment the counter at the appropriate bin and assign the appropriate zBias.
+		pChunk->zBias += (BYTE)depth_adjustment_map[key]++;
 
 		lastDistance = 0;
 


### PR DESCRIPTION
This prevents z-fighting that may appear between monsters, players and monsters and single item stacks.