### PR TITLE
fix: Quest node accumulation on monsters (NPCs)

### DIFF
--- a/kod/util/questengine.kod
+++ b/kod/util/questengine.kod
@@ -7275,8 +7275,25 @@ CheckQuestDeadlines()
 %%
    ClearAllQuests()
    {
+      local oRoom, oObject, each_obj;
+
       send( self, @DeleteActiveQuests );
       send( self, @Suspend );
+
+      % Clear all quest nodes from monsters
+      for oRoom in Send(SYS,@GetRooms)
+      {
+         for oObject in Send(oRoom,@GetHolderActive)
+         {
+            each_obj = Send(oRoom,@HolderExtractObject,#data=oObject);
+         
+            if IsClass(each_obj,&Monster)
+            {
+               Send(each_obj,@ClearActiveQuests);
+            }
+         }
+      }
+      
       plQuestTemplates = $;
       plDefaultNPCList = $;
       plQuestNodeTemplates = $;
@@ -7393,11 +7410,12 @@ CheckQuestDeadlines()
       return;
    }
 
-   Jumpstart()
-   "A quick and dirty way to get things running again."
+   Reset()
+   "Resets the quest engine: clears and rebuilds quests and recreates the quest nodes."
    {
-      send(self,@Recreate);
-      send(self,@RecreateQuestNodes);
+      Send(self,@ClearAllQuests);
+      Send(self,@Recreate);
+      Send(self,@RecreateQuestNodes);
 
       return;
    }


### PR DESCRIPTION
Over time, monsters' `plActiveQuestNodes` lists have been observed to accumulate more quest nodes than expected. This appears to be related to the QuestEngine's `Jumpstart()` functionality, which recreates quests but doesn't properly clean up existing quest nodes from monsters.

This PR makes the following changes:
* Modifies the `ClearAllQuests()` function to remove all quest nodes from every monster.
* Renames `Jumpstart()` to `Reset()` and integrates the updated `ClearAllQuests()` within this new function to ensure that quest data is fully reset.

## Testing
* Navigate to an NPC like the Princess in `castle2c`.
* Observe the plActiveQuestNodes list. It should start with several nodes and accumulate additional ones with each quest engine cycle.
* Run the new Reset() function on the quest engine.
* Note that this reset clears all active quests. For instance, if you previously said 'join' to the Princess and received a letter to deliver, after resetting, the destination NPC should no longer accept the quest item.

## Background
Typically, after a new server initialization or a RecreateAll, three quest-related events take place in sequence:
1. `QuestEngine::ClearAllQuests`
2. `QuestEngine::Recreate`
3. `QuestEngine::RecreateQuestNodes`

Additionally, there is `QuestEngine::Jumpstart`, a function that appears to have been intended as a way to quickly seed NPCs with active quest nodes and potentially revive a stalled quest engine (how I've seen it used today). However, Jumpstart introduces a major issue: it can add active quest nodes beyond the defined limits in the quest engine templates. For example, an NPC that should have 50 active quest nodes might end up with 400.

**Theory: The Intended Use of Jumpstart**

I believe Jumpstart was designed to quickly populate NPCs with quest nodes, possibly as a way to bypass the quest timer and ensure quests are immediately available. This might have been useful in earlier versions of the game or in cases where the system needed an immediate boost. However, in the current game state, the quest timer naturally populates nodes within a few cycles, even at today’s player counts. This makes Jumpstart not only unnecessary but actively problematic.

**Additional Considerations**
* `ClearAllQuests` does not clear quest nodes attached to NPCs (monsters). Normally, this isn’t an issue because `ClearAllQuests` is only used within `RecreateAll`, ensuring the entire system is rebuilt cleanly.
* Instead of Jumpstart, what we actually need is a way to reset the quest engine and repopulate NPC quest nodes without requiring a full `RecreateAll`. We can use this to fix the current problem and reset the quest engine in the future.