### PR TITLE
Fixes mail subject handling tied to recipient count

### DIFF
--- a/module/mailnews/mailfile.c
+++ b/module/mailnews/mailfile.c
@@ -133,7 +133,6 @@ void MailNewMessage(int server_index, char *sender, int num_recipients,
    auto subject_strs = std::vector<std::string>(num_subjects);
    char *subject = "";
    char *ptr;
-   int i, num;
    int subject_id_index = 0;
    char filename[FILENAME_MAX + MAX_PATH];
    char date[MAXDATE];
@@ -155,7 +154,7 @@ void MailNewMessage(int server_index, char *sender, int num_recipients,
 
    /* Add recipients' names */
    num = 0;
-   for (i = 0; i < num_recipients; i++)
+   for (int i = 0; i < num_recipients; i++)
    {
       if (num++ > 0)
          strcat(new_msg, ", "); 

--- a/module/mailnews/mailfile.c
+++ b/module/mailnews/mailfile.c
@@ -134,6 +134,7 @@ void MailNewMessage(int server_index, char *sender, int num_recipients,
    char *subject = "";
    char *ptr;
    int i, num;
+   int subject_id_index = 1;
    char filename[FILENAME_MAX + MAX_PATH];
    char date[MAXDATE];
    MailHeader header;
@@ -168,6 +169,7 @@ void MailNewMessage(int server_index, char *sender, int num_recipients,
       subject_strs[i] = GetString(hInst, subject_ids[i]);
       if (strncmp(message, subject_strs[i].c_str(), subject_strs[i].size()) == 0)
       {
+         subject_id_index = i;
          subject_found = True;
          break;
       }
@@ -175,8 +177,8 @@ void MailNewMessage(int server_index, char *sender, int num_recipients,
 
    if (subject_found)
    {
-      /* Skip "Subject: " leader */
-      subject = message + subject_strs[i].size();
+      /* Skip "Subject: " or other translation leading string */
+      subject = message + subject_strs[subject_id_index].size();
 
       /* Skip subject line; have to deal with \n (from users) or \r\n (from kod resources) */
       ptr = strchr(subject, '\n');
@@ -195,7 +197,7 @@ void MailNewMessage(int server_index, char *sender, int num_recipients,
    }
 
    /* Add "Subject:" field to message */
-   strcat(new_msg, subject_strs[i].c_str());
+   strcat(new_msg, subject_strs[subject_id_index].c_str());
    strcat(new_msg, subject);
    strcat(new_msg, "\r\n");
    

--- a/module/mailnews/mailfile.c
+++ b/module/mailnews/mailfile.c
@@ -133,6 +133,7 @@ void MailNewMessage(int server_index, char *sender, int num_recipients,
    auto subject_strs = std::vector<std::string>(num_subjects);
    char *subject = "";
    char *ptr;
+   int num;
    int subject_id_index = 0;
    char filename[FILENAME_MAX + MAX_PATH];
    char date[MAXDATE];

--- a/module/mailnews/mailfile.c
+++ b/module/mailnews/mailfile.c
@@ -134,7 +134,7 @@ void MailNewMessage(int server_index, char *sender, int num_recipients,
    char *subject = "";
    char *ptr;
    int i, num;
-   int subject_id_index = 1;
+   int subject_id_index = 0;
    char filename[FILENAME_MAX + MAX_PATH];
    char date[MAXDATE];
    MailHeader header;


### PR DESCRIPTION
This fixes a critical issue where mail subject handling was incorrectly tied to the number of recipients.

Previously, the subject line could be written in the wrong position. If there were more than three recipients, the client would crash.

To resolve this, I adjusted the logic by tracking the subject ID separately.

This supports blank subjects, which appeared to be a problem when this bug surfaced.