### PR TITLE
feat: improve item description formatting and misdirection display

### DIFF
--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -220,46 +220,76 @@ messages:
       return;
    }
 
-   CreateDesc(bShowall=FALSE)
+   CreateDesc(bShowAll=FALSE)
+   "Creates the item's full description text by combining the base description "
+   "with attribute descriptions and condition information. When bShowAll is FALSE, "
+   "unidentified attributes show a generic message and misdirection attributes "
+   "display their fake descriptions alongside real attributes. When bShowAll is "
+   "TRUE, all attributes including misdirection are revealed. The description "
+   "uses proper formatting with line breaks separating the base description, "
+   "attributes section, and condition information."
    {
-      local bAlreadyBlind, bIdentified, oItemAtt, i, iNum;
+      local bAlreadyBlind, bFirstAttribute, bIdentified, oItemAtt, i, iNum;
 
       bAlreadyBlind = FALSE;
+      bFirstAttribute = TRUE;
       ClearTempString();
       Send(self,@DoBaseDesc);
 
-      if Send(self,@HasAttribute,#ItemAtt=IA_MISDIRECTION) AND NOT bShowAll
+      % Add line break before attributes if any exist
+      if plItem_Attributes <> $
       {
-         oItemAtt = Send(SYS,@FindItemAttByNum,#num=IA_MISDIRECTION);
-         Send(oItemAtt,@AppendMisdirectedDesc,#oItem=self,
-              #lData=Send(self,@GetAttributeData,#ItemAtt=IA_MISDIRECTION));
+         AppendTempString("\n\n");
       }
-      else
-      {
-         for i in plItem_Attributes
-         {
-            iNum = Send(self,@GetNumFromCompound,#compound=First(i));
-            oItemAtt = Send(SYS,@FindItemAttByNum,#num=iNum);
-            bIdentified = Send(self,@GetIDStatusFromCompound,
-                               #compound=First(i));
 
-            if NOT (bIdentified OR bShowAll)
+      for i in plItem_Attributes
+      {
+         iNum = Send(self,@GetNumFromCompound,#compound=First(i));
+
+         % Misdirection: show fake attribute even if real one is hidden
+         if iNum = IA_MISDIRECTION AND NOT bShowAll
+         {
+            % But we still want to show the fake attribute it creates
+            oItemAtt = Send(SYS,@FindItemAttByNum,#num=IA_MISDIRECTION);
+            if NOT bFirstAttribute
             {
-               if bAlreadyBlind
-               {
-                  continue;
-               }
-               else
-               {
-                  AppendTempString(itematt_generic);
-                  bAlreadyBlind = TRUE;
-               }
+               AppendTempString("  ");
             }
-            else
+            Send(oItemAtt,@AppendMisdirectedDesc,
+               #oItem=self,
+               #lData=Send(self,@GetAttributeData,#ItemAtt=IA_MISDIRECTION));
+            bFirstAttribute = FALSE;
+            continue;
+         }
+
+         oItemAtt = Send(SYS,@FindItemAttByNum,#num=iNum);
+         bIdentified = Send(self,@GetIDStatusFromCompound,#compound=First(i));
+
+         % Handle unidentified attributes - show generic message once, then skip others
+         if NOT (bIdentified OR bShowAll)
+         {
+            if NOT bAlreadyBlind
             {
-               Send(oItemAtt,@AppendDesc,#oItem=self,#lData=i);
+               if NOT bFirstAttribute
+               {
+                  AppendTempString("  ");
+               }
+               AppendTempString(itematt_generic);
+               bFirstAttribute = FALSE;
+               bAlreadyBlind = TRUE;
             }
-         }       
+            continue;
+         }
+         else
+         {
+            % Add spacing and append actual attribute description
+            if NOT bFirstAttribute
+            {
+               AppendTempString("  ");
+            }
+            Send(oItemAtt,@AppendDesc,#oItem=self,#lData=i);
+            bFirstAttribute = FALSE;
+         }
       }
 
       % Special things for number items, etc.

--- a/kod/object/passive/itematt/iadurabl.kod
+++ b/kod/object/passive/itematt/iadurabl.kod
@@ -38,7 +38,7 @@ resources:
  
    itematt_durable_name = "well-crafted %s"
    durable_dm = "durable"
-   itematt_durable_desc_1 = "  The craftsmanship of this "
+   itematt_durable_desc_1 = "The craftsmanship of this "
    itematt_durable_desc_2 = " is admirable, obviously the result of hundreds of hours of work by expert hands."
 
 classvars:

--- a/kod/object/passive/itematt/iaengrav.kod
+++ b/kod/object/passive/itematt/iaengrav.kod
@@ -28,7 +28,7 @@ constants:
 
 resources:
 
-    ItemAtt_Engraved_desc_1 = "  The words '"
+    ItemAtt_Engraved_desc_1 = "The words '"
     ItemAtt_Engraved_desc_2 = "' are delicately engraved on the edge."
 
 classvars:

--- a/kod/object/passive/itematt/iamade.kod
+++ b/kod/object/passive/itematt/iamade.kod
@@ -31,7 +31,7 @@ constants:
 
 resources:
  
-   itematt_made_desc = "  It shimmers insubstantially."
+   itematt_made_desc = "It shimmers insubstantially."
    iaMade_gone = "Your %s disappears in a puff of smoke."
    
 classvars:

--- a/kod/object/passive/itematt/iamisdir.kod
+++ b/kod/object/passive/itematt/iamisdir.kod
@@ -38,7 +38,7 @@ constants:
 
 resources:
  
-   itematt_misdirection_desc = "  An illusion has been cast on this item, hiding it's true abilities."
+   itematt_misdirection_desc = "An illusion has been cast on this item, hiding it's true abilities."
    iaMisdirection_gone = "The illusion around your %s fades, and you can see it for what it truly is."
    
 classvars:

--- a/kod/object/passive/itematt/iashroud.kod
+++ b/kod/object/passive/itematt/iashroud.kod
@@ -31,7 +31,7 @@ constants:
 
 resources:
  
-   itematt_shroud_desc = " A cloak of magic surrounds it."
+   itematt_shroud_desc = "A cloak of magic surrounds it."
    iashroud_gone = "The mystical cloak slips away from your %s."
    iashroud_name = "shrouded %s"
 

--- a/kod/object/passive/itematt/iatransc.kod
+++ b/kod/object/passive/itematt/iatransc.kod
@@ -26,7 +26,7 @@ constants:
 
 resources:
  
-   itematttranscendant_desc = "  It glows with a soft, white light."
+   itematttranscendant_desc = "It glows with a soft, white light."
    itematttranscendant_name = "transcendant %s"
 
    transcendant_DM = "transcendant"

--- a/kod/object/passive/itematt/weapatt/wablindr.kod
+++ b/kod/object/passive/itematt/weapatt/wablindr.kod
@@ -27,7 +27,7 @@ constants:
 
 resources:
 
-   weapattblinder_desc = "  Q's insignia is emblazoned on the metal of the weapon."      
+   weapattblinder_desc = "Q's insignia is emblazoned on the metal of the weapon."      
    blinder_fail_use = "You are not yet ready to use %s%s."
    blinder_worked = "%s%s stumbles away, screaming and clutching %s eyes!"
    blinder_dm = "blinder"

--- a/kod/object/passive/itematt/weapatt/wabonker.kod
+++ b/kod/object/passive/itematt/weapatt/wabonker.kod
@@ -26,7 +26,7 @@ constants:
 
 resources:
 
-   weapattbonker_desc = "  Mocker's signature flamboyantly emblazons the pommel."      
+   weapattbonker_desc = "Mocker's signature flamboyantly emblazons the pommel."      
    bonker_dm = "bonker"
 
 classvars:

--- a/kod/object/passive/itematt/weapatt/wacerem.kod
+++ b/kod/object/passive/itematt/weapatt/wacerem.kod
@@ -27,7 +27,7 @@ constants:
    include blakston.khd   
 
 resources:
-   weapattcerem_desc = "  Beautiful and ornate, this weapon is obviously "
+   weapattcerem_desc = "Beautiful and ornate, this weapon is obviously "
       "unsuitable for blood combat, though it might provide "
    weapattcerem_desc2 = " edge in games and tourneys."   
    weapatt_ceremonial_name = "ceremonial %s"

--- a/kod/object/passive/itematt/weapatt/wacursed.kod
+++ b/kod/object/passive/itematt/weapatt/wacursed.kod
@@ -31,7 +31,7 @@ constants:
 
 resources:
 
-   weapattcursed_desc = "  It glows with a pale red aura."
+   weapattcursed_desc = "It glows with a pale red aura."
    cursedweapon_fail_unuse= "%s%s seems to cling to your hand!"
    weapattcursed_name = "cursed %s"
 

--- a/kod/object/passive/itematt/weapatt/waench.kod
+++ b/kod/object/passive/itematt/weapatt/waench.kod
@@ -36,7 +36,7 @@ constants:
 resources:
    
    waEnchant_gone = "Your %s suddenly seems a little more... ordinary."
-   waEnchanted = " This weapon has been dedicated to Kraanan's glory."
+   waEnchanted = "This weapon has been dedicated to Kraanan's glory."
    waEnchanted_name = "enchanted %s"
    enchanted_dm = "enchanted"
 

--- a/kod/object/passive/itematt/weapatt/waexpert.kod
+++ b/kod/object/passive/itematt/weapatt/waexpert.kod
@@ -24,7 +24,7 @@ constants:
 resources:
 
    weapattexpert_desc = \
-      "  Colhorr's signature is engraved on the handle of this weapon.  This "
+      "Colhorr's signature is engraved on the handle of this weapon.  This "
       "weapon looks to provide "
    weapattexpert_desc2 = " advantage - in the right hands."
    weapattexpert_name = "%s of the master"

--- a/kod/object/passive/itematt/weapatt/wafactn.kod
+++ b/kod/object/passive/itematt/weapatt/wafactn.kod
@@ -32,11 +32,11 @@ constants:
 
 resources:
 
-   weapatt_faction_princess = "  The princess' sigil is embossed on the weapon, promising "
+   weapatt_faction_princess = "The princess' sigil is embossed on the weapon, promising "
    weapatt_faction_princess2 = " advantage in the defense of her honor."
-   weapatt_faction_duke = "  The duke's family crest is embossed on the weapon, offering "
+   weapatt_faction_duke = "The duke's family crest is embossed on the weapon, offering "
    weapatt_faction_duke2 = " advantage in his quest for the throne."
-   weapatt_faction_rebel = "  The rebel army flag is embossed on the weapon, giving "
+   weapatt_faction_rebel = "The rebel army flag is embossed on the weapon, giving "
    weapatt_faction_rebel2 = " advantage for the rebellion."
 
    weapatt_faction_duke_name = "%s of the duke"

--- a/kod/object/passive/itematt/weapatt/waghall.kod
+++ b/kod/object/passive/itematt/weapatt/waghall.kod
@@ -31,7 +31,7 @@ constants:
 
 resources:
 
-   weapattguildhalldesc= "  The crest of "
+   weapattguildhalldesc= "The crest of "
    weapattguildhalldesc2 = " is inscribed on the hilt of the weapon, suggesting "
    weapattguildhalldesc3 = " bonus in the defense of that hall."
    weapattdefender_name = "%s of the defender"

--- a/kod/object/passive/itematt/weapatt/waglow.kod
+++ b/kod/object/passive/itematt/weapatt/waglow.kod
@@ -26,7 +26,7 @@ constants:
 
 resources:
 
-   weapattglowing_desc = "  It glows softly like a torch."
+   weapattglowing_desc = "It glows softly like a torch."
    weapattglowing_name = "glowing %s"
 
    waglowing_gone = "Your %s stops glowing."

--- a/kod/object/passive/itematt/weapatt/waparal.kod
+++ b/kod/object/passive/itematt/weapatt/waparal.kod
@@ -28,7 +28,7 @@ constants:
 resources:
 
    weapattParalyzer_desc = \
-      "  A glow that can only be described as Zjiriaesqe surrounds the weapon."      
+      "A glow that can only be described as Zjiriaesqe surrounds the weapon."      
    Paralyzer_dm = "Paralyzer"
    paralyzer_fail_use = "You are not ready to use %s%s."
    holder_worked = "%s%s seems rooted to the very ground!"

--- a/kod/object/passive/itematt/weapatt/wapunish.kod
+++ b/kod/object/passive/itematt/weapatt/wapunish.kod
@@ -29,7 +29,7 @@ constants:
 
 resources:
 
-   weapattpunisher_desc = "  The emblem of a fist holding an ankh rests in the pommel of this weapon, promising "
+   weapattpunisher_desc = "The emblem of a fist holding an ankh rests in the pommel of this weapon, promising "
    weapattpunisher_desc2 = " advantage in the fight for justice."
    punisher_fail_use = "As you grab the hilt of %s%s, you scream out in pain and let go!"
    weapattpunisher_name = "%s of the just"

--- a/kod/object/passive/itematt/weapatt/wapurge.kod
+++ b/kod/object/passive/itematt/weapatt/wapurge.kod
@@ -27,7 +27,7 @@ constants:
 
 resources:
 
-   weapattpurger_desc = "  The sign of Psychochild is engraved on the weapon."      
+   weapattpurger_desc = "The sign of Psychochild is engraved on the weapon."      
    purger_fail_use = "You are not yet ready to use %s%s."
    purger_worked_user = "Your weapon tears at the magic surrounding %s%s."
    purger_worked_target = "%s%s's weapon tears at the magic surrounding you!"

--- a/kod/object/passive/itematt/weapatt/waspell.kod
+++ b/kod/object/passive/itematt/weapatt/waspell.kod
@@ -26,7 +26,7 @@ constants:
 
 resources:
 
-   WeapAttSpellCaster_desc = "  Mystical energy flits about this weapon."      
+   WeapAttSpellCaster_desc = "Mystical energy flits about this weapon."      
    WeapAttSpellCaster_dm = "spellcaster"
 
 classvars:

--- a/kod/object/passive/itematt/weapatt/waspellt.kod
+++ b/kod/object/passive/itematt/weapatt/waspellt.kod
@@ -119,7 +119,6 @@ messages:
          rName = iaSpellType_acid;
       }
       
-      AppendTempString("  ");
       AppendTempString(rName);
 
       % If not faked, then add maker information if available.

--- a/kod/object/passive/itematt/weapatt/watwist.kod
+++ b/kod/object/passive/itematt/weapatt/watwist.kod
@@ -26,7 +26,7 @@ constants:
 
 resources:
 
-   weapatt_twister_desc = "  A swirling green 'GMT' is stamped into the pommel."
+   weapatt_twister_desc = "A swirling green 'GMT' is stamped into the pommel."
    twister_dm = "twister"
 
    weapatt_twister_victim_effect = "~gYou feel disoriented, losing your bearings."

--- a/kod/object/passive/itematt/weapatt/wavamper.kod
+++ b/kod/object/passive/itematt/weapatt/wavamper.kod
@@ -26,7 +26,7 @@ constants:
 
 resources:
 
-   weapattVamper_desc = "  An unholy glow seems to suck all life from the air around the weapon."      
+   weapattVamper_desc = "An unholy glow seems to suck all life from the air around the weapon."      
    Vamper_dm = "Vamper"
    Vamper_fail_use = "You are not ready to use %s%s."
    Vamper_fail_use_karma = "You are not unholy enough to wield this despotic thing."


### PR DESCRIPTION
## What
- improved item description formatting by adding line breaks between base description, attributes, and condition sections
fixed spacing issues by removing hardcoded leading spaces from item attribute descriptions
   - now there are 3 distinct sections when viewing an item's description
      - 1/ base item description "this is a mace"
      - 2/ unique attributes (if available) "it can hold people"
      - 3/ item health / durability (if relevant) "it's nearly broken"
- enhanced misdirection / artifice behavior to show both real and fake attributes together instead of hiding real attributes

## Why
- item descriptions were previously displayed as large blocks of text that were difficult to read, especially for items with multiple magical attributes
- the old misdirection system completely hid real attributes when showing fake ones, which didn't make sense from a gameplay perspective 
  - a deceptive merchant would want to show the item's real value plus fake enhancements to make it seem like a better deal
  - also due to the way the rarity grade system displays rarities by counting unique item attributes, rarity level did not match the artifice description (example: a rare item would appear as only have one attribute but a one attribute item should appear uncommon)

## How
- modified the `CreateDesc` function in `item.kod` to add `\n\n` line breaks before the attributes section and before condition information
- removed hardcoded 2-space prefixes from item attribute description strings across multiple files (like `wablindr.kod`, `waspellt.kod`, etc.)
- implemented proper spacing logic using a `bFirstAttribute` flag to add 2 spaces between attributes
- updated misdirection handling to process fake attributes normally in the attribute loop rather than replacing all real attributes with fake ones

## Example

### Before
<img src="https://github.com/user-attachments/assets/6b00cfb5-357f-4138-816e-f19747c2bf78" />

> Lethal in appearance, this weapon is actually only minimally effective. Its spiked head is made of soft metal and its wooden shaft is thin and brittle. Q's insignia is emblazoned on the metal of the weapon. This mace is in flawless condition.

### After
<img src="https://github.com/user-attachments/assets/4788c3fe-10cd-4623-b4d4-7229dfeb22a7" />

> Lethal in appearance, this weapon is actually only minimally effective. Its spiked head is made of soft metal and its wooden shaft is thin and brittle.
>
> Q's insignia is emblazoned on the metal of the weapon.
>
> This mace is in flawless condition.
