### PR TITLE
fix: fixes item dropping logic in logoff ghost

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -2436,6 +2436,12 @@ messages:
 
    DropItem(droppedItem=$, targetGhost=$, dropRoom=$, dropRow=0, dropCol=0,
             index=$, merge=TRUE)
+   % Removes the specified item (by object or index) from the player's inventory and drops it in the specified location.
+   % Returns TRUE if the item was successfully dropped, FALSE otherwise.
+   %
+   % IMPORTANT: This function is assumed NOT to add items to the inventory.
+   % If this behavior changes, review all code that loops over inventory and calls DropItem,
+   % as it may result in infinite loops or other unintended consequences.
    {
       local oItem, oDropRoom, iDropRow, iDropCol, oItemAtt;
       

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -290,8 +290,8 @@ messages:
             }
             else
             {
-               % Don't need to increment unless the item stayed in the
-               %  inventory.
+               % Only increment the index if the item could not be dropped and
+               % remained in inventory.
                i = i + 1;
             }
          }

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -282,13 +282,17 @@ messages:
       {
          % just drop everything
          i = 1;
-         while i <= iNumItemsInventory AND Send(poGhostedPlayer,@GetNumItemsInInventory) > 0
+         while i <= iNumItemsInventory
          {
             if NOT Send(poGhostedPlayer,@DropItem,#index=i,#targetGhost=self)
             {
                % Don't need to increment unless the item stayed in the
                %  inventory.
                i = i + 1;
+            }
+            else
+            {
+               iNumItemsInventory = iNumItemsInventory - 1;
             }
          }
       }

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -282,7 +282,7 @@ messages:
       {
          % just drop everything
          i = 1;
-         while i <= iNumItemsInventory
+         while i <= iNumItemsInventory AND Send(poGhostedPlayer,@GetNumItemsInInventory) > 0
          {
             if NOT Send(poGhostedPlayer,@DropItem,#index=i,#targetGhost=self)
             {

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -284,15 +284,15 @@ messages:
          i = 1;
          while i <= iNumItemsInventory
          {
-            if NOT Send(poGhostedPlayer,@DropItem,#index=i,#targetGhost=self)
+            if Send(poGhostedPlayer,@DropItem,#index=i,#targetGhost=self)
+            {
+               iNumItemsInventory = iNumItemsInventory - 1;
+            }
+            else
             {
                % Don't need to increment unless the item stayed in the
                %  inventory.
                i = i + 1;
-            }
-            else
-            {
-               iNumItemsInventory = iNumItemsInventory - 1;
             }
          }
       }


### PR DESCRIPTION
This PR fixes a loop issue in the logoff ghost's item dropping logic when dropping everything.

**Bug Example**
With 1 droppable item in inventory:
1. `iNumItemsInventory = 1`
2. First iteration: `i = 1`, drop succeeds
3. `i` stays at 1 (we don't increment on successful drops)
4. Second iteration: `i = 1 <= iNumItemsInventory (1)` is true
5. Try to drop item at index 1 again, but inventory is empty

On the server side, an error will be thrown from `Player::FindItemByIndex`, as there is no longer an item at index 1.