### PR TITLE
fix: clear `plOverlays` in `FactionTroop::CreateTreasure`

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/troop.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/troop.kod
@@ -1058,6 +1058,7 @@ messages:
       }
       
       plUsing = $;
+      plOverlays = $;
 
       % Don't propagate.  We do everything here.
       return;


### PR DESCRIPTION
This PR seeks to address garbage collection issues I believe are related to faction troops. Recent errors in the production server logs are consistent with these logs I've seen locally when saving. While I can't reproduce consistently, I think the problem may be that `CreatureTreasure` clears `plUsing` but not `plOverlays`. Since `AddEquipmentObject` adds to both lists, deleted items remain in `plOverlays`, possibly causing these garbage collection errors.

**Fix:** Clear `plOverlays` when clearing `plUsing` in `CreateTreasure`

### Log Sample
```
Jan 14 2026 18:41:26 | -------------------------------------------------------------------------------------
Jan 14 2026 19:42:59 | GetObjectByID can't retrieve deleted OBJECT 5332 which was CLASS LongSword
Jan 14 2026 19:42:59 | ResetObjectReference death by garbage collection
Jan 14 2026 19:42:59 | RenumberListNodesReferences got object death in list node 67974 first
Jan 14 2026 19:42:59 | GetObjectByID can't retrieve deleted OBJECT 5332 which was CLASS LongSword
Jan 14 2026 19:42:59 | ResetObjectReference death by garbage collection
Jan 14 2026 19:42:59 | RenumberListNodesReferences got object death in list node 67975 first
Jan 14 2026 19:42:59 | GetObjectByID can't retrieve deleted OBJECT 5333 which was CLASS LeatherArmor
Jan 14 2026 19:42:59 | ResetObjectReference death by garbage collection
Jan 14 2026 19:42:59 | RenumberListNodesReferences got object death in list node 67976 first
Jan 14 2026 19:42:59 | GetObjectByID can't retrieve deleted OBJECT 5334 which was CLASS PrincessShield
Jan 14 2026 19:42:59 | ResetObjectReference death by garbage collection
Jan 14 2026 19:42:59 | RenumberListNodesReferences got object death in list node 67977 first
Jan 14 2026 19:42:59 | GetObjectByID can't retrieve deleted OBJECT 5334 which was CLASS PrincessShield
Jan 14 2026 19:42:59 | ResetObjectReference death by garbage collection
Jan 14 2026 19:42:59 | RenumberListNodesReferences got object death in list node 67978 first
Jan 14 2026 19:47:30 | -------------------------------------------------------------------------------------
Jan 14 2026 21:16:00 | GetObjectByID can't retrieve deleted OBJECT 5402 which was CLASS LongSword
Jan 14 2026 21:16:00 | ResetObjectReference death by garbage collection
Jan 14 2026 21:16:00 | RenumberListNodesReferences got object death in list node 23852 first
Jan 14 2026 21:16:00 | GetObjectByID can't retrieve deleted OBJECT 5402 which was CLASS LongSword
Jan 14 2026 21:16:00 | ResetObjectReference death by garbage collection
Jan 14 2026 21:16:00 | RenumberListNodesReferences got object death in list node 23853 first
Jan 14 2026 21:16:00 | GetObjectByID can't retrieve deleted OBJECT 5403 which was CLASS ScaleArmor
Jan 14 2026 21:16:00 | ResetObjectReference death by garbage collection
Jan 14 2026 21:16:00 | RenumberListNodesReferences got object death in list node 23854 first
Jan 14 2026 21:16:00 | GetObjectByID can't retrieve deleted OBJECT 5404 which was CLASS DukeShield
Jan 14 2026 21:16:00 | ResetObjectReference death by garbage collection
Jan 14 2026 21:16:00 | RenumberListNodesReferences got object death in list node 23855 first
Jan 14 2026 21:16:00 | GetObjectByID can't retrieve deleted OBJECT 5404 which was CLASS DukeShield
Jan 14 2026 21:16:00 | ResetObjectReference death by garbage collection
Jan 14 2026 21:16:00 | RenumberListNodesReferences got object death in list node 23856 first
Jan 14 2026 21:16:26 | -------------------------------------------------------------------------------------
```