### PR TITLE
feature: Adds directional placement to rented room objects

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/decoratr.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/decoratr.kod
@@ -57,7 +57,8 @@ resources:
    Decorator_painting_instructions = \
       "Please stand near where you'd like the painting and say 'here'.  I can only "
       "hang it in four different spots, but I'll do my best to fit your needs."
-   Decorator_object_placement = "Please stand where you'd like the object and say 'here'."
+   Decorator_object_placement = "Please stand where you'd like the object, look in the "
+      "direction it should face, and say 'here'."
    Decorator_object_removal = "Please stand nearer the object you'd like removed."
 
    Decorator_bed_blocked = \

--- a/kod/object/active/holder/room/rentroom.kod
+++ b/kod/object/active/holder/room/rentroom.kod
@@ -934,7 +934,7 @@ messages:
             oDecorativeObject = Create(getClass(template)); 
          }
 
-         Send(self,@NewHold,#what=oDecorativeObject,
+         Send(self,@NewHold,#what=oDecorativeObject,#new_angle=Send(who,@GetAngle),
              #new_row=Send(who,@GetRow),#new_col=Send(who,@GetCol),
              #fine_row=iSnapFineRow,#fine_col=iSnapFineCol);
 


### PR DESCRIPTION
This PR updates object placement in rented rooms to align the object's orientation with the player's facing direction. This change primarily affects multi-sided objects, such as the personal chest. The decorator's dialog has been updated to reflect this.

The decorator says this when placing an object is requested, **bolded** text is newly added:
> Please stand where you'd like the object, **look in the direction it should face,** and say 'here'."

Fixes #646 