### PR TITLE
fix: skip orphaned client inventory corner bitmaps

### DIFF
--- a/module/merintr/drawint.c
+++ b/module/merintr/drawint.c
@@ -775,13 +775,12 @@ void InterfaceDrawElements(HDC hdc)
 
   for (i=0; i < NUM_AUTO_ELEMENTS; i++)
   {
-	  //	Temp. disable xxx
-/*	  if( i >= ELEMENT_ULTOP && i <= ELEMENT_LRRIGHT )
-		  continue;
+	  /* Skip inventory corner bitmaps.  The inventory edge repeaters
+	     (ELEMENT_ITOP through ELEMENT_IRIGHT) are already skipped in
+	     the repeater loop below, so these corners have no connecting
+	     edges and draw as floating fragments. */
 	  if( i >= ELEMENT_IULTOP && i <= ELEMENT_ILRRIGHT )
 		  continue;
-	  if( i == ELEMENT_BLLBOTTOM || i == ELEMENT_BLRBOTTOM )
-		  continue;*/
 
     OffscreenWindowBackground(NULL, elements[i].x, elements[i].y, elements[i].width, elements[i].height);
     


### PR DESCRIPTION
## What
- Stopped drawing the 8 inventory corner bitmap elements that appear as floating fragments in the sidebar with no connecting edges
- Fixes #1324

## Why
- The inventory edge repeaters (`ELEMENT_ITOP` through `ELEMENT_IRIGHT`) are already skipped in the repeater draw loop, so all four inventory corners draw without any border strips connecting them

## How
- Re-enabled the `ELEMENT_IULTOP` through `ELEMENT_ILRRIGHT` skip that was commented out in the `InterfaceDrawElements` loop
- Removed the surrounding dead commented-out code

## Example
- The floating corner fragments around the inventory area are no longer drawn
<img width="756" height="155" alt="image" src="https://github.com/user-attachments/assets/9eb58236-cabf-485b-b2ca-fb08fb8a9bc2" />