### PR TITLE
Update Shroud description

### DIFF
--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -2182,6 +2182,10 @@ messages:
             iItemModifier = iItemModifier/2;
          }
       }
+	  
+      % Bind the bonuses to reasonable values.
+      iPrimaryBonus = bound(iPrimaryBonus,0,30);
+      iSecondaryBonus = bound(iSecondaryBonus,0,10);
       
       if viSchool = SS_JALA
       {
@@ -2192,15 +2196,11 @@ messages:
          %  with normal combat, etc.
          % Secondary bonus is based off of HPs.  Non-mules get bigger bonuses.
          iPrimaryBonus = Send(who,@GetInstrumentLevel);
-         iSecondaryBonus = Send(who,@GetMaxHealth)/12;
+         iSecondaryBonus = bound(Send(who,@GetMaxHealth)/12,0,10);
       }
 
       iPowerBonus = Send(Send(SYS,@GetParliament),@GetFactionSpellPowerBonus,
                          #who=who,#theSpell=self);
-
-      % Bind the bonuses to reasonable values.
-      iPrimaryBonus = bound(iPrimaryBonus,0,30);
-      iSecondaryBonus = bound(iSecondaryBonus,0,10);
 
       iSpellPower = iPrimaryBonus + iSecondaryBonus + iPowerBonus + iBase;
            

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -2182,10 +2182,6 @@ messages:
             iItemModifier = iItemModifier/2;
          }
       }
-	  
-      % Bind the bonuses to reasonable values.
-      iPrimaryBonus = bound(iPrimaryBonus,0,30);
-      iSecondaryBonus = bound(iSecondaryBonus,0,10);
       
       if viSchool = SS_JALA
       {
@@ -2196,11 +2192,15 @@ messages:
          %  with normal combat, etc.
          % Secondary bonus is based off of HPs.  Non-mules get bigger bonuses.
          iPrimaryBonus = Send(who,@GetInstrumentLevel);
-         iSecondaryBonus = bound(Send(who,@GetMaxHealth)/12,0,10);
+         iSecondaryBonus = Send(who,@GetMaxHealth)/12;
       }
 
       iPowerBonus = Send(Send(SYS,@GetParliament),@GetFactionSpellPowerBonus,
                          #who=who,#theSpell=self);
+
+      % Bind the bonuses to reasonable values.
+      iPrimaryBonus = bound(iPrimaryBonus,0,30);
+      iSecondaryBonus = bound(iSecondaryBonus,0,10);
 
       iSpellPower = iPrimaryBonus + iSecondaryBonus + iPowerBonus + iBase;
            

--- a/kod/object/passive/spell/shroud.kod
+++ b/kod/object/passive/spell/shroud.kod
@@ -22,7 +22,7 @@ resources:
    shroud_name_rsc = "shroud"
    shroud_icon_rsc = ishroud.bgf
    shroud_desc_rsc = \
-	"Used to protect a warrior's tools against polluting magics.  Requires a large amount of inexpensive reagents."
+	"Used to protect a warrior's tools against polluting magics.  Requires mushrooms, elderberries, and herbs to cast."
    shroud_lable_rsc = "Shrouder."
    
 


### PR DESCRIPTION
Updated text description for Shroud so it will state the reagents required to cast the spell, so players won't be confused on what the spell needs.  This will make it consistent to other spells' descriptions.