### PR TITLE
fix: remove leading space from unidentified item description

### DIFF
--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -34,7 +34,7 @@ resources:
    item_broken_battle_clothing_plural = "Your %s fall into useless tatters!"
 
    itematt_generic = \
-      " At first glance, it seems quite ordinary, but there is something odd "
+      "At first glance, it seems quite ordinary, but there is something odd "
       "about it you can't put your finger on."
 
    nakedleftarm_male = blg.bgf


### PR DESCRIPTION
## What

- removed leading space from `itematt_generic` unidentified item description in `item.kod`

## Why

- follow-up to #1267 and #1297 which established 3-paragraph item description format
- paragraph 2 (attributes) already gets `\n\n` prefix from `AppendAttributeDescriptions()`
- other item attributes like `wablindr.kod` don't have leading spaces
- unidentified items only show `itematt_generic` in paragraph 2, so no inter-attribute spacing needed

## How

- changed `" At first glance..."` to `"At first glance..."`


## Example (before fix)
<img width="763" height="382" alt="image" src="https://github.com/user-attachments/assets/736a951a-dca8-42cd-9d80-5697e17c4db0" />
