### PR TITLE
fix: error when interacting with the spring of vitality while affected by Second Wind

### DIFF
--- a/kod/object/active/holder/room/monsroom/orccav5x.kod
+++ b/kod/object/active/holder/room/monsroom/orccav5x.kod
@@ -45,13 +45,14 @@ properties:
 
    prMusic = OrcCave5Ext_music
 
+   poPoolWater = $
+
 messages:
 
-   CreateStandardExits()
+   Constructor()
    {
-      plEdge_exits = $;
-      plEdge_Exits = Cons([LEAVE_EAST, RID_ORC_CAVE5, 12, 4, ROTATE_NONE], plEdge_exits);
-      plEdge_Exits = Cons([LEAVE_WEST, RID_ORC_PIT, 64, 68, ROTATE_NONE], plEdge_exits);
+      % Create food item that can stand in for pool water
+      poPoolWater = Create(&Food);
 
       propagate;
    }
@@ -77,7 +78,7 @@ messages:
    UserDrink(who=$)
    {
       %% someone presses space bar in the pool, gets a cute little boost.
-      if NOT Send(who,@ReqEatSomething,#filling=viFilling,#what=self)
+      if NOT Send(who,@ReqEatSomething,#filling=viFilling,#what=poPoolWater)
       {
          return TRUE;
       }      
@@ -104,7 +105,16 @@ messages:
       propagate;
    }
 
+   Delete()
+   {
+      if poPoolWater <> $
+      {
+         Send(poPoolWater,@Delete);
+         poPoolWater = $;
+      }
 
+      propagate;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/room/monsroom/orccav5x.kod
+++ b/kod/object/active/holder/room/monsroom/orccav5x.kod
@@ -45,14 +45,13 @@ properties:
 
    prMusic = OrcCave5Ext_music
 
-   poPoolWater = $
+   poFoodProxy = $ % A food object used to interface with user drink requests
 
 messages:
 
    Constructor()
    {
-      % Create food item that can stand in for pool water
-      poPoolWater = Create(&Food);
+      poFoodProxy = Create(&Food);
 
       propagate;
    }
@@ -78,7 +77,7 @@ messages:
    UserDrink(who=$)
    {
       %% someone presses space bar in the pool, gets a cute little boost.
-      if NOT Send(who,@ReqEatSomething,#filling=viFilling,#what=poPoolWater)
+      if NOT Send(who,@ReqEatSomething,#filling=viFilling,#what=poFoodProxy)
       {
          return TRUE;
       }      
@@ -107,10 +106,10 @@ messages:
 
    Delete()
    {
-      if poPoolWater <> $
+      if poFoodProxy <> $
       {
-         Send(poPoolWater,@Delete);
-         poPoolWater = $;
+         Send(poFoodProxy,@Delete);
+         poFoodProxy = $;
       }
 
       propagate;

--- a/kod/object/active/holder/room/monsroom/orccav5x.kod
+++ b/kod/object/active/holder/room/monsroom/orccav5x.kod
@@ -45,13 +45,22 @@ properties:
 
    prMusic = OrcCave5Ext_music
 
-   poFoodProxy = $ % A food object used to interface with user drink requests
+   poFoodProxy = $  % A food object used to interface with user drink requests
 
 messages:
 
    Constructor()
    {
       poFoodProxy = Create(&Food);
+
+      propagate;
+   }
+
+   CreateStandardExits()
+   {
+      plEdge_exits = $;
+      plEdge_Exits = Cons([LEAVE_EAST, RID_ORC_CAVE5, 12, 4, ROTATE_NONE], plEdge_exits);
+      plEdge_Exits = Cons([LEAVE_WEST, RID_ORC_PIT, 64, 68, ROTATE_NONE], plEdge_exits);
 
       propagate;
    }


### PR DESCRIPTION
This PR fixes #1216 by providing a consumable resource for `ReqEatSomething` to work with, whereas it was previously the room itself being passed along. I'm not a huge fan of my `poFoodProxy` naming and open to suggestions if it's an issue.

### Notes
* The spring of vitality is found in `oc5b`