### PR TITLE
 fix: adjust Esseldi responses to mana node queries

### DIFF
--- a/kod/util/library.kod
+++ b/kod/util/library.kod
@@ -1324,7 +1324,7 @@ messages:
 
       plSpeechLib = Cons(
      [&FiveCouncilor, [
-      [[LT_nodes], 0, [LIBACT_MANA_NODE_LIST, 1], 1]
+      [[LT_nodes], 0, [LIBACT_MANA_NODE_LIST, 1]]
      ]],plSpeechLib);
 
 %Wanderers


### PR DESCRIPTION
## What

- removed the spam filter key from Esseldi's "nodes" speech trigger
- this allows multiple players to ask about their mana nodes without blocking each other

## Why

- players reported that Esseldi often wouldn't respond when asked about mana nodes
- the "nodes" trigger shared spam key 1 with "quest", so saying "quest" first would block "nodes"
- additionally, mana node responses are player specific (each player has their own list), so spam filtering doesn't make sense here - if 3 players ask about nodes, each should get their own answer
- speculation: I think this spam filter was copy-pasted from other NPC dialog without considering the per-player mana node query

## How

- modified `CreateSpeechLibrary()` in `library.kod`
- removed the 4th element (spam key) from the FiveCouncilor "nodes" speech entry
- triggers without a spam key bypass the spam filter entirely (`Length(j) > 3` check)

## Example

### Before
```text
Player A: "nodes"
Esseldi: [tells Player A their nodes, key 1 added to spam list]
Player B: "nodes"
Esseldi: [no response - key 1 already on spam list]
```

### After
```text
Player A: "nodes"
Esseldi: [tells Player A their nodes]
Player B: "nodes"
Esseldi: [tells Player B their nodes]
```

## Testing
```text
dm go rid_b6
```

1. Say "quest" near Esseldi
2. Immediately say "nodes" - he should respond with your mana node list
3. Have a second player say "nodes" - they should also get a response

## Deployment Note

After merging, the speech library must be reinitialized:

```text
show instances library
send o <object_id> reinitialize
```

Example:
```text
show instances library
-> OBJECT 4
send o 4 reinitialize
```