### PR TITLE
fix: adjust herald shield description format

### DIFF
--- a/kod/object/item/passitem/defmod/shield/guilshld.kod
+++ b/kod/object/item/passitem/defmod/shield/guilshld.kod
@@ -184,9 +184,12 @@ messages:
       return;
    }
 
-   AppendDesc()
+   DoBaseDesc()
    {
       local a, b, x;
+
+      % Call parent to append base description first
+      AppendTempString(vrDesc);
 
       % sample: "The pattern on this shield is rose astride gold;
       %          the traditional mark of the Foobars.  The eye of
@@ -233,7 +236,7 @@ messages:
       if piInsigniaType = INSIG_REBEL { AppendTempString( guildshield_insig_rebel); }
       if piInsigniaType = INSIG_NONE { AppendTempString(guildshield_insig_none); }
 
-      propagate;
+      return;
    }
 
    Randomize()


### PR DESCRIPTION
## What
- Fixed herald shield `guilshld.kod` description formatting by moving heraldry/color pattern text from `AppendDesc()` to `DoBaseDesc()`
- The color pattern (e.g., "The pattern on this shield is gris tierced in bend sinister by gris.") now appears as part of the base description rather than in the durability section

## Why
- Herald shields were not following the 3-section description format established in the item description refactor #1267 and #1283 
- The color/pattern information was incorrectly placed in the durability section because it was in `AppendDesc() `instead of `DoBaseDesc()`
- This caused the description order to be: Base → Attributes → Pattern+Durability (wrong) instead of Base+Pattern → Attributes → Durability (correct)

## How
- Changed from overriding `AppendDesc()` to overriding `DoBaseDesc()`
- Replaced propagate with explicit `AppendTempString(vrDesc)` to append base description first, then heraldry pattern
- This follows the same pattern as other items where `DoBaseDesc() `handles all base description text and `AppendDesc()` only handles condition/durability

## Example
### Before:
<img width="763" height="372" alt="image" src="https://github.com/user-attachments/assets/74bf269e-f5ff-4a93-9193-f1f9ab28f5ca" />

```
Heavy metal shields of this style are decorated in the standards of its owner guild.

The words 'testing' are delicately engraved on the edge.

The pattern on this shield is gris tierced in bend sinister by gris. This herald shield shines with smooth perfection.
```

### After:

<img width="763" height="372" alt="image" src="https://github.com/user-attachments/assets/d536e73a-5131-4f2d-91aa-84bf3b17eaaa" />

```
Heavy metal shields of this style are decorated in the standards of its owner guild. The pattern on this shield is gris tierced in bend sinister by gris.

The words 'testing' are delicately engraved on the edge.

This herald shield shines with smooth perfection.
```

## Flow
### Normal Flow
``` mermaid 
flowchart TD
    subgraph "CreateDesc() in item.kod"
        A["1. DoBaseDesc()"] --> B["2. AppendAttributeDescriptions()"]
        B --> C["3. AppendConditionDescription()"]
    end
    
    A --> A1["Base item text<br/>'This is a mace...'"]
    B --> B1["Magic attributes<br/>'Engraved with testing...'"]
    C --> C1["Durability<br/>'Shines with perfection.'"]
```

### Mace example
``` mermaid
flowchart LR
    subgraph "mace.kod"
        M1["vrDesc = 'Lethal in appearance...'"]
    end
    
    subgraph "item.kod CreateDesc()"
        D1["DoBaseDesc()"] --> D2["AppendAttributeDescriptions()"] --> D3["AppendConditionDescription()"]
    end
    
    M1 --> D1
    D1 --> O1["'Lethal in appearance...'"]
    D2 --> O2["'\\n\\nEngraved text...'"]
    D3 --> O3["'\\n\\nThis mace shines...'"]
```

### Herald Shield broken (before)
``` mermaid
flowchart TD
    subgraph "OLD guilshld.kod"
        G1["vrDesc = 'Heavy metal shields...'"]
        G2["AppendDesc() had pattern text"]
    end
    
    subgraph "item.kod CreateDesc()"
        D1["1. DoBaseDesc()"] --> D2["2. AppendAttributeDescriptions()"] --> D3["3. AppendConditionDescription()"]
        D3 --> D4["calls AppendDesc()"]
    end
    
    G1 --> D1
    D1 --> O1["'Heavy metal shields...'"]
    D2 --> O2["'\\n\\nEngraved text...'"]
    D4 --> G2
    G2 --> O3["'\\n\\nThe pattern is gris...<br/>This herald shield shines...'"]
    
    style G2 fill:#f66,stroke:#333
    style O3 fill:#f66,stroke:#333
```

### Herald Shield fixed (now)
``` mermaid
flowchart TD
    subgraph "NEW guilshld.kod"
        G1["DoBaseDesc() has:<br/>1. vrDesc<br/>2. Pattern text"]
    end
    
    subgraph "item.kod CreateDesc()"
        D1["1. DoBaseDesc()"] --> D2["2. AppendAttributeDescriptions()"] --> D3["3. AppendConditionDescription()"]
        D3 --> D4["calls AppendDesc()"]
    end
    
    G1 --> D1
    D1 --> O1["'Heavy metal shields...<br/>The pattern is gris...'"]
    D2 --> O2["'\\n\\nEngraved text...'"]
    D4 --> O3["'\\n\\nThis herald shield shines...'"]
    
    style G1 fill:#6f6,stroke:#333
    style O1 fill:#6f6,stroke:#333
```