### PR TITLE
Remove problematic Line of Sight check for wall elements

### DIFF
--- a/kod/object/active/wallelem.kod
+++ b/kod/object/active/wallelem.kod
@@ -260,7 +260,6 @@ messages:
 
          if (iLongRange = piRange
              OR iDistanceSquared <= (piRange * piRange))
-            AND send(poOwner,@LineOfSight,#obj1=self,#obj2=what)
          {
             return TRUE;
          }


### PR DESCRIPTION
Wall elements currently require Line of Sight to affect targets, which is a notoriously buggy check that essentially renders wall spells useless anywhere near walls. Considering the extremely short range on wall elements (essentially requiring you to stand in them or run through them), this doesn't really make sense. If you're standing in a wall of fire, you should be getting burned. This longstanding bug has resulted in an enormous number of cheating accusations and arguments, as players do indeed 'run right through' each other's webs, spores, and firewalls on an unpredictable basis.