### PR TITLE
fix: disciple robe description paragraph formatting

### DIFF
--- a/kod/object/item/passitem/defmod/armor/robe/robedisc.kod
+++ b/kod/object/item/passitem/defmod/armor/robe/robedisc.kod
@@ -415,18 +415,28 @@ messages:
       return;
    }
 
-   AppendDesc()
+   DoBaseDesc()
    {
-      local oSpell;
+      local oSpell, lData;
+
+      if Send(self,@HasAttribute,#ItemAtt=IA_NEW_DESCRIPTION)
+      {
+         lData = Send(self,@GetAttributeData,#ItemAtt=IA_NEW_DESCRIPTION);
+         AppendTempString(Nth(lData,2));
+      }
+      else
+      {
+         AppendTempString(vrDesc);
+      }
 
       % Find a spell, any spell, so we can get the string out of it for which school we are.
-      oSpell = send(SYS,@FindSpellByNum,#num=SID_BLINK);
-   
+      oSpell = Send(SYS,@FindSpellByNum,#num=SID_BLINK);
+
       AppendTempString(RobeInsignia_school_info1);
       AppendTempString(Send(oSpell,@GetSchoolStr,#iSchool=piSchool));
       AppendTempString(RobeInsignia_school_info2);
-   
-      propagate;
+
+      return;
    }
 
 


### PR DESCRIPTION
## What

- Moved school insignia info from `AppendDesc()` to `DoBaseDesc()` in `robedisc.kod`

## Why

Same issue as #1329 (Riija sword) - school info was appearing in paragraph 3 (durability) instead of paragraph 1 (base description).

See #1267 and #1297 for the 3-paragraph format established for item descriptions.

## Examples
### Before
<img width="763" height="382" alt="meridian_GD0HE7q7pV" src="https://github.com/user-attachments/assets/7aa2953c-0b81-4eef-8480-ff263e35c82f" />

### After
<img width="763" height="382" alt="meridian_FlNmsRuDr5" src="https://github.com/user-attachments/assets/1c1ccf86-adbc-40a1-8149-de87fcc3bd99" />

### After with "engrave" attribute
<img width="763" height="382" alt="image" src="https://github.com/user-attachments/assets/286c30e1-3e4d-46bb-9d60-6581d1074fb3" />


## How

Same pattern as #1329:
- Changed `AppendDesc()` to `DoBaseDesc()`
- Replicated parent's `IA_NEW_DESCRIPTION` check
- Uses `return` instead of `propagate`
