### PR TITLE
gameplay: Modifies Hunt PE reactivation to hide icon, show message to target

### DIFF
--- a/kod/object/passive/spell/multicst/hunt.kod
+++ b/kod/object/passive/spell/multicst/hunt.kod
@@ -225,6 +225,17 @@ messages:
       return FALSE;
    }
 
+   RestartEnchantmentEffect(who=$, state=$)
+   {
+      Send(who,@MsgSendUser,#message_rsc=hunt_gain_trackers);
+
+      return;
+   }
+
+   ShowEnchantmentIcon(type=$)
+   {
+      return FALSE;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This PR updates Hunt so that when the effect reactivates (e.g., when a player logs on), the PE icon is not drawn and the target is notified. Previously, Hunt could activate on a target without a PE icon (consistent with #addicon=FALSE), but on reactivation the icon would incorrectly appear.

* The PE icon will no longer be drawn on reactivation.
* The target player will instead receive the same notification they get when first hit with Hunt.

One caveat: if a player is the target of multiple hunts, the notification will be shown multiple times. Since Hunt is the only spell of this nature, this should be a rare enough edge case to not require special handling. Happy to explore a solution to this if we deem it necessary.

Note: Hunt is currently disabled.