### PR TITLE
Fix armor swapping logic when wearing robes

### DIFF
--- a/kod/object/item/passitem/defmod/armor/robe.kod
+++ b/kod/object/item/passitem/defmod/armor/robe.kod
@@ -143,7 +143,7 @@ messages:
          % This is conflicting armor - try to unequip the robe
          if Send(poOwner,@TryUnuseItem,#what=self)
          {
-            propagate;
+            return TRUE;
          }
          
          return FALSE;


### PR DESCRIPTION
**Issue:**
Switching from robes to armor failed because `Robe::ReqUseSomething` propagated to the parent Armor class after successfully unequipping the robe. The parent class attempted to unequip the already-removed robe, failed, and returned FALSE, blocking the new armor equip.

**Fix:**
Updated `Robe::ReqUseSomething` to return TRUE immediately after a successful unequip. This prevents the erroneous propagation to the parent class and allows the new armor to be equipped.

https://github.com/user-attachments/assets/39d4d5ae-d9e4-4053-ab91-2fd2d6ebd0b5

Fixes: https://github.com/Meridian59/Meridian59/issues/1320