### PR TITLE
Fix arm color resetting to default base layer instead of equipped shirt

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8791,7 +8791,7 @@ messages:
       {
          for i in plUsing
          {
-            if IsClass(i,&Shirt)
+            if Send(i,@GetItemUseType) & ITEM_USE_SHIRT
             {
                Send(i,@SetArms);
                


### PR DESCRIPTION
Fixes a visual bug where player arms would revert to the default base layer color instead of the equipped shirt color when `ResetPlayerArms` was called (e.g., when unequipping robes).

Updated `ResetPlayerArms` to use `GetCurrentShirtColor`. This method correctly checks the player's inventory for an equipped shirt and returns its palette translation, falling back to the default base layer only if no shirt is worn.

`ResetPlayerArms` now delegates arm setup to an equipped shirt (calling SetArms) when no gauntlet overrides are present, ensuring shirt-specific arm graphics (e.g., Tanktop's naked arms) are restored correctly after removing robes.

https://github.com/user-attachments/assets/9f795b19-bcaa-44ed-bf37-6332c7293264

Testing: Equipped colored shirt / undershirt with armor, gauntlets (with/without) and switching to robes and back - verifying the correct look of the characters arms.

Fixes: https://github.com/Meridian59/Meridian59/issues/1322