### PR TITLE
Fix: Typo in Chalice of the Rain messages

### DIFF
--- a/kod/object/item/passitem/chalice.kod
+++ b/kod/object/item/passitem/chalice.kod
@@ -25,11 +25,11 @@ resources:
 
    chalice_cant_get = "You try to pick up the chalice, but it mystically clings to the stone altar."
 
-   chalice_use = "You sip a bit of the water out of the Chalice of Rain."
-   chalice_empty = "The Chalice of Rain crumbles to dust in your hand as you sip the last bit of water from it."
+   chalice_use = "You sip a bit of the water out of the Chalice of the Rain."
+   chalice_empty = "The Chalice of the Rain crumbles to dust in your hand as you sip the last bit of water from it."
    chalice_combine = "You pour the water from one Chalice into the other."
    chalice_cant_use_pkill = "Only those who have walked the path of peace may partake of the chalice."
-   chalice_refilled = "The Chalice of Rain glows faintly for a moment, renewed by the spirit of Shal'ille that permeates the area."
+   chalice_refilled = "The Chalice of the Rain glows faintly for a moment, renewed by the spirit of Shal'ille that permeates the area."
    chalice_refilled_sound = water_scoop01.wav
 
    chalice_condition_exc = " is filled to the brim with pure water."


### PR DESCRIPTION
Old messages when the chalice was used, empty or refilled said "Chalice of Rain", the name is "Chalice of THE Rain", now updated and added "THE".