### PR TITLE
fix: make morph who list names color correctly

### DIFF
--- a/clientd3d/color.c
+++ b/clientd3d/color.c
@@ -449,29 +449,28 @@ WORD GetItemListColor(HWND hwnd, int type, item_rarity_grade text_color_value)
 */
 COLORREF GetPlayerNameColor(int flags,const char*name)
 {
-    debug(("GetPlayerNameColor: flags=0x%08X name=%s\n", flags, name));
 	if (GetDrawingEffect(flags) == OF_BLACK)
 		return NAME_COLOR_BLACK_FG;
 	
-    // If morphed, temporarily add OF_PLAYER for name coloring
+	/* If morphed, temporarily add OF_PLAYER for name coloring */
     int color_flags = flags;
-    if (flags & OF_MORPH)
+    if (flags & OF_MORPHED)
         color_flags |= OF_PLAYER;
 
     switch (GetPlayerFlags(color_flags))
     {
 		case PF_DM:
 			return NAME_COLOR_DM_FG;
-		case PF_KILLER:
-			return NAME_COLOR_KILLER_FG;
-		case PF_OUTLAW:
-			return NAME_COLOR_OUTLAW_FG;
 		case PF_CREATOR:
 			return NAME_COLOR_CREATOR_FG;
 		case PF_SUPER:
 			return NAME_COLOR_SUPER_FG;
 		case PF_EVENTCHAR:
 			return NAME_COLOR_EVENT_FG;
+		case PF_KILLER:
+			return NAME_COLOR_KILLER_FG;
+		case PF_OUTLAW:
+			return NAME_COLOR_OUTLAW_FG;
             
     default:
 			return NAME_COLOR_NORMAL_FG;

--- a/clientd3d/color.c
+++ b/clientd3d/color.c
@@ -449,11 +449,17 @@ WORD GetItemListColor(HWND hwnd, int type, item_rarity_grade text_color_value)
 */
 COLORREF GetPlayerNameColor(int flags,const char*name)
 {
+    debug(("GetPlayerNameColor: flags=0x%08X name=%s\n", flags, name));
 	if (GetDrawingEffect(flags) == OF_BLACK)
 		return NAME_COLOR_BLACK_FG;
+	
+    // If morphed, temporarily add OF_PLAYER for name coloring
+    int color_flags = flags;
+    if (flags & OF_MORPH)
+        color_flags |= OF_PLAYER;
 
-	switch (GetPlayerFlags(flags))
-	{
+    switch (GetPlayerFlags(color_flags))
+    {
 		case PF_DM:
 			return NAME_COLOR_DM_FG;
 		case PF_KILLER:

--- a/include/proto.h
+++ b/include/proto.h
@@ -359,6 +359,7 @@ enum {
 #define OF_GETTABLE      0x00000010    // Set if player can try to pick up object
 #define OF_CONTAINER     0x00000020    // Set if player can put objects inside this one
 #define OF_NOEXAMINE     0x00000040    // Set if player CAN'T examine object
+#define OF_MORPHED       0x00000080    // Set if player is morphed
 #define OF_OFFERABLE     0x00000200    // Set if object can be offered to
 #define OF_BUYABLE       0x00000400    // Set if object can be bought from
 #define OF_ACTIVATABLE   0x00000800    // Set if object can be activated

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -66,8 +66,8 @@
    CONTAINER_YES     = 0x00000020
    LOOK_YES          = 0
    LOOK_NO           = 0x00000040
+   MORPHED_YES       = 0x00000080
 
-   % unused       = 0x00000080
 
    INVISIBLE_YES     = 0x00000100
    INVISIBLE_NO      = 0

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2540,6 +2540,7 @@ messages:
          % so the who list dialog box does not color shadowformed names black 
          AddPacket(4,Send(i,@GetObjectFlags) & ~DRAWFX_INVISIBLE);
       }
+
       SendPacket(poSession);
       
       return;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2540,7 +2540,7 @@ messages:
          % so the who list dialog box does not color shadowformed names black 
          AddPacket(4,Send(i,@GetObjectFlags) & ~DRAWFX_INVISIBLE);
       }
-
+      
       SendPacket(poSession);
       
       return;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2533,22 +2533,11 @@ messages:
       AddPacket(1,BP_PLAYERS,2,Length(lUsers));
       for i in lUsers
       {
-         if SEnd(i,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
-            AND Send(i,@GetIllusionForm) <> $
-         {
-            % If the user is morphed, we send the illusion form's name.
-            rName = Send(Send(i,@GetIllusionForm),@GetTrueName);
-         }
-         else
-         {
-            % Otherwise, we send the user's true name.
          rName = Send(i,@GetTrueName);
-
          AddPacket(4,i, 4,rName, STRING_RESOURCE,rName);
          % Clear the DRAWFX_INVISIBLE flag of which DRAWFX_BLACK is a subset
          % so the who list dialog box does not color shadowformed names black 
          AddPacket(4,Send(i,@GetObjectFlags) & ~DRAWFX_INVISIBLE);
-         }
       }
       SendPacket(poSession);
       
@@ -7316,16 +7305,24 @@ messages:
 
       oIllusion = Send(self,@GetIllusionForm);
 
-      % If we're morphed, get rid of any "player" flags
+      % If we're morphed, get rid of certain "player" flags
       if Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
          AND oIllusion <> $
          AND IsClass(oIllusion,&Monster)
       {
-         iFlags = (iFlags & ~USER_YES & ~OFFER_YES & ~PLAYER_PK
-                   & ~PLAYER_OUTLAW);
-         iFlags = (iFlags & ~PLAYER_DM & ~PLAYER_CREATOR & ~PLAYER_SUPER);
-      }
+         iFlags = (iFlags & ~USER_YES & ~OFFER_YES);
+         iFlags = iFlags | MORPHED_YES;
 
+         % Recheck and add PK/OUTLAW flags if appropriate
+         if piFlags & PFLAG_MURDERER
+         {
+            iFlags = iFlags | PLAYER_PK;
+         }
+         if piFlags & PFLAG_OUTLAW
+         {
+            iFlags = iFlags | PLAYER_OUTLAW;
+         }
+      }
       return iFlags;
    }
 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2534,6 +2534,7 @@ messages:
       for i in lUsers
       {
          rName = Send(i,@GetTrueName);
+
          AddPacket(4,i, 4,rName, STRING_RESOURCE,rName);
          % Clear the DRAWFX_INVISIBLE flag of which DRAWFX_BLACK is a subset
          % so the who list dialog box does not color shadowformed names black 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2533,14 +2533,23 @@ messages:
       AddPacket(1,BP_PLAYERS,2,Length(lUsers));
       for i in lUsers
       {
+         if SEnd(i,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+            AND Send(i,@GetIllusionForm) <> $
+         {
+            % If the user is morphed, we send the illusion form's name.
+            rName = Send(Send(i,@GetIllusionForm),@GetTrueName);
+         }
+         else
+         {
+            % Otherwise, we send the user's true name.
          rName = Send(i,@GetTrueName);
 
          AddPacket(4,i, 4,rName, STRING_RESOURCE,rName);
          % Clear the DRAWFX_INVISIBLE flag of which DRAWFX_BLACK is a subset
          % so the who list dialog box does not color shadowformed names black 
          AddPacket(4,Send(i,@GetObjectFlags) & ~DRAWFX_INVISIBLE);
+         }
       }
-      
       SendPacket(poSession);
       
       return;


### PR DESCRIPTION
## What
- Updated who list name coloring logic so that morphed players retain their correct color (PK, outlaw, DM, etc.) instead of defaulting to white
- Added a new `MORPHED_YES `flag to the client object flags
- Fixes #1068

## Why
- Previously, when a player became morphed, their name color would revert to white (even if they were an outlaw, PK, DM, etc)
- With the new flag and updated logic, the client can distinguish morphed players and apply the correct name color throughout morph and afterwards

## Details
- Defined `MORPHED_YES `in the client/server shared flags
  - Took the last available flag bit
  - We needed something to distinguish a morphed player since the normal player flags are stripped when morphed
- Adjusted both server and client code so that the correct status color is preserved for morphed players

## Result
- Morphed players now always display the appropriate name color
