### PR TITLE
fix stat list rendering when using mouse wheel, both Windows and Wine

### DIFF
--- a/module/merintr/statlist.c
+++ b/module/merintr/statlist.c
@@ -165,6 +165,10 @@ LRESULT CALLBACK StatsListProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lP
       	 return 0;
       break;
 
+   case WM_MOUSEWHEEL:
+      InvalidateRect(hList, NULL, TRUE);
+      break;
+
       HANDLE_MSG(hwnd, WM_VSCROLL, StatsListVScroll);
 
    case WM_ERASEBKGND:


### PR DESCRIPTION
Pretty self explanatory, here is a video, and on Windows this bug looks different, but it is still fixed by these three lines:
https://github.com/user-attachments/assets/a896c088-5857-4c8e-9e77-b5cc585c58d0

I had another idea on how to fix this:
```c
   case WM_MOUSEWHEEL:
   {
      WPARAM code;
      int zDelta = GET_WHEEL_DELTA_WPARAM(wParam);

      if (zDelta < 0) {
              code = MAKEWPARAM(SB_LINEDOWN, 0);
              zDelta = -zDelta;
      } else {
              code = MAKEWPARAM(SB_LINEUP, 0);
      }
      zDelta /= WHEEL_DELTA;

      while (zDelta --> 0) {
              SendMessage(hList, WM_VSCROLL, code, 0);
      }

      return 0;
   }
```
But `InvalidateRect` is way cleaner, because it doesn't override the default windows handler for mouse wheel.