### PR TITLE
Knight shield drop rate

### DIFF
--- a/kod/object/passive/trestype/skel2t.kod
+++ b/kod/object/passive/trestype/skel2t.kod
@@ -30,7 +30,7 @@ messages:
    {
       plTreasure = [ [ &Mushroom, 25 ],
                      [ &RedMushroom, 20 ],
-                     [ &Snack, 19 ],
+                     [ &Snack, 15 ],
                      [ &Money, 15 ],
                      [ &NeruditeArrow, 5 ],
                      [ &Emerald, 5 ],


### PR DESCRIPTION
Recently we updated monster loot tables (PR #971). As part of that change, Knight Shields were removed from some loot tables and reduced from approximately 15% to 1% on others, which had the side-effect of sharply reducing their availability.

As a result, Knight Shields are now roughly as rare as plate armor. This unintentionally increases the difficulty of completing Jonas loyalty quests and makes Knight Shields disproportionately hard to acquire relative to their intended role in progression. The specific impact of increasing Knight Shield rarity was not explicitly discussed in the original change.

This PR makes a minimal adjustment by increasing the Knight Shield drop rate on battered skeletons to 5%. To keep the overall loot distribution stable, this increase is offset by a small reduction to a low-value, stackable filler item added in PR #971. The intent is not to revert prior loot-table cleanup, but to partially offset the effective rarity increase and restore Knight Shield availability closer to its pre-change role - ensuring the item is realistically obtainable by players who actively seek it, while preserving overall rarity and economic balance.