### PR TITLE
fix: prevent client startup flickering and splash screen jumps

### DIFF
--- a/clientd3d/statoffl.c
+++ b/clientd3d/statoffl.c
@@ -124,13 +124,8 @@ void OfflineResize(int xsize, int ysize)
    button_origin.y = max(0, min(bm_origin.y + bm_height, ysize - button_height));
 
    if (hwndDialButton != NULL)
-   {
      MoveWindow(hwndDialButton, button_origin.x, button_origin.y, 
 		button_width, button_height, TRUE);
-     // Show button now that it's positioned correctly
-     if (!IsWindowVisible(hwndDialButton))
-        ShowWindow(hwndDialButton, SW_SHOW);
-   }
    InvalidateRect(hMain, NULL, TRUE);  /* redraw all */
 }
 /****************************************************************************/
@@ -174,7 +169,7 @@ void IntroShowSplash(void)
    showing_splash = true;
 
    hwndDialButton = CreateWindow("button", NULL, 
-		WS_CHILD,
+		WS_CHILD | WS_VISIBLE,
 		0, 0, 0, 0, hMain, (HMENU) IDC_DIALBUTTON,
 		hInst, NULL);
    SetWindowText(hwndDialButton, GetString(hInst, IDS_INTRO));
@@ -216,7 +211,7 @@ void IntroShowSplash(void)
    button_width = bm_width;
    button_height = BUTTON_YSIZE;
 
-   /* Position splash and button based on current window size */
+   /* Simulate resize to get positions right */
    GetClientRect(hMain, &rect);
    OfflineResize(rect.right, rect.bottom);
 


### PR DESCRIPTION
## What

- Fixed visual glitch where splash screen appeared offset then jumped to center when starting maximized
- Also addresses small glitch upon startup where the client window itself will jump to maximized size (if closed as maximized)

## Why

- When client was closed while maximized, reopening briefly showed splash in wrong position before snapping to center
- `SetWindowPlacement` with `SW_SHOWMAXIMIZED` does not maximize immediately - it only stores intent
- Actual resize happens at `ShowWindow` time, which is after `IntroShowSplash` runs
- `GetClientRect` during `IntroShowSplash` returned pre-maximize dimensions (wrong)
- Splash positioned based on wrong size, then WM_SIZE corrected it causing visible jump
- PR #1171 exacerbated this by inlining intro code that previously had DLL loading delays

## How

- We use `WM_SETREDRAW FALSE` to completely disable visual updates
- Call `ShowWindow(SW_SHOWMAXIMIZED)` to force actual resize while hidden
- Hide window, re-enable redraw
- Window is now at correct size but invisible - no flash
- `IntroShowSplash` now gets correct dimensions from `GetClientRect`

## Timing

```text
Before: SetWindowPlacement (stores intent) -> IntroShowSplash (wrong size) -> ShowWindow (resize) -> jump
After:  WM_SETREDRAW OFF -> ShowWindow (resize) -> Hide -> WM_SETREDRAW ON -> IntroShowSplash (correct) -> Show
```
