### PR TITLE
Restore User_Got_Some message to players when number argument is null

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3688,7 +3688,7 @@ messages:
                if Send(what,@ReqNewOwner,#what=oSplit)
                {
                   % Possible conditions: iNumber is less than number argument
-                  %   becauses iCan_hold was less than number OR
+                  %   because iCan_hold was less than number OR
                   %   iNumber equals iCan_hold and number is $ OR
                   %   iNumber equals number and we don't need to send user_got_some
                   % Note that if number argument is null and we can hold the whole stack

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3687,7 +3687,13 @@ messages:
                }
                if Send(what,@ReqNewOwner,#what=oSplit)
                {
-                  if iCan_hold < iNumber
+                  % Possible conditions: iNumber is less than number argument
+                  %   becauses iCan_hold was less than number OR
+                  %   iNumber equals iCan_hold and number is $ OR
+                  %   iNumber equals number and we don't need to send user_got_some
+                  % Note that if number argument is null and we can hold the whole stack
+                  %   we don't end up here because ReqNewHold evaluates true
+                  if iNumber <> number
                   {
                      Send(self,@MsgSendUser,#message_rsc=user_got_some,
                         #parm1=Send(what,@GetName));


### PR DESCRIPTION
PR 722 fixed a common cause of server errors but inadvertently prevented the user_got_some message from being sent to players when they pick up item stacks off the ground but can't hold the entire stack of number items.

I tested:

-Mortal user picking up a stack they can't hold all of from the ground - no errors
-Mortal user removing a stack they can't hold all of from a chest - no errors

The actual code change is one line - a long comment describes the three possible options for the comparison / conditional statement.