### PR TITLE
Roll back #1144 as it was losing R admin parameters

### DIFF
--- a/blakserv/adminfn.c
+++ b/blakserv/adminfn.c
@@ -789,7 +789,6 @@ void AdminTable(int len_command_table,admin_table_type command_table[],int sessi
 	}
 
 	/* check parameters */
-
 	for (i=0;i<MAX_ADMIN_PARM;i++)
 	{
 		if (command_table[index].parm_type[i] == N)
@@ -827,13 +826,9 @@ void AdminTable(int len_command_table,admin_table_type command_table[],int sessi
 			admin_parm[i] = (admin_parm_type)num;
 			break;
 		case R :
-			// Don't go off end of string if parameter is missing
-      if (prev_tok + strlen(prev_tok) >= command + strlen(command))
-      {
-        admin_parm[i] = (admin_parm_type) (command + strlen(command));
-      } else {
-        admin_parm[i] = (admin_parm_type) (prev_tok + strlen(prev_tok) + 1);
-      }
+      /* remember how strtok works to see why this works */
+      admin_parm[i] = (admin_parm_type) (prev_tok + strlen(prev_tok) + 1);
+
 			/* now make sure no more params */
 			prev_tok = NULL;
 			break;


### PR DESCRIPTION
This proposed fix doesn't work given what strtok does. Ideally we would use std::string instead of strtok for argument parsing.