### PR TITLE
Fix newsgroup articles not loading

### DIFF
--- a/module/mailnews/mailnews.c
+++ b/module/mailnews/mailnews.c
@@ -260,7 +260,7 @@ bool HandleArticles(char *ptr, long len)
 	 return false;
       }
 
-      len = ExtractString(&ptr, len, article->title, MAX_SUBJECT);
+      len = ExtractString(&ptr, len, article->title, MAX_NEWS_SUBJECT);
       if (len == -1)
       {
 	 list_destroy(list);
@@ -270,7 +270,10 @@ bool HandleArticles(char *ptr, long len)
    }
 
    if (len != 0)
-      return false;
+   {
+     list_destroy(list);
+     return false;
+   }
 
    ReceiveArticles(newsgroup, part, max_part, list);
    return true;

--- a/module/mailnews/news.h
+++ b/module/mailnews/news.h
@@ -13,6 +13,10 @@
 #define _NEWS_H
 
 #define MAXARTICLE 4096      /* Max length of news article */
+// Max length of a news article subject.  This needs to be larger than a mail subject
+// line, because some news articles are auto-generated and have longer subjects than are
+// allowed to users.
+static const int MAX_NEWS_SUBJECT = 300;
 
 /* Permissions to be able to read and post news */
 #define NEWS_READ 0x01
@@ -24,7 +28,7 @@ typedef struct
    long num;                       /* Index # of article */
    long time;                      /* Time article was posted */
    char poster[MAXUSERNAME];       /* Person who posted article */
-   char title[MAX_SUBJECT];        /* Title string of article */
+   char title[MAX_NEWS_SUBJECT];   /* Title string of article */
 } NewsArticle;
 
 typedef struct {


### PR DESCRIPTION
Subject lines were limited to 50 characters, but auto-generated guild war news articles exceeded this if guild names were too long.