### PR TITLE
Adjust alpha enablement to prevent unwanted blending world edges

### DIFF
--- a/clientd3d/d3drender_bgoverlays.c
+++ b/clientd3d/d3drender_bgoverlays.c
@@ -22,8 +22,8 @@ void D3DRenderBackgroundOverlays(const BackgroundOverlaysRenderStateParams& bgoR
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZENABLE, TRUE);
 
 	// Enable alpha blending and alpha testing for subsequent rendering
-    IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHABLENDENABLE, TRUE);
-    IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, TRUE);
+	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHABLENDENABLE, TRUE);
+	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, TRUE);
 
 	D3DRenderPoolReset(bgoRenderStateParams.worldPool, &D3DMaterialWorldPool);
 	D3DCacheSystemReset(bgoRenderStateParams.worldCacheSystem);
@@ -285,8 +285,8 @@ void D3DRenderBackgroundOverlays(const BackgroundOverlaysRenderStateParams& bgoR
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGENABLE, TRUE);
 
 	// Disable alpha blending and alpha testing
-    IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHABLENDENABLE, FALSE);
-    IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, FALSE);
+	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHABLENDENABLE, FALSE);
+	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, FALSE);
 
 	// restore the correct material and view matrices.
 	MatrixIdentity(&bgoRenderStateParams.transformMatrix);

--- a/clientd3d/d3drender_bgoverlays.c
+++ b/clientd3d/d3drender_bgoverlays.c
@@ -21,6 +21,10 @@ void D3DRenderBackgroundOverlays(const BackgroundOverlaysRenderStateParams& bgoR
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, FALSE);
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZENABLE, TRUE);
 
+	// Enable alpha blending and alpha testing for subsequent rendering
+    IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHABLENDENABLE, TRUE);
+    IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, TRUE);
+
 	D3DRenderPoolReset(bgoRenderStateParams.worldPool, &D3DMaterialWorldPool);
 	D3DCacheSystemReset(bgoRenderStateParams.worldCacheSystem);
 
@@ -279,6 +283,10 @@ void D3DRenderBackgroundOverlays(const BackgroundOverlaysRenderStateParams& bgoR
 
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, TRUE);
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGENABLE, TRUE);
+
+	// Disable alpha blending and alpha testing
+    IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHABLENDENABLE, FALSE);
+    IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, FALSE);
 
 	// restore the correct material and view matrices.
 	MatrixIdentity(&bgoRenderStateParams.transformMatrix);

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -194,10 +194,6 @@ void D3DRenderSkyBox(Draw3DParams* params, int angleHeading, int anglePitch, con
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZENABLE, TRUE);
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGENABLE, TRUE);
 
-	// Restore alpha blending and alpha testing for subsequent rendering
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHABLENDENABLE, TRUE);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, TRUE);
-
 	// restore the correct view matrix
 	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_VIEW, &view);
 }

--- a/clientd3d/d3drender_world.c
+++ b/clientd3d/d3drender_world.c
@@ -75,12 +75,6 @@ long D3DRenderWorld(
 
 	// Adjusted Alpha Testing and Blending
 	D3DRENDER_SET_ALPHATEST_STATE(gpD3DDevice, TRUE, alpha_test_threshold, D3DCMP_GREATEREQUAL);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHABLENDENABLE, TRUE);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, TRUE);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF, alpha_test_threshold);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAFUNC, D3DCMP_GREATEREQUAL);
 
 	// Set up texture filtering
 	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR);
@@ -146,6 +140,9 @@ long D3DRenderWorld(
 
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_CULLMODE, D3DCULL_NONE);
 	SetZBias(gpD3DDevice, 1);
+
+	// Disable alpha testing and blending
+	D3DRENDER_SET_ALPHATEST_STATE(gpD3DDevice, FALSE, alpha_test_threshold, D3DCMP_GREATEREQUAL);
 
 	return timeWorld;
 }
@@ -2039,8 +2036,7 @@ void D3DRenderLMapPostWallAdd(WallData* pWall, d3d_render_pool_new* pPool, unsig
 void D3DGeometryBuildNew(
 	const WorldRenderParams& worldRenderParams,
 	const WorldPropertyParams& worldPropertyParams,
-	const LightAndTextureParams& lightAndTextureParams, 
-	bool transparent_pass)
+	const LightAndTextureParams& lightAndTextureParams)
 {
 	int			count;
 	BSPnode		*pNode = NULL;
@@ -2059,14 +2055,6 @@ void D3DGeometryBuildNew(
 			case BSPinternaltype:
 				for (pWall = pNode->u.internal.walls_in_plane; pWall != NULL; pWall = pWall->next)
 				{
-
-					// Determine if the wall is transparent
-					bool isTransparent = (pWall->pos_sidedef && pWall->pos_sidedef->flags & WF_TRANSPARENT) ||
-						(pWall->neg_sidedef && pWall->neg_sidedef->flags & WF_TRANSPARENT);
-
-					if (!ShouldRenderInCurrentPass(transparent_pass, isTransparent))
-						continue;
-
 					int	flags, wallFlags;
 
 					flags = 0;

--- a/clientd3d/d3drender_world.c
+++ b/clientd3d/d3drender_world.c
@@ -73,7 +73,7 @@ long D3DRenderWorld(
 
 	auto timeWorld = timeGetTime();
 
-	// Adjusted Alpha Testing and Blending
+	// Enable alpha testing
 	D3DRENDER_SET_ALPHATEST_STATE(gpD3DDevice, TRUE, alpha_test_threshold, D3DCMP_GREATEREQUAL);
 
 	// Set up texture filtering
@@ -141,7 +141,7 @@ long D3DRenderWorld(
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_CULLMODE, D3DCULL_NONE);
 	SetZBias(gpD3DDevice, 1);
 
-	// Disable alpha testing and blending
+	// Disable alpha testing
 	D3DRENDER_SET_ALPHATEST_STATE(gpD3DDevice, FALSE, alpha_test_threshold, D3DCMP_GREATEREQUAL);
 
 	return timeWorld;

--- a/clientd3d/d3drender_world.c
+++ b/clientd3d/d3drender_world.c
@@ -2036,7 +2036,8 @@ void D3DRenderLMapPostWallAdd(WallData* pWall, d3d_render_pool_new* pPool, unsig
 void D3DGeometryBuildNew(
 	const WorldRenderParams& worldRenderParams,
 	const WorldPropertyParams& worldPropertyParams,
-	const LightAndTextureParams& lightAndTextureParams)
+	const LightAndTextureParams& lightAndTextureParams, 
+	bool transparent_pass)
 {
 	int			count;
 	BSPnode		*pNode = NULL;
@@ -2055,6 +2056,14 @@ void D3DGeometryBuildNew(
 			case BSPinternaltype:
 				for (pWall = pNode->u.internal.walls_in_plane; pWall != NULL; pWall = pWall->next)
 				{
+
+					// Determine if the wall is transparent
+					bool isTransparent = (pWall->pos_sidedef && pWall->pos_sidedef->flags & WF_TRANSPARENT) ||
+						(pWall->neg_sidedef && pWall->neg_sidedef->flags & WF_TRANSPARENT);
+
+					if (!ShouldRenderInCurrentPass(transparent_pass, isTransparent))
+						continue;
+
 					int	flags, wallFlags;
 
 					flags = 0;


### PR DESCRIPTION
We have some unwanted blending taking place between static world geometry and the skybox. This issue is most obvious at certain times of the day when the sky is bright on screens such as the outskirts of Barloque or the Flatlands.

To solve this we correct when and where alpha blending is enabled/disabled.

Before:
![image](https://github.com/user-attachments/assets/7053a7b3-7cf6-4c7b-baa4-984eb4c8f80e)
![image](https://github.com/user-attachments/assets/3874dde7-5aed-483d-9d5c-f9b65d8095c0)

After:
![image](https://github.com/user-attachments/assets/74a79a97-7686-46be-9f8a-cea23be1ebe3)
![image](https://github.com/user-attachments/assets/6242408f-0e29-47f6-95c4-4071ebf5a25d)
