### PR TITLE
Fix dark patches near lights when monsters die during flash effect    

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -1087,10 +1087,6 @@ static int CalculateFlickeredIntensity(const LightSourceData &lightData, float *
    if (lightData.objFlags & (OF_FLICKERING | OF_FLASHING))
    {
       flickerBrightness = (float) lightData.lightAdjust / GetFlickerLevel();
-      // Clamp to non-negative to handle flashing lights where SIN() can go negative.
-      // Negative brightness would cause invalid color values.
-      flickerBrightness = flickerBrightness;
-       //std::max(flickerBrightness, 0.0f);
       flickeredIntensity = (int) (D3DLightScale(lightData.baseIntensity) * flickerBrightness);
    }
    else
@@ -1147,13 +1143,9 @@ static void InitializeLightProperties(d_light *light,
    }
 
    // Set xyz scales (all three axes use same value)
-   // Ensure minimum intensity of 1 to prevent division by zero in inverse scale
-   // calculations and in d3drender_objects.c distance calculations.
-   // This can occur when flickering/flashing lights have lightAdjust near zero.
-   int safeIntensity = flickeredIntensity; //std::max(flickeredIntensity, 1);
-   light->xyzScale.x = safeIntensity;
-   light->xyzScale.y = safeIntensity;
-   light->xyzScale.z = safeIntensity;
+   light->xyzScale.x = flickeredIntensity;
+   light->xyzScale.y = flickeredIntensity;
+   light->xyzScale.z = flickeredIntensity;
 
    // Calculate inverse scales
    light->invXYZScale.x = 1.0f / light->xyzScale.x;


### PR DESCRIPTION
Fix dark patches appearing around dynamic lights when monsters die during lightning bolt flash effect.
                                                                                                                                             
When a monster dies during the screen flash effect (`effects.invert > 0`), the static geometry cache rebuild would bake incorrect lighting values from `GetLightPaletteIndex()` returning `PALETTE_INVERT`. This fix defers the cache rebuild until after the flash effect ends, ensuring correct lighting values are used.

This is currently an issue on the live game - a little tricky to spot given the specifics of the bug.

<img width="2105" height="1249" alt="patches-bug" src="https://github.com/user-attachments/assets/a5dc0e1d-e817-4494-b0c9-6b0551483066" />

Fixes: https://github.com/Meridian59/Meridian59/issues/1370
