### PR TITLE
fix: herald shield description spacing

### DIFF
--- a/kod/object/item/passitem/defmod/shield/guilshld.kod
+++ b/kod/object/item/passitem/defmod/shield/guilshld.kod
@@ -64,7 +64,7 @@ resources:
    guildshield_window_overlay_rsc = povshldE.bgf
 
    guildshield_desc_rsc = \
-      "Heavy metal shields of this style are decorated in the standards of its owner guild. "
+      "Heavy metal shields of this style are decorated in the standards of its owner guild."
 
    guildshield_heraldry_prefix = "The pattern on this shield is "
 
@@ -194,6 +194,7 @@ messages:
       %          the traditional mark of the Foobars.  The eye of
       %          Riija is staring ahead."
 
+      AppendTempString("  ");
       AppendTempString(guildshield_heraldry_prefix);
 
       % color 1


### PR DESCRIPTION
## What
- Removed trailing spaces from herald shield description resources
- Fixed spacing from single space to double space in description (to match the rest of the description and other items)
- Moved sentence spacing logic from resources to code in `DoBaseDesc()`
- related to #1297 

## Why
- Trailing spaces in resources caused extra whitespace at end of description paragraphs
- Spacing between sentences (two spaces) are now managed in code, not embedded in resource strings
- Follows same pattern used elsewhere in the codebase (e.g., `item.kod`)

## How
- Modified `guilshld.kod`:
  - Removed trailing space from `guildshield_desc_rsc`
  - Removed trailing spaces from all `guildshield_insig_*` resources
  - Added `AppendTempString("   ")` before heraldry prefix and before insignia text
  - Removed `INSIG_NONE` case (was appending empty string)
  - Removed unused `guildshield_insig_none` resource

## Example

### Before
<img alt="meridian_kk1xp4wuZJ" src="https://github.com/user-attachments/assets/61e0d9a6-b2a1-4f0c-87cd-ca1a08338e94" />
(single space between sentences, trailing space at end)

### After
<img alt="meridian_hGdteJ6D7V" src="https://github.com/user-attachments/assets/f4203c1f-c6e3-453a-8429-719f312e20f0" />
(two spaces between all sentences, no trailing whitespace)