### PR TITLE
fix: Correct logoff penalty calculation by using absolute value

### DIFF
--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -381,7 +381,7 @@ messages:
          }
 
          iLoops = 0;
-         LossCounter = LossCounter - (numSpellPointsLost/BaseLossAmount);
+         LossCounter = LossCounter - (numSpellPointsLost/Abs(BaseLossAmount));
          while (LossCounter > 0) and (iLoops < 200)
          {
             iLoops = iLoops + 1;
@@ -457,7 +457,7 @@ messages:
          }
 
          iLoops = 0;
-         LossCounter = LossCounter - (numSkillPointsLost/BaseLossAmount);
+         LossCounter = LossCounter - (numSkillPointsLost/Abs(BaseLossAmount));
          while LossCounter > 0 AND iLoops < 100
          {
             iLoops = iLoops + 1;


### PR DESCRIPTION
Fixed bug where BaseLossAmount division was amplifying penalties instead of reducing them. Since BaseLossAmount is negative (-2 for murderers, -1 for non-murderers), dividing by it was inverting the math. Now using Abs(BaseLossAmount) for both spell and skill penalty calculations.