### PR TITLE
change: align Jala Necklace bulk and weight with other God's Gifts

### DIFF
--- a/kod/object/item/passitem/instrum/jalaneck.kod
+++ b/kod/object/item/passitem/instrum/jalaneck.kod
@@ -45,8 +45,8 @@ classvars:
    viGround_group = 2
 
    viValue_average = 2000
-   viWeight = 75
-   viBulk = 150
+   viBulk = 20
+   viWeight = 25
 
    
 properties:


### PR DESCRIPTION
This PR adjusts the Jala Necklace's weight and bulk to match other God's Gifts. The necklace's weight has been reduced from 75 to 25, and its bulk from 150 to 20 (consistent with GGs).

Closes #1127