### PR TITLE
Persist sandstorm effects

### DIFF
--- a/clientd3d/bspload.c
+++ b/clientd3d/bspload.c
@@ -180,8 +180,7 @@ Bool BSPRooFileLoad(char *fname, room_type *room)
    room->num_sidedefs = num_sidedefs;
 
    gD3DRedrawAll |= D3DRENDER_REDRAW_ALL;
-    
-    D3DFxInit();
+   D3DFxInit();
 
 	playerOldPos.x = 0;
 	playerOldPos.y = 0;

--- a/clientd3d/bspload.c
+++ b/clientd3d/bspload.c
@@ -180,6 +180,8 @@ Bool BSPRooFileLoad(char *fname, room_type *room)
    room->num_sidedefs = num_sidedefs;
 
    gD3DRedrawAll |= D3DRENDER_REDRAW_ALL;
+    
+    D3DFxInit();
 
 	playerOldPos.x = 0;
 	playerOldPos.y = 0;

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -574,8 +574,6 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	if (gD3DRedrawAll & D3DRENDER_REDRAW_ALL)
 	{
-		D3DFxInit();
-
 		D3DCacheSystemReset(&gWorldCacheSystemStatic);
 		D3DCacheSystemReset(&gWallMaskCacheSystem);
 


### PR DESCRIPTION
During https://github.com/Meridian59/Meridian59/pull/950/ `SandstormInit` from `BSPRooFileLoad`. 

`SandstormInit` should be called only once per room. Therefore its new location in `D3DRenderBegin` isn't suitable as it can be called more than once per room and this will stop the effect from displaying.

We return back to its original position to ensure sandstorm is visually functioning correctly.

There also appears to be visual bug with sandstorm on the live game. 
The good news is that that issue appears to be resolved with the latest on github.