### PR TITLE
feat: Add territory and faction war newsglobes

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -349,6 +349,7 @@
    NID_GUILD_CHARTER = 10
    NID_GODROOM = 14
    NID_GUILD_NEWS = 15
+   NID_TERRITORY_NEWS = 16
 
    % NOTE: Guilds now use their RID_ numbers as their NIDs.  Do not assign them
    %  their own NID.

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/crnthtwn/cnambassador.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/crnthtwn/cnambassador.kod
@@ -1,0 +1,26 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+CorNothAmbassador is CorNothTown
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   cornothambassador_name_rsc = "Baron Gerah Springer"
+
+classvars:
+
+   vrName = cornothambassador_name_rsc
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/crnthtwn/makefile
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/crnthtwn/makefile
@@ -5,6 +5,6 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\crnthtwn.bof
-BOFS  = cnurchin.bof cngrocer.bof cnsarge.bof cninnk.bof cntailor.bof
+BOFS  = cnurchin.bof cngrocer.bof cnsarge.bof cninnk.bof cntailor.bof cnambassador.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/active/holder/room/duke3.kod
+++ b/kod/object/active/holder/room/duke3.kod
@@ -88,6 +88,7 @@ messages:
 
    CreateStandardObjects()
    {
+      local oNews;
 
       Send(self,@NewHold,#what=Create(&Brazier),#new_row=9,#new_col=18,
            #fine_row=48,#fine_col=48);
@@ -100,6 +101,15 @@ messages:
 
       Send(self,@NewHold,#what=Create(&Throne),
            #new_row=10,#new_col=20,#fine_row=32,#fine_col=32,#new_angle=ANGLE_SOUTH);
+
+      oNews = Send(SYS,@FindNewsByNum,#num=NID_TERRITORY_NEWS);
+      if oNews = $
+      {
+         oNews = Create(&TerritoryNews,#nid=NID_TERRITORY_NEWS);
+      }
+      Send(self,@NewHold,#what=oNews,#new_row=15,#new_col=16,
+         #fine_row=24,#fine_col=24,#new_angle=ANGLE_SOUTH_EAST);
+
       propagate;
    }
 

--- a/kod/object/active/holder/room/jasperrm/jastavrn.kod
+++ b/kod/object/active/holder/room/jasperrm/jastavrn.kod
@@ -20,9 +20,7 @@ resources:
    room_name_JasperTavern = "Pietro's Wicked Brews"
 
    jasbar_music = bar.mid
-   jastav_adv_icon = jbook.bgf
-   jastav_adv_name = "Tales of Adventure"
-   jastav_adv_desc = "Stories from the people of Meridian, collected by Bards"
+
 classvars:
 
    vrName = room_name_jaspertavern
@@ -50,9 +48,6 @@ messages:
 
       Send(self,@NewHold,#what=Create(&JasperBartender),
 	   #new_row=15,#new_col=6,#new_angle=ANGLE_NORTH);
-
-      oNews = Create(&Newslink,#nid=NID_ADVENTURE,#name=jastav_adv_name,#icon=jastav_adv_icon,#desc=jastav_adv_desc);
-      Send(self,@NewHold,#what=oNews,#new_row=16,#new_col=2,#fine_row=8,#fine_col=32,#new_angle = ANGLE_NORTH_EAST);
 
 % Stools N of Bar
       Send(self,@NewHold,#what=Create(&BarStool),
@@ -119,6 +114,9 @@ messages:
       Send(self,@NewHold,#what=Create(&Brazier),
 	   #new_row=10,#new_col=8,#fine_col=0,#fine_row=0);
 
+      oNews = Create(&TerritoryNewsLink,#nid=NID_TERRITORY_NEWS);
+      Send(self,@NewHold,#what=oNews,#new_row=16,#new_col=2,
+         #fine_row=8,#fine_col=32,#new_angle=ANGLE_NORTH_EAST);
 
       propagate;
    }

--- a/kod/object/active/holder/room/monsroom/castle2c.kod
+++ b/kod/object/active/holder/room/monsroom/castle2c.kod
@@ -56,6 +56,8 @@ messages:
 
    CreateStandardObjects()
    {
+      local oNews;
+      
       % throne
 
       Send(self,@NewHold,#what=Create(&PrincessGuard),
@@ -73,7 +75,12 @@ messages:
       Send(self,@NewHold,#what=Create(&Throne),
            #new_row=33,#new_col=23,#fine_col=48,#new_angle=ANGLE_NORTH);
 
-   propagate;
+
+      oNews = Create(&TerritoryNewsLink,#nid=NID_TERRITORY_NEWS);
+      Send(self,@NewHold,#what=oNews,#new_row=29,#new_col=19,
+         #fine_row=32,#fine_col=23,#new_angle=ANGLE_NORTH_EAST);
+
+      propagate;
    }
 
 

--- a/kod/object/passive/news/makefile
+++ b/kod/object/passive/news/makefile
@@ -5,6 +5,6 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\news.bof
-BOFS = newsanno.bof newsgld.bof newsjust.bof newsadv.bof GuildWarNews.bof
+BOFS = newsanno.bof newsgld.bof newsjust.bof newsadv.bof GuildWarNews.bof territorynews.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/news/territorynews.kod
+++ b/kod/object/passive/news/territorynews.kod
@@ -1,0 +1,38 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+TerritoryNews is News
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   territorynews_icon_rsc = jbook.bgf
+
+classvars:
+
+   vrIcon = territorynews_icon_rsc
+
+messages:
+
+   GetNewsPermission(what = $)
+   {
+      if (IsClass(what,&CorNothAmbassador) OR IsClass(what,&DM))
+      {
+         return NEWS_PERMISSION_READ_WRITE;
+      }
+
+      return NEWS_PERMISSION_READ;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/newslink/makefile
+++ b/kod/object/passive/newslink/makefile
@@ -1,0 +1,10 @@
+#
+# Makefile for compiling the Blakod
+#
+
+!include $(TOPDIR)\common.mak
+
+DEPEND = ..\newslink.bof
+BOFS = territorynewslink.bof
+
+!include $(KODDIR)\kod.mak

--- a/kod/object/passive/newslink/territorynewslink.kod
+++ b/kod/object/passive/newslink/territorynewslink.kod
@@ -1,0 +1,32 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+TerritoryNewsLink is NewsLink
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   territorynewslink_icon_rsc = jbook.bgf
+   territorynewslink_name_rsc = "Territory War Dispatches"
+   territorynewslink_desc_rsc = "Faction claims, battles, and city control across the territories."
+
+properties:
+
+   vrName = territorynewslink_name_rsc
+   vrDesc = territorynewslink_desc_rsc
+   vrIcon = territorynewslink_icon_rsc
+
+messages:
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/util/factgame/territry.kod
+++ b/kod/util/factgame/territry.kod
@@ -26,6 +26,7 @@ resources:
    TerritoryGame_rebel = "the rebel Jonas"
    TerritoryGame_unfactioned = "the unfactioned"
 
+   TerritoryGame_bonus_territory_title = "~I%s now %s the city of %s!"
    TerritoryGame_bonus_territory = "~IHaving claimed %q, %s now also %s the city of %s!"
    TerritoryGame_control = "control"
    TerritoryGame_controls = "controls"
@@ -39,6 +40,16 @@ resources:
    TerritoryGame_her = "her"
    TerritoryGame_his = "his"
    TerritoryGame_their = "their"
+
+   territory_string_title_1 = " now "
+   territory_string_title_2 = " "
+   territory_string_title_3 = "!"
+
+   territory_string_body_1 = "Having claimed "
+   territory_string_body_2 = ", "
+   territory_string_body_3 = " now also "
+   territory_string_body_4 = " the city of "
+   territory_string_body_5 = "!"
 
 properties:
 
@@ -585,7 +596,7 @@ messages:
 
    SendBonusTownMessage(faction=$,town=$)
    {
-      local i, sTowns, rFaction, rControls, rCity;
+      local i, sTowns, rFaction, rControls, rCity, oBook, territory_news_title, territory_news_body;
 
       sTowns = createString();
       clearTempString();
@@ -645,6 +656,33 @@ messages:
                #parm1=sTowns,#type1=STRING_RESOURCE,
                #parm2=rFaction,#parm3=rControls,#parm4=rCity);
       }
+
+      ClearTempString();
+      AppendTempString(rFaction); 
+      AppendTempString(territory_string_title_1); 
+      AppendTempString(rControls);
+      AppendTempString(territory_string_title_2); 
+      AppendTempString(rCity); 
+      AppendTempString(territory_string_title_3);
+      territory_news_title = CreateString(); 
+      SetString(territory_news_title, GetTempString());
+
+      ClearTempString();
+      AppendTempString(territory_string_body_1); 
+      AppendTempString(sTowns); 
+      AppendTempString(territory_string_body_2);
+      AppendTempString(rFaction); 
+      AppendTempString(territory_string_body_3); 
+      AppendTempString(rControls);
+      AppendTempString(territory_string_body_4); 
+      AppendTempString(rCity); 
+      AppendTempString(territory_string_body_5);
+      territory_news_body = CreateString(); 
+      SetString(territory_news_body, GetTempString());
+
+      % Post to the territory news
+      oBook = Send(SYS,@FindNewsByNum,#num=NID_TERRITORY_NEWS);
+      Send(oBook,@PostNews,#what=Create(&CorNothAmbassador),#title=territory_news_title,#body=territory_news_body);
 
       return;
    }

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -65,6 +65,16 @@ resources:
 
    system_admin_message = "%q"
 
+   faction_war_kill_title_1 = " bested by "
+   faction_war_kill_title_2 = "."
+   faction_war_kill_body_1 = " has been bested by faction rival "
+   faction_war_kill_body_2 = " during a land claim attempt"
+   faction_war_kill_body_3 = "."
+   faction_war_kill_body_4 = "\n--------------------------------"
+   faction_war_kill_body_5 = "\nLocation: "
+   faction_war_kill_body_6 = "\nFactions: "
+   faction_war_kill_body_7 = " vs "
+
    system_char_module = char.dll
 
    % charinfo stuff
@@ -1456,7 +1466,8 @@ messages:
    {
       local i, rMessage, oSoldierShield, oGuild, oKillerGuild,
             param2, param3, param4, param5, param6, param7, type5, type7,
-            war_string1, war_string2, oBook, oMaster;
+            war_string1, war_string2, oRoom, oFlag, oBook, oMaster, oParl, 
+            territory_news_title, territory_news_body, rVicFaction, rKilFaction;
 
       if IsClass(what,&Guest)
          OR (killer = $)
@@ -1551,6 +1562,59 @@ messages:
                {
                   rMessage = system_user_killed_shield;
                   % Parameters set by default
+
+                  ClearTempString();
+                  AppendTempString(Send(what,@GetTrueName));
+                  AppendTempString(faction_war_kill_title_1);
+                  AppendTempString(Send(killer,@GetTrueName));
+                  AppendTempString(faction_war_kill_title_2);
+                  territory_news_title = CreateString();
+                  SetString(territory_news_title, GetTempString());
+
+                  ClearTempString();
+                  AppendTempString(Send(what,@GetTrueName));
+                  AppendTempString(faction_war_kill_body_1);
+                  AppendTempString(Send(killer,@GetTrueName));
+
+                  oRoom = Send(what,@GetOwner);
+                  oParl = Send(SYS,@GetParliament);
+                  oFlag = Send(oRoom,@FindHoldingActive,#class=&Flagpole);
+
+                  if (oFlag <> $ AND Send(oFlag,@IsClaimAttemptInProgress))
+                  {
+                     AppendTempString(faction_war_kill_body_2);
+                  } 
+
+                  AppendTempString(faction_war_kill_body_3);
+                  AppendTempString(faction_war_kill_body_4);
+                                    
+                  if (oParl <> $)
+                  {
+                     rVicFaction = Send(oParl,@GetFactionLiegeName,#faction=Send(what,@GetFaction));
+                     rKilFaction = Send(oParl,@GetFactionLiegeName,#faction=Send(killer,@GetFaction));
+                  }
+
+                  if (oRoom <> $)
+                  {
+                     AppendTempString(faction_war_kill_body_5);
+                     AppendTempString(Send(oRoom,@GetName));
+                  }
+
+                  if (rVicFaction <> $ AND rKilFaction <> $)
+                  {
+                     AppendTempString(faction_war_kill_body_6);
+                     AppendTempString(rVicFaction);
+                     AppendTempString(faction_war_kill_body_7);
+                     AppendTempString(rKilFaction);
+                  }
+
+                  territory_news_body = CreateString();
+                  SetString(territory_news_body, GetTempString());
+
+                  % Post to the territory news
+                  oBook = Send(SYS,@FindNewsByNum,#num=NID_TERRITORY_NEWS);
+                  Send(oBook,@PostNews,#what=Create(&CorNothAmbassador),#title=territory_news_title,      
+                     #body=territory_news_body);
                }
 
                % A guild war?


### PR DESCRIPTION
This PR adds territory and faction war ledgers that record and displays war updates. Currently, these updates are only visible to players who are online. These new ledgers are located in the Duke and Princess' throne rooms, and the Jasper Tavern. The ledgers record player soldier vs. player soldier kills and major land claims (i.e. claiming a town). These posts are authored by Baron Gerah Springer, who I opted to create a class for in the hopes of future expansion -- happy to dial back if that's too much.

### Notes
* This PR removes resources in `jastavnr.kod`. The resources were for a Bard's newsglobe that isn't present on 101. There is at least one other instance of it on 101 though, in the Marion adventurers hall.

### Screenshots
<img width="604" height="424" alt="image" src="https://github.com/user-attachments/assets/32abe8a1-a23b-46f8-ae1e-ab37b642aace" />
<img width="604" height="424" alt="image" src="https://github.com/user-attachments/assets/64560a18-c608-4d15-99ce-846be0b64da4" />
<img width="604" height="424" alt="image" src="https://github.com/user-attachments/assets/a830ca67-49aa-4183-95b3-c19b7b568429" />


Related: #701 