### PR TITLE
fix: prevent Admins and DMs from receiving improvement cap messages

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
@@ -504,9 +504,7 @@ messages:
    }
 
    CheckAdvancementPoints()
-   "Returns TRUE to exempt DMs from the advancement cap.  Regular players "
-   "have a limit on how much they can advance per hour per room; DMs are "
-   "not subject to this limit regardless of pbAdvancement setting."
+   "Always returns TRUE for DMs."
    {
       return TRUE;
    }


### PR DESCRIPTION
## What
- removed improvement cap messages for Admins and DMs
  - in #1266 improvement cap messages were added but tweaks were needed to prevent Admins and DMs from getting those messages
  - modified `DM::CheckAdvancementPoints()` in `dm.kod` to always return TRUE
    - removed the conditional check for `pbAdvancement` flag that was causing improvement cap messages to appear
    - added function comment explaining the exemption

## Why

- a developer reported receiving room improvement limit messages on a fresh server after using `dm get spells` and `dm get skills`, then casting Armageddon
- root cause: the old DM override only exempted when `pbAdvancement = FALSE`, but Admin class has `pbAdvancement = TRUE` by default

## How

- changed `DM::CheckAdvancementPoints()` to always return TRUE instead of conditionally checking `pbAdvancement`
  - the `pbAdvancement` flag controls whether DMs CAN advance (presumably for testing purposes)
   - the cap and its educational messages should never apply to them regardless of this flag

## Example

### Before

Admin casts Armageddon in a room and sees:
> You feel like you've practiced all you can in this location.  Perhaps a change of scenery would help refresh your mind.

### After

Admin casts Armageddon repeatedly with no advancement cap messages.

---

## Why the Message Appeared

- the admin had maxed (99%) spells, so nothing was improving, but the message appeared anyway
  - every spell cast triggers `CheckAdvancementPoints()` as part of the school casting bonus system
    - when this check returned FALSE (at cap), there was a chance to display an educational message

```mermaid
flowchart TD
    A["Admin casts Armageddon"] --> B["AddSchoolCast() called"]
    B --> C["CheckAdvancementPoints() called"]
    C --> D{"DM with pbAdvancement = TRUE?"}
    D -->|"Yes (Admin default)"| E["Propagate to parent class"]
    E --> F{"At advancement cap?"}
    F -->|"Yes"| G{"Random 1-8 = 1?"}
    G -->|"Yes (12.5%)"| H["Show educational message"]
    G -->|"No (87.5%)"| I["Continue silently"]
    
    style D fill:#ff0000,color:#fff
    style H fill:#ff0000,color:#fff
```

The fix makes DMs always return TRUE at the first check, never reaching the parent class logic.

```mermaid
flowchart TD
    A["Admin casts Armageddon"] --> B["AddSchoolCast() called"]
    B --> C["CheckAdvancementPoints() called"]
    C --> D{"Is DM class?"}
    D -->|"Yes"| E["Return TRUE immediately"]
    E --> F["No message, full bonus"]
    
    style E fill:#2f9e44,color:#fff
    style F fill:#2f9e44,color:#fff
```