### PR TITLE
fix: prevent extra spacing from blank attribute descriptions

### DIFF
--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -237,7 +237,7 @@ messages:
    "Adds all visible attribute descriptions to the temp string with formatting. "
    "When bShowAll is TRUE, all attributes including misdirection are revealed."
    {
-      local bAlreadyBlind, bFirstAttribute, bHasVisibleAttributes;
+      local bHasVisibleAttributes;
       
       bHasVisibleAttributes = Send(self,@HasVisibleAttributes,#bShowAll=bShowAll);
       if bHasVisibleAttributes


### PR DESCRIPTION
## What
- fixed item description spacing issues where invisible attributes caused unwanted gaps
  - Refactored `CreateDesc()` in `item.kod` to improve maintainability by decomposing into focused helper methods

## Why
- PR #1267 added proper paragraph spacing between description sections but missed 2 edge cases
- Invisible attributes `IA_PKPOINTER` and `IA_CORPSEPOINTER` were causing extra spacing in item descriptions
- The monolithic `CreateDesc()` function was complex and hard to maintain

## How
- Simplified the attribute visibility detection logic to check `Send(oItemAtt,@GetDesc) <> resource_blank`
- Split `CreateDesc()` into helper functions:
  - `HasVisibleAttributes()` - checks for displayable attributes
  - `ProcessAttributeList()` - handles attribute processing logic
  - `AppendConditionDescription()` - formats condition information


### Flowchart Logic
``` mermaid
flowchart TD
    A[CreateDesc called] --> B[ClearTempString]
    
    %% BASE DESCRIPTION SECTION
    subgraph BASE [" BASE DESCRIPTION "]
        B --> C[DoBaseDesc - Add base item description]
    end
    
    %% ATTRIBUTES SECTION
    subgraph ATTRS [" ITEM ATTRIBUTES "]
        C --> D[AppendAttributeDescriptions]
        D --> E[HasVisibleAttributes?]
        
        E --> F{Any visible attributes?}
        F -->|No| SKIP1[Skip attributes section]
        F -->|Yes| G[Add section separator \\n\\n]
        
        G --> H[ProcessAttributeList]
        
        %% ATTRIBUTE PROCESSING SUBLOGIC
        subgraph ATTRLOGIC [" Attribute Processing Logic "]
            H --> J[Loop through plItem_Attributes]
            
            J --> K{Is IA_MISDIRECTION?}
            K -->|Yes| L[Add fake misdirection desc]
            K -->|No| M{Is identified or ShowAll?}
            
            M -->|No| N{Already shown generic?}
            N -->|No| O[Show itematt_generic once]
            N -->|Yes| P[Skip this attribute]
            
            M -->|Yes| Q{GetDesc = resource_blank?}
            Q -->|Yes| R[Skip invisible attribute<br/>IA_PKPOINTER, IA_CORPSEPOINTER]
            Q -->|No| S[Add spacing if not first attribute]
            
            S --> T[AppendDesc - Add attribute description]
        end
        
        L --> U[Continue to next attribute]
        O --> U
        P --> U  
        R --> U
        T --> U
        
        U --> V{More attributes?}
        V -->|Yes| J
        V -->|No| SKIP1
    end
    
    %% CONDITION SECTION
    subgraph COND [" CONDITION INFORMATION "]
        SKIP1 --> W[AppendConditionDescription]
        W --> X{vbShow_condition AND<br/>piHits_init > 0?}
        X -->|Yes| Y[Add section separator \\n\\n<br/>Item has durability system]
        X -->|No| Z[Skip condition section<br/>No durability or not configured]
        
        Y --> AA[AppendDesc - Add condition text<br/>'is in excellent condition']
        Z --> BB[Return complete description]
    end
    
    AA --> BB
```