### PR TITLE
fix: MOTD `CenterWindow` function in `blakserv` win interface

### DIFF
--- a/blakserv/interface.c
+++ b/blakserv/interface.c
@@ -586,7 +586,6 @@ void StartupComplete()
 void InterfaceCreate(HWND hwnd,WPARAM wParam,LPARAM lParam)
 {
 	SetWindowText(hwnd,BlakServNameString());
-	CenterWindow(hwnd, NULL);
 }
 
 void InterfaceCreateTabControl(HWND hwnd) 

--- a/blakserv/interface.c
+++ b/blakserv/interface.c
@@ -22,7 +22,6 @@
 	
 */
 
-#define NOMINMAX
 #include "blakserv.h"
 #include <mmsystem.h>
 #include <windowsx.h>

--- a/blakserv/interface.c
+++ b/blakserv/interface.c
@@ -1046,12 +1046,9 @@ void CenterWindow(HWND hwnd, HWND hwndParent)
     RECT rcDlg, rcParent, rcScreen;
     int x, y;
 
-    #define min(a, b) ((a) < (b) ? (a) : (b))
-    #define max(a, b) ((a) > (b) ? (a) : (b))
-
     if (hwndParent == NULL)
         hwndParent = GetDesktopWindow();
-  
+
     GetWindowRect(hwndParent, &rcParent);
     GetWindowRect(hwnd, &rcDlg);
 
@@ -1071,8 +1068,8 @@ void CenterWindow(HWND hwnd, HWND hwndParent)
         rcScreen = mi.rcWork;  // Use working area excluding taskbar
 
         // Adjust position to ensure the child window is fully visible
-        x = max(rcScreen.left, min(x, rcScreen.right - rcDlg.right));
-        y = max(rcScreen.top, min(y, rcScreen.bottom - rcDlg.bottom));
+        x = std::max(rcScreen.left, std::min(x, rcScreen.right - rcDlg.right));
+		y = std::max(rcScreen.top, std::min(y, rcScreen.bottom - rcDlg.bottom));
     }
     else
     {
@@ -1085,9 +1082,6 @@ void CenterWindow(HWND hwnd, HWND hwndParent)
     }
 
     SetWindowPos(hwnd, NULL, x, y, 0, 0, SWP_NOSIZE | SWP_NOACTIVATE);
-
-    #undef min
-    #undef max
 }
 
 INT_PTR CALLBACK InterfaceDialogMotd(HWND hwnd,UINT message,WPARAM wParam,LPARAM lParam)

--- a/blakserv/interface.c
+++ b/blakserv/interface.c
@@ -1088,12 +1088,11 @@ void CenterWindow(HWND hwnd, HWND hwndParent)
 INT_PTR CALLBACK InterfaceDialogMotd(HWND hwnd,UINT message,WPARAM wParam,LPARAM lParam)
 {
 	char s[2000];
-	HWND hwndParent = GetParent(hwnd);
 	
 	switch (message)
 	{
 	case WM_INITDIALOG :
-        CenterWindow(hwnd, hwndParent);
+        CenterWindow(hwnd, GetParent(hwnd));
 		
 		Edit_LimitText(GetDlgItem(hwnd,IDC_MOTD),sizeof(s)-1);
 		

--- a/blakserv/interface.c
+++ b/blakserv/interface.c
@@ -586,6 +586,7 @@ void StartupComplete()
 void InterfaceCreate(HWND hwnd,WPARAM wParam,LPARAM lParam)
 {
 	SetWindowText(hwnd,BlakServNameString());
+	CenterWindow(hwnd, NULL);
 }
 
 void InterfaceCreateTabControl(HWND hwnd) 
@@ -1027,50 +1028,78 @@ void InterfaceReloadSystem()
 	LeaveServerLock();
 }
 
-/* stolen from client, 9/19/95
-*
-* CenterWindow: Center one window over another.  Also ensure that the
-*   centered window (hwnd) is completely on the screen.  
-*   Call when processing the WM_INITDIALOG message of dialogs, or
-*   WM_CREATE in WndProcs. 
+/* 
+* CenterWindow: Centers the child window (hwnd) over the parent window 
+*   (hwndParent) while ensuring it's fully visible on the screen, even 
+*   across multiple monitors. The window is positioned within the 
+*   working area of the monitor, excluding taskbars. If hwndParent is NULL, 
+*   the desktop window is used as the parent.
+*   
+* Parameters:
+*   hwnd        - Handle to the child window.
+*   hwndParent  - Handle to the parent window. NULL uses the desktop.
+*   
+* Call this function during WM_INITDIALOG or WM_CREATE to center dialog 
+* boxes or other child windows.
 */
 void CenterWindow(HWND hwnd, HWND hwndParent)
 {
-	RECT rcDlg, rcParent;
-	int screen_width, screen_height, x, y;
-	
-	/* If dialog has no parent, then its parent is really the desktop */
-	if (hwndParent == NULL)
-		hwndParent = GetDesktopWindow();
-	
-	GetWindowRect(hwndParent, &rcParent);
-	GetWindowRect(hwnd, &rcDlg);
-	
-	/* Move dialog rectangle to upper left (0, 0) for ease of calculation */
-	OffsetRect(&rcDlg, -rcDlg.left, -rcDlg.top);
-	
-	x = rcParent.left + (rcParent.right - rcParent.left)/2 - rcDlg.right/2;
-	y = rcParent.top + (rcParent.bottom - rcParent.top)/2 - rcDlg.bottom/2;
-	
-	
-	/* Make sure that child window is completely on the screen */
-	screen_width  = GetSystemMetrics(SM_CXSCREEN);
-	screen_height = GetSystemMetrics(SM_CYSCREEN);
-	
-	x = std::max(0, std::min(x, (int) (screen_width  - rcDlg.right)));
-   y = std::max(0, std::min(y, (int) (screen_height - rcDlg.bottom)));
-	
-	SetWindowPos(hwnd, NULL, x, y, 0, 0, SWP_NOSIZE | SWP_NOACTIVATE);
+    RECT rcDlg, rcParent, rcScreen;
+    int x, y;
+
+    #define min(a, b) ((a) < (b) ? (a) : (b))
+    #define max(a, b) ((a) > (b) ? (a) : (b))
+
+    if (hwndParent == NULL)
+        hwndParent = GetDesktopWindow();
+  
+    GetWindowRect(hwndParent, &rcParent);
+    GetWindowRect(hwnd, &rcDlg);
+
+    // Move dialog rectangle to upper left (0, 0) for ease of calculation
+    OffsetRect(&rcDlg, -rcDlg.left, -rcDlg.top);
+
+    // Default position: center over parent window
+    x = rcParent.left + (rcParent.right - rcParent.left) / 2 - rcDlg.right / 2;
+    y = rcParent.top + (rcParent.bottom - rcParent.top) / 2 - rcDlg.bottom / 2;
+
+    // Get the monitor information for the parent window
+    MONITORINFO mi;
+    mi.cbSize = sizeof(MONITORINFO);
+    HMONITOR hMonitor = MonitorFromWindow(hwndParent, MONITOR_DEFAULTTONEAREST);
+    if (GetMonitorInfo(hMonitor, &mi))
+    {
+        rcScreen = mi.rcWork;  // Use working area excluding taskbar
+
+        // Adjust position to ensure the child window is fully visible
+        x = max(rcScreen.left, min(x, rcScreen.right - rcDlg.right));
+        y = max(rcScreen.top, min(y, rcScreen.bottom - rcDlg.bottom));
+    }
+    else
+    {
+        // Fallback to center the window on the primary monitor if monitor info fails
+        int screen_width = GetSystemMetrics(SM_CXSCREEN);
+        int screen_height = GetSystemMetrics(SM_CYSCREEN);
+
+        x = (screen_width - rcDlg.right) / 2;
+        y = (screen_height - rcDlg.bottom) / 2;
+    }
+
+    SetWindowPos(hwnd, NULL, x, y, 0, 0, SWP_NOSIZE | SWP_NOACTIVATE);
+
+    #undef min
+    #undef max
 }
 
 INT_PTR CALLBACK InterfaceDialogMotd(HWND hwnd,UINT message,WPARAM wParam,LPARAM lParam)
 {
 	char s[2000];
+	HWND hwndParent = GetParent(hwnd);
 	
 	switch (message)
 	{
 	case WM_INITDIALOG :
-		CenterWindow(hwnd,NULL);
+        CenterWindow(hwnd, hwndParent);
 		
 		Edit_LimitText(GetDlgItem(hwnd,IDC_MOTD),sizeof(s)-1);
 		

--- a/blakserv/interface.c
+++ b/blakserv/interface.c
@@ -22,6 +22,7 @@
 	
 */
 
+#define NOMINMAX
 #include "blakserv.h"
 #include <mmsystem.h>
 #include <windowsx.h>
@@ -1068,8 +1069,8 @@ void CenterWindow(HWND hwnd, HWND hwndParent)
         rcScreen = mi.rcWork;  // Use working area excluding taskbar
 
         // Adjust position to ensure the child window is fully visible
-        x = std::max(rcScreen.left, std::min(x, rcScreen.right - rcDlg.right));
-		y = std::max(rcScreen.top, std::min(y, rcScreen.bottom - rcDlg.bottom));
+        x = std::max<LONG>(rcScreen.left, std::min<LONG>(x, rcScreen.right - rcDlg.right));
+		y = std::max<LONG>(rcScreen.top, std::min<LONG>(y, rcScreen.bottom - rcDlg.bottom));
     }
     else
     {


### PR DESCRIPTION
# What

- makes MOTD pop-up dialog box appear centered on the `blakserv` application window on Windows
- modifies `CenterWindow` function in`blakserv` Windows application
- adds support for multiple monitors

# Why

- #608 fixed issues with the Meridian 59 client, this adds similar fixes to the Meridian 59 `blakserv` application
- Fixes the MOTD dialog box appearing on the wrong screen 
    - for example, screen 1 has the application but the MOTD dialog box will open on screen 2

# Notes

- The "Are you sure you want to exit?" dialog box will appear on the correct monitor, but centered on the desktop not the application
  - I looked into fixing this, but that message box is a system-managed dialog box which is difficult to modify
    - I tried a few workarounds but since it does open on the correct monitor, it seems ok
- I also looked into trying to have the application "remember" where the application was placed on the desktop, so it would re-open in the same spot
  - I looked into how to save the position in the registry but it also seemed like I was adding too much complexity since the server should really be run from Linux in production

# Examples

### Before
- MOTD appears on first monitor, always, even when the application is on the second monitor
https://github.com/user-attachments/assets/a0885076-6a85-4151-8703-9dad9a25b5c1


### After
- MOTD opens centered on the application
https://github.com/user-attachments/assets/c96e9f79-8d92-40a0-97ec-df24d0aa290e

