### PR TITLE
Update disarm.kod

### DIFF
--- a/kod/object/passive/skill/disarm.kod
+++ b/kod/object/passive/skill/disarm.kod
@@ -83,8 +83,17 @@ messages:
        iAbility=send(who,@GetSkillAbility,#skill_num=viSkill_num);
        num = ((100-reqstat)*iAbility/100) + reqstat;
        num = (num + 1 + modifier) / DISARM_FACTOR;
-       
-       if random(1,100) < num
+
+       if(num < 1)
+       {
+         num = 1;
+       }
+       else
+       {
+         num = num * 10;
+       }
+
+       if random(1,1000) < num
        {
          return TRUE;
        }


### PR DESCRIPTION
Fix `SuccessChance()` so that low agility users can have Disarm succeed sometimes.  Without this fix, users with agility between 1 and 8 will not be able to have Disarm trigger successfully.