### PR TITLE
Apply hierarchical sort to buy & withdraw lists for consistent UX

### DIFF
--- a/clientd3d/buy.c
+++ b/clientd3d/buy.c
@@ -464,9 +464,15 @@ BOOL CostListDrawItem(const DRAWITEMSTRUCT *lpdis)
  */
 void BuyList(object_node seller, list_type items)
 {
+   list_type sorted_list, l;
    BuyDialogStruct dlg_info;
+   sorted_list = NULL;
 
-   dlg_info.items = items;
+   // Separate contents into number items and other items and alpha sort
+   for (l = items; l != NULL; l = l->next)
+      sorted_list = list_add_sorted_item(sorted_list, (l->data), CompareObjectNameAndNumber);
+   
+   dlg_info.items = sorted_list;
    dlg_info.seller_id = seller.id;
    dlg_info.seller_name = seller.name_res;
    dlg_info.cost = 0;
@@ -475,6 +481,7 @@ void BuyList(object_node seller, list_type items)
       /* Give user list of things to select from */
       SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_BUY), hMain, BuyDialogProc, (LPARAM) &dlg_info);
 
+   list_delete(sorted_list);
    ObjectListDestroy(items);
 }
 /*****************************************************************************/
@@ -486,9 +493,15 @@ void BuyList(object_node seller, list_type items)
  */
 void WithdrawalList(object_node seller, list_type items)
 {
+   list_type sorted_list, l;
    BuyDialogStruct dlg_info;
+   sorted_list = NULL;
 
-   dlg_info.items = items;
+   // Separate contents into number items and other items and alpha sort
+   for (l = items; l != NULL; l = l->next)
+      sorted_list = list_add_sorted_item(sorted_list, (l->data), CompareObjectNameAndNumber);
+   
+   dlg_info.items = sorted_list;
    dlg_info.seller_id = seller.id;
    dlg_info.seller_name = seller.name_res;
    dlg_info.cost = 0;
@@ -497,5 +510,6 @@ void WithdrawalList(object_node seller, list_type items)
       /* Give user list of things to select from */
       SafeDialogBoxParam(hInst, MAKEINTRESOURCE(IDD_WITHDRAWAL), hMain, WithdrawalDialogProc, (LPARAM) &dlg_info);
 
+   list_delete(sorted_list);
    ObjectListDestroy(items);
 }


### PR DESCRIPTION
The changes made in [#565](https://github.com/Meridian59/Meridian59/pull/565) have made organization in rooms and guild halls a far smoother experience - this PR applies the same hierarchical sort to the 'buy' and 'withdraw' boxes so it can be enjoyed by those who frequent vault-men and NPC merchants alike. 

Code-wise the changes are very straight-forward; it applies the algorithm introduced by @CardiovascularMike in #565 > `GotObjectContents`.

This PR was tested on every NPC willing to make sales in Barloque, as well as Obert with both the 'buy' and 'withdraw' commands.

