### PR TITLE
feature: Revised waterskin `piNumber` to modify availability

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/jasprtwn/jsmerch.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/jasprtwn/jsmerch.kod
@@ -67,8 +67,8 @@ messages:
 		      Create(&Shirt,#color=XLAT_TO_PURPLE),
 
             Create(&Torch),
-            Create(&Waterskin),
-
+            
+            Create(&Waterskin,#number=4),
             Create(&Sapphire,#number=1),
             Create(&Emerald,#number=2),
             Create(&PurpleMushroom,#number=2),

--- a/kod/object/item/passitem/numbitem/food/watrskin.kod
+++ b/kod/object/item/passitem/numbitem/food/watrskin.kod
@@ -43,8 +43,8 @@ classvars:
 
 properties:
 
-   viNutrition = 10
-   viFilling = 20
+   viNutrition = 3
+   viFilling = 6
    piNumber = 2
 
 messages:

--- a/kod/object/item/passitem/numbitem/food/watrskin.kod
+++ b/kod/object/item/passitem/numbitem/food/watrskin.kod
@@ -43,9 +43,9 @@ classvars:
 
 properties:
 
-   viFilling = 6
-   viNutrition = 3
-   piNumber = 20
+   viNutrition = 10
+   viFilling = 20
+   piNumber = 2
 
 messages:
 

--- a/kod/object/item/passitem/numbitem/food/watrskin.kod
+++ b/kod/object/item/passitem/numbitem/food/watrskin.kod
@@ -43,8 +43,8 @@ classvars:
 
 properties:
 
-   viNutrition = 3
    viFilling = 6
+   viNutrition = 3
    piNumber = 2
 
 messages:


### PR DESCRIPTION
This PR adjusts the `piNumber` value for waterskins to align better with other food items, making them more suitable for monster treasure drops.

It has been adjusted from 20 to 2, consistent with similar food items.

### Impact
* **Zombies:** Now drop 2 waterskins instead of 20.
* **Zhieu B'hob:** Now starts with a quantity of 4 waterskins instead of 20 for sale.

### Deployment Notes
* Send `SetForSale` to Zhieu B'hob to update his item list