### PR TITLE
Mirror background textures on the x-axis

### DIFF
--- a/clientd3d/d3drender_bgoverlays.c
+++ b/clientd3d/d3drender_bgoverlays.c
@@ -138,6 +138,8 @@ void D3DRenderBackgroundOverlays(const BackgroundOverlaysRenderStateParams& bgoR
 		static const float u[4] = { epsilon, 1.0f - epsilon, 1.0f - epsilon, epsilon };
 		static const float v[4] = { epsilon, epsilon, 1.0f - epsilon, 1.0f - epsilon };
 
+		// Normally, you'd assign these in a predictable (e.g., top-left to bottom-right) order. 
+		// Here, we intentionally swap certain indices to mirror the texture along the X-axis.
 		pChunk->st0[0].s = u[1];
 		pChunk->st0[0].t = v[0];
 		pChunk->st0[1].s = u[0];

--- a/clientd3d/d3drender_bgoverlays.c
+++ b/clientd3d/d3drender_bgoverlays.c
@@ -94,10 +94,9 @@ void D3DRenderBackgroundOverlays(const BackgroundOverlaysRenderStateParams& bgoR
 		bg_overlay_pos.y = y;
 		bg_overlay_pos.z = z;
 
-		D3DMATRIX rot, mat, spin;
+		D3DMATRIX rot, mat;
 		MatrixIdentity(&mat);
 		MatrixIdentity(&rot);
-		MatrixIdentity(&spin);
 
 		const float FULL_CIRCLE_TO_DEGREES = 360.0f / 4096.0f;
 		const float DEGREES_TO_RADIANS = PI / 180.0f;
@@ -108,9 +107,6 @@ void D3DRenderBackgroundOverlays(const BackgroundOverlaysRenderStateParams& bgoR
 
 		MatrixRotateY(&rot, (float)angleHeading * FULL_CIRCLE_TO_DEGREES * DEGREES_TO_RADIANS);
 		MatrixRotateX(&mat, (float)anglePitch * ANGLE_RANGE_TO_DEGREES * DEGREES_TO_RADIANS);
-		// Rotate to match orientation of the original asset images.
-		MatrixRotateZ(&spin, -90.0f * DEGREES_TO_RADIANS); 
-		MatrixMultiply(&rot, &rot, &spin);
 		MatrixTranspose(&rot, &rot);
 		MatrixTranslate(&mat, bg_overlay_pos.x, bg_overlay_pos.z, bg_overlay_pos.y);
 		MatrixMultiply(&pChunk->xForm, &rot, &mat);
@@ -142,13 +138,13 @@ void D3DRenderBackgroundOverlays(const BackgroundOverlaysRenderStateParams& bgoR
 		static const float u[4] = { epsilon, 1.0f - epsilon, 1.0f - epsilon, epsilon };
 		static const float v[4] = { epsilon, epsilon, 1.0f - epsilon, 1.0f - epsilon };
 
-		pChunk->st0[0].s = u[0];
+		pChunk->st0[0].s = u[1];
 		pChunk->st0[0].t = v[0];
-		pChunk->st0[1].s = u[1];
+		pChunk->st0[1].s = u[0];
 		pChunk->st0[1].t = v[1];
-		pChunk->st0[2].s = u[2];
+		pChunk->st0[2].s = u[3];
 		pChunk->st0[2].t = v[2];
-		pChunk->st0[3].s = u[3];
+		pChunk->st0[3].s = u[2];
 		pChunk->st0[3].t = v[3];
 
 		pChunk->indices[0] = 1;


### PR DESCRIPTION
Adjust the texture coordinates (s and t) of the vertices of a background overlay to mirror the texture on the x-axis.
Since [rotating the backgrounds](https://github.com/Meridian59/Meridian59/pull/1016) to match the origin image orientations, the background objects were no longer clickable. To prevent this, we revert the change and instead we swap the s coordinates of the vertices. The background objects are once again clickable.

before:
![image](https://github.com/user-attachments/assets/3e6ec456-6700-4e24-b2ca-defc50f3329d)

after:
![image](https://github.com/user-attachments/assets/16dcbc71-b5cf-4bcc-88d1-a7cafc75e0c5)

Fixes: #1039 