### PR TITLE
fix: address Windows blakserv dialog crashes

### DIFF
--- a/blakserv/chanbuf.h
+++ b/blakserv/chanbuf.h
@@ -15,7 +15,7 @@
 
 enum
 {
-   CHANBUF_SIZE = 2000
+   CHANBUF_SIZE = 1000
 };
 
 typedef struct

--- a/blakserv/chanbuf.h
+++ b/blakserv/chanbuf.h
@@ -15,7 +15,7 @@
 
 enum
 {
-   CHANBUF_SIZE = 1000
+   CHANBUF_SIZE = 2000
 };
 
 typedef struct

--- a/blakserv/interface.c
+++ b/blakserv/interface.c
@@ -1159,7 +1159,7 @@ INT_PTR CALLBACK InterfaceDialogTabPage(HWND hwnd,UINT message,WPARAM wParam,LPA
 
 void InterfaceTabPageCommand(HWND hwnd,int id, HWND hwndCtl, UINT codeNotify)
 {
-	char s[2000];
+	char s[CHANBUF_SIZE];
 	
 	switch (codeNotify)
 	{

--- a/blakserv/interface.c
+++ b/blakserv/interface.c
@@ -1159,7 +1159,7 @@ INT_PTR CALLBACK InterfaceDialogTabPage(HWND hwnd,UINT message,WPARAM wParam,LPA
 
 void InterfaceTabPageCommand(HWND hwnd,int id, HWND hwndCtl, UINT codeNotify)
 {
-	char s[400];
+	char s[2000];
 	
 	switch (codeNotify)
 	{

--- a/blakserv/interface.c
+++ b/blakserv/interface.c
@@ -1159,7 +1159,7 @@ INT_PTR CALLBACK InterfaceDialogTabPage(HWND hwnd,UINT message,WPARAM wParam,LPA
 
 void InterfaceTabPageCommand(HWND hwnd,int id, HWND hwndCtl, UINT codeNotify)
 {
-	char s[2000];
+	char s[400];
 	
 	switch (codeNotify)
 	{

--- a/blakserv/interface.c
+++ b/blakserv/interface.c
@@ -1167,19 +1167,19 @@ void InterfaceTabPageCommand(HWND hwnd,int id, HWND hwndCtl, UINT codeNotify)
 		if (id == IDC_LOG_LIST || id == IDC_ERROR_LIST || id == IDC_DEBUG_LIST)
 		{
 			int sel = ListBox_GetCurSel(hwndCtl);
-            if (sel == LB_ERR)  // nothing selected
-                return;
+			if (sel == LB_ERR)  // nothing selected
+				return;
 
-            int len = ListBox_GetTextLen(hwndCtl, sel);
-            if (len == LB_ERR)  // couldn’t get length
-                return;
+			int len = ListBox_GetTextLen(hwndCtl, sel);
+			if (len == LB_ERR)  // couldn’t get length
+				return;
 			
-			if (len > 0 && len < sizeof(s))
-            {
+			if (len < (int)sizeof(s))
+			{
 				ListBox_GetText(hwndCtl, sel, s);
-        		ShowCopyableMessageDialog(hwndMain, s);
+				ShowCopyableMessageDialog(hwndMain, s);
 			}
-			else if (len >= sizeof(s))
+			else
 			{
 				char warning[200];
 				snprintf(warning, sizeof(warning), 
@@ -1187,8 +1187,8 @@ void InterfaceTabPageCommand(HWND hwnd,int id, HWND hwndCtl, UINT codeNotify)
 					"Maximum supported: %zu characters.", len, sizeof(s)-1);
 				ShowCopyableMessageDialog(hwndMain, warning);
 			}
-			break;
 		}
+		break;
 	}
 }
 

--- a/blakserv/interface.c
+++ b/blakserv/interface.c
@@ -1166,10 +1166,29 @@ void InterfaceTabPageCommand(HWND hwnd,int id, HWND hwndCtl, UINT codeNotify)
 	case LBN_DBLCLK :
 		if (id == IDC_LOG_LIST || id == IDC_ERROR_LIST || id == IDC_DEBUG_LIST)
 		{
-			ListBox_GetText(hwndCtl,ListBox_GetCurSel(hwndCtl),s);
-        	ShowCopyableMessageDialog(hwndMain, s);
+			int sel = ListBox_GetCurSel(hwndCtl);
+            if (sel == LB_ERR)  // nothing selected
+                return;
+
+            int len = ListBox_GetTextLen(hwndCtl, sel);
+            if (len == LB_ERR)  // couldn’t get length
+                return;
+			
+			if (len > 0 && len < sizeof(s))
+            {
+				ListBox_GetText(hwndCtl, sel, s);
+        		ShowCopyableMessageDialog(hwndMain, s);
+			}
+			else if (len >= sizeof(s))
+			{
+				char warning[200];
+				snprintf(warning, sizeof(warning), 
+					"Debug message too long to display (%d characters).\n"
+					"Maximum supported: %zu characters.", len, sizeof(s)-1);
+				ShowCopyableMessageDialog(hwndMain, warning);
+			}
+			break;
 		}
-		break;
 	}
 }
 

--- a/blakserv/interface.c
+++ b/blakserv/interface.c
@@ -1171,7 +1171,7 @@ void InterfaceTabPageCommand(HWND hwnd,int id, HWND hwndCtl, UINT codeNotify)
 				return;
 
 			int len = ListBox_GetTextLen(hwndCtl, sel);
-			if (len == LB_ERR)  // couldn’t get length
+			if (len == LB_ERR)
 				return;
 			
 			if (len < (int)sizeof(s))


### PR DESCRIPTION
## What
- adds safety checks when displaying `listbox` item text to prevent stack overflow and handle invalid selections
- increases interface buffer size by using established channel constant `CHANBUF_SIZE`
- fixes #1258

## Why
- previously, the function directly called `ListBox_GetText` with the result of `ListBox_GetCurSel` without error checking
  - this could cause buffer overflow on very long messages or undefined behavior if no item was selected
  - the changed version validates the selection index and ensures the retrieved text length fits safely within the buffer
- changed static 400 byte interface buffer size to use `channel.c`  constant `CHANBUF_SIZE` (currently 1000 bytes)

## Notes
- added `LB_ERR` checks for `ListBox_GetCurSel` and `ListBox_GetTextLen`
- displays a warning dialog if a message exceeds the supported buffer size

## Example
### Before
https://github.com/user-attachments/assets/17385931-b2ae-4c92-a394-1e2026c01bba

### After
https://github.com/user-attachments/assets/49789734-efff-4101-a856-13b3fbb268ee

