### PR TITLE
change: Reduces purchase prices for unrestricted merchant NPCs (Roq and Wulfgang)

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/assassin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/assassin.kod
@@ -98,7 +98,7 @@ classvars:
    viAttributes = MOB_NOMOVE | MOB_NOFIGHT | MOB_BUYER | MOB_TEACHER
    viOccupation = MOB_ROLE_ASSASSIN
 
-   viMerchant_markup = MERCHANT_EXPENSIVE
+   viMerchant_markup = MERCHANT_RIPOFF
 
 properties:
 

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcmerch.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcmerch.kod
@@ -40,7 +40,7 @@ classvars:
    vrIcon = kocatanTradeMaster_icon_rsc
    vrDesc = kocatanTradeMaster_desc_rsc
 
-   viMerchant_markup = MERCHANT_EXPENSIVE
+   viMerchant_markup = MERCHANT_RIPOFF
 
    viAttributes = MOB_NOFIGHT | MOB_SELLER | MOB_RANDOM | MOB_LISTEN | MOB_NOMOVE | MOB_RECEIVE | MOB_BUYER | MOB_COND_SELLER
    viOccupation = MOB_ROLE_MERCHANT


### PR DESCRIPTION
This PR reduces the purchase prices offered by Roq and Wulfgang from (`EXPENSIVE`) 60% to (`RIPOFF`) 50% of item value, because their unique ability to purchase any item type warrants a more conservative pricing structure.

A small example of the change in action:

Current `EXPENSIVE` offer:

![Screenshot 2025-04-06 190345](https://github.com/user-attachments/assets/14290440-dad4-42c5-a680-a8b8fa31d4a4)

Updated `RIPOFF` offer:

![Screenshot 2025-04-06 190726](https://github.com/user-attachments/assets/b614375e-d014-4de9-b947-4aeab540cd95)



Closes #1125 