### PR TITLE
Correction to bHotspot default value

### DIFF
--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -643,7 +643,7 @@ void D3DRenderOverlaysDraw(
 
 			for (list2 = *pRNode->obj.overlays; list2 != NULL; list2 = list2->next)
 			{
-				bHotspot = true;
+				bHotspot = false;
 
 				pOverlay = (Overlay*)list2->data;
 


### PR DESCRIPTION
Incorrectly set `bHotspot` value during deconstruction - needs to default to false not true.
This was causing incorrect rendering issues when another player had some equipment and used magic.
Also remove a useless comment that was added previously

https://github.com/Meridian59/Meridian59/pull/916/files#diff-006128dfe5afe1d5b5b42cb04abcb98e0b6c96c74c3e4c6ab70fd3177cb9021cL7447
