### PR TITLE
fix rendering of enchantments on Wine

### DIFF
--- a/module/merintr/enchant.c
+++ b/module/merintr/enchant.c
@@ -223,6 +223,7 @@ void EnchantmentsMovePlayer(void)
       x += width + ENCHANT_BORDER;
       ShowWindow(e->hwnd, SW_SHOWNORMAL);
       // basically no op on Windows, but fixes Wine rendering
+      // https://github.com/Meridian59/Meridian59/pull/1337
       InvalidateRect(e->hwnd, NULL, FALSE);
    }
 }
@@ -254,6 +255,7 @@ void EnchantmentsMoveRoom(void)
       x -= width + ENCHANT_BORDER;
       ShowWindow(e->hwnd, SW_SHOWNORMAL);
       // basically no op on Windows, but fixes Wine rendering
+      // https://github.com/Meridian59/Meridian59/pull/1337
       InvalidateRect(e->hwnd, NULL, FALSE);
    }
 }


### PR DESCRIPTION
Another day, another Wine fix. This time I even have a screenshot of the problem:
<img width="1196" height="765" alt="enchantments-wine-broken" src="https://github.com/user-attachments/assets/b2c63c59-4077-46cb-ac86-15893953a3e2" />

The problem arises when an enchantment times out and the enchantments need to be moved (`EnchantmentsMovePlayer`/ `EnchantmentsMoveRoom`). What happens is that the enchantments do in fact get moved, but are not rerendered on the new position, so they are there, but not visible.

That is because for some reason `MoveWindow` (well on Wine actually `NtUserSetWindowPos`, but that doesn't matter right now), doesn't produce the `WM_PAINT` message even though the `bRepaint` is set to `TRUE`. I think it has to do with the fact that the enchantment is actually a "button" (`CreateWindow` class). Anyway `MoveWindow` is at least so kind that it removes all the artifacts, so to fix the problem I just added a call to `InvalidateRect`.

Windows shouldn't be affected at all, but you never know. I will test it later.