### PR TITLE
chore: regenerate `dlg\dialog.txt` from `dlg\npc.tab`

### DIFF
--- a/dlg/dialog.txt
+++ b/dlg/dialog.txt
@@ -2714,7 +2714,7 @@ send o 0 speechlibtrigger who class FourCouncilor trigger q hunter
 send o 0 speechlibquote who class FourCouncilor quote q ~kDrechx says, "The hunters relationship with her sword seems unhealthy to me.  It is unnatural, and hence it is not good for the body."
 
 send o 0 speechlibtrigger who class FourCouncilor trigger q jasper
-send o 0 speechlibquote who class FourCouncilor quote q ~kDrechx says, "Since the intrusion of Jonas and the rebellion into their lives I must say that the citizen's health is much improved.  Although I could not reccomend it as a usual treatment."
+send o 0 speechlibquote who class FourCouncilor quote q ~kDrechx says, "Since the intrusion of Jonas and the rebellion into their lives I must say that the citizen's health is much improved.  Although I could not recommend it as a usual treatment."
 
 send o 0 speechlibtrigger who class FourCouncilor trigger q Ker'toth
 send o 0 speechlibquote who class FourCouncilor quote q ~kDrechx says, "He was deformed, if I remember the story correctly.  The people did not like the fact that their leader was so hunched over and quiet.  The story said that the king lost his voice. How can you have a king with no voice?"
@@ -2738,7 +2738,7 @@ send o 0 speechlibtrigger who class FourCouncilor trigger q princess
 send o 0 speechlibquote who class FourCouncilor quote q ~kDrechx says, "She has what it takes to rule the land, yet there is a naivete that prevents my full support."
 
 send o 0 speechlibtrigger who class FourCouncilor trigger q sword of the hunt
-send o 0 speechlibquote who class FourCouncilor quote q ~kDrechx says, "Anything that makes the body dependant on foreign material is ultimately bad for the person.  I know these weapons seem to aid the Hunter immensely but I often wonder about the toll it takes on the body."
+send o 0 speechlibquote who class FourCouncilor quote q ~kDrechx says, "Anything that makes the body dependent on foreign material is ultimately bad for the person.  I know these weapons seem to aid the Hunter immensely but I often wonder about the toll it takes on the body."
 
 send o 0 speechlibtrigger who class FourCouncilor trigger q sword of the hunt
 send o 0 speechlibquote who class FourCouncilor quote q ~kDrechx says, "I hear that it is magical."
@@ -2894,7 +2894,7 @@ send o 0 randomlibquote who class GuildCreator quote q ~kFrular flips through hi
 
 send o 0 randomlibquote who class GuildCreator quote q ~kOn the floor behind Frular, you can see a spool of fine golden thread.
 
-send o 0 randomlibquote who class GuildCreator quote q ~kFrular says, "My favored guildhall comes with the name the Bookmaster's Guild House. If managed with half a knat's brain, the guild who inhabits her can make shillings in great measure by openning her doors to the public."
+send o 0 randomlibquote who class GuildCreator quote q ~kFrular says, "My favored guildhall comes with the name the Bookmaster's Guild House. If managed with half a knat's brain, the guild who inhabits her can make shillings in great measure by opening her doors to the public."
 
 send o 0 speechlibtrigger who class Heretic trigger q Aythya
 send o 0 speechlibquote who class Heretic quote q ~kMiriana says, "Cows go to heaven, Goats go to the Underworld."
@@ -5779,7 +5779,7 @@ send o 0 speechlibtrigger who class KocatanWeaponsMaster trigger q TEACH
 send o 0 speechlibquote who class KocatanWeaponsMaster quote q ~kKochtal says, "I may be able to train you in the ways of archery."
 
 send o 0 speechlibtrigger who class KocatanWeaponsMaster mood int LIBRES_MOOD_GOOD trigger q utom
-send o 0 speechlibquote who class KocatanWeaponsMaster quote q ~kKochtal says, "I do not know your word for the hald men who our mighty Konima beat back all those centuries ago."
+send o 0 speechlibquote who class KocatanWeaponsMaster quote q ~kKochtal says, "I do not know your word for the half men who our mighty Konima beat back all those centuries ago."
 
 send o 0 randomlibquote who class KocatanWeaponsMaster mood int LIBRES_MOOD_BAD quote q ~kKochtal says, "You offend our settlement. You would be wise to leave."
 
@@ -6343,7 +6343,7 @@ send o 0 speechlibtrigger who class MarionElder mood int LIBRES_MOOD_GOOD trigge
 send o 0 speechlibquote who class MarionElder quote q ~kRan er'Hoth says, "Seek him out. Go to the mountains and find him."
 
 send o 0 speechlibtrigger who class MarionElder mood int LIBRES_MOOD_GOOD trigger q alzahakar
-send o 0 speechlibquote who class MarionElder quote q ~kRan er'Hoth says, "A very intelligent and hard working but naïve sorcerer who foolishly believed that he could harness the power of the magics. He has spent his life vying for mastery and understanding of a range of disciplines, Shal'ille, Kraanan, Qor, I believe, and Faren. Impressive, but misguided, for the power of these various forces have twisted his mind so that he is paranoid and delusive."
+send o 0 speechlibquote who class MarionElder quote q ~kRan er'Hoth says, "A very intelligent and hard working but naive sorcerer who foolishly believed that he could harness the power of the magics. He has spent his life vying for mastery and understanding of a range of disciplines, Shal'ille, Kraanan, Qor, I believe, and Faren. Impressive, but misguided, for the power of these various forces have twisted his mind so that he is paranoid and delusive."
 
 send o 0 speechlibtrigger who class MarionElder mood int LIBRES_MOOD_NEUTRAL trigger q baby spider
 send o 0 speechlibquote who class MarionElder quote q ~kRan er'Hoth says, "Baby spiders are a nuisance, and a potentially deadly one so you must stay aware while in the forest. They shouldn't give you too many problems, though, as even the most inexperienced adventurers can deal with a baby spider. The biggest threat they pose is that sooner or later they grow up to become full grown spiders."
@@ -6555,7 +6555,7 @@ send o 0 speechlibtrigger who class MarionHealer trigger q cor NOTH
 send o 0 speechlibquote who class MarionHealer quote q ~kLady Aftyn says, "A city condemned, but not upon its nature or its sins. Within Cor Noth is a desecrated temple, Oh Tears of Shal'ille! Our Tender Lady Shal'ille placed a temple in the center of Cor Noth, upon the site of an ancient, holy place. 'Tis known as Ivory Chapel, contained in the most holy of manuscripts."
 
 send o 0 speechlibtrigger who class MarionHealer trigger q council
-send o 0 speechlibquote who class MarionHealer quote q ~kLady Aftyn says, "The Council are much revered, for by and large the are amongst the most learned men in the land. Now without the King that placed them thus they are unfounded in authority and their great wisdom mislaid."
+send o 0 speechlibquote who class MarionHealer quote q ~kLady Aftyn says, "The Council are much revered, for by and large they are amongst the most learned men in the land. Now without the King who placed them thus, they are unfounded in authority and their great wisdom mislaid."
 
 send o 0 speechlibtrigger who class MarionHealer trigger q crypt
 send o 0 speechlibquote who class MarionHealer quote q ~kLady Aftyn says, "I hear that some foul power has caused the ancient dead to walk the crypt. By Shal'ille's power they must be put back to rest!"
@@ -6573,7 +6573,7 @@ send o 0 speechlibtrigger who class MarionHealer trigger q jasper
 send o 0 speechlibquote who class MarionHealer quote q ~kLady Aftyn says, "There is much work to be done in Jasper, for they are an ungodly people."
 
 send o 0 speechlibtrigger who class MarionHealer trigger q jonas
-send o 0 speechlibquote who class MarionHealer quote q ~kLady Aftyn, "Jonas is a good man, he saw that things had to change.  ‘'Tis a good sight more than others have done lately."
+send o 0 speechlibquote who class MarionHealer quote q ~kLady Aftyn, "Jonas is a good man, he saw that things had to change.  'Tis a good sight more than others have done lately."
 
 send o 0 speechlibtrigger who class MarionHealer trigger q king
 send o 0 speechlibquote who class MarionHealer quote q ~kLady Aftyn says, "What's this? What of his Majesty?"
@@ -7036,7 +7036,7 @@ send o 0 speechlibtrigger who class PrincessLiege trigger q insignia
 send o 0 speechlibquote who class PrincessLiege quote q ~kPrincess Kateriina says, "Thou hath no reason to carry my insignia."
 
 send o 0 speechlibtrigger who class PrincessLiege trigger q jasper
-send o 0 speechlibquote who class PrincessLiege quote q ~kPrincess Kateriina says, "Jasper produces such pretty gems.  It is a shame that they have chosen to rebel against order and stability, but I am sure in time they shall recognize the error of thier actions."
+send o 0 speechlibquote who class PrincessLiege quote q ~kPrincess Kateriina says, "Jasper produces such pretty gems.  It is a shame that they have chosen to rebel against order and stability, but I am sure in time they shall recognize the error of their actions."
 
 send o 0 speechlibtrigger who class PrincessLiege trigger q join
 send o 0 speechlibquote who class PrincessLiege quote q ~kPrincess Kateriina says, "There is little reason to join at this time."


### PR DESCRIPTION
# What

- regenerates `dlg\dialog.txt` after spelling corrections took effect on `dlg\npc.tab` in #1061 

# Why

- the spelling corrections implemented in #1061 applied to `npc.tab` 
  - in order for the changes to apply to a M59 server, the `dialog.txt` file must be regenerated by the `dlg\dialogconvert.py` script (done by this PR).

# Notes

- also contains some encoding fixes for `dialog.txt` that were applied to `npc.tab`