### PR TITLE
Nerudite Sword damage types fix

### DIFF
--- a/kod/object/active/holder/room/temple.kod
+++ b/kod/object/active/holder/room/temple.kod
@@ -26,6 +26,8 @@ resources:
    temple_close = "Close"
 
    temple_music = temple.mid
+   
+   item_cleansed_in_pool = "The sacred waters of Shal'ille glimmer briefly."
 
 classvars:
 
@@ -69,9 +71,51 @@ messages:
          }
       }
       
+      if new_row >= 8 AND new_row <= 11
+         AND new_col >= 11 AND new_col <= 13
+         AND what <> $
+         AND IsClass(what,&Item)
+      {
+         Send(self,@ItemDroppedInSacredPool,#what=what);
+      }
+      
       propagate;
    }
    
+   ItemDroppedInSacredPool(what=$)
+   {
+      local i, oItemAtt, iNum, oPlayer;
+
+      % Fix Nerudite swords with incorrect type flags
+      if IsClass(what,&NeruditeSword)
+      {
+         % Ensure Kraanan enchantment is gone
+         for i in Send(what,@GetItemAttributes)
+         {
+             iNum = Send(what,@GetNumFromCompound,#compound=First(i));
+             
+             if iNum = WA_ENCHANTED
+             {
+                oItemAtt = Send(SYS,@FindItemAttByNum,#num=iNum);
+                Send(oItemAtt,@RemoveFromItem,#oItem=what);
+             }
+         }
+         
+         % Now remove any lingering ATCK_WEAP_MAGIC or ATCK_WEAP_NONMAGIC flags
+         Send(what,@SetTypeFlag,#flag=ATCK_WEAP_MAGIC,#value=FALSE);
+         Send(what,@SetTypeFlag,#flag=ATCK_WEAP_NONMAGIC,#value=FALSE);
+         
+         oPlayer = Send(what,@GetOwner);
+         if oPlayer <> $
+            AND IsClass(oPlayer,&Player)
+         {
+            Send(oPlayer,@MsgSendUser,#message_rsc=item_cleansed_in_pool);
+         }
+      }
+
+      return;
+   }
+
    LeaveHold(what=$)
    {
       if isClass(what,&Scepter)

--- a/kod/object/item/passitem/weapon/neruswd.kod
+++ b/kod/object/item/passitem/weapon/neruswd.kod
@@ -90,6 +90,16 @@ messages:
       propagate;
    }
 
+   CanEnchant(oSpell = $)
+   "Nerudite swords cannot be enchanted to Kraanan."
+   {
+      if Send(oSpell,@GetSpellNum) = SID_ENCHANT_WEAPON
+      {
+         return FALSE;
+      }
+
+      propagate;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
At some point Nerudite Swords were made enchantable by dedications, but this also included Kraanan Enchantments, which use damage type flags rather than spell type additions. Nerudite Swords do not naturally have ATCK_WEAP_NONMAGIC or ATCK_WEAP_MAGIC flags.

Enchanting them to Kraanan adds an ATCK_WEAP_MAGIC flag, then leaves them with a permanent ATCK_WEAP_NONMAGIC flag when it wears off, indefinitely 'bugging' the nerudite sword - it makes the weapon quite a bit worse against monsters. The resistances of mobs were definitely not designed with weapons that were both nerudite and magic/nonmagic in mind, so the results are confusing. The age-old "Uhh my neru's not working" mind-boggle. It's an invisible problem that simply couldn't be figured out from in-game information.

In this pull, I've blocked Nerudite Swords from being enchanted to Kraanan. There are no currently situations where an ATCK_WEAP_MAGIC flag improves a nerudite sword's performance against a monster, I believe. It's purely a negative. And when it becomes ATCK_WEAP_NONMAGIC, it's even worse - so this shouldn't affect balance or player behavior. Kraanan enchantments also do not have any effect on PvP, so there's no problem there.

Over the years, I have found numerous examples in-game of Nerudite Swords with lingering ATCK_WEAP_MAGIC and ATCK_WEAP_NONMAGIC flags. So, I added an effect to the pool of water in the Shal'ille temple - if you want to fix your bugged Nerudite Sword, you can drop it in the water there, and it will remove any existing Kraanan enchantment (which will persist for a few days after a patch) and any lingering incorrect flags. If you don't want to do this, no problem, just keep it as is. (since some people swear by their Kraanan enchantments...) If you do cleanse it, a neat little message will inform you something happened.