### PR TITLE
Restore the scrolls that were removed from the game

### DIFF
--- a/kod/object/passive/trestype/skel4t.kod
+++ b/kod/object/passive/trestype/skel4t.kod
@@ -31,7 +31,7 @@ messages:
    
    constructed()
    {
-      plTreasure = [ [ &BlueMushroom, 25 ],
+      plTreasure = [ [ &BlueMushroom, 23 ],
                      [ &BlueDragonScale, 10 ],
                      [ &SilverArrow, 10 ],
                      [ &DarkAngelFeather, 10 ],
@@ -40,6 +40,8 @@ messages:
                      [ &Diamond,  8 ],					 
                      [ &Money, 7 ],
                      [ &InkyCap, 5 ],
+                     [ &SummonPoisonFogScroll, 1 ],
+                     [ &WindScroll, 1 ],
                      [ &KillingFieldScroll, 1 ],
                      [ &Circlet, 1 ],
                      [ &DementWand, 1 ],


### PR DESCRIPTION
Poison Fog and Winds scrolls were (I assume accidentally) removed from the game with the latest treasure type changes that were intended to lower 'clutter'. While the Poison Fog scroll isn't widely used, Winds scrolls are a combat staple, and Daemon skeletons were the only source.