### PR TITLE
fix: handle background id 0 for D3D skyboxes

### DIFF
--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -137,6 +137,8 @@ static bool D3DRenderBackgroundSet(ID background);
 */
 bool D3DRenderUpdateSkyBox(DWORD background)
 {
+	if (background == 0) return false;
+
 	if (gpSkyboxTextures[0][0] == NULL)
 	{
 		D3DRenderBackgroundsLoad("./resource/skya.bsf", 0);


### PR DESCRIPTION
## What

- Treat background id `0` as “no skybox” in the D3D renderer, and avoid calling `D3DRenderBackgroundSet` / `LookupRsc(0)` when a room reports `background == 0`.

## Why

- `0` is a valid value meaning “no background,” but during room recreates it seems rooms, indoor rooms specifically, report `background == 0` near the finish line.
- In the D3D client this surfaces as `"Missing resource 0"` logs and the missing-resource dialog, even though nothing was actually broken in the room data.
- The software renderer already effectively treats `0` as “no background”; the D3D path should behave the same way.

## Testing

- Run a room recreate while present in an indoor room like Familiars or the Tos Adventurer's Hall. Note the presence of a "Missing resource 0" client debug message and the resource dialog.