### PR TITLE
Check that passwords contain no invalidate characters during validation

### DIFF
--- a/aws/src/m59utils/python/lib/python3.12/site-packages/m59utils.py
+++ b/aws/src/m59utils/python/lib/python3.12/site-packages/m59utils.py
@@ -139,4 +139,8 @@ def util_validate_password(password, password2):
     if len(password) < 6 or len(password) > 32:
         return False
 
+    # Check for non-ASCII characters
+    if any(ord(char) > 127 for char in password):
+        return False
+
     return True


### PR DESCRIPTION
Ensure only ASCII character set passwords are considered valid