### PR TITLE
qol: Adds an additional entry point for the Jasper tavern door

### DIFF
--- a/kod/object/active/holder/room/jasperrm/jaswest.kod
+++ b/kod/object/active/holder/room/jasperrm/jaswest.kod
@@ -71,6 +71,7 @@ messages:
 
       plExits = Cons([ 44, 25, RID_JAS_INN, 3, 8, ROTATE_NONE ],plExits);
       plExits = Cons([ 44, 26, RID_JAS_INN, 3, 8, ROTATE_NONE ],plExits);
+      plExits = Cons([ 64, 20, RID_JAS_TAVERN, 3, 6, ROTATE_NONE ],plExits);
       plExits = Cons([ 64, 21, RID_JAS_TAVERN, 3, 6, ROTATE_NONE ],plExits);
       plExits = Cons([ 31, 27, RID_JAS_ELDER_HUT, 10, 6, ROTATE_NONE ],plExits);
       plExits = Cons([ 32, 28, RID_JAS_ELDER_HUT, 10, 6, ROTATE_NONE ],plExits);


### PR DESCRIPTION
The existing door texture spans two coordinates, but only one was set as an entry point. This makes entering the tavern frustrating at times. This PR simply adds a second coordinate to fully cover the visual width of the door, making entry more intuitive.