### PR TITLE
gameplay: Adds PvP cooldown to prevent free penalty chance after/during combat

### DIFF
--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -270,11 +270,22 @@ messages:
       numItemsLost = Send(poGhostedPlayer,@GetNumItemsInInventory);
       LossCounter = Send(poGhostedPlayer,@GetNumItemsInInventory)
                     * penaltyCounter / iEquivDeath;
-
-      if penaltyCounter < iEquivDeath
-         AND Random(1,iEquivDeath-1) < penaltyCounter
+ 
+      if penaltyCounter < iEquivDeath 
       {
-         LossCounter = LossCounter + 1;
+         % If the player recently attacked someone within the last 6 hours, they can't get a free penalty
+         if Send(poGhostedPlayer,@GetLastPlayerAttackTime) + 
+            Send(Send(SYS,@GetSettings),@GetLogoffPenaltyPvPTime) > GetTime()
+         {
+            LossCounter = LossCounter + 1;
+         }
+         else
+         {
+            if Random(1,iEquivDeath-1) < penaltyCounter
+            {
+               LossCounter = LossCounter + 1;
+            }
+         }
       }
 
       iNumItemsInventory = Send(poGhostedPlayer,@GetNumItemsInInventory);

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -93,6 +93,9 @@ properties:
    % Time in seconds that ghosts will last before taking a penalty
    piLogoffPenaltyGhostTime = 600
 
+   % Time in seconds after attack a player that prevents getting a free penalty
+   piLogoffPenaltyPvPTime = 12 * 60 * 60 % 12 hours
+
    %
    % Guild hall settings
    %
@@ -342,6 +345,11 @@ messages:
    GetLogoffPenaltyGhostTime()
    {
       return piLogoffPenaltyGhostTime;
+   }
+
+   GetLogoffPenaltyPvPTime()
+   {
+      return piLogoffPenaltyPvPTime;
    }
 
    AlwaysCheckMonsterChasers()


### PR DESCRIPTION
This PR addresses community feedback about logoff penalties in PVP, notably the ability for some players to rotate through multiple characters for free penalties. This change makes penalties consistent for anyone who has "recently" (arbitrarily set to 12 hours) attacked another player while applying the existing penalty system to everyone else.

### New Property
This change introduces a new Settings property, `piLogoffPenaltyPvPTime`, which can be used to adjust just how "recent" an attack must be to flag a character as not getting a free penalty.

### Testing
- Verify PvP timer blocks free penalties after attacking another player
- Confirm normal penalty system still works for non-PvP scenarios