### PR TITLE
fix: corrects loop variables in `roofile.c`

### DIFF
--- a/blakserv/roofile.c
+++ b/blakserv/roofile.c
@@ -71,7 +71,7 @@ bool BSPRooFileLoadServer(char *fname, room_type *room)
       if (read(infile, room->grid[i], room->cols) != room->cols)
       {
 	 for (j=0; j <= i; j++)
-	    FreeMemory(MALLOC_ID_ROOM,room->grid[i],room->cols);
+	    FreeMemory(MALLOC_ID_ROOM,room->grid[j],room->cols);
 	 FreeMemory(MALLOC_ID_ROOM,room->grid,room->rows * sizeof(char *));
 
 	 close(infile);
@@ -87,7 +87,7 @@ bool BSPRooFileLoadServer(char *fname, room_type *room)
       if (read(infile, room->flags[i], room->cols) != room->cols)
       {
 	 for (j=0; j <= i; j++)
-	    FreeMemory(MALLOC_ID_ROOM,room->flags[i],room->cols);
+	    FreeMemory(MALLOC_ID_ROOM,room->flags[j],room->cols);
 	 FreeMemory(MALLOC_ID_ROOM,room->flags,room->rows * sizeof(char *));
 
 	 close(infile);


### PR DESCRIPTION
The cleanup loops in `BSPRooFileLoadServer` used the wrong index when freeing grid rows. The loops iterate with `j` but freed `room->grid[i]` instead of `room->grid[j]`, so only the current row was freed, leaking all other rows 0.