### PR TITLE
fix: add unwrap sound to all gift classes

### DIFF
--- a/kod/object/item/passitem/gift.kod
+++ b/kod/object/item/passitem/gift.kod
@@ -47,8 +47,6 @@ classvars:
 
    viValue_average = 30
 
-   vrGift_open_wav = gift_open_wav
-
 properties:
 
    poGiftGiver = $     %% if poGiftGIver = $, then it's from the gods.
@@ -181,7 +179,7 @@ messages:
       send(poOwner,@MsgSendUser,#message_rsc=gift_open,
            #parm1=send(poContents,@GetIndef),#parm2=send(poContents,@GetName));
       
-      Send(what,@WaveSendUser,#wave_rsc=vrGift_open_wav);
+      Send(what,@WaveSendUser,#wave_rsc=gift_open_wav);
 
       oldOwner = poOwner;
       send(poOwner,@LeaveHold,#what=self);

--- a/kod/object/item/passitem/gift.kod
+++ b/kod/object/item/passitem/gift.kod
@@ -181,7 +181,7 @@ messages:
       send(poOwner,@MsgSendUser,#message_rsc=gift_open,
            #parm1=send(poContents,@GetIndef),#parm2=send(poContents,@GetName));
       
-      Send(what,@WaveSendUser,#wave_rsc=gift_open_wav);
+      Send(what,@WaveSendUser,#wave_rsc=vrGift_open_wav);
 
       oldOwner = poOwner;
       send(poOwner,@LeaveHold,#what=self);

--- a/kod/object/item/passitem/spcgift2.kod
+++ b/kod/object/item/passitem/spcgift2.kod
@@ -40,6 +40,8 @@ classvars:
 
    viValue_average = 30
 
+   vrGift_open_wav = gift_open_wav
+
 properties:
 
    poContents = $
@@ -119,6 +121,8 @@ messages:
 
       send(poOwner,@MsgSendUser,#message_rsc=SpecialGiftTwo_open,
            #parm1=send(poContents,@GetIndef),#parm2=send(poContents,@GetName));
+
+      Send(what,@WaveSendUser,#wave_rsc=vrGift_open_wav);
 
       oldOwner = poOwner;
       send(poOwner,@LeaveHold,#what=self);

--- a/kod/object/item/passitem/spcgift2.kod
+++ b/kod/object/item/passitem/spcgift2.kod
@@ -40,8 +40,6 @@ classvars:
 
    viValue_average = 30
 
-   vrGift_open_wav = gift_open_wav
-
 properties:
 
    poContents = $
@@ -122,7 +120,7 @@ messages:
       send(poOwner,@MsgSendUser,#message_rsc=SpecialGiftTwo_open,
            #parm1=send(poContents,@GetIndef),#parm2=send(poContents,@GetName));
 
-      Send(what,@WaveSendUser,#wave_rsc=vrGift_open_wav);
+      Send(what,@WaveSendUser,#wave_rsc=gift_open_wav);
 
       oldOwner = poOwner;
       send(poOwner,@LeaveHold,#what=self);

--- a/kod/object/item/passitem/specgift.kod
+++ b/kod/object/item/passitem/specgift.kod
@@ -40,6 +40,8 @@ classvars:
 
    viValue_average = 30
 
+   vrGift_open_wav = gift_open_wav
+
 properties:
 
    poContents = $
@@ -119,6 +121,8 @@ messages:
 
       send(poOwner,@MsgSendUser,#message_rsc=SpecialGift_open,
            #parm1=send(poContents,@GetIndef),#parm2=send(poContents,@GetName));
+
+      Send(what,@WaveSendUser,#wave_rsc=vrGift_open_wav);
 
       oldOwner = poOwner;
       send(poOwner,@LeaveHold,#what=self);

--- a/kod/object/item/passitem/specgift.kod
+++ b/kod/object/item/passitem/specgift.kod
@@ -40,8 +40,6 @@ classvars:
 
    viValue_average = 30
 
-   vrGift_open_wav = gift_open_wav
-
 properties:
 
    poContents = $
@@ -122,7 +120,7 @@ messages:
       send(poOwner,@MsgSendUser,#message_rsc=SpecialGift_open,
            #parm1=send(poContents,@GetIndef),#parm2=send(poContents,@GetName));
 
-      Send(what,@WaveSendUser,#wave_rsc=vrGift_open_wav);
+      Send(what,@WaveSendUser,#wave_rsc=gift_open_wav);
 
       oldOwner = poOwner;
       send(poOwner,@LeaveHold,#what=self);


### PR DESCRIPTION
# What

- added `unwrap.wav` sound to `specialgift.kod` and `specialgift2.kod`

# Why

- in #975 I didn't include two gift classes because I didn't realize there were others
  - as a result two types of gifts did not make the gift unwrap sound

# Testing Notes

- no errors in server log or client debug window when opening any of the 3 gift classes
- no errors on build
- sound works for all 3 gift classes now