### PR TITLE
fix: client inventory texture glitch

### DIFF
--- a/module/merintr/inventry.c
+++ b/module/merintr/inventry.c
@@ -287,9 +287,13 @@ void InventoryDisplayScrollbar(void)
 	      inventory_area.cx, inventory_area.cy,
 	      FALSE);
 
-   MoveWindow(hwndInv, 0, 0, 
-	      inventory_area.cx - inventory_scrollbar_width, inventory_area.cy,
-	      FALSE);
+   /* When no scrollbar, hwndInv fills the full dialog width so no uncovered
+      strip shows the parent window background on the right edge. */
+   int inv_width = has_scrollbar
+      ? inventory_area.cx - inventory_scrollbar_width
+      : inventory_area.cx;
+
+   MoveWindow(hwndInv, 0, 0, inv_width, inventory_area.cy, FALSE);
 
    MoveWindow(hwndInvScroll, inventory_area.cx - inventory_scrollbar_width,
 	      0, inventory_scrollbar_width,
@@ -418,7 +422,17 @@ INT_PTR CALLBACK InventoryDialogProc(HWND hwnd, UINT message, WPARAM wParam, LPA
       return FALSE;
 
    case WM_ERASEBKGND:
+   {
+      /* Fill the entire dialog area with the inventory background texture.
+         Without this, empty cells in the last partial row and gaps between
+         the item grid and the dialog edge show the wrong background. */
+      HDC hdc = (HDC)wParam;
+      RECT rc;
+      GetClientRect(hwnd, &rc);
+      DrawWindowBackgroundColor(&inventory_bkgnd, hdc, &rc,
+         inventory_area.x, inventory_area.y, -1);
       return 1;
+   }
 
       HANDLE_MSG(hwnd, WM_VSCROLL, InventoryVScroll);
 
@@ -1242,9 +1256,9 @@ void DisplayInventory(list_type inventory)
    }
 
    InventoryScrollRange();
-   if (num_items > rows * cols)
-      InventoryDisplayScrollbar();
    WindowEndUpdate(hwndInv);
+
+   InventoryDisplayScrollbar();
 }
 /************************************************************************/
 /*
@@ -1400,6 +1414,11 @@ void ShowInventory(bool bShow)
 HWND GetHwndInv()
 {
 	return hwndInv;
+}
+/************************************************************************/
+HWND GetHwndInvDialog()
+{
+	return hwndInvDialog;
 }
 
 /************************************************************************/

--- a/module/merintr/inventry.h
+++ b/module/merintr/inventry.h
@@ -44,6 +44,7 @@ void AnimateInventory(int dt);
 
 void ShowInventory(bool bShow);
 HWND GetHwndInv();
+HWND GetHwndInvDialog();
 RawBitmap* pinventory_bkgnd();
 
 #endif /* #ifndef _INVENTRY_H */

--- a/module/merintr/mermain.c
+++ b/module/merintr/mermain.c
@@ -136,9 +136,11 @@ void InterfaceRedrawModule(HDC hdc)
   StatsDraw();
   if( StatsGetCurrentGroup() == STATS_INVENTORY )
   {
-    InvalidateRect( GetHwndInv(), NULL, FALSE );
-    ShowInventory(true);
-    InventoryRedraw();
+    /* Repaint the inventory dialog and all its children (item grid and
+       scrollbar) so they draw on top of the sidebar background.  hMain
+       has no WS_CLIPCHILDREN, so the background fill covers them. */
+    RedrawWindow(GetHwndInvDialog(), NULL, NULL,
+       RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN | RDW_UPDATENOW);
   }
 }
 


### PR DESCRIPTION
## What

- Fixed the sidebar background texture bleeding through the inventory panel
  after `InterfaceRedrawModule` repaints
- Related to #1324 

## Why

- `hMain` has no `WS_CLIPCHILDREN`, so when the sidebar background is drawn
  it paints over the entire inventory dialog and its children
- `InterfaceRedrawModule` then called `InvalidateRect(GetHwndInv(), NULL, FALSE)`,
  which only targeted the item grid (not the dialog or scrollbar) and passed
  `FALSE` for erase, so the dialog's `WM_ERASEBKGND` never fired
- The dialog's `WM_ERASEBKGND` handler returned 1 without painting anything,
  so even if it had fired, no background texture would have been drawn
- `hwndInv` was always sized to leave room for the scrollbar even when hidden,
  leaving a strip of uncovered dialog on the right edge
- `DisplayInventory` only called `InventoryDisplayScrollbar()` when
  `num_items > rows * cols`, so layout was not recalculated when item count
  dropped below the scroll threshold

## How

- `InventoryDialogProc` `WM_ERASEBKGND` now fills the entire dialog with the
  inventory background texture via `DrawWindowBackgroundColor`
- `InterfaceRedrawModule` now calls `RedrawWindow` with `RDW_INVALIDATE`,
  `RDW_ERASE`, `RDW_ALLCHILDREN`, and `RDW_UPDATENOW` on the inventory dialog
  so the dialog, item grid, and scrollbar all repaint after the sidebar fill
- Added `GetHwndInvDialog()` accessor to expose the dialog handle
- `InventoryDisplayScrollbar` sizes `hwndInv` to the full dialog width when
  `has_scrollbar` is false
- `DisplayInventory` always calls `InventoryDisplayScrollbar()`

## Example

- Sidebar texture no longer bleeds through the inventory panel after redraw
<img width="756" height="615" alt="image" src="https://github.com/user-attachments/assets/c6e4417e-16bd-4c8b-928e-24bc545b239e" />
