### PR TITLE
feature: re-add Tos and BQ hometown chance

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -6939,22 +6939,35 @@ messages:
    "This sets one of the many hometowns to be the initial hometown."
    {
       local rand;
+      rand = random(1,8);
       
-      rand = random(1,10);    
-      
-      if rand < 4
+      if rand = 1
       {
          piHomeroom = RID_MAR_INN;
-      }   
+      }
       else
       {
-         if rand > 7
+         if rand = 2
          {
-            piHomeroom = RID_JAS_INN;
+            piHomeroom = RID_COR_INN;
          }
          else
          {
-            piHomeroom = RID_COR_INN;
+            if rand = 3
+            {
+               piHomeroom = RID_JAS_INN;
+            }
+            else
+            {
+               if rand < 6
+               {
+                  piHomeroom = RID_BAR_INN;
+               }
+               else
+               {
+                  piHomeroom = RID_TOS_INN;
+               }
+            }
          }
       }
       

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -6939,7 +6939,7 @@ messages:
    "This sets one of the many hometowns to be the initial hometown."
    {
       local rand;
-      rand = random(1,8);
+      rand = random(1,5);
       
       if rand = 1
       {
@@ -6959,7 +6959,7 @@ messages:
             }
             else
             {
-               if rand < 6
+               if rand = 4
                {
                   piHomeroom = RID_BAR_INN;
                }


### PR DESCRIPTION
# What

- re-added Tos and Barloque (BQ) as possible hometowns when a player leaves Raza through the portal
- kept old towns in and changed chance to be equal among all 5 towns (20%)

# Why

- a long time ago (maybe 10+ years?), Tos and BQ were removed as possible hometowns
- it appears that this was done to reduce pking of newbies outside of Tos
- that doesn't seem to apply any longer
