### PR TITLE
Upgrade existing statues

### DIFF
--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -521,7 +521,6 @@ messages:
       local iSkin_xlat;
 
       % Send overlay bitmap info to user.  
-
       % Player has 8 standard overlays: right arm, left arm, legs, head, eyes, 
       % mouth, nose, hair
 

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -516,9 +516,9 @@ messages:
 
       if pbIsHairVisible = $
       {
-         % We added ability to show facial overlays but for existing statues it will 
-         % have the number of overlays already calculated, this number may be incorrect.
-         % To upgrade the statue we reset the frames having first correct set the new properties.
+         % We added the ability to show facial overlays on statues but for existing statues 
+         % the number of overlays was already calculated and this number may be incorrect!
+         % To upgrade the statue we reset the frames having first correctly set the new properties.
          Debug("Upgrading an old statue");
          prFacialOverlay = Send(poOriginal,@GetFacialOverlay);
          pbIsHairVisible = Send(poOriginal,@IsHairVisible);

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -92,7 +92,6 @@ properties:
 
    piOverlays = 8
    piColor = 0
-   piUpgraded = FALSE
 
 messages:
 

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -513,6 +513,7 @@ messages:
       prFacialOverlay = Send(poOriginal,@GetFacialOverlay);
       pbIsHairVisible = Send(poOriginal,@IsHairVisible);
       Send(self,@ResetFrames);
+      return;
    }
 
    SendOverlays()

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -510,7 +510,7 @@ messages:
 
       % We added the ability to show facial overlays (patch 1.3.2 / client 732).
       % To upgrade the statue we reset the frames having first correctly set the new properties.
-      % This function to be removed after is has been run via "send class" from admin mode on the server.
+      % This function to be removed after it has been run via "send class" from admin mode on the server.
       prFacialOverlay = Send(poOriginal,@GetFacialOverlay);
       pbIsHairVisible = Send(poOriginal,@IsHairVisible);
       Send(self,@ResetFrames);

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -524,7 +524,7 @@ messages:
 
       % Player has 8 standard overlays: right arm, left arm, legs, head, eyes, 
       % mouth, nose, hair
-
+      
       %% number of overlays
       AddPacket(1, piOverlays);
 

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -524,6 +524,7 @@ messages:
 
       % Player has 8 standard overlays: right arm, left arm, legs, head, eyes, 
       % mouth, nose, hair
+
       %% number of overlays
       AddPacket(1, piOverlays);
 

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -508,10 +508,9 @@ messages:
    UpgradeStatue()
    {
 
-      % We added the ability to show facial overlays (patch 1.3.2 / client 732) but for existing statues 
-      % the number of overlays was already calculated and this number may be incorrect!
+      % We added the ability to show facial overlays (patch 1.3.2 / client 732).
       % To upgrade the statue we reset the frames having first correctly set the new properties.
-      % Function to be removed after is has been run via "send class" from admin mode on the server.
+      % This function to be removed after is has been run via "send class" from admin mode on the server.
       prFacialOverlay = Send(poOriginal,@GetFacialOverlay);
       pbIsHairVisible = Send(poOriginal,@IsHairVisible);
       Send(self,@ResetFrames);

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -521,9 +521,9 @@ messages:
       local iSkin_xlat;
 
       % Send overlay bitmap info to user.  
+
       % Player has 8 standard overlays: right arm, left arm, legs, head, eyes, 
       % mouth, nose, hair
-
       %% number of overlays
       AddPacket(1, piOverlays);
 

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -92,6 +92,7 @@ properties:
 
    piOverlays = 8
    piColor = 0
+   piUpgraded = FALSE
 
 messages:
 
@@ -513,6 +514,18 @@ messages:
 
       % Player has 8 standard overlays: right arm, left arm, legs, head, eyes, 
       % mouth, nose, hair
+
+      if pbIsHairVisible = $
+      {
+         % We added ability to show facial overlays but for existing statues it will 
+         % have the number of overlays already calculated, this number may be incorrect.
+         % To upgrade the statue we reset the frames having first correct set the new properties.
+         Debug("Upgrading an old statue");
+         prFacialOverlay = Send(poOriginal,@GetFacialOverlay);
+         pbIsHairVisible = Send(poOriginal,@IsHairVisible);
+         Send(self,@ResetFrames);
+         Debug("Upgrade of statue complete.");
+      }
       
       %% number of overlays
       AddPacket(1, piOverlays);

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -505,6 +505,16 @@ messages:
       return;
    }
 
+   UpgradeStatue()
+   {
+      % We added the ability to show facial overlays on statues but for existing statues 
+      % the number of overlays was already calculated and this number may be incorrect!
+      % To upgrade the statue we reset the frames having first correctly set the new properties.
+      prFacialOverlay = Send(poOriginal,@GetFacialOverlay);
+      pbIsHairVisible = Send(poOriginal,@IsHairVisible);
+      Send(self,@ResetFrames);
+   }
+
    SendOverlays()
    {
       local iSkin_xlat;
@@ -514,18 +524,6 @@ messages:
       % Player has 8 standard overlays: right arm, left arm, legs, head, eyes, 
       % mouth, nose, hair
 
-      if pbIsHairVisible = $
-      {
-         % We added the ability to show facial overlays on statues but for existing statues 
-         % the number of overlays was already calculated and this number may be incorrect!
-         % To upgrade the statue we reset the frames having first correctly set the new properties.
-         Debug("Upgrading an old statue");
-         prFacialOverlay = Send(poOriginal,@GetFacialOverlay);
-         pbIsHairVisible = Send(poOriginal,@IsHairVisible);
-         Send(self,@ResetFrames);
-         Debug("Upgrade of statue complete.");
-      }
-      
       %% number of overlays
       AddPacket(1, piOverlays);
 

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -507,9 +507,11 @@ messages:
 
    UpgradeStatue()
    {
-      % We added the ability to show facial overlays on statues but for existing statues 
+
+      % We added the ability to show facial overlays (patch 1.3.2 / client 732) but for existing statues 
       % the number of overlays was already calculated and this number may be incorrect!
       % To upgrade the statue we reset the frames having first correctly set the new properties.
+      % Function to be removed after is has been run via "send class" from admin mode on the server.
       prFacialOverlay = Send(poOriginal,@GetFacialOverlay);
       pbIsHairVisible = Send(poOriginal,@IsHairVisible);
       Send(self,@ResetFrames);

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -6430,14 +6430,6 @@ messages:
       return Send(oHall,@ChooseStatues);
    }
 
-   UpgradeStatues()
-   "One time upgrade for all Statues to support for new facial overlays"
-   " added in patch 1.3.2 / client 732. Safe to run a multiple tmes, if you wish."
-   {
-      Send(&Statue, @UpgradeStatue);
-      return;
-   }
-
    %%% Dynamic lighting
 
    GetRGB(iRed = 0, iGreen = 0, iBlue = 0, bPercent = TRUE, bNegative = FALSE)

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -6431,12 +6431,12 @@ messages:
    }
 
    UpgradeStatues()
-   "One time upgrade statues to cater for new facial overlays, added in 1.3.2 / client 732."
-   "Save to run a second time, if you dare."
+   "One time upgrade for all Statues to support for new facial overlays"
+   " added in patch 1.3.2 / client 732. Safe to run a multiple tmes, if you wish."
    {
       local room,plPassiveObjects,i,each_obj,statues_upgraded;
       debug("Statues upgrade started");
-      statues_upgraded = 0
+      statues_upgraded = 0;
       for room in plRooms
       {
          plPassiveObjects = Send(room, @GetPlPassive);
@@ -6445,13 +6445,12 @@ messages:
             each_obj = Send(room,@HolderExtractObject,#data=i);
             if IsClass(each_obj, &Statue)
             {
-               debug("Found a statue: %s upgrading", Send(each_obj, @GetName));
                Send(each_obj, @UpgradeStatue);
-               statues_upgraded = (statues_upgraded+1)
+               statues_upgraded = statues_upgraded+1;
             }
          }
       }
-      debug("%i statues successfully upgraded", statues_upgraded);
+      debug("Total statues upgraded: ", statues_upgraded);
       return;
    }
 

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -6430,6 +6430,31 @@ messages:
       return Send(oHall,@ChooseStatues);
    }
 
+   UpgradeStatues()
+   "One time upgrade statues to cater for new facial overlays, added in 1.3.2 / client 732."
+   "Save to run a second time, if you dare."
+   {
+      local room,plPassiveObjects,i,each_obj,statues_upgraded;
+      debug("Statues upgrade started");
+      statues_upgraded = 0
+      for room in plRooms
+      {
+         plPassiveObjects = Send(room, @GetPlPassive);
+         for i in plPassiveObjects
+         {
+            each_obj = Send(room,@HolderExtractObject,#data=i);
+            if IsClass(each_obj, &Statue)
+            {
+               debug("Found a statue: %s upgrading", Send(each_obj, @GetName));
+               Send(each_obj, @UpgradeStatue);
+               statues_upgraded = (statues_upgraded+1)
+            }
+         }
+      }
+      debug("%i statues successfully upgraded", statues_upgraded);
+      return;
+   }
+
    %%% Dynamic lighting
 
    GetRGB(iRed = 0, iGreen = 0, iBlue = 0, bPercent = TRUE, bNegative = FALSE)

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -6434,23 +6434,7 @@ messages:
    "One time upgrade for all Statues to support for new facial overlays"
    " added in patch 1.3.2 / client 732. Safe to run a multiple tmes, if you wish."
    {
-      local room,plPassiveObjects,i,each_obj,statues_upgraded;
-      debug("Statues upgrade started");
-      statues_upgraded = 0;
-      for room in plRooms
-      {
-         plPassiveObjects = Send(room, @GetPlPassive);
-         for i in plPassiveObjects
-         {
-            each_obj = Send(room,@HolderExtractObject,#data=i);
-            if IsClass(each_obj, &Statue)
-            {
-               Send(each_obj, @UpgradeStatue);
-               statues_upgraded = statues_upgraded+1;
-            }
-         }
-      }
-      debug("Total statues upgraded: ", statues_upgraded);
+      Send(&Statue, @UpgradeStatue);
       return;
    }
 


### PR DESCRIPTION
After we added the ability to show overlays on statues: https://github.com/Meridian59/Meridian59/pull/927

We found out that any existing statues that had overlays that were created before this upgrade would have a mismatch between the number of calculated overlays and the overlays sent to the client. We create a one time upgrade to solve this, fixing any existing statues that need to be recalibrated.

Testing:

Created a server pre-upgrade and reset the statues and saved the game state. Upgraded post https://github.com/Meridian59/Meridian59/pull/927 - got the bug and then ran this fix, saw the one time upgrade applied to all statues and the bug was gone.