### PR TITLE
fix: fine lute description spacing and typo

### DIFF
--- a/kod/object/item/passitem/instrum/lute/finelute.kod
+++ b/kod/object/item/passitem/instrum/lute/finelute.kod
@@ -19,9 +19,9 @@ resources:
    FineLute_name_rsc = "fine lute"
    FineLute_icon_rsc = music.bgf
    FineLute_overlay_rsc = luteov.bgf
-   FineLute_desc_rsc = "The lute is of a higher quality than most lutes.   "
+   FineLute_desc_rsc = "The lute is of a higher quality than most lutes.  "
         "The instrument has been constructed flawlessly and the dark stain was obviously applied by a master craftsman.  "
-		  "Its pine construction offers a richer sound than the more common rosewoods lutes."
+		  "Its pine construction offers a richer sound than the more common rosewood lutes."
 
 classvars:
 


### PR DESCRIPTION
# What

- removed extra spacing in `fine lute` vs other lutes (was 3 spaces vs 2)
- removed "s" from rosewoods since it is being used as a descriptor and not a noun
   - before: 
     > Its pine construction offers a richer sound than the more common rosewood**S** lutes.

# Why

- trivial fix but improves the description and provides consistency with other lute descriptions like `lute` and `true lute`