### PR TITLE
Fix rescue bug in kocatan rentable rooms

### DIFF
--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -870,8 +870,6 @@ messages:
 
       % this is ugly to do it here, but was lowest risk to add as an emergency patch
       % change this later by overriding GetRegion() please!
-	  
-	  local LocRentedRoom;
 
       if (piRoom_num >= RID_GUEST_BASE) and (piRoom_num < RID_NEWB_BASE)
       {
@@ -887,15 +885,8 @@ messages:
       {
          return RID_KOCATAN;
       }
-	  
-      % Rentable rooms are not using piRoom_num like other rooms.
-      % To distinguish a rented room on the kocatan island from one on mainland
-      % we are using GetLocation to retrieve which Inn the rented room belongs to,
-      % if it belongs to RID_KOC_INN we return RID_KOCATAN  
-	  
-      LocRentedRoom = Send(self,@GetLocation);
-	  
-      if (piRoom_num = RID_GUILDH12) or (piRoom_num = RID_GUILDH13) or (LocRentedRoom = RID_KOC_INN)
+
+      if (piRoom_num = RID_GUILDH12) or (piRoom_num = RID_GUILDH13)
       {
          return RID_KOCATAN;
       }

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -886,7 +886,7 @@ messages:
          return RID_KOCATAN;
       }
 
-      if (piRoom_num = RID_GUILDH12) or (piRoom_num = RID_GUILDH13) or (prRoom = KocatanRentableRoom_roo)
+      if (piRoom_num = RID_GUILDH12) or (piRoom_num = RID_GUILDH13) or (vrName = KocatanRentableRoom_name)
       {
          return RID_KOCATAN;
       }

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -886,7 +886,7 @@ messages:
          return RID_KOCATAN;
       }
 
-      if (piRoom_num = RID_GUILDH12) or (piRoom_num = RID_GUILDH13)
+      if (piRoom_num = RID_GUILDH12) or (piRoom_num = RID_GUILDH13) or (prRoom = KocatanRentableRoom_roo)
       {
          return RID_KOCATAN;
       }

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -871,8 +871,7 @@ messages:
       % this is ugly to do it here, but was lowest risk to add as an emergency patch
       % change this later by overriding GetRegion() please!
 	  
-	  local lRoom_data;
-	  lRoom_data = Send(self,@GetLocation);
+	  local LocRentedRoom;
 
       if (piRoom_num >= RID_GUEST_BASE) and (piRoom_num < RID_NEWB_BASE)
       {
@@ -888,8 +887,15 @@ messages:
       {
          return RID_KOCATAN;
       }
-
-      if (piRoom_num = RID_GUILDH12) or (piRoom_num = RID_GUILDH13) or (lRoom_data = RID_KOC_INN)
+	  
+      % Rentable rooms are not using piRoom_num like other rooms.
+      % To distinguish a rented room on the kocatan island from one on mainland
+      % we are using GetLocation to retrieve which Inn the rented room belongs to,
+      % if it belongs to RID_KOC_INN we return RID_KOCATAN  
+	  
+      LocRentedRoom = Send(self,@GetLocation);
+	  
+      if (piRoom_num = RID_GUILDH12) or (piRoom_num = RID_GUILDH13) or (LocRentedRoom = RID_KOC_INN)
       {
          return RID_KOCATAN;
       }

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -870,6 +870,9 @@ messages:
 
       % this is ugly to do it here, but was lowest risk to add as an emergency patch
       % change this later by overriding GetRegion() please!
+	  
+	  local lRoom_data;
+	  lRoom_data = Send(self,@GetLocation);
 
       if (piRoom_num >= RID_GUEST_BASE) and (piRoom_num < RID_NEWB_BASE)
       {
@@ -886,7 +889,7 @@ messages:
          return RID_KOCATAN;
       }
 
-      if (piRoom_num = RID_GUILDH12) or (piRoom_num = RID_GUILDH13) or (vrName = KocatanRentableRoom_name)
+      if (piRoom_num = RID_GUILDH12) or (piRoom_num = RID_GUILDH13) or (lRoom_data = RID_KOC_INN)
       {
          return RID_KOCATAN;
       }

--- a/kod/object/active/holder/room/rentroom/kocrent.kod
+++ b/kod/object/active/holder/room/rentroom/kocrent.kod
@@ -126,11 +126,6 @@ messages:
    
    GetRegion()
    {
-      % Rentable rooms are not using piRoom_num like other rooms.
-      % To distinguish a rented room on the kocatan island from one on mainland
-      % we are using GetRegion to return where the rented room belongs to,
-      % in this case RID_KOCATAN
-	  
       return RID_KOCATAN;
    }
 

--- a/kod/object/active/holder/room/rentroom/kocrent.kod
+++ b/kod/object/active/holder/room/rentroom/kocrent.kod
@@ -123,6 +123,17 @@ messages:
 
       return;
    }
+   
+   GetRegion()
+   {
+      % Rentable rooms are not using piRoom_num like other rooms.
+      % To distinguish a rented room on the kocatan island from one on mainland
+      % we are using GetRegion to return where the rented room belongs to,
+      % in this case RID_KOCATAN
+	  
+      return RID_KOCATAN;
+   }
+
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
There is a bug with the new rentable rooms in kocatan, if you cast rescue when in a rented room it sends you to your hometown on mainland instead of The Aerie Guest House, this is because this room is not treated as a RID_KOCATAN.

The problem is that rentable rooms are not using piRoom_num (they do not have a room number) and you cannot distinguish a mainland room from a kocatan room.