### PR TITLE
fix: Properly move `IDC_APPLY` control when description dialog is resized

### DIFF
--- a/clientd3d/dialog.c
+++ b/clientd3d/dialog.c
@@ -31,6 +31,7 @@ static ChildPlacement desc_controls[] = {
 	{ IDC_USE,         RDI_BOTTOM },
 	{ IDC_UNUSE,       RDI_BOTTOM },
 	{ IDC_INSIDE,      RDI_BOTTOM },
+	{ IDC_APPLY,       RDI_BOTTOM },
 	{ IDC_ACTIVATE,    RDI_BOTTOM },
 	{ IDC_URLLABEL,    RDI_BOTTOM },
 	{ IDC_URLBUTTON,   RDI_BOTTOM },


### PR DESCRIPTION
This PR adds `IDC_APPLY` to the set of controls that are repositioned when the object description dialog is resized, such as when using non-default fonts. Previously, `IDC_APPLY` was not included and remained stationary, which appears to have been an oversight rather than an intentional choice.

Here is an example of what happens today:
![image](https://github.com/user-attachments/assets/d53f9273-d7bf-42d0-b86f-32a684656d9e)

And once updated:
![image](https://github.com/user-attachments/assets/fdd6e27a-b9f8-431e-b370-afd0fd244e92)
![image](https://github.com/user-attachments/assets/a994d3a8-0f6f-4e2d-87b7-f4117325cf0f)

Closes #1028 