### PR TITLE
client: Disable middle and right mouse buttons for text area resizing

### DIFF
--- a/clientd3d/statgame.c
+++ b/clientd3d/statgame.c
@@ -212,7 +212,7 @@ void GameMouseButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT keyFla
 
    SetFocus(hMain);
 
-   if (text_area_resize_zone) {
+   if (text_area_resize_zone && keyFlags & MK_LBUTTON) {
        // Start text area resize.
        text_area_resize_inprogress = true;
        previous_mouse_position = { x,y };


### PR DESCRIPTION
This PR restricts support for text/chat area resizing to the left mouse button only. Previously, the middle and right mouse buttons were supported but are buttons that don’t have corresponding “up” handlers, which can lead to a frustrating user experience (see #1224).

Closes #1224