### PR TITLE
Correctly return from SengBackgroundObjects

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2238,7 +2238,7 @@ messages:
          Send(i,@AddBackgroundObject,#who=self);
       }
 
-      propagate;
+      return;
    }
 
    LoadMailNews()


### PR DESCRIPTION
Toko detected an error in the logs following https://github.com/Meridian59/Meridian59/pull/992/

```
[user.bof (2241)] SendBlakodMessage can't propagate MESSAGE SendBackgroundObjects (14377) in CLASS User (1)
```

We correct this by returning rather than propagating in SengBackgroundObjects.