### PR TITLE
fix: Removes duplicate `plReflections` list deletion causing log error

### DIFF
--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -1004,8 +1004,6 @@ messages:
                Send(j,@Delete);
             }
 
-            plReflections = DelListElem(plReflections,i);
-
             break;
          }
       }


### PR DESCRIPTION
This PR removes an unnecessary `DelListElem` call leading to a log error. The issue is that the individual reflection `Delete` call above handles the updating of `plReflections`, so the list has already been manipulated by the time we reach the modified line here.

This can be reproduced by creating a reflection, moving to another room, then logging off.

### Relevant log errors
```
Sep 04 2025 02:51:50 | [memmap/reflectn.bof (131)] C_SendMessage OBJECT 1299596 CLASS Reflection can't send MESSAGE GetDef (10071) to non-object 0,0
Sep 04 2025 02:51:50 | [memmap/reflectn.bof (126)] C_SendMessage OBJECT 1299596 CLASS Reflection can't send MESSAGE getname (10040) to non-object 0,0
Sep 04 2025 02:52:06 | [memmap/system.bof (1009)] C_DelListElem object 0 can't delete elem from non-list 0,0
```