### PR TITLE
Adds 24-hour duration to DM-added weapon spell attributes

### DIFF
--- a/kod/object/passive/itematt/weapatt/waspellt.kod
+++ b/kod/object/passive/itematt/weapatt/waspellt.kod
@@ -20,7 +20,7 @@ WeapAttSpellType is WeaponAttribute
 %
 %      [WA_ATTACKSPELLTYPE, timer, spell_attack_type ]
 %   
-%       timer::the length of time, from 1 to 25 realtime hours,
+%       timer::the length of time, from 1 to 24 realtime hours,
 %         that the enchantment lasts (depending on spell factors).
 %       spell_attack_type : as defined in blakston.khd.
 %          examples: ATCK_SPELL_FIRE, ATCK_SPELL_UNHOLY, ATCK_SPELL_ACID
@@ -35,6 +35,9 @@ WeapAttSpellType is WeaponAttribute
 constants:
 
    include blakston.khd
+
+   ONE_HOUR_IN_MILLISECONDS = 3600000
+   ONE_DAY_IN_MILLISECONDS = 86400000
 
 resources:
    
@@ -193,7 +196,7 @@ messages:
       if send(self,@ReqAddToItem,#state1=iSpellType,#oItem=oWeapon)
       {
          send(self,@AddToItem,#oItem=oWeapon,#state1=iSpellType,
-              #timer_duration=86400000,#random_gen=TRUE);
+              #timer_duration=ONE_DAY_IN_MILLISECONDS,#random_gen=TRUE);
               
          return TRUE;
       }
@@ -265,7 +268,8 @@ messages:
       if send(self,@ReqAddToItem,#state1=iSpellType,#oItem=oItem)
       {
          send(self,@AddToItem,#oItem=oItem,#state1=iSpellType,
-              #timer_duration=random(3600000,86400000),#random_gen=TRUE);
+              #timer_duration=random(ONE_HOUR_IN_MILLISECONDS,ONE_DAY_IN_MILLISECONDS),
+              #random_gen=TRUE);
       }
       
       return;

--- a/kod/object/passive/itematt/weapatt/waspellt.kod
+++ b/kod/object/passive/itematt/weapatt/waspellt.kod
@@ -40,12 +40,12 @@ resources:
    
    iaSpelltype_gone = "Your %s suddenly seems a little more... ordinary."
 
-   iaSpelltype_holy = "  The weapon glows with a pure, white light."
-   iaSpelltype_unholy = "  The weapon seems to reek of malevolence."
-   iaSpelltype_fire = "  The weapon is hot to the touch."
-   iaSpelltype_cold = "  It is icy cold to the touch."
-   iaSpelltype_shock = "  Nearly invisible currents run the length of the blade."
-   iaSpelltype_acid = "  A thin coating of acid covers the length of the blade."
+   iaSpelltype_holy = "The weapon glows with a pure, white light."
+   iaSpelltype_unholy = "The weapon seems to reek of malevolence."
+   iaSpelltype_fire = "The weapon is hot to the touch."
+   iaSpelltype_cold = "It is icy cold to the touch."
+   iaSpelltype_shock = "Nearly invisible currents run the length of the blade."
+   iaSpelltype_acid = "A thin coating of acid covers the length of the blade."
 
    iaSpelltype_name_holy = "holy %s"
    iaSpelltype_name_unholy = "unholy %s"
@@ -115,7 +115,8 @@ messages:
       {
          rName = iaSpellType_acid;
       }
-         
+      
+      AppendTempString("  ");
       AppendTempString(rName);
 
       % If not faked, then add maker information if available.

--- a/kod/object/passive/itematt/weapatt/waspellt.kod
+++ b/kod/object/passive/itematt/weapatt/waspellt.kod
@@ -40,12 +40,12 @@ resources:
    
    iaSpelltype_gone = "Your %s suddenly seems a little more... ordinary."
 
-   iaSpelltype_holy = "The weapon glows with a pure, white light."
-   iaSpelltype_unholy = "The weapon seems to reek of malevolence."
-   iaSpelltype_fire = "The weapon is hot to the touch."
-   iaSpelltype_cold = "It is icy cold to the touch."
-   iaSpelltype_shock = "Nearly invisible currents run the length of the blade."
-   iaSpelltype_acid = "A thin coating of acid covers the length of the blade."
+   iaSpelltype_holy = "  The weapon glows with a pure, white light."
+   iaSpelltype_unholy = "  The weapon seems to reek of malevolence."
+   iaSpelltype_fire = "  The weapon is hot to the touch."
+   iaSpelltype_cold = "  It is icy cold to the touch."
+   iaSpelltype_shock = "  Nearly invisible currents run the length of the blade."
+   iaSpelltype_acid = "  A thin coating of acid covers the length of the blade."
 
    iaSpelltype_name_holy = "holy %s"
    iaSpelltype_name_unholy = "unholy %s"

--- a/kod/object/passive/itematt/weapatt/waspellt.kod
+++ b/kod/object/passive/itematt/weapatt/waspellt.kod
@@ -191,8 +191,8 @@ messages:
       
       if send(self,@ReqAddToItem,#state1=iSpellType,#oItem=oWeapon)
       {
-         send(self,@AddToItem,#oItem=oWeapon, #state1=iSpellType,
-              #random_gen=TRUE);
+         send(self,@AddToItem,#oItem=oWeapon,#state1=iSpellType,
+              #timer_duration=86400000,#random_gen=TRUE);
               
          return TRUE;
       }

--- a/kod/object/passive/itematt/weapatt/waspellt.kod
+++ b/kod/object/passive/itematt/weapatt/waspellt.kod
@@ -36,8 +36,8 @@ constants:
 
    include blakston.khd
 
-   ONE_HOUR_IN_MILLISECONDS = 3600000
-   ONE_DAY_IN_MILLISECONDS = 86400000
+   ONE_HOUR_IN_MILLISECONDS = 60 * 60 * 1 * 1000
+   ONE_DAY_IN_MILLISECONDS = 60 * 60 * 24 * 1000
 
 resources:
    


### PR DESCRIPTION
This PR addresses an issue with DM-added weapon attributes of the spell attack type. Currently, when these attributes are added via `dm create itematt holy`, for example, a timer is not provided. It's needed by a later check and its absence causes the errors seen in #1007.

These weapon attributes are randomly generated with a duration of 1-24 hours. For the DM version, I chose 24-hours as anything created by a god ought to last a while.

I also snuck in a small change to the spell type descriptions that get appended for consistency with all other text formatting.

### Testing
* `dm get item mace`
* Equip the mace
* `dm create itematt holy`
* Examine the mace to verify it's enchanted with a holy attack
* Verify the error logs are clear of issues


This fixes #1007 