### PR TITLE
Fixed map annotation saving/loading.

### DIFF
--- a/clientd3d/mapfile.c
+++ b/clientd3d/mapfile.c
@@ -184,7 +184,7 @@ bool MapFileLoadRoom(room_type *room)
          return false;
        if (fread(&room->annotations[i].y, 1, 4, mapfile) != 4)
          return false;
-       if (fread(room->annotations[i].text, MAX_ANNOTATION_LEN, 1, mapfile) != MAX_ANNOTATION_LEN)
+       if (fread(room->annotations[i].text, 1, MAX_ANNOTATION_LEN, mapfile) != MAX_ANNOTATION_LEN)
          return false;
      }     
    }
@@ -259,7 +259,7 @@ bool MapFileSaveRoom(room_type *room)
          return false;
        if (fwrite(&room->annotations[i].y, 1, 4, mapfile) != 4)
          return false;
-       if (fwrite(room->annotations[i].text, MAX_ANNOTATION_LEN, 1, mapfile) != MAX_ANNOTATION_LEN)
+       if (fwrite(room->annotations[i].text, 1, MAX_ANNOTATION_LEN, mapfile) != MAX_ANNOTATION_LEN)
          return false;
      }
    }


### PR DESCRIPTION
It looks like this code was broken by [df09588 ](https://github.com/Meridian59/Meridian59/commit/c4dc423f579db539b59f0a41c0a1303afeb2daf4) and then partially fixed in [df09588](https://github.com/Meridian59/Meridian59/commit/df095889a5c6c072d0ab1308bba5abead2c38b41)

Root cause is that fread and fwrite uses SIZE and COUNT parameters and return COUNT success, so the read/write functions for Map Annotations specifically was still broken. Writing 100 objects of size 1 rather than 1 object of size 100, then testing success for 100. This effectively means that only a single map annotation could be saved and/or loaded per map, as the check on both sides would fail and stop after the first map annotation.

Testing was done locally. To confirm the bug I went into my local server, created a map annotation, left/re-entered and confirmed it worked. Then create a second map annotation, left/re-entered and confirmed that it did not work. To confirm the bug is fixed, I repeated this example and confirmed that the second annotation worked. I also tested setting multiple at the same time and deleting annotations, which all worked as expected.