### PR TITLE
fix: disable map annotation creation when annotations are disabled via Preferences

### DIFF
--- a/clientd3d/annotate.c
+++ b/clientd3d/annotate.c
@@ -134,6 +134,9 @@ void MapAnnotationClick(int x, int y)
    MapAnnotation *a;
    Bool existed;  // True if editing an existing annotation
 
+   if (!config.map_annotations)
+     return;
+
    MapScreenToRoom(&x, &y, TRUE);
 
    // See if close to an annotation


### PR DESCRIPTION
This PR adds a check to prevent map annotations from being created when they are disabled in Preferences. Without this, users can still create annotations via the minimap, leading to the issue described in #1167 and tooltip text will appear unexpectedly in the game window.