### PR TITLE
fix: Stores enchantment timers in proper format when player is offline

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -2722,15 +2722,24 @@ messages:
       {
          oTimer = $;
       }
-      else 
+      else
       {
-         if lastcall
+         if NOT Send(self,@IsLoggedOn)
          {
-            oTimer = CreateTimer(self,@EnchantmentTimer,time);
+            % Player is offline. Store time in frozen integer format.
+            oTimer = time;
          }
          else
          {
-            oTimer = CreateTimer(self,@PeriodicEnchantmentTimer,time);
+            % Player is online. Create a timer.
+            if lastcall
+            {
+               oTimer = CreateTimer(self,@EnchantmentTimer,time);
+            }
+            else
+            {
+               oTimer = CreateTimer(self,@PeriodicEnchantmentTimer,time);
+            }
          }
       }
 


### PR DESCRIPTION
This PR adds a logged-in check when starting a personal enchantment. If the player is offline, the enchantment timer is stored in the same integer format used for offline (frozen) enchantments. Previously, no such check existed, and starting certain enchantments (e.g., Hunt) on an offline player would store a Timer instead of an integer, causing the enchantment to eventually "break" when `ReactivateAllEnchantments` is called.

Related: #807, #1096  