### PR TITLE
set skip_selection before ComboBox_SetEditSel to fix Wine

### DIFF
--- a/clientd3d/textin.c
+++ b/clientd3d/textin.c
@@ -121,6 +121,7 @@ void TextInputResize(int xsize, int ysize, AREA view)
 void TextInputSetFocus(bool forward)
 {
    SetFocus(hwndInput);
+   skip_selection = false;
    ComboBox_SetEditSel(hwndInput, 0, -1);  // select all text
 }
 /************************************************************************/
@@ -161,6 +162,7 @@ void TextInputSetText(char *text, bool focus)
    if (focus)
       SetFocus(hwndInput);
 
+   skip_selection = false;
    ComboBox_SetEditSel(hwndInput, len, len);  // Move caret to end of text
 }
 /************************************************************************/


### PR DESCRIPTION
I wasn't satisfied with the last commit, because I was basically deleting a feature willy-nilly, but now it is perfect. Here is some copypasta from the last [PR](https://github.com/Meridian59/Meridian59/pull/1333).

This is another Linux/Wine fix. It fixes the say, tell, broadcast and chat buttons on Wine, so that the cursor and selection in the text box behave as expected.

The problem is that all calls to ComboBox_SetEditSel (except the first one) don't actually work, because of the "default behavior override" in TextInputProc. My theory is that Windows and Wine parse ComboBox messages a little bit differently, meaning that the EM_SETSEL case is never executed on Windows, but is executed on Wine. So this commit shouldn't break Windows, but it should fix Wine. (I will ask someone with Windows machine to test it).
