### PR TITLE
fix: order-of-operations bug in invis, magic shield, and umbrella

### DIFF
--- a/kod/object/passive/spell/persench/invis.kod
+++ b/kod/object/passive/spell/persench/invis.kod
@@ -79,8 +79,7 @@ messages:
       }
 
       Send(first(lTargets),@ResetPlayerFlagList);
-      Send(first(lTargets),@AddDefenseModifier,#what=self);
-      
+
       propagate;
    }
 
@@ -102,8 +101,14 @@ messages:
       return random(iDuration/2,iDuration);
    }
 
-   GetStateValue(iSpellpower=$)
+   GetStateValue(target=$, iSpellpower=0)
    {
+      % Add defense modifier here, after parent class confirms target is valid.
+      if target <> $
+      {
+         Send(target,@AddDefenseModifier,#what=self);
+      }
+
       return iSpellpower;
    }
 

--- a/kod/object/passive/spell/persench/mshield.kod
+++ b/kod/object/passive/spell/persench/mshield.kod
@@ -63,13 +63,6 @@ messages:
 
       return;
    }
-	 
-   CastSpell(who = $,lTargets = $)
-   {
-      Send(first(lTargets),@AddDefenseModifier,#what=self);
-      
-      propagate;
-   }
 
    GetDuration(iSpellPower=$)
    {
@@ -83,8 +76,14 @@ messages:
       return iDuration;
    }
 
-   GetStateValue(iSpellpower=$)
+   GetStateValue(target=$, iSpellpower=0)
    {
+      % Add defense modifier here, after parent class confirms target is valid.
+      if target <> $
+      {
+         Send(target,@AddDefenseModifier,#what=self);
+      }
+
       return iSpellpower;
    }
 

--- a/kod/object/passive/spell/persench/umbrella.kod
+++ b/kod/object/passive/spell/persench/umbrella.kod
@@ -78,13 +78,6 @@ messages:
       propagate;
    }
 
-   CastSpell(who = $, iSpellpower = $)
-   {
-      Send(who,@AddDefenseModifier,#what=self);
-      
-      propagate;
-   }
-
    EndEnchantment(who = $,state = $)
    {
       Send(who,@RemoveDefenseModifier,#what=self);
@@ -92,8 +85,14 @@ messages:
       propagate;
    }
 
-   GetStateValue(iSpellpower=$)
+   GetStateValue(target=$, iSpellpower=0)
    {
+      % Add defense modifier here, after parent class confirms target is valid.
+      if target <> $
+      {
+         Send(target,@AddDefenseModifier,#what=self);
+      }
+
       return iSpellpower;
    }
 


### PR DESCRIPTION

## What
- Moved `AddDefenseModifier` calls from `CastSpell` to `GetStateValue` in three spells:
  - Invisibility
  - Magic Shield
  - Umbrella
- Fixes #1327 

## Why
- There were server errors like this:
```
[memmap/invis.bof (125)] InterpretBinaryAssign can't add 2 vars 1,926 and 0,0
```
- This meant the game was trying to look up an enchantment's spellpower when the enchantment didn't exist.

### Root Cause: Order-of-Operations Issue
- The bug was caused by an order-of-operations issue in the spell casting flow. The child class added the defense modifier before the parent class validated the target was still online:

```mermaid
flowchart TD
    subgraph OLD["OLD CODE (Buggy)"]
        A1[invis.kod::CastSpell] --> A2[AddDefenseModifier]
        A2 --> A3[propagate to parent]
        A3 --> A4{IsLoggedOn?}
        A4 -->|NO| A5[return FALSE]
        A4 -->|YES| A6[StartEnchantment]
        
        A2 -.->|"Defense modifier EXISTS"| ORPHAN((ORPHAN))
        A5 -.->|"Enchantment MISSING"| ORPHAN
    end
    
    style A2 fill:#ff0000,color:#fff
    style A5 fill:#ff0000,color:#fff
    style ORPHAN fill:#ff0000,color:#fff
```

If the target logged off between `AddDefenseModifier` and the parent's `IsLoggedOn` check:
- Defense modifier: **EXISTS** (added before check)
- Enchantment: **MISSING** (parent aborted)

Later, if the player on which the enchantment was cast was hit by anything,  `ModifyDefensePower` would be called and would look up the enchantment's spellpower but would only find `$`, generating the error.

## How
- `GetStateValue` is now called from inside the parent's `StartEnchantment` call, meaning that `GetStateValue` only runs AFTER:
  - The target has been validated
  - The logged-on check has passed
  - The spell will be applied

```mermaid
flowchart TD
    subgraph NEW["NEW CODE (Fixed)"]
        B1[Child CastSpell] --> B2[propagate to parent]
        B2 --> B3{IsLoggedOn?}
        B3 -->|NO| B4[return FALSE]
        B3 -->|YES| B5[StartEnchantment]
        B5 --> B6[GetStateValue called]
        B6 --> B7[AddDefenseModifier]
        B7 --> B8[Enchantment created]
        
        B4 -.->|"Nothing added yet"| SAFE((SAFE))
        B8 -.->|"Both exist together"| ATOMIC((ATOMIC))
    end
    
    style B4 fill:#2f9e44,color:#fff
    style B7 fill:#2f9e44,color:#fff
    style B8 fill:#2f9e44,color:#fff
    style SAFE fill:#2f9e44,color:#fff
    style ATOMIC fill:#2f9e44,color:#fff
```
Now the defense modifier and enchantment are created atomically - either both exist or neither does.

## Follows Existing Pattern
- These spells already add defense modifiers in `GetStateValue` correctly:
  - Gaze of the Basilisk
  - Shadow Form
  - Armor of Gort

- This fix applies the same pattern to three spells that were not doing it in a safe, atomic, way.