### PR TITLE
Fix misspelling of transcendent in dm create itematt command

### DIFF
--- a/kod/object/passive/itematt/iatransc.kod
+++ b/kod/object/passive/itematt/iatransc.kod
@@ -29,7 +29,7 @@ resources:
    itematttranscendant_desc = "It glows with a soft, white light."
    itematttranscendant_name = "transcendant %s"
 
-   transcendant_DM = "transcendent"
+   transcendent_DM = "transcendent"
 
 classvars:
 
@@ -45,7 +45,7 @@ classvars:
 
 
    viDifficulty = 3
-   vrDM_Trigger = transcendant_DM
+   vrDM_Trigger = transcendent_DM
 
 properties:
 


### PR DESCRIPTION
When using the dm create itematt command, the keyword for the transcendent (soft white light) property is misspelled as "transcendant."  This corrects it to the proper spelling as "transcendent."