### PR TITLE
fix: Improvements to map annotations and tooltips

### DIFF
--- a/clientd3d/annotate.c
+++ b/clientd3d/annotate.c
@@ -175,9 +175,7 @@ void MapAnnotationClick(int x, int y)
       }
    }
 
-   // Clear any open tooltips
-   HWND hToolTips = TooltipGetControl();
-   SendMessage(hToolTips, TTM_POP, 0, 0);
+   TooltipReset();
 
    if (DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_ANNOTATE), hMain, MapAnnotationDialogProc,
                       (LPARAM) index) == IDOK)

--- a/clientd3d/annotate.c
+++ b/clientd3d/annotate.c
@@ -54,8 +54,8 @@ void MapAnnotationGetText(TOOLTIPTEXT *ttt)
 {
   int index;
 
-//   if (!MapVisible())
-//      return;
+   if (!config.map_annotations || !config.drawmap)
+      return;
 
   index = ttt->hdr.idFrom;
 
@@ -134,7 +134,7 @@ void MapAnnotationClick(int x, int y)
    MapAnnotation *a;
    Bool existed;  // True if editing an existing annotation
 
-   if (!config.map_annotations)
+   if (!config.map_annotations || !config.drawmap)
      return;
 
    MapScreenToRoom(&x, &y, TRUE);
@@ -175,6 +175,10 @@ void MapAnnotationClick(int x, int y)
       }
    }
 
+   // Clear any open tooltips
+   HWND hToolTips = TooltipGetControl();
+   SendMessage(hToolTips, TTM_POP, 0, 0);
+
    if (DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_ANNOTATE), hMain, MapAnnotationDialogProc,
                       (LPARAM) index) == IDOK)
    {
@@ -185,8 +189,6 @@ void MapAnnotationClick(int x, int y)
          current_room.annotations[index].y = y;
       }
    }
-
-   TooltipReset();
 
    RedrawAll();  // In case we added or removed an annotation
 }

--- a/clientd3d/annotate.c
+++ b/clientd3d/annotate.c
@@ -175,9 +175,7 @@ void MapAnnotationClick(int x, int y)
       }
    }
 
-   TooltipReset();
-
-   if (DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_ANNOTATE), hMain, MapAnnotationDialogProc,
+   if (SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_ANNOTATE), hMain, MapAnnotationDialogProc,
                       (LPARAM) index) == IDOK)
    {
       current_room.annotations_changed = True;

--- a/clientd3d/buy.c
+++ b/clientd3d/buy.c
@@ -473,7 +473,7 @@ void BuyList(object_node seller, list_type items)
 
    if (hwndBuyDialog == NULL)
       /* Give user list of things to select from */
-      DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_BUY), hMain, BuyDialogProc, (LPARAM) &dlg_info);
+      SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_BUY), hMain, BuyDialogProc, (LPARAM) &dlg_info);
 
    ObjectListDestroy(items);
 }
@@ -495,7 +495,7 @@ void WithdrawalList(object_node seller, list_type items)
 
    if (hwndBuyDialog == NULL)
       /* Give user list of things to select from */
-      DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_WITHDRAWAL), hMain, WithdrawalDialogProc, (LPARAM) &dlg_info);
+      SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_WITHDRAWAL), hMain, WithdrawalDialogProc, (LPARAM) &dlg_info);
 
    ObjectListDestroy(items);
 }

--- a/clientd3d/client.def
+++ b/clientd3d/client.def
@@ -26,6 +26,7 @@ EXPORTS
 	ResetUserData
 	WebLaunchBrowser
 	InitMenuPopupHandler
+	SafeDialogBoxParam
 
 ; Keyboard handling
 	KeyAddTable

--- a/clientd3d/color.c
+++ b/clientd3d/color.c
@@ -258,7 +258,7 @@ void UserSelectColors(WORD fg, WORD bg)
 	info.fg = fg;
 	info.bg = bg;
 
-	DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_COLOR), hMain,
+	SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_COLOR), hMain,
 		ColorDialogProc, (LPARAM) &info);
 }
 /************************************************************************/

--- a/clientd3d/dialog.c
+++ b/clientd3d/dialog.c
@@ -736,6 +736,7 @@ void AbortGameDialogs(void)
 /************************************************************************/
 /*
 * SafeDialogBoxParam:  A wrapper for DialogBoxParam that resets tooltips when a dialog is opened.
+*   This is necessary because tooltips are not reset when a dialog is opened.
 */
 INT_PTR __stdcall SafeDialogBoxParam(HINSTANCE hInstance, LPCSTR lpTemplate, HWND hWndParent, DLGPROC lpDialogFunc, LPARAM dwInitParam)
 {

--- a/clientd3d/dialog.c
+++ b/clientd3d/dialog.c
@@ -665,10 +665,11 @@ void DisplayDescription(object_node *obj, BYTE flags, char *description,
 	// Different dialog for players
 	template_id = (obj->flags & OF_PLAYER) ? IDD_DESCPLAYER : IDD_DESC;
 	
+	TooltipReset();
+	
 	DialogBoxParam(hInst, MAKEINTRESOURCE(template_id), hDescParent,
                  DescDialogProc, reinterpret_cast<LPARAM>(&info));
 	
-	TooltipReset();
 	SetDescParams(NULL, DESC_NONE);
 }
 /************************************************************************/

--- a/clientd3d/dialog.c
+++ b/clientd3d/dialog.c
@@ -665,9 +665,7 @@ void DisplayDescription(object_node *obj, BYTE flags, char *description,
 	// Different dialog for players
 	template_id = (obj->flags & OF_PLAYER) ? IDD_DESCPLAYER : IDD_DESC;
 	
-	TooltipReset();
-	
-	DialogBoxParam(hInst, MAKEINTRESOURCE(template_id), hDescParent,
+	SafeDialogBoxParam(hInst, MAKEINTRESOURCE(template_id), hDescParent,
                  DescDialogProc, reinterpret_cast<LPARAM>(&info));
 	
 	SetDescParams(NULL, DESC_NONE);
@@ -734,4 +732,13 @@ void AbortGameDialogs(void)
 	AbortAnnotateDialog();
 	AbortPasswordDialog();
 	AbortPreferencesDialog();
+}
+/************************************************************************/
+/*
+* SafeDialogBoxParam:  A wrapper for DialogBoxParam that resets tooltips when a dialog is opened.
+*/
+INT_PTR __stdcall SafeDialogBoxParam(HINSTANCE hInstance, LPCSTR lpTemplate, HWND hWndParent, DLGPROC lpDialogFunc, LPARAM dwInitParam)
+{
+    TooltipReset();
+    return DialogBoxParam(hInstance, lpTemplate, hWndParent, lpDialogFunc, dwInitParam);
 }

--- a/clientd3d/dialog.c
+++ b/clientd3d/dialog.c
@@ -738,7 +738,7 @@ void AbortGameDialogs(void)
 * SafeDialogBoxParam:  A wrapper for DialogBoxParam that resets tooltips when a dialog is opened.
 *   This is necessary because tooltips are not reset when a dialog is opened.
 */
-INT_PTR __stdcall SafeDialogBoxParam(HINSTANCE hInstance, LPCSTR lpTemplate, HWND hWndParent, DLGPROC lpDialogFunc, LPARAM dwInitParam)
+INT_PTR SafeDialogBoxParam(HINSTANCE hInstance, LPCSTR lpTemplate, HWND hWndParent, DLGPROC lpDialogFunc, LPARAM dwInitParam)
 {
     TooltipReset();
     return DialogBoxParam(hInstance, lpTemplate, hWndParent, lpDialogFunc, dwInitParam);

--- a/clientd3d/dialog.h
+++ b/clientd3d/dialog.h
@@ -81,7 +81,7 @@ typedef struct {
    DWORD minAmount;	      /* minimum allowable value */
 } AmountDialogStruct;
 
-M59EXPORT INT_PTR __stdcall SafeDialogBoxParam(HINSTANCE hInstance, LPCSTR lpTemplate, HWND hWndParent, DLGPROC lpDialogFunc, LPARAM dwInitParam);
+M59EXPORT INT_PTR SafeDialogBoxParam(HINSTANCE hInstance, LPCSTR lpTemplate, HWND hWndParent, DLGPROC lpDialogFunc, LPARAM dwInitParam);
 
 M59EXPORT void SetDescParams(HWND hParent, int flags);
 M59EXPORT void DisplayDescription(object_node *obj, BYTE flags, char *description, 

--- a/clientd3d/dialog.h
+++ b/clientd3d/dialog.h
@@ -81,6 +81,7 @@ typedef struct {
    DWORD minAmount;	      /* minimum allowable value */
 } AmountDialogStruct;
 
+M59EXPORT INT_PTR __stdcall SafeDialogBoxParam(HINSTANCE hInstance, LPCSTR lpTemplate, HWND hWndParent, DLGPROC lpDialogFunc, LPARAM dwInitParam);
 
 M59EXPORT void SetDescParams(HWND hParent, int flags);
 M59EXPORT void DisplayDescription(object_node *obj, BYTE flags, char *description, 
@@ -96,7 +97,6 @@ INT_PTR CALLBACK DescDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
 INT_PTR CALLBACK AmountDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);
 void AbortGameDialogs(void);
 void FilterChangedDescription(char *desc);
-
 void AnimateDescription(int dt);
 
 /* lookdlg.c */

--- a/clientd3d/lookdlg.c
+++ b/clientd3d/lookdlg.c
@@ -479,7 +479,7 @@ Bool InputNumber(HWND hParent, HWND hwnd, int x, int y, int *returnValue, int st
    dlg_info.minAmount = minValue;
    dlg_info.maxAmount = maxValue;
    
-   if (IDCANCEL == DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_AMOUNT), hParent,
+   if (IDCANCEL == SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_AMOUNT), hParent,
       AmountDialogProc, (LPARAM) &dlg_info))
       return False;  /* Don't select item */
 
@@ -596,14 +596,14 @@ list_type DisplayLookList(HWND hParent, char *title, list_type l, int flags)
 
    /* If multiple selections allowed, make list box multiple select */
    if (flags & LD_MULTIPLESEL)
-      valid = DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_ITEMLISTMULTIPLE), hParent,
+      valid = SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_ITEMLISTMULTIPLE), hParent,
 			     LookDialogProc, (LPARAM) &dlg_info);
    else 
       if (flags & LD_SORT)
-	 valid = DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_ITEMLISTSORTED), hParent,
+	 valid = SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_ITEMLISTSORTED), hParent,
 				LookDialogProc, (LPARAM) &dlg_info);
       else
-	 valid = DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_ITEMLISTSINGLE), hParent,
+	 valid = SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_ITEMLISTSINGLE), hParent,
 				LookDialogProc, (LPARAM) &dlg_info);
 
    if( info != NULL )

--- a/clientd3d/msgbox.c
+++ b/clientd3d/msgbox.c
@@ -146,7 +146,7 @@ int ClientMessageBox(HWND hwndParent, const char *text, char *title, UINT style)
    s.title = title;
    s.style = style;
 
-   retval = DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_MSGBOX), hwndParent, 
+   retval = SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_MSGBOX), hwndParent, 
 			   ClientMsgBoxProc, (LPARAM) &s);
    box_up = False;
    return retval;

--- a/clientd3d/say.c
+++ b/clientd3d/say.c
@@ -82,7 +82,7 @@ void FreeCurrentUsers(void)
 */
 void UserWho(void)
 {
-	DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_WHO), hMain,
+	SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_WHO), hMain,
 		WhoDialogProc, (LPARAM) current_users);
 }
 

--- a/clientd3d/tooltip.c
+++ b/clientd3d/tooltip.c
@@ -106,19 +106,9 @@ HWND TooltipGetControl(void)
 }
 /****************************************************************************/
 /*
- * TooltipReset:  When a modal dialog box is displayed, window messages from the
- *   dialog's parent (e.g. the main window) don't get relayed to the tooltip, since
- *   the dialog handles them.  This causes the tooltip to get a mouse down event, but
- *   no mouse up event, which makes the tooltips break.  Here we simulate the mouse
- *   up events to fake out the tooltip after a dialog is dismissed.
+ * TooltipReset:  Clear any open tooltips
  */
 void TooltipReset(void)
 {
-  MSG msg;
-  
-  msg.hwnd = hMain;
-  msg.message = WM_LBUTTONUP;
-  SendMessage(hToolTips, TTM_RELAYEVENT, TRUE, (LPARAM) &msg);
-  msg.message = WM_RBUTTONUP;
-  SendMessage(hToolTips, TTM_RELAYEVENT, TRUE, (LPARAM) &msg);
+  SendMessage(hToolTips, TTM_POP, 0, 0);
 }

--- a/clientd3d/transfer.c
+++ b/clientd3d/transfer.c
@@ -258,7 +258,7 @@ void __cdecl DownloadError(HWND hParent, char *fmt, ...)
       vsnprintf(s, sizeof(s), fmt,marker);
       va_end(marker);
       
-      retval = DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_FTPERROR), hMain, ErrorDialogProc, 
+      retval = SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_FTPERROR), hMain, ErrorDialogProc, 
 			   (LPARAM) s);
       
       if (retval == IDOK)

--- a/module/admin/admindlg.c
+++ b/module/admin/admindlg.c
@@ -280,7 +280,7 @@ void AdminDlgCommand(HWND hDlg, int cmd_id, HWND hwndCtl, UINT codeNotify)
 
       index = ListBox_GetCurSel(hwndCtl);
       if (index != LB_ERR)
-	 DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_ADMINVALUE), hDlg, AdminValueDialogProc, index);
+	 SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_ADMINVALUE), hDlg, AdminValueDialogProc, index);
       break;
 
    case IDC_OWNERBUTTON:
@@ -560,7 +560,7 @@ INT_PTR CALLBACK AdminMoveDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPA
 Bool AdminGetString(HWND hParent, char *buf)
 {
    int retval;
-   retval = DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_ADMINSTRING), hParent, 
+   retval = SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_ADMINSTRING), hParent, 
 			   AdminStringDialogProc, (LPARAM) buf);
    
    if (retval == IDCANCEL)

--- a/module/mailnews/mailread.c
+++ b/module/mailnews/mailread.c
@@ -68,7 +68,7 @@ void UserReadMail(void)
    if (hReadMailDlg == NULL)
    {
       // Don't ask for new mail; might need to wait for user list
-      if (CreateDialog(hInst, MAKEINTRESOURCE(IDD_MAILREAD), NULL, ReadMailDialogProc) == NULL)
+      if (SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_MAILREAD), NULL, ReadMailDialogProc, 0) == NULL)
          debug(("CreateDialog failed for read mail dialog\n"));
    }
    else

--- a/module/mailnews/newsread.c
+++ b/module/mailnews/newsread.c
@@ -74,7 +74,7 @@ void UserReadNews(object_node *obj, char *desc, WORD newsgroup, BYTE permissions
    s.permissions = permissions;
    s.desc = desc;
 
-   DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_NEWSREAD), cinfo->hMain,
+   SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_NEWSREAD), cinfo->hMain,
                   ReadNewsDialogProc, (LPARAM)&s);
 }
 /****************************************************************************/

--- a/module/mailnews/newssend.c
+++ b/module/mailnews/newssend.c
@@ -45,7 +45,7 @@ Bool UserPostArticle(HWND hParent, WORD newsgroup, ID name_rsc, char *title)
    s.newsgroup = newsgroup;
    s.subject = title;
    s.group_name_rsc = name_rsc;
-   retval = DialogBoxParam(hInst, MAKEINTRESOURCE(IDD_NEWSPOST), hParent,
+   retval = SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_NEWSPOST), hParent,
 			   PostNewsDialogProc, (LPARAM) &s);
 
    if (retval == IDOK)


### PR DESCRIPTION
This PR introduces a couple of improvements to map annotations behavior:

1. **Annotations and tooltips are now fully disabled if either "Show dynamic minimap" or "Map annotations" is turned off.** 
One could argue there's some benefit to having them display, but I think it's more confusing to have tooltips appear for annotations the player can't see.

2. **Tooltips are now properly cleared when many dialogs are displayed.** 
I added a wrapper around `DialogBoxParam` that calls an updated `TooltipReset()` beforehand. This helps clear lingering tooltips before most dialogs appear. I skipped a few dialogs that likely don’t interact with tooltips.

I recorded this video to show a variety of conditions under these changes:
- Players cannot create or edit map annotations, or see their tooltips, if either the minimap is disabled
- Players cannot create or edit map annotations, or see their tooltips, if either map annotations are disabled
- An annotation's tooltip will no longer remain under the mouse cursor if an annotation is edited, or if the Look dialog is brought up. Not shown are the other scenarios:
  - When the who dialog is opened
  - When a buy dialog is opened
  - When a newsglobe is opened
  - When the mail reader is opened
  - When an offer dialog is opened
  - When the color selector is opened

https://github.com/user-attachments/assets/a43c7be9-7ef2-4b91-9414-c4fd3da63402
