### PR TITLE
fix: small typo in prism.kod

### DIFF
--- a/kod/object/item/passitem/prism.kod
+++ b/kod/object/item/passitem/prism.kod
@@ -46,7 +46,7 @@ resources:
    prism_new_caster_tocaster = "You join in the chanting of an incantation."
    prism_lack_casters = "You feel like the prism has the power to cast the spell, but lacks the right symmetry of focal energy."
    prism_chant_over = "The prism darkens and a blanket of silence seems to settle over you as the chant ceases."
-   prism_desc_location_rsc = "  If you peer closely you can see a miniture landscape inside the prism, it appears to be "
+   prism_desc_location_rsc = "  If you peer closely you can see a miniature landscape inside the prism, it appears to be "
 
    prism_charged_wav_rsc = portal.wav
 


### PR DESCRIPTION
# What

- fixed small typo in `prism.kod`
- "miniture" to "miniature"
- > If you peer closely you can see a **miniature** landscape

# Why

- tiny fixes add up over time