### PR TITLE
fix: persist object coordinates when moving to new room

### DIFF
--- a/kod/util.kod
+++ b/kod/util.kod
@@ -25,7 +25,7 @@ messages:
    "Places <what> up to <max_distance> squares away from <new_row>,<new_col>."
    "If <new_angle> = $ and moving in a room, old angle is preserved."
    {
-      local distance,i,j,row,col,calc_max_dist,room_rows,room_cols;
+      local distance,i,j,row,col,room_rows,room_cols;
 
       if what = $ OR where = $ OR new_row = $ OR new_col = $
       {
@@ -42,19 +42,8 @@ messages:
       }
 
       % calculate max distance that's still in room (could be tighter)
-      calc_max_dist = max_distance;
       room_rows = Send(where,@GetRoomRows);
       room_cols = Send(where,@GetRoomCols);
-
-      if calc_max_dist > room_rows
-      {
-         calc_max_dist = room_rows;
-      }
-
-      if calc_max_dist > room_cols
-      {
-         calc_max_dist = room_cols;
-      }
 
       distance = 0;
       while distance <= max_distance
@@ -163,6 +152,9 @@ messages:
                   Send(where,@NewHold,#what=what,#new_row=new_row,#new_col=new_col,
                        #fine_row=fine_row,#fine_col=fine_col);
                }
+
+               % Notify the room that this *new* object has moved in
+               Send(where,@SomethingMoved,#what=what,#new_row=new_row,#new_col=new_col,#fine_row=fine_row,#fine_col=fine_col);
             }
 
             return TRUE;


### PR DESCRIPTION
This PR adds a `SomethingChanged` call when players land in a new room. Without it, coordinates don’t update correctly, so if a player logs out and back in before moving, they can respawn in the wrong spot.

You can reproduce this by using the UW portal: teleport through, don’t move, log off, and log back in—you’ll appear at the UW portal’s coordinates. The same issue occurs with the Raza portal and likely in other cases where objects, including players, are teleported into a new room.

I also removed an unused variable, `calc_max_dist`.

Credit to @cyberjunk for catching this [many years earlier](https://github.com/OpenMeridian/Meridian59/commit/a5a958d9d76866703a69c8ab2807a9658d5d0e9f). I happened to stumble across their solution, which verified my thinking, and offered up the unused variable cleanup as well.