### PR TITLE
feature: Decrease Icky's base light level to be consistent with caves

### DIFF
--- a/kod/object/active/holder/room/monsroom/objroom/cave2.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/cave2.kod
@@ -37,7 +37,7 @@ properties:
 
    prMusic = cave2_music
 
-   piBaseLight = LIGHT_DARK
+   piBaseLight = LIGHT_MIN
 
    piOutside_factor = OUTDOORS_2
 


### PR DESCRIPTION
This updates the light level of Icky Cave from `LIGHT_DARK` to `LIGHT_MIN`.

In the codebase:

- `LIGHT_MIN` is used for caves, sewers, and Brax.
- `LIGHT_VERY_DARK` is used for areas where darkness is desired but not extreme (e.g., boss rooms like the throne room, orc pit, lupogg king lair, lich maze, and deep forests).
- `LIGHT_DARK` is used for spaces with high walls, forests, or "spooky" areas like Castle Victoria and the graveyard.

Given these conventions, `LIGHT_MIN` is a better fit for Icky Cave and other cave rooms.

Related to #1108 