### PR TITLE
feat: add improvement cap prompts when player hits cap

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -705,6 +705,19 @@ resources:
    player_logged_on_wav_rsc = player_login_or_out.wav
    player_logged_off_wav_rsc = player_logout2.wav
    
+
+   player_advancement_cap_hit_1 = \
+      "~IYou feel like you've practiced all you can in this location.  "
+      "Perhaps a change of scenery would help refresh your mind."
+
+   player_advancement_cap_hit_2 = \
+      "~IYour training seems to have stagnated here. Moving to a different "
+      "area might allow you to continue improving your abilities."
+
+   player_advancement_cap_hit_3 = \
+      "~IYou sense that this place holds no more lessons for you right now.  "
+      "Exploring other locations could renew your capacity for learning."
+
 classvars:
 
    viHand_space = 2
@@ -7491,9 +7504,31 @@ messages:
    CheckAdvancementPoints()
    "Checks to be sure a player isn't at the limit yet."
    {
+      local iMessage;
+
       if piAdvancement_points < ADVANCEMENT_LIMIT
       {
          return TRUE;
+      }
+
+      % Player has hit the advancement cap.  Show educational message occasionally
+      % about moving to different rooms to continue practicing (12.5% chance).
+      if Random(1,8) = 1
+      {
+         iMessage = Random(1,3);
+         
+         if iMessage = 1
+         {
+            Send(self,@MsgSendUser,#message_rsc=player_advancement_cap_hit_1);
+         }
+         if iMessage = 2
+         {
+            Send(self,@MsgSendUser,#message_rsc=player_advancement_cap_hit_2);
+         }
+         if iMessage = 3
+         {
+            Send(self,@MsgSendUser,#message_rsc=player_advancement_cap_hit_3);
+         }
       }
       
       return FALSE;


### PR DESCRIPTION
## What
- adds educational messages to prompt players to change rooms when they hit the current room advancement cap for skills and spells
- this change provides informational messages only and leaves the improvement system and caps as they are

## Why
- players currently hit the 10-point advancement limit and continue casting spells/practicing skills without knowing why they can't improve, wasting reagents and money for 15-22 minutes until the timer resets
- the existing anti-botting system reduces advancement points by 2 when players change rooms, but this mechanic is hidden from players, leading to frustration and resource waste
  - many veteran players DO know about this dynamic and have an advantage over those that don't; it's an open secret
- the intent of the advancement limit was to prompt players to go out into the world and not bot in one room, but without messages to tell the player that, it's unlikely they will

## Expected Impact
- reduces player frustration and resource waste
- educates players about intended game mechanics
- preserves anti-botting functionality while improving user experience

## Notes
- modified `CheckAdvancementPoints()` in `player.kod` to show educational messages when players hit the advancement cap and could have improved (if they didn't hit the limit)
- added 12.5% chance for message display to avoid spam and making it too accurate while ensuring players learn the mechanic within ~8 attempts of possible improvements
- added 3x varied message resources) to prevent repetitive messaging
   - >You feel like you've practiced all you can in this location.  Perhaps a change of scenery would help refresh your mind.
   - >Your training seems to have stagnated here.  Moving to a different area might allow you to continue improving your abilities.
   - >You sense that this place holds no more lessons for you right now.  Exploring other locations could renew your capacity for learning.
- messages only trigger for improvable spells/skills rolls when they could have possibly improved
  - the existing spell/skill systems in `skill.kod` and `spell.kod` already check for max ability (≥99%) before calling `CheckAdvancementPoints()`

## Example
<img width="905" height="206" alt="image" src="https://github.com/user-attachments/assets/42f2328b-533d-4b06-8194-6c3080013422" />
