### PR TITLE
gameplay: Re-enables Hunt, will ultimately cast unsuccessful if target player is offline after channeling

### DIFF
--- a/kod/object/passive/spell/multicst/hunt.kod
+++ b/kod/object/passive/spell/multicst/hunt.kod
@@ -43,6 +43,9 @@ resources:
 
    hunt_lost_trackers = "You seem to have managed to lose your trackers!"
    hunt_gain_trackers = "You sense that someone knows where you are..."
+   hunt_target_offline = \
+      "You feel the magical trail begin to reach out in vain for your target, "
+      "but finding nothing it dissipates.  The target is no longer in the world."
 
 classvars:
 
@@ -76,14 +79,6 @@ properties:
    % Spell is harmful to the player it's cast upon.
    viHarmful = TRUE
 
-   % Disabled temporarily 
-   % When used on offline targets who log on during it's duration, the target
-   % will be tracked indefinitely. Offline players' timers are "frozen", but 
-   % Hunt introduces an active timer that decouples from the enchantment during
-   % reactivation of timers (when the player logs on). This should be addressed
-   % or the spell reworked before enabling.
-   pbEnabled = FALSE
-
 messages:      
 
    Constructed()  
@@ -110,6 +105,17 @@ messages:
       local i, oTarget;
 
       oTarget = First(lTargets);
+
+      % Check if target is online before applying the enchantment
+      if oTarget <> $ AND NOT Send(oTarget,@IsLoggedOn)
+      {
+         for i in lCasters
+         {
+            Send(i,@MsgSendUser,#message_rsc=hunt_target_offline);
+         }
+         
+         return;
+      }
 
       for i in Send(oPrism,@GetCasters)
       {


### PR DESCRIPTION
This PR looks to bring Hunt back online by addressing its offline timer issues (see #807). Instead of a global change to enchantments (#1192), this looks to address Hunt's issues in `hunt.kod` alone. Under these changes, after successfully channeling a prism cast, Hunt will fail if the player was online at the start of channeling but is offline at the end, when Hunt is finally cast. Feedback is given to the player to help them understand:

> You feel the magical trail begin to reach out in vain for your target, but finding nothing it dissipates.  The target is no longer in the world.

While this fix should allow Hunt to function again in its current form, I believe the spell could be enhanced further by scaling the frequency of location updates based on the casters' average spellpower, providing a progression path for casters and in that way, some protection for targeted players.