### PR TITLE
Original static dynamic lights look and appearance

### DIFF
--- a/clientd3d/d3drender_lights.c
+++ b/clientd3d/d3drender_lights.c
@@ -132,8 +132,8 @@ static int CalculateFlickeredIntensity(const LightSourceData& lightData, float* 
    }
    else
    {
-      // Non-flickering lights use the original DLIGHT_SCALE formula to preserve
-      // their pre-flicker-feature appearance (radius and brightness).
+      // Non-flickering lights scale their intensity directly via DLIGHT_SCALE
+      // to maintain consistent radius and brightness independent of the dynamic flicker system.
       flickeredIntensity = DLIGHT_SCALE(lightData.baseIntensity);
    }
 

--- a/clientd3d/d3drender_lights.c
+++ b/clientd3d/d3drender_lights.c
@@ -132,7 +132,9 @@ static int CalculateFlickeredIntensity(const LightSourceData& lightData, float* 
    }
    else
    {
-      flickeredIntensity = D3DLightScale(lightData.baseIntensity);
+      // Non-flickering lights use the original DLIGHT_SCALE formula to preserve
+      // their pre-flicker-feature appearance (radius and brightness).
+      flickeredIntensity = DLIGHT_SCALE(lightData.baseIntensity);
    }
 
    if (outFlickerBrightness)

--- a/kod/object/passive/flikerer/dynlight.kod
+++ b/kod/object/passive/flikerer/dynlight.kod
@@ -34,6 +34,9 @@ properties:
    % What color?  Default is pure white.
    viLightColor = LIGHT_BWHITE
 
+   % Disable flickering so it uses the original steady light appearance.
+   pbIsFlickering = FALSE
+
 messages:
 
    Constructor(iFlags = LIGHT_FLAG_ON, iIntensity = 255, iColor = LIGHT_BWHITE, bVisible=FALSE)


### PR DESCRIPTION
Restore non-flickering lights to their pre-dynamic flicker state, ensuring that KOD-defined light sources (e.g., wall torches and fire pits) render correctly as as expected. We also prime new dynamic lights to not be flicking, to support the current mechanics used to place such lights in game.

<img width="2589" height="1538" alt="image" src="https://github.com/user-attachments/assets/10f6f96b-b8df-4559-b2f3-14b9a11faf1c" />
