### PR TITLE
Correction to render parameters

### DIFF
--- a/clientd3d/d3drender_bgoverlays.h
+++ b/clientd3d/d3drender_bgoverlays.h
@@ -18,7 +18,7 @@ struct BackgroundOverlaysRenderStateParams {
     d3d_render_cache_system* worldCacheSystem;
     const D3DMATRIX& view;
     D3DMATRIX& transformMatrix;
-    RECT& d3dRect;
+    const RECT& d3dRect;
 
     BackgroundOverlaysRenderStateParams(
         LPDIRECT3DVERTEXDECLARATION9 vertexDeclarationParam,
@@ -27,7 +27,7 @@ struct BackgroundOverlaysRenderStateParams {
         d3d_render_cache_system* worldCacheSystemParam,
         const D3DMATRIX& viewParam,
         D3DMATRIX& transformMatrixParam,
-        RECT d3dRectParam)
+        const RECT& d3dRectParam)
         : vertexDeclaration(vertexDeclarationParam),
           driverProfile(driverProfileParam),
           worldPool(worldPoolParam),

--- a/clientd3d/d3drender_objects.h
+++ b/clientd3d/d3drender_objects.h
@@ -114,7 +114,7 @@ struct ObjectsRenderParams {
 
 	LPDIRECT3DVERTEXDECLARATION9 vertexDeclaration;
 	LPDIRECT3DVERTEXDECLARATION9 vertexDeclarationInvisible;
-	d3d_driver_profile driverProfile;
+	const d3d_driver_profile& driverProfile;
 
 	d3d_render_pool_new* renderPool;
 	d3d_render_cache_system* cacheSystem;
@@ -128,7 +128,7 @@ struct ObjectsRenderParams {
     ObjectsRenderParams(
         LPDIRECT3DVERTEXDECLARATION9 vertexDeclarationParam,
         LPDIRECT3DVERTEXDECLARATION9 vertexDeclarationInvisibleParam,
-        d3d_driver_profile driverProfileParam,
+        const d3d_driver_profile& driverProfileParam,
         d3d_render_pool_new* renderPoolParam,
         d3d_render_cache_system* cacheSystemParam,
         D3DMATRIX viewParam,


### PR DESCRIPTION
`d3dRect` contained nonsense values, causing bad calculations for visible area calculations, preventing background overlays from being clickable. We fix `d3dRect` in render bgoverlays and also optimize `driverProfile` in render objects.