### PR TITLE
gameplay: Only strip Vale boon when karma alignment flips

### DIFF
--- a/kod/object/passive/mananode/feynode.kod
+++ b/kod/object/passive/mananode/feynode.kod
@@ -39,6 +39,7 @@ classvars:
 
 properties:
 
+   piPreviousKarma = FEYNODE_GOOD
    piKarma = 0
 
 messages:
@@ -70,8 +71,15 @@ messages:
    }
 
    StripUsers()
+   "Strip users based on their karma."
    {
       local lUsers, i;
+
+      % If the karma hasn't changed to opposite, don't strip users.
+      if (piPreviousKarma = piKarma)
+      {
+         return;
+      }
 
       lUsers = Send(SYS,@GetUsers);
       if piKarma = FEYNODE_GOOD
@@ -100,6 +108,8 @@ messages:
             }
          }
       }
+
+      piPreviousKarma = piKarma;
 
       return;
    }

--- a/kod/object/passive/mananode/feynode.kod
+++ b/kod/object/passive/mananode/feynode.kod
@@ -13,7 +13,7 @@ FeyNode is ManaNode
 % FeyNode has three properties that make it distinct:
 % 1) It gives twice as much mana
 % 2) Only people of matching karma can meld with it.
-% 3) When created, it strips everyone of opposing mana of their link
+% 3) When created, if polarity flips, it strips everyone of opposing mana of their link
 
 constants:
 
@@ -75,7 +75,7 @@ messages:
    {
       local lUsers, i;
 
-      % If the karma hasn't changed to opposite, don't strip users.
+      % If the karma hasn't changed to the opposite polarity, don't strip users.
       if (piPreviousKarma = piKarma)
       {
          return;


### PR DESCRIPTION
This PR updates the Vale node to track its previous karma alignment and only strip mana boons from players when the node flips between good and evil. If the alignment stays within the same polarity, no action is taken.

In practice, this means:
* If a player with negative karma melds with a negative Vale node, then later raises their karma, raising the same negative node again won’t remove their boon.
* But if the server raises the positive node instead, their boon will be stripped — because the node flipped alignment and they no longer match.

This change keeps the intended gameplay behavior but avoids unnecessary disruption when the node is raised without actually changing sides.

Addresses and closes #1149 