### PR TITLE
Fix for primary bonus for Jala spells

### DIFF
--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -2182,6 +2182,10 @@ messages:
             iItemModifier = iItemModifier/2;
          }
       }
+	  
+      % Bind the bonuses to reasonable values.
+      iPrimaryBonus = bound(iPrimaryBonus,0,30);
+      iSecondaryBonus = bound(iSecondaryBonus,0,10);
       
       if viSchool = SS_JALA
       {
@@ -2192,15 +2196,11 @@ messages:
          %  with normal combat, etc.
          % Secondary bonus is based off of HPs.  Non-mules get bigger bonuses.
          iPrimaryBonus = Send(who,@GetInstrumentLevel);
-         iSecondaryBonus = Send(who,@GetMaxHealth)/12;
+         iSecondaryBonus = bound(Send(who,@GetMaxHealth)/12,0,10);
       }
 
       iPowerBonus = Send(Send(SYS,@GetParliament),@GetFactionSpellPowerBonus,
                          #who=who,#theSpell=self);
-
-      % Bind the bonuses to reasonable values.
-      iPrimaryBonus = bound(iPrimaryBonus,0,30);
-      iSecondaryBonus = bound(iSecondaryBonus,0,10);
 
       iSpellPower = iPrimaryBonus + iSecondaryBonus + iPowerBonus + iBase;
            


### PR DESCRIPTION
Jala's primary bonus is unintentionally capped at 30 when it's supposed to exceed that cap based on your instrument.

Normally the primary bonus to most spell schools is capped at a max of 30.  However, comments left about Jala spells state that its primary bonus is based on the wielded instrument, and that the bonus can go up to 40 because instruments with higher bonuses were harder to find.

Unfortunately, the primary bonus for Jala would first be calculated by getting the instrument level, then afterwards the bounds for primary bonuses sets it back to the max of 30.  This meant true lutes gave the same strength as fine lutes.

This PR does the following:
  - The bounds for the primary and secondary bonuses were moved above the if-statement for Jala, which allows it to override the values with its own calculations for Jala spells.
  - A bound is applied again on iSecondaryBonus for Jala, so it can maintain its intended max cap of 10.

I tested this on a 150HP player character with normal lute, fine lute, and true lute.  The true lute can now give the instrument power of 40, and the secondary bonus is capped at 10 as intended.