### PR TITLE
Fixed a typo in comments

### DIFF
--- a/kod/object/passive/itematt/weapatt/waparal.kod
+++ b/kod/object/passive/itematt/weapatt/waparal.kod
@@ -12,7 +12,7 @@ WeapAttParalyzer is WeaponAttribute
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-%  This weapon has a chance to blind the opponent every time it does
+%  This weapon has a chance to hold the opponent every time it does
 %     damage.
 %
 %  Form is: 


### PR DESCRIPTION
Typo in comments, was blind, is now hold

Stumbled across this when I was looking at weaponatt