### PR TITLE
fix: Remove redundant `LeaveHold` calls for gifts as single-use items

### DIFF
--- a/kod/object/item/passitem/gift.kod
+++ b/kod/object/item/passitem/gift.kod
@@ -182,7 +182,6 @@ messages:
       Send(what,@WaveSendUser,#wave_rsc=gift_open_wav);
 
       oldOwner = poOwner;
-      send(poOwner,@LeaveHold,#what=self);
       send(self,@NewOwner,#what=$);
       send(oldOwner,@NewHold,#what=poContents);
 

--- a/kod/object/item/passitem/spcgift2.kod
+++ b/kod/object/item/passitem/spcgift2.kod
@@ -123,7 +123,6 @@ messages:
       Send(what,@WaveSendUser,#wave_rsc=gift_open_wav);
 
       oldOwner = poOwner;
-      send(poOwner,@LeaveHold,#what=self);
       send(self,@NewOwner,#what=$);
       send(oldOwner,@NewHold,#what=poContents);
 

--- a/kod/object/item/passitem/specgift.kod
+++ b/kod/object/item/passitem/specgift.kod
@@ -123,7 +123,6 @@ messages:
       Send(what,@WaveSendUser,#wave_rsc=gift_open_wav);
 
       oldOwner = poOwner;
-      send(poOwner,@LeaveHold,#what=self);
       send(self,@NewOwner,#what=$);
       send(oldOwner,@NewHold,#what=poContents);
 


### PR DESCRIPTION
This PR removes redundant calls to `LeaveHold` for gift classes (`Gift`, `SpecialGift`, and `SpecialGiftTwo`). These items are already flagged as single-use types and are automatically removed from the player's inventory, so the explicit `LeaveHold` call is unnecessary. These redundant calls were triggering a client debug message about a non-existent item in the player's inventory.  

To reproduce the issue, these gift classes can be distributed to all users using the following commands:  
```
send o 0 globalgive number int 1 classtype c Gift
send o 0 globalgive number int 1 classtype c SpecialGift
send o 0 globalgive number int 1 classtype c SpecialGiftTwo
```  

Testing included monitoring object counts before and after opening the items and garbage collection. This was done by deleting all users except my test account and using `show instances` to track the counts.

Fixes #1050 