### PR TITLE
Remove suspicious stats invalidation during draw.

### DIFF
--- a/module/merintr/statlist.c
+++ b/module/merintr/statlist.c
@@ -247,7 +247,6 @@ void StatsListDrawStat(const DRAWITEMSTRUCT *lpdis, bool selected, bool bShowSpe
    Statistic *s;
    char str[MAXRSCSTRING + 10];
    RECT r;
-   int lastItem = ListBox_GetCount(lpdis->hwndItem) - 1;
    RECT rcWnd;
 
    GetClientRect(lpdis->hwndItem,&rcWnd);
@@ -286,14 +285,6 @@ void StatsListDrawStat(const DRAWITEMSTRUCT *lpdis, bool selected, bool bShowSpe
       areaIcon.cy = ENCHANT_SIZE;
       DrawObjectIcon(lpdis->hDC, s->list.icon, 0, true, &areaIcon, NULL, 0, 0, true);
       break;
-   }
-   if (lastItem == (int)lpdis->itemID)
-   {
-      RECT rcWnd;
-      GetClientRect(lpdis->hwndItem,&rcWnd);
-      rcWnd.top = lpdis->rcItem.bottom;
-      if (rcWnd.top < rcWnd.bottom)
-	 InvalidateRect(lpdis->hwndItem,&rcWnd,TRUE);
    }
 }
 /*****************************************************************************/


### PR DESCRIPTION
This was apparently responsible for rendering failing on Wine.  Presumably the Wine implementation of list boxes continually generates window messages while drawing the stats or spells lists, meaning that MainIdle never gets called and rendering never happens.