### PR TITLE
fix: adjust Riija sword item description formatting

### DIFF
--- a/kod/object/item/passitem/weapon/riijaswd.kod
+++ b/kod/object/item/passitem/weapon/riijaswd.kod
@@ -74,16 +74,28 @@ messages:
       propagate;	 
    }
 
-   AppendDesc()
+   DoBaseDesc()
    {
+      local lData;
+
+      if Send(self,@HasAttribute,#ItemAtt=IA_NEW_DESCRIPTION)
+      {
+         lData = Send(self,@GetAttributeData,#ItemAtt=IA_NEW_DESCRIPTION);
+         AppendTempString(Nth(lData,2));
+      }
+      else
+      {
+         AppendTempString(vrDesc);
+      }
+
       if poQuester <> $
       {
-         AppendTempString(RiijaSword_desc_append1) ;
-         AppendTempString(send(poQuester,@GetTrueName));
+         AppendTempString(RiijaSword_desc_append1);
+         AppendTempString(Send(poQuester,@GetTrueName));
          AppendTempString(RiijaSword_desc_append2);
       }
-      
-      propagate;
+
+      return;
    }
    
    GetQuester()


### PR DESCRIPTION
## What

- Moved quester inscription from `AppendDesc()` to `DoBaseDesc()` in `riijaswd.kod`

## Why

- Follow-up to #1267 and #1297 which established 3-paragraph item description format:
  1. `DoBaseDesc()` - base item description
  2. `AppendAttributeDescriptions()` - magic attributes
  3. `AppendDesc()` / `AppendConditionDescription()` - durability/condition
- The quester inscription ("Some of the runes say...") is a physical feature of this sword instance, not condition/durability info
- Previously, paragraph 3 showed: `"  Some of the runes say..."` followed by durability text, with awkward spacing
- Now paragraph 1 includes the inscription as part of the base description, and paragraph 3 correctly shows only durability

## How

- Changed `AppendDesc()` to `DoBaseDesc()`
- Replicated parent's `IA_NEW_DESCRIPTION` check to preserve admin custom description compatibility
- Uses `return` (not `propagate`) because parent `Item::DoBaseDesc()` also returns, and propagating would duplicate the base description

## Example
### Before
<img width="382" height="225" alt="meridian_DxmTh7xs5R" src="https://github.com/user-attachments/assets/feed7c32-8162-4101-9c6b-cd55da69bb26" />

### After
<img width="382" height="225" alt="meridian_fNOxZFleTt" src="https://github.com/user-attachments/assets/1f86465c-ccca-4499-b150-61f4d063b18c" />

## Call Flow

**BEFORE** (inscription in wrong paragraph):

```
CreateDesc() in item.kod
|
+-> Send(self,@DoBaseDesc)
|   |
|   |   RiijaSword has no DoBaseDesc, so...
|   |
|   +-> Item::DoBaseDesc()
|         AppendTempString(vrDesc);  <-- vrDesc = RiijaSword_desc_rsc
|         return;
|
+-> Send(self,@AppendAttributeDescriptions)  <-- Paragraph 2
|
+-> Send(self,@AppendConditionDescription)
    |
    +-> eventually calls AppendDesc()
        |
        +-> RiijaSword::AppendDesc()
              AppendTempString(inscription);  <-- WRONG PLACE
              propagate;
              |
              +-> Parent adds durability text
```

**AFTER** (inscription in paragraph 1):

```
CreateDesc() in item.kod
|
+-> Send(self,@DoBaseDesc)
|   |
|   +-> RiijaSword::DoBaseDesc()
|         if IA_NEW_DESCRIPTION? use custom desc, else use vrDesc
|         AppendTempString(inscription); <-- NOW IN PARAGRAPH 1
|         return;
|
+-> Send(self,@AppendAttributeDescriptions)  <-- Paragraph 2
|
+-> Send(self,@AppendConditionDescription)   <-- Paragraph 3 (durability only)
```

## Notes

### Why we override DoBaseDesc() entirely instead of extending it

In Blakod, `propagate` means "call the parent's version of this function and don't return to the child."  There's no way to say "run the parent first, then add more."  So we can't do:

```
DoBaseDesc()
{
   propagate;  // goes to parent, never comes back
   AppendTempString(inscription);  // NEVER RUNS
}
```

Instead, we must replicate the parent's logic and add our extension:

```
DoBaseDesc()
{
   // Replicate parent's IA_NEW_DESCRIPTION check
   if Send(self,@HasAttribute,#ItemAtt=IA_NEW_DESCRIPTION)
   {
      lData = Send(self,@GetAttributeData,#ItemAtt=IA_NEW_DESCRIPTION);
      AppendTempString(Nth(lData,2));
   }
   else
   {
      AppendTempString(vrDesc);
   }

   // Then add our inscription
   AppendTempString(inscription);
   return;
}
```

This preserves compatibility with `IA_NEW_DESCRIPTION` (admin-granted custom descriptions) while adding the quester inscription.

### The "proper" alternative

A more extensible solution would add a hook in `Item::DoBaseDesc()`:

```
DoBaseDesc()
{
   // ... existing IA_NEW_DESCRIPTION check ...
   AppendTempString(vrDesc);
   Send(self,@AppendBaseDescDetails);  // NEW: let children add more
   return;
}

AppendBaseDescDetails()
{
   return;  // default does nothing
}
```

Then RiijaSword would just override `AppendBaseDescDetails()` to add the inscription, but modifying the core `Item` class for one quest item is overkill - replicating logic seems preferable for this edge case.