### PR TITLE
Fix: Mana focus to give mana regen

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5499,7 +5499,7 @@ messages:
    CalculateManaTime()
    "Calculate # of milliseconds until user will gain a mana point"
    {
-      local iTime, lJalaInfo, oJalaSpell, iJalaPower, oSpell;
+      local iTime, lJalaInfo, oJalaSpell, iJalaPower, oSpell, iSpellPower;
 
       if piMana > piMax_mana
       {
@@ -5538,7 +5538,8 @@ messages:
          oSpell = Send(SYS,@FindSpellByNum,#Num=SID_MANA_FOCUS);
          if Send(self,@IsEnchanted,#what=oSpell)
          {
-            iTime = Send(oSpell,@AdjustManaTime,#who=self,#time=iTime);
+            iSpellPower = send(oSpell,@GetSpellPower,#who=self);
+            iTime = Send(oSpell,@AdjustManaTime,#time=iTime,#iSpellPower=iSpellPower);
          }
       }
 

--- a/kod/object/passive/spell/focus.kod
+++ b/kod/object/passive/spell/focus.kod
@@ -120,12 +120,11 @@ messages:
       return;
    }
    
-   AdjustManaTime(who = $, time = 0)
+   AdjustManaTime(time = 0, iSpellPower = 0)
    "Reduces time passed in so that mana regens faster.  Returns reduced time."
    {
-      local iTime,iSpellPower;
+      local iTime;
 
-      iSpellPower = send(self,@GetSpellPower,#who=who);
       iTime = (time * (200-iSpellPower)) / 200;
       iTime = bound(iTime,500,60000);
 

--- a/kod/object/passive/spell/focus.kod
+++ b/kod/object/passive/spell/focus.kod
@@ -120,11 +120,12 @@ messages:
       return;
    }
    
-   AdjustManaTime(time=0, iSpellPower=0)
+   AdjustManaTime(who = $, time = 0)
    "Reduces time passed in so that mana regens faster.  Returns reduced time."
    {
-      local iTime;
+      local iTime,iSpellPower;
 
+      iSpellPower = send(self,@GetSpellPower,#who=who);
       iTime = (time * (200-iSpellPower)) / 200;
       iTime = bound(iTime,500,60000);
 


### PR DESCRIPTION
Many years ago a changed was added to the spell mana focus, it was supposed to make mana focus increase mana regen, but it has never worked because the spellpower was never recieved.

The code in player.kod:
**iTime = Send(oSpell,@AdjustManaTime,#who=self,#time=iTime);**

the _old_ code in focus.kod:
**AdjustManaTime(time=0, iSpellPower=0)**