### PR TITLE
gameplay: Ability to flag items as excluded from logoff penalties

### DIFF
--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -247,7 +247,7 @@ messages:
             LossAmount, iNumItemsInventory, numItemsLost, iLoops, iStamina,
             iStart, lSpells, iSpellAbility, iAbilityNum, numSpellPointsLost,
             lSkills, iSkillAbility, numSkillPointsLost, iEquivDeath,
-            oSoldierShield, oItem;
+            oSoldierShield, oItem, iItemsDropped;
 
       % Sanity check: Are they logged on?
       If Send(poGhostedPlayer,@IsLoggedOn)
@@ -295,9 +295,13 @@ messages:
       }
       else
       {
-         debug("LogoffGhost: Starting drop process for",Send(poGhostedPlayer,@GetTrueName),
-               "- Need to drop",LossCounter,"items from",numItemsLost,"total items",
-               "- PenaltyCounter:",penaltyCounter,"of",iEquivDeath);
+         % Log initial state
+         debug("LogoffGhost:",Send(poGhostedPlayer,@GetTrueName),
+               "- Initial inventory:",iNumItemsInventory,"items",
+               "- Need to drop:",LossCounter,"items",
+               "- Penalty:",penaltyCounter,"of",iEquivDeath);
+
+         iItemsDropped = 0;
 
          while LossCounter > 0 AND iNumItemsInventory > 0
          {
@@ -314,9 +318,11 @@ messages:
             % strategically in their inventory
             i = Random(1,iNumItemsInventory);
             iStart = i;
+
+            % Track if we've looped through the inventory 
             bLooped = FALSE;
             
-            % Keep trying until we've checked every slot once
+            % Try each inventory slot once, starting from and returning to a random position
             while (i <> iStart OR NOT bLooped)
             {
                % Check if current item is included in logoff penalties
@@ -326,18 +332,19 @@ messages:
                   % Try to drop the item
                   if Send(poGhostedPlayer,@DropItem,#index=i,#targetGhost=self)
                   {
+                     iItemsDropped = iItemsDropped + 1;
+                     debug("LogoffGhost: Dropped item",iItemsDropped,":",
+                           Send(oItem,@GetName),"at index",i);
+
                      % Item was dropped, so decrement the losses handed out
                      LossCounter = LossCounter - 1;
                      iNumItemsInventory = Send(poGhostedPlayer,@GetNumItemsInInventory);
                      
-                     % When we drop an item, all items after it shift down one slot
-                     % So we need to stay at the same index to check what shifted into this position
-                     i = i - 1;  % Counteract the i + 1 that happens next
-                     break;
+                     continue; % Try this slot again (we don't advance the index)
                   }
                }
                
-               % Move to next slot
+               % Advance to next slot, wrapping around to start if needed
                i = i + 1;
                if i > iNumItemsInventory
                {
@@ -346,17 +353,21 @@ messages:
                }
             }
             
-            % If we checked every slot and couldn't drop anything, bail out
+            % Exit if we've checked every slot without finding droppable items
             if i = iStart AND bLooped
             {
+               debug("LogoffGhost: No more droppable items found.",
+                     "Still need to drop:",LossCounter,"items");
                break;
             }
          }
 
-         debug("LogoffGhost: Drop process complete for",Send(poGhostedPlayer,@GetTrueName),
-               "- Started with",numItemsLost,"items,",
-               "dropped",(numItemsLost - iNumItemsInventory),"items,",
-               "remaining:",iNumItemsInventory);
+         % Log final state with complete summary
+         debug("LogoffGhost: Drop complete for",Send(poGhostedPlayer,@GetTrueName),
+               "- Started with:",numItemsLost,"items",
+               "- Dropped:",iItemsDropped,"items",
+               "- Attempted to drop:",LossCounter + iItemsDropped,"items",
+               "- Remaining:",iNumItemsInventory,"items");
       }
 
       % Correct the number of items lost by subtracting out the items left in

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -32,6 +32,7 @@ resources:
 
    LogoffGhost_penalty_mail_Sender = "Your guardian angel"
 
+   % TODO: Add something about items unaffected by penalties
    LogoffGhost_penalty_mail = "Subject: Penalties for logging off in an unsafe area\n"
       "You have suffered some penalties for logging off in an unsafe area:\n"
       "You lost %q items, %q spell points, and %q skill points."
@@ -246,7 +247,7 @@ messages:
             LossAmount, iNumItemsInventory, numItemsLost, iLoops, iStamina,
             iStart, lSpells, iSpellAbility, iAbilityNum, numSpellPointsLost,
             lSkills, iSkillAbility, numSkillPointsLost, iEquivDeath,
-            oSoldierShield;
+            oSoldierShield, oItem;
 
       % Sanity check: Are they logged on?
       If Send(poGhostedPlayer,@IsLoggedOn)
@@ -282,7 +283,7 @@ messages:
       {
          % just drop everything
          i = 1;
-         while i <= iNumItemsInventory
+         while i <= Send(poGhostedPlayer,@GetNumItemsInInventory)
          {
             if NOT Send(poGhostedPlayer,@DropItem,#index=i,#targetGhost=self)
             {
@@ -294,33 +295,68 @@ messages:
       }
       else
       {
+         debug("LogoffGhost: Starting drop process for",Send(poGhostedPlayer,@GetTrueName),
+               "- Need to drop",LossCounter,"items from",numItemsLost,"total items",
+               "- PenaltyCounter:",penaltyCounter,"of",iEquivDeath);
+
          while LossCounter > 0 AND iNumItemsInventory > 0
          {
-            % try to drop a Random item
             iNumItemsInventory = Send(poGhostedPlayer,@GetNumItemsInInventory);
-            i = Random(1,iNumItemsInventory);
-            if NOT Send(poGhostedPlayer,@DropItem,#index=i,#targetGhost=self)
+            
+            % Sanity check
+            if iNumItemsInventory = 0
             {
-               % If the Random drop fails, scan through and drop the first one
-               %  we can.
-               i = 1;
-               while i <= iNumItemsInventory
-                     AND NOT Send(poGhostedPlayer,@DropItem,#index=i,
-                                  #targetGhost=self)
-               {
-                  i = i + 1;
-               }
-
-               % If we got all the way through the inventory without dropping
-               %  anything, bail.
-               if i > Send(poGhostedPlayer,@GetNumItemsInInventory)
-               {
-                  LossCounter = 1;
-               }
+               break;
             }
 
-            LossCounter = LossCounter - 1;
+            % Start from a random position in inventory since starting at the
+            % beginning or end would let players protect items by placing them
+            % strategically in their inventory
+            i = Random(1,iNumItemsInventory);
+            iStart = i;
+            bLooped = FALSE;
+            
+            % Keep trying until we've checked every slot once
+            while (i <> iStart OR NOT bLooped)
+            {
+               % Check if current item is included in logoff penalties
+               oItem = Send(poGhostedPlayer,@FindItemByIndex,#index=i);
+               if oItem <> $ AND Send(oItem,@DropsOnUnsafeLogoff)
+               {
+                  % Try to drop the item
+                  if Send(poGhostedPlayer,@DropItem,#index=i,#targetGhost=self)
+                  {
+                     % Item was dropped, so decrement the losses handed out
+                     LossCounter = LossCounter - 1;
+                     iNumItemsInventory = Send(poGhostedPlayer,@GetNumItemsInInventory);
+                     
+                     % When we drop an item, all items after it shift down one slot
+                     % So we need to stay at the same index to check what shifted into this position
+                     i = i - 1;  % Counteract the i + 1 that happens next
+                     break;
+                  }
+               }
+               
+               % Move to next slot
+               i = i + 1;
+               if i > iNumItemsInventory
+               {
+                  i = 1;
+                  bLooped = TRUE;
+               }
+            }
+            
+            % If we checked every slot and couldn't drop anything, bail out
+            if i = iStart AND bLooped
+            {
+               break;
+            }
          }
+
+         debug("LogoffGhost: Drop process complete for",Send(poGhostedPlayer,@GetTrueName),
+               "- Started with",numItemsLost,"items,",
+               "dropped",(numItemsLost - iNumItemsInventory),"items,",
+               "remaining:",iNumItemsInventory);
       }
 
       % Correct the number of items lost by subtracting out the items left in

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -247,7 +247,8 @@ messages:
             LossAmount, iNumItemsInventory, numItemsLost, iLoops, iStamina,
             iStart, lSpells, iSpellAbility, iAbilityNum, numSpellPointsLost,
             lSkills, iSkillAbility, numSkillPointsLost, iEquivDeath,
-            oSoldierShield, oItem, iItemsDropped;
+            oSoldierShield, oItem, lDroppableItems, iNumToDrop, iRandomIndex, 
+            iItemsDropped, lDropList;
 
       % Sanity check: Are they logged on?
       If Send(poGhostedPlayer,@IsLoggedOn)
@@ -295,79 +296,67 @@ messages:
       }
       else
       {
+         % For partial drop penalties, we first build a list of items that can 
+         % be dropped. Then we randomly select items from that list to create 
+         % a drop list. We then drop all items in the drop list.
+
+         % Build list of droppable items
+         lDroppableItems = $;
+         i = 1;
+
+         while i <= Send(poGhostedPlayer,@GetNumItemsInInventory)
+         {
+            oItem = Send(poGhostedPlayer,@FindItemByIndex,#index=i);
+            if oItem <> $ AND Send(oItem,@DropsOnUnsafeLogoff)
+            {
+               lDroppableItems = Cons(oItem, lDroppableItems);
+            }
+            i = i + 1;
+         }
+
          % Log initial state
          debug("LogoffGhost:",Send(poGhostedPlayer,@GetTrueName),
-               "- Initial inventory:",iNumItemsInventory,"items",
+               "- Initial inventory:",numItemsLost,"items",
                "- Need to drop:",LossCounter,"items",
+               "- Droppable items:",Length(lDroppableItems),"items",
                "- Penalty:",penaltyCounter,"of",iEquivDeath);
 
+         % Calculate how many items to actually drop
+         iNumToDrop = Bound(LossCounter, 0, Length(lDroppableItems));
          iItemsDropped = 0;
 
-         while LossCounter > 0 AND iNumItemsInventory > 0
+         % Build drop list by randomly selecting items
+         lDropList = $;
+         while iNumToDrop > 0 AND Length(lDroppableItems) > 0
          {
-            iNumItemsInventory = Send(poGhostedPlayer,@GetNumItemsInInventory);
+            % Pick a random item from our list of droppables
+            iRandomIndex = Random(1, Length(lDroppableItems));
+            oItem = Nth(lDroppableItems, iRandomIndex);
             
-            % Sanity check
-            if iNumItemsInventory = 0
-            {
-               break;
-            }
+            % Add to drop list and remove from droppable list
+            lDropList = Cons(oItem, lDropList);
+            lDroppableItems = DelListElem(lDroppableItems, oItem);
+            iNumToDrop = iNumToDrop - 1;
+         }
 
-            % Start from a random position in inventory since starting at the
-            % beginning or end would let players protect items by placing them
-            % strategically in their inventory
-            i = Random(1,iNumItemsInventory);
-            iStart = i;
-
-            % Track if we've looped through the inventory 
-            bLooped = FALSE;
-            
-            % Try each inventory slot once, starting from and returning to a random position
-            while (i <> iStart OR NOT bLooped)
+         % Now drop all items in the drop list
+         for oItem in lDropList
+         {
+            if Send(poGhostedPlayer,@DropItem,#droppedItem=oItem,#targetGhost=self)
             {
-               % Check if current item is included in logoff penalties
-               oItem = Send(poGhostedPlayer,@FindItemByIndex,#index=i);
-               if oItem <> $ AND Send(oItem,@DropsOnUnsafeLogoff)
-               {
-                  % Try to drop the item
-                  if Send(poGhostedPlayer,@DropItem,#index=i,#targetGhost=self)
-                  {
-                     iItemsDropped = iItemsDropped + 1;
-                     debug("LogoffGhost: Dropped item",iItemsDropped,":",
-                           Send(oItem,@GetName),"at index",i);
-
-                     % Item was dropped, so decrement the losses handed out
-                     LossCounter = LossCounter - 1;
-                     iNumItemsInventory = Send(poGhostedPlayer,@GetNumItemsInInventory);
-                     
-                     continue; % Try this slot again (we don't advance the index)
-                  }
-               }
-               
-               % Advance to next slot, wrapping around to start if needed
-               i = i + 1;
-               if i > iNumItemsInventory
-               {
-                  i = 1;
-                  bLooped = TRUE;
-               }
-            }
-            
-            % Exit if we've checked every slot without finding droppable items
-            if i = iStart AND bLooped
-            {
-               debug("LogoffGhost: No more droppable items found.",
-                     "Still need to drop:",LossCounter,"items");
-               break;
+               iItemsDropped = iItemsDropped + 1;
+               debug("LogoffGhost: Dropped item",iItemsDropped,":",
+                     Send(oItem,@GetName),"at index",i);
             }
          }
 
-         % Log final state with complete summary
+         % Log final state
          debug("LogoffGhost: Drop complete for",Send(poGhostedPlayer,@GetTrueName),
-               "- Started with:",numItemsLost,"items",
+               "- Started with:",numItemsLost,"items", 
                "- Dropped:",iItemsDropped,"items",
-               "- Attempted to drop:",LossCounter + iItemsDropped,"items",
-               "- Remaining:",iNumItemsInventory,"items");
+               "- Attempted to drop:",iNumToDrop + iItemsDropped,"items",
+               "- Remaining:",Send(poGhostedPlayer,@GetNumItemsInInventory),"items");
+
       }
 
       % Correct the number of items lost by subtracting out the items left in

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -32,7 +32,6 @@ resources:
 
    LogoffGhost_penalty_mail_Sender = "Your guardian angel"
 
-   % TODO: Add something about items unaffected by penalties
    LogoffGhost_penalty_mail = "Subject: Penalties for logging off in an unsafe area\n"
       "You have suffered some penalties for logging off in an unsafe area:\n"
       "You lost %q items, %q spell points, and %q skill points."

--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -1827,5 +1827,15 @@ messages:
       return;
    }
 
+   DropsOnUnsafeLogoff()
+   "Returns TRUE if the item can be dropped by logoff ghosts."
+   {
+      % Excluded from unsafe logoff penalties:
+      % - Anything that won't be dropped on death
+      % - Anything with the IA_MADE attribute (create weapon, create food)
+      return Send(self,@DropOnDeath) AND 
+         NOT Send(self,@HasAttribute,#ItemAtt=IA_MADE);
+   }
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/inscript/ballot.kod
+++ b/kod/object/item/passitem/inscript/ballot.kod
@@ -46,5 +46,10 @@ messages:
 	  return;
    }
 
+   DropsOnUnsafeLogoff()
+   {
+      return FALSE;
+   }
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This PR addresses #269 by updating how item drops are handled during logoff penalties. Previously, players could avoid meaningful penalties by filling their inventory with cheap or disposable items. 

💭 **Submitting as a draft for a sanity check on the overall approach.**
🗒️ **Debug statements in temporarily for testing and validation.**

### Key Changes

* Adds a new `DropsOnLogoffDeath` method to the Item interface.
* Updates `InflictPenalties` item drop logic with a two-phased approach:
    1. Build a list of droppable items and randomly select items from that list to drop
    2. Drop those chosen items in a separate pass
* Applies the new behavior to:
    * Items created by spells (e.g., created weapons, created food).
    * Ballots (set to false for now).

Also fixes an issue in the “drop all” logic where the loop could run unnecessarily. Previously, the loop used a static inventory count even as items were being removed. Now it properly tracks the current inventory size after each drop.

### Some scenarios to consider and test
1. An empty inventory
2. An inventory made up entirely of ballots
3. An inventory with a wedding ring (should not drop on death)
4. An inventory with _created_ weapons and/or created food

### Notes
* **Fun fact:** If a player hits the logoff ghost penalty limit, an Amulet of Shadows can still be selected as a drop—meaning it’s possible for the amulet to kill the player while they’re logged off.

Closes #269 