### PR TITLE
Software rendering object flicker uses time over frames

### DIFF
--- a/clientd3d/animate.c
+++ b/clientd3d/animate.c
@@ -34,6 +34,7 @@
 
 static int  animation_timer = 0;   // id of animation timer, or 0 if none
 static DWORD timeLastFrame;
+static int flickerTimer = FLICKER_PERIOD;  // Global timer for OF_FLICKERING objects (milliseconds)
 
 #define TIME_FULL_OBJECT_PHASE 1800
 static int phaseStates[] = {
@@ -173,21 +174,16 @@ bool AnimateObject(object_node *obj, int dt)
 
    if (OF_FLICKERING == (OF_BOUNCING & obj->flags))
    {
-      // Initialize timer on first use
-      if (obj->flickerTime == 0)
-         obj->flickerTime = FLICKER_PERIOD;
+      // Use global flicker timer that counts down
+      flickerTimer -= dt;
       
       // Check if time to flicker
-      if (obj->flickerTime <= (DWORD)min(dt, 50))
+      if (flickerTimer <= 0)
       {
-         int flicker_value = rand() % FLICKER_LEVEL;       
-         obj->flickerTime = FLICKER_PERIOD;
+         int flicker_value = rand() % FLICKER_LEVEL;
+         flickerTimer = FLICKER_PERIOD;  // Reset timer
          obj->lightAdjust = flicker_value;
          need_redraw = true;
-      }
-      else
-      {
-         obj->flickerTime -= min(dt, 50);
       }
    }
 

--- a/clientd3d/object.h
+++ b/clientd3d/object.h
@@ -88,7 +88,6 @@ typedef struct {
    BYTE      normal_translation;  // Palette translation when not moving
    BYTE      secondtranslation;   // Overriding, additional second translation.
    WORD	     bounceTime;
-   DWORD	 flickerTime;        // For time-based flickering
    WORD	     phaseTime;
    int	     boundingHeight;
    int	     boundingWidth;


### PR DESCRIPTION
Correction to object flicking to use time over frames

Before:
https://github.com/user-attachments/assets/ec662d4b-c165-4170-9b09-de8851d2ed7e

After:
https://github.com/user-attachments/assets/eeea4582-f73b-40c3-bac2-3f2f2c346f39

