### PR TITLE
chore: rename colliding sound files

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -260,7 +260,7 @@ resources:
    user_doesnt_know_spell = "You have not yet learned the spell '%s'!"
 
    user_wave_welcome = welcome.wav
-   user_wave_killed = killed.wav
+   user_wave_killed = killed_voice.wav
 
    user_midi_killed = killed.mid
 

--- a/kod/object/active/holder/room/monsroom/forest2.kod
+++ b/kod/object/active/holder/room/monsroom/forest2.kod
@@ -24,7 +24,7 @@ resources:
    room_forest2 = forest2.roo
    room_name_forest2 = "The Forests of Meridian"
 
-   forest2_noise = forest.wav
+   forest2_noise = ambforest.wav
 
    forest2_music = walk2.mid
 

--- a/kod/object/active/holder/room/tosrm/tosarena.kod
+++ b/kod/object/active/holder/room/tosrm/tosarena.kod
@@ -27,7 +27,6 @@ resources:
 
    TosArena_music = pk_fm.mid
 
-   TosArena_commence_wav = forest.wav
    wind_sound_tosarena = ambcntry.wav
    wind1_sound_tosarena = rs_wind.wav
 


### PR DESCRIPTION
## What

- adjusted references to `killed.wav` and `forest.wav`
  - renamed the `user_wave_killed`  `killed.wav` resource to `killed_voice.wav`
  - renamed the `forest.wav` ambient sound to `ambforest.wav`
  - removed an unused reference to `forest.wav` in `tosarena.kod`

## Why
- as part of the audio refactor in https://github.com/Meridian59/Meridian59/pull/1293 the client will consolidate sound resources in .ogg format (no more .mid or .wav)
- some .wav and .mid references used the same name but were separate extensions, but now that everything is .ogg those files collide
  - `killed.wav` and `killed.mid`
  - `forest.wav` and `forest.mid`