### PR TITLE
Add conditional seller attribute to Hanla zax'Ta

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcbowmak.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcbowmak.kod
@@ -35,7 +35,7 @@ classvars:
    vrDesc = KocatanBowMaker_desc_rsc
    viMerchant_markup = MERCHANT_EXPENSIVE
 
-   viAttributes = MOB_NOFIGHT | MOB_SELLER | MOB_RANDOM | MOB_LISTEN | MOB_NOMOVE | MOB_RECEIVE
+   viAttributes = MOB_NOFIGHT | MOB_SELLER | MOB_RANDOM | MOB_LISTEN | MOB_NOMOVE | MOB_RECEIVE | MOB_COND_SELLER
    viOccupation = MOB_ROLE_BLACKSMITH
 
    viGender = GENDER_FEMALE


### PR DESCRIPTION
Hanla zax'Ta has a conditional sale of Kriipa claws - however it is currently broken.

We add the conditional seller attribute `MOB_COND_SELLER` that will enable this functionality. The `MOB_COND_SELLER ` attribute is required for the seller to have their `InitCondSale` called, enabling any conditional sales (via monster Constructor or library ReInitialize)

Will require a `send o 0 RecreateAll` from server side to enable from an existing setup.