### PR TITLE
fix: Revises the placement of braziers in Joguer's (`barapoth`)

### DIFF
--- a/kod/object/active/holder/room/barlqrm/barapoth.kod
+++ b/kod/object/active/holder/room/barlqrm/barapoth.kod
@@ -64,9 +64,9 @@ messages:
            #new_row=3,#new_col=6,#new_angle=ANGLE_SOUTH);
 
       Send(self,@NewHold,#what=Create(&Brazier),
-           #new_row=9,#new_col=3);
+           #new_row=6,#new_col=3);
       Send(self,@NewHold,#what=Create(&Brazier),
-           #new_row=9,#new_col=9);
+           #new_row=6,#new_col=7);
 %      Send(self,@NewHold,#what=Create(&Brazier),
 %           #new_row=3,#new_col=3,#fine_col=0,#fine_row=0);
 %      (no light circle for this brazier)

--- a/kod/object/active/holder/room/barlqrm/barapoth.kod
+++ b/kod/object/active/holder/room/barlqrm/barapoth.kod
@@ -67,9 +67,9 @@ messages:
            #new_row=6,#new_col=3);
       Send(self,@NewHold,#what=Create(&Brazier),
            #new_row=6,#new_col=7);
-%      Send(self,@NewHold,#what=Create(&Brazier),
-%           #new_row=3,#new_col=3,#fine_col=0,#fine_row=0);
-%      (no light circle for this brazier)
+      Send(self,@NewHold,#what=Create(&Brazier),
+          #new_row=3,#new_col=3,#fine_col=15,#fine_row=20);
+     
       propagate;
    }
 


### PR DESCRIPTION
This PR adds three braziers to Joguer's—two that were clearly meant to be there but were missing, and a third that was commented out. The room has two flickering light sectors that weren’t properly matched with light sources, and the third brazier adds a nice touch behind the counter.

![image](https://github.com/user-attachments/assets/6ff7b933-8038-4f29-841c-7b357b18417b)

![image](https://github.com/user-attachments/assets/5ea1126b-fb23-4b19-aafc-f49da4f54af5)

![image](https://github.com/user-attachments/assets/164d6322-5c7b-4723-989d-e28e0581c779)
