### PR TITLE
fix: bridge logic bugs in `temprii`

### DIFF
--- a/kod/object/active/holder/room/temprii.kod
+++ b/kod/object/active/holder/room/temprii.kod
@@ -562,52 +562,28 @@ messages:
    IsObjectInTempleRegion(what=$,row=0,col=0)
    "Returns TRUE if the object is in the temple region"
    {
-      if ((row >= 4 AND col >= 13) 
-            AND (row <= 30 AND col <= 44))
-      {
-         return TRUE;
-      }
-
-      return FALSE;
+      return ((row >= 4 AND col >= 13) AND (row <= 30 AND col <= 44));
    }
 
    IsObjectInBridgeRegion(what=$,row=0,col=0)
-   "Returns TRUE if the object is in the bridge region or it's adjacent buffer areas"
+   "Returns TRUE if the object is in the bridge region or its adjacent buffer areas"
    {
-      if Send(self,@IsObjectInBridgeBufferZone,#what=what,#row=row,#col=col) 
-         OR Send(self,@IsObjectOnBridge,#what=what,#row=row,#col=col)
-      {
-         return TRUE;
-      }
-
-      return FALSE;
+      return Send(self,@IsObjectInBridgeBufferZone,#what=what,#row=row,#col=col) 
+         OR Send(self,@IsObjectOnBridge,#what=what,#row=row,#col=col);
    }
 
    IsObjectOnBridge(what=$,row=0,col=0)
    "Returns TRUE if the object is on the bridge"
    {
-      if ((row > 32 AND row < 45) 
-         AND ((col = 30 OR col = 31)))
-      {
-         return TRUE;
-      }
-
-      return FALSE;
+      return ((row > 32 AND row < 45) AND ((col = 30 OR col = 31)));
    }
 
    IsObjectInBridgeBufferZone(what=$,row=0,col=0)
    "Returns TRUE if the object is in the bridge's left or right buffer areas"
    {
-      if (((row >= 31 AND col >= 26) 
-            AND (row <= 44 AND col <= 29))
-         OR ((row >= 31 AND col >= 32) 
-            AND (row <= 45 AND col <= 35))
-         OR (row = 45 AND col = 29))
-      {
-         return TRUE;
-      }
-
-      return FALSE;
+      return (((row >= 31 AND col >= 26) AND (row <= 44 AND col <= 29))
+         OR ((row >= 31 AND col >= 32) AND (row <= 45 AND col <= 35))
+         OR (row = 45 AND col = 29));
    }
 
 end


### PR DESCRIPTION
This PR fixes issues in `temprii` related to objects falling from the bridge, and adds new helper methods to make the logic more readable.

### Issue 1: `if` precedence bug causes non-Player objects to trigger Player logic
`SomethingMoved` had incorrect operator precedence in its coordinate check that allowed non-Player objects (e.g. `Reflection`, apparitions, and such) to trigger the Player-specific hurl logic. This would present itself as a series of server log messages like the following:

```
Jan 08 2026 21:38:17 | [temprii.bof (425)] SendBlakodMessage CLASS Reflection (13760) OBJECT 6828 can't find a handler for MESSAGE LoseHealth (12923)
Jan 08 2026 21:38:42 | [temprii.bof (500)] SendBlakodMessage CLASS Reflection (13760) OBJECT 6828 can't find a handler for MESSAGE EffectSendUserDuration (12782)
Jan 08 2026 21:38:42 | [temprii.bof (501)] SendBlakodMessage CLASS Reflection (13760) OBJECT 6828 can't find a handler for MESSAGE EffectSendUserXLat (12922)
```

However, it would also present itself as additional player folly messages and player fall sound effects, which were also sometimes repeated. I believe the repetition is a result of `PlayerHurledSelfOffCliffs` being called both times in `SomethingMoved`.

**Fix:** Added parenthesis to ensure the player check applies to all coordinate ranges.

### Issue 2: Race condition when monsters are killed on bridge
When a monster (or `Reflection`, etc) spawned on the bridge makes its first movement, `SomethingMoved` calls `Send(what,@Killed)`. That in turn calls `Send(self,@Delete)`, deleting the monster before `MoveTimer` can complete its `PostMoveTimer` call, resulting in:

```
Jan 08 2026 21:28:52 | [monster.bof (1169)] C_SendMessage OBJECT 6862 CLASS Reflection can't send MESSAGE PostMoveTimer (13481) to non-object 0,0
```

**Fix:** Based on precedent in `monster.kod::KilledSomething`, `Send` changed to `Post` because this is similar to the self-kill logic that calls for `Post` there. The same monster check has been added to `NewHold` to catch freshly spawned monsters.