### PR TITLE
feature: Adds a unique treasure table for Frogman

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -1591,6 +1591,7 @@
    TID_DARK_ANGEL    = 51
    TID_MUMMY         = 52
    TID_THRASHER      = 53
+   TID_FROGMAN       = 54
 
    %%% English articles
 

--- a/kod/object/active/holder/nomoveon/battler/monster/frogman.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/frogman.kod
@@ -42,7 +42,7 @@ classvars:
    vrDead_icon = frogman_dead_icon_rsc
    vrDead_name = frogman_dead_name_rsc
 
-   viTreasure_type = TID_MEDIUM_HUMAN
+   viTreasure_type = TID_FROGMAN
 
    viSpeed = SPEED_AVERAGE
    viAttack_type = ATCK_WEAP_PIERCE

--- a/kod/object/passive/trestype/frogmant.kod
+++ b/kod/object/passive/trestype/frogmant.kod
@@ -1,0 +1,44 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+FrogmanTreasure is TreasureType
+
+constants:
+   
+   include blakston.khd
+   
+classvars:
+
+
+properties:
+   
+   piTreasure_num = TID_FROGMAN
+   piDiff_seed = 5
+   piItem_att_chance = 3
+
+messages:  
+   
+      constructed()
+   {
+         plTreasure = [ [ &BlueMushroom, 24 ],
+                        [ &Mushroom, 24 ],
+                        [ &ElderBerry, 24 ],
+                        [ &EntrootBerry, 9 ],
+                        [ &PurpleMushroom, 9 ],
+                        [ &DarkAngelFeather, 5 ],
+                        [ &InkyCap, 4],
+                        [ &MagicShieldPotion, 1 ]
+                     ];
+
+      propagate;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/trestype/makefile
+++ b/kod/object/passive/trestype/makefile
@@ -12,6 +12,7 @@ BOFS = wimptres.bof notres.bof spquent.bof med-tght.bof wmp-medt.bof \
 	caveorct.bof orcwizt.bof orcpitt.bof avart.bof avarsht.bof \
 	avarcht.bof lupkingt.bof dflyt.bof licht.bof \
 	dethspdt.bof skel2t.bof skel3t.bof skel4t.bof narthylt.bof \
-	wrmlarvt.bof wrmquent.bof dangelt.bof newbietrs.bof thrasht.bof
+	wrmlarvt.bof wrmquent.bof dangelt.bof newbietrs.bof thrasht.bof \
+	frogmant.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -3452,6 +3452,7 @@ messages:
       Create(&ZombieTreasure);
       Create(&EntTreasure);
       Create(&MummyTreasure);
+      Create(&FrogmanTreasure);
 
       Create(&CaveOrcTreasure);
       Create(&OrcWizardTreasure);


### PR DESCRIPTION
This PR revisits the Frogman treasure table after #758 (credit to @Gar103), making adjustments based on the discussion in that PR to give the Frogman a unique treasure table—without, hopefully, any controversial changes.

Per past discussions, the Frogman should roughly align with Skeletons, who fall are a mid-range target for good karma players. The Frogman is a target for evil-aligned players and offers reagents that make sense in that regard.

Item | Drop Rate (%)
-- | --
Blue Mushroom | 24%
Mushroom | 24%
Elder Berry | 24%
Entroot Berry | 9%
Purple Mushroom | 9%
Dark Angel Feather | 5%
Inky Cap | 4%
Magic Shield Potion | 1%

#### Here is an example of loot gathered after 10 kills:
![image](https://github.com/user-attachments/assets/141d91b5-f9f3-4530-824c-bfbac80bb6a3)

Closes #466