### PR TITLE
Fix long-range projectile rendering and travel time

### DIFF
--- a/clientd3d/project.c
+++ b/clientd3d/project.c
@@ -91,8 +91,10 @@ void ProjectileAdd(Projectile *p, ID source_obj, ID dest_obj, BYTE speed, WORD f
       distance = sqrtf(dx_f * dx_f + dy_f * dy_f + dz_f * dz_f) / FINENESS;
 
       // Calculate normal increment based on speed
-      // speed is in grid squares per 10 seconds, distance is in grid squares
-      float normal_increment = ((float) speed) / 1000.0f / distance;
+      // The server sends speed as "grid squares per 10 seconds", and increment is
+      // "progress per millisecond", so we divide by 10000 (10 seconds = 10000 milliseconds).
+      // This matches the calculation in MoveObject2() in moveobj.c.
+      float normal_increment = ((float) speed) / 10000.0f / distance;
 
       // Cap maximum travel time to prevent extremely long-range projectiles from taking
       // 30+ seconds to arrive, which breaks gameplay (attack sounds/animations finish


### PR DESCRIPTION
Support visuals for long range projectiles (e.g. arrows and fireball).

Projectiles traveling to long-range targets were not rendering at all. Debug logs revealed projectile positions were being set to INT_MIN (-2,147,483,648), indicating integer overflow during motion calculations.

Example from additional logging:
```
Processing projectile at (-2147483648,-2147483648), icon=27593
Projectile dist=-2021769, dx=2147417145, dy=2147399097
```

Added `MAX_PROJECTILE_TRAVEL_TIME` to automatically boost projectile speed at extreme ranges, preventing the 10+ second travel times that created poor audio-visual feedback. Projectiles now arrive within a maximum of 10 seconds regardless of distance, while maintaining normal speed for typical combat ranges. 

Fixes: https://github.com/Meridian59/Meridian59/issues/1354