### PR TITLE
fix: Removes mollusk from graphics makefile

### DIFF
--- a/resource/graphics/makefile
+++ b/resource/graphics/makefile
@@ -16,7 +16,6 @@ BGFS = \
 	$(OUTDIR)\ring3.bgf \
 	$(OUTDIR)\povmystsw.bgf \
 	$(OUTDIR)\splash.bgf \
-	$(OUTDIR)\mollusk.bgf \
 	$(OUTDIR)\moon.bgf
 
 all: makedirs $(BGFS)


### PR DESCRIPTION
This PR removes the mollusk BGF from the compilation process. Since we no longer compile this file (see #903), it’s unnecessary and is currently triggering an error message. 

```
...
Building graphics
Unable to load bitmap file mol000ug.bmp
NMAKE : fatal error U1077: '..\..\bin\makebgf.EXE' : return code '0x1'
```