### PR TITLE
Make the Chalice of the rain function like rescue and elusion

### DIFF
--- a/kod/object/item/passitem/chalice.kod
+++ b/kod/object/item/passitem/chalice.kod
@@ -28,7 +28,7 @@ resources:
    chalice_use = "You sip a bit of the water out of the Chalice of Rain."
    chalice_empty = "The Chalice of Rain crumbles to dust in your hand as you sip the last bit of water from it."
    chalice_combine = "You pour the water from one Chalice into the other."
-   chalice_cant_use_pkill = "Only innocents may partake of the chalice."
+   chalice_cant_use_pkill = "Only those who have walked the path of peace may partake of the chalice."
    chalice_refilled = "The Chalice of Rain glows faintly for a moment, renewed by the spirit of Shal'ille that permeates the area."
    chalice_refilled_sound = water_scoop01.wav
 

--- a/kod/object/item/passitem/chalice.kod
+++ b/kod/object/item/passitem/chalice.kod
@@ -175,7 +175,6 @@ messages:
             Send(what, @MsgSendUser, #message_rsc = chalice_cant_use_pkill);
             return FALSE;
          }
-
          % Prevent use if you can't fight.
          if Send(what,@CheckPlayerFlag,#flag=PFLAG_NO_FIGHT)
          {

--- a/kod/object/item/passitem/chalice.kod
+++ b/kod/object/item/passitem/chalice.kod
@@ -175,6 +175,7 @@ messages:
             Send(what, @MsgSendUser, #message_rsc = chalice_cant_use_pkill);
             return FALSE;
          }
+
          % Prevent use if you can't fight.
          if Send(what,@CheckPlayerFlag,#flag=PFLAG_NO_FIGHT)
          {

--- a/kod/object/item/passitem/chalice.kod
+++ b/kod/object/item/passitem/chalice.kod
@@ -167,15 +167,15 @@ messages:
    {
       if (IsClass(what,&Player))
       {
-         % Prevent use if you're red.  This is because player killers
-         % were using this to escape too easily after kills.
-         if Send(what,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
-		     OR Send(what,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
+         % Prevent use just after attacking someone (as rescue/elusion)
+         if Send(who, @GetLastPlayerAttackTime) + 
+            Send(Send(SYS, @GetSettings), @TeleportAttackDelaySec) >
+            GetTime()
          {
-            Send(what, @MsgSendUser, #message_rsc = chalice_cant_use_pkill);
+            Send(who, @MsgSendUser, #message_rsc = spell_too_soon_since_attacking);
             return FALSE;
          }
-         
+
          % Prevent use if you can't fight.
          if Send(what,@CheckPlayerFlag,#flag=PFLAG_NO_FIGHT)
          {

--- a/kod/object/item/passitem/chalice.kod
+++ b/kod/object/item/passitem/chalice.kod
@@ -168,11 +168,11 @@ messages:
       if (IsClass(what,&Player))
       {
          % Prevent use just after attacking someone (as rescue/elusion)
-         if Send(who, @GetLastPlayerAttackTime) + 
+         if Send(what, @GetLastPlayerAttackTime) + 
             Send(Send(SYS, @GetSettings), @TeleportAttackDelaySec) >
             GetTime()
          {
-            Send(who, @MsgSendUser, #message_rsc = spell_too_soon_since_attacking);
+            Send(what, @MsgSendUser, #message_rsc = chalice_cant_use_pkill);
             return FALSE;
          }
 

--- a/kod/object/item/passitem/chalice.kod
+++ b/kod/object/item/passitem/chalice.kod
@@ -175,7 +175,7 @@ messages:
             Send(what, @MsgSendUser, #message_rsc = chalice_cant_use_pkill);
             return FALSE;
          }
-
+         
          % Prevent use if you can't fight.
          if Send(what,@CheckPlayerFlag,#flag=PFLAG_NO_FIGHT)
          {


### PR DESCRIPTION
The Chalice was adjusted back in 2013 to allow all players (not just non-angled) to partake. However, it was changed to prevent all outlaw/red characters from using it instead. As per original follow up discussions in 2013: we correct the use of the Chalice to make it fair and consistent with rescue/elusion: https://github.com/Meridian59/Meridian59/pull/37#issuecomment-13698080

This brings a level playing field to the use of the chalice for all.

testing:

Confirmed working as expected when used on local server. Unable to chalice away and see new message until timer condition is met.