### PR TITLE
Add class exclusion list to `Holder::CountHoldingHowMany` and exclude DMs from customer list

### DIFF
--- a/kod/object/active/holder.kod
+++ b/kod/object/active/holder.kod
@@ -158,10 +158,11 @@ messages:
       return FALSE;
    }
 
-   CountHoldingHowMany(class = $)
-   "Does not count quantity in a numbitem (500 apples counts as 1)"
+   CountHoldingHowMany(class = $, lExcludeClasses = $)
+   "Counts objects of the given class, excluding specified classes, "
+   "ignoring quantity in numbitem (500 apples counts as 1)."
    {
-      local n,i,each_obj;
+      local n;
 
       if class = $
       {
@@ -170,25 +171,48 @@ messages:
 
       n = 0;
 
-      for i in plActive
-      {
-         each_obj = Send(self,@HolderExtractObject,#data=i);
-         if isClass(each_obj, class)
-         {
-            n = n + 1;
-         }
-      }
-
-      for i in plPassive
-      {
-         each_obj = Send(self,@HolderExtractObject,#data=i);
-         if isClass(each_obj, class)
-         {
-            n = n + 1;
-         }
-      }
+      % Count matching objects in both active and passive lists
+      n = Send(self,@CountMatchingObjects,#object_list=plActive,
+           #class=class,#lExcludeClasses=lExcludeClasses);
+      n = n + Send(self,@CountMatchingObjects,#object_list=plPassive,
+           #class=class,#lExcludeClasses=lExcludeClasses);
 
       return n;
+   }
+
+   CountMatchingObjects(object_list = $, class = $, lExcludeClasses = $)
+   "Helper function to count objects of a given class, excluding specified classes"
+   {
+      local i, each_obj, lExclude, count;
+
+      count = 0;
+      
+      for i in object_list
+      {
+         each_obj = Send(self,@HolderExtractObject,#data=i);
+         if isClass(each_obj, class)
+         {
+            % Only increment if no excluded classes or doesn't match any excluded class
+            count = count + 1;
+            
+            % Check excluded classes if any exist
+            if lExcludeClasses <> $
+            {
+               lExclude = lExcludeClasses;
+               while lExclude <> $
+               {
+                  if IsClass(each_obj, First(lExclude))
+                  {
+                     count = count - 1;
+                     break;
+                  }
+                  lExclude = Rest(lExclude);
+               }
+            }
+         }
+      }
+
+      return count;
    }
 
    CountHoldingSummoned()

--- a/kod/object/active/holder.kod
+++ b/kod/object/active/holder.kod
@@ -169,8 +169,6 @@ messages:
          return 0;
       }
 
-      n = 0;
-
       % Count matching objects in both active and passive lists
       n = Send(self,@CountMatchingObjects,#object_list=plActive,
            #class=class,#lExcludeClasses=lExcludeClasses);
@@ -195,19 +193,15 @@ messages:
             % Only increment if no excluded classes or doesn't match any excluded class
             count = count + 1;
             
-            % Check excluded classes if any exist
-            if lExcludeClasses <> $
+            lExclude = lExcludeClasses;
+            while lExclude <> $
             {
-               lExclude = lExcludeClasses;
-               while lExclude <> $
+               if IsClass(each_obj, First(lExclude))
                {
-                  if IsClass(each_obj, First(lExclude))
-                  {
-                     count = count - 1;
-                     break;
-                  }
-                  lExclude = Rest(lExclude);
+                  count = count - 1;
+                  break;
                }
+               lExclude = Rest(lExclude);
             }
          }
       }

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -5066,7 +5066,7 @@ messages:
             return TRUE;
          }
       
-         if Send(poOwner,@CountHoldingHowMany,#class=&Player) > 1
+         if Send(poOwner,@CountHoldingHowMany,#class=&Player,#lExcludeClasses=[&DM]) > 1
          {
             Send(self,@Say,#message_rsc=monster_refuse_service);
             Send(self,@SayToOne,#target=who,


### PR DESCRIPTION
Currently, murderers cannot purchase from lawful NPCs when DMs are present in the room (even hidden DMs), as DMs are counted as fellow customers. This creates unintended interference with normal gameplay.

This PR adds the ability to exclude specific classes (like DMs) when counting objects in a holder. By updating the lawful NPC checks to ignore DMs present in the room, DMs will no longer be counted as fellow customers and murderers can go about their business.

### Testing
- Verify murderers can purchase from lawful NPCs when:
  - No other players are present (only DMs)
  - DMs are hidden in the room
  - DMs are visible in the room
- Verify existing behavior remains unchanged when:
  - Regular players are present
  - No DMs are present

Fixes #1140