### PR TITLE
fix: self-delete orphaned wall elements in `PeriodicEffect`

### DIFF
--- a/kod/object/active/wallelem.kod
+++ b/kod/object/active/wallelem.kod
@@ -199,6 +199,13 @@ messages:
 
       if vbPeriodic
       {
+         %% self-delete orphaned wall elements
+         if poOwner = $ OR NOT IsClass(poOwner,&Room)
+         {
+            Post(self, @Delete);
+            return;
+         }
+
          for i in send(poOwner,@GetHolderActive)
          {
             oObject = send(poOwner,@HolderExtractobject,#data=i);

--- a/kod/object/active/wallelem.kod
+++ b/kod/object/active/wallelem.kod
@@ -202,7 +202,7 @@ messages:
          %% self-delete orphaned wall elements
          if poOwner = $ OR NOT IsClass(poOwner,&Room)
          {
-            Post(self, @Delete);
+            Post(self,@Delete);
             return;
          }
 


### PR DESCRIPTION
## What
- adds a high level guard in `ActiveWallElement`'s `PeriodicEffect` to self-delete a wall element if it is orphaned (i.e., has no valid room owner)

## Why
- prevents error spam caused by orphaned wall elements attempting to access their owner after failed placement or room deletion
- ensures all wall element types inheriting from `ActiveWallElement` are robust against this issue

## Notes
- fixes #1232
  - complements other fix https://github.com/Meridian59/Meridian59/commit/eab11f5a70445922fa26ac82e6cf613ae5d0cdcb
- this fix is in [`wallelem.kod`]https://github.com/Meridian59/Meridian59/blob/master/kod/object/active/wallelem.kod) so all child wall spells benefit automatically 
  - [bramble.kod](https://github.com/Meridian59/Meridian59/blob/master/kod/object/active/holder/nomoveon/battler/monster/BRAMBLE.kod) as a "monster"  is a special case but it seems ok
