### PR TITLE
Remove FINAL build flag in favor of RETAIL

### DIFF
--- a/clientd3d/client.c
+++ b/clientd3d/client.c
@@ -11,9 +11,14 @@
 */
 
 #include <assert.h>
-#include <crtdbg.h>
 
 #include "client.h"
+
+#ifdef M59_RETAIL
+  // Minidump reporting
+  #include "bugsplat.h"
+#endif
+
 
 HWND hMain = NULL;             /* Main window */
 HINSTANCE hInst = NULL;           /* Program's instance */

--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -66,9 +66,6 @@ typedef INT64 int64;
 /* To make sure we are using the right version of the client */
 #define P_CATCH 3
 
-/* Enable for "retail", official builds, not for the open source version */
-//#define M59_RETAIL
-
 extern void GetGamePath( char *szGamePath );
 
 extern LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
@@ -102,11 +99,6 @@ M59EXPORT void _cdecl dprintf(const char *fmt,...);
 #include <string>
 #include <vector>
 #include <algorithm>
-
-#ifdef M59_RETAIL
-  // Minidump reporting
-  #include "bugsplat.h"
-#endif
 
 #include "resource.h"
 #include "proto.h"

--- a/clientd3d/makefile
+++ b/clientd3d/makefile
@@ -25,8 +25,7 @@ LIBS =  \
 	ole32.lib OpenAL32.lib \
 	d3d9.lib libpng.lib zlib.lib
 
-# Setting RETAIL=1 turns on the Miles Sound System, which we can't
-# put in the open source version
+# Setting RETAIL=1 includes Bugsplat; not needed for development
 !ifdef RETAIL
 
 CFLAGS = $(CFLAGS) -DM59_RETAIL

--- a/common.mak
+++ b/common.mak
@@ -2,9 +2,9 @@
 
 # defining RELEASE compiles optimized
 # defining NODEBUG omits debugging information
-# defining FINAL implies release, and also removes debugging strings from client executable 
+# defining RETAIL implies release, and also removes debugging strings from client executable 
 
-!ifdef FINAL
+!ifdef RETAIL
 RELEASE = 1
 NODPRINTFS = 1
 !endif

--- a/common.mak.linux
+++ b/common.mak.linux
@@ -2,9 +2,9 @@
 
 # defining RELEASE compiles optimized
 # defining NODEBUG omits debugging information
-# defining FINAL implies release, and also removes debugging strings from client executable 
+# defining RETAIL implies release, and also removes debugging strings from client executable 
 
-ifdef FINAL
+ifdef RETAIL
 RELEASE = 1
 NODPRINTFS = 1
 endif


### PR DESCRIPTION
The RETAIL build setting includes Bugsplat and enables the prod login system.