### PR TITLE
Adds catch for invalid or unavailable locale in mailread

### DIFF
--- a/module/mailnews/mailread.c
+++ b/module/mailnews/mailread.c
@@ -479,7 +479,17 @@ int StringToTimestamp(const char *dateStr)
    // Use a string stream to parse the date and time, leveraging locale
    // to support the translation of month strings.
    std::istringstream input(dateStr);
-   input.imbue(std::locale(localeName));
+
+   try
+   {
+      input.imbue(std::locale(localeName));
+   }
+   catch (const std::runtime_error &e)
+   {
+      debug(("Failed to set locale: %s. Falling back to default.\n", e.what()));
+      input.imbue(std::locale("C"));
+   }
+   
    input >> std::get_time(&tm, "%a %b %d, %Y %H:%M");
 
    if (input.fail())


### PR DESCRIPTION
Patch 1.4 introduced mail sorting, which relies on the system locale for parsing. After release, exceptions were reported, likely due to the user's system not supporting the specified locale. This PR adds a fallback: if setting the locale fails, the client catches the issue and falls back to the "C" locale. Before implementing this change, I tested by forcing a bad locale (e.g., setting `localeName` to `bad_locale`), which previously caused the client to crash. With the fallback in place, the crash is avoided, and English mail is parsed correctly using the default locale.

My theory is that the new support for Portuguese (Brazil) may have introduced a mismatch with standard Portuguese (non-Brazilian) or another unexpected locale configuration, triggering this issue.

A limitation of this change is that it defaults to the "C" locale, which only supports English parsing. However, if the user's system doesn’t support the locale, they wouldn’t have Portuguese email headers in the first place, so this fallback provides at least a functional baseline for parsing.