### PR TITLE
fix: client proportional scrollbar thumb and wheel tracking for spells/skills lists

### DIFF
--- a/module/merintr/statlist.c
+++ b/module/merintr/statlist.c
@@ -29,6 +29,7 @@ extern HWND hStats;
 static int num_visible;             // # of stats visible in list box
 
 static int StatListFindItem(int num);
+static void StatsListUpdateScrollPos(HWND hwnd, int pos);
 static LRESULT CALLBACK StatsListProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 static void StatsListDrawStat(const DRAWITEMSTRUCT *lpdis, bool selected);
 static int  StatsListGetItemHeight(void);
@@ -87,13 +88,22 @@ void StatsListResize(list_type stats)
 
    // Hide scrollbar if not needed
    num_visible = (stats_area.cy - y) / std::max(ListBox_GetItemHeight(hList, 0), 1);
+   SCROLLINFO si = { sizeof(si), SIF_RANGE | SIF_PAGE | SIF_POS };
    if (num_visible >= ListBox_GetCount(hList))
-     SetScrollRange(hList, SB_VERT, 0, 0, TRUE);
+   {
+      si.nMin = 0;
+      si.nMax = 0;
+      si.nPage = 0;
+      si.nPos = 0;
+   }
    else
-     {
-       SetScrollRange(hList, SB_VERT, 0, ListBox_GetCount(hList) - num_visible, TRUE);
-       SetScrollPos(hList, SB_VERT, ListBox_GetTopIndex(hList), TRUE);
-     }
+   {
+      si.nMin = 0;
+      si.nMax = ListBox_GetCount(hList) - 1;
+      si.nPage = num_visible;
+      si.nPos = ListBox_GetTopIndex(hList);
+   }
+   SetScrollInfo(hList, SB_VERT, &si, TRUE);
 
 	if( StatsGetCurrentGroup() != STATS_INVENTORY )			//	ajw
 		ShowWindow(hList, SW_NORMAL);
@@ -154,6 +164,16 @@ int StatListFindItem(int num)
 }
 /************************************************************************/
 /*
+ * StatsListUpdateScrollPos:  Set the scrollbar thumb position.
+ */
+void StatsListUpdateScrollPos(HWND hwnd, int pos)
+{
+   SCROLLINFO si = { sizeof(si), SIF_POS };
+   si.nPos = pos;
+   SetScrollInfo(hwnd, SB_VERT, &si, TRUE);
+}
+/************************************************************************/
+/*
  * StatsListProc:  Subclassed window procedure for list box.
  */
 LRESULT CALLBACK StatsListProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
@@ -166,8 +186,21 @@ LRESULT CALLBACK StatsListProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lP
       break;
 
    case WM_MOUSEWHEEL:
-      InvalidateRect(hList, NULL, TRUE);
-      break;
+   {
+      /* Let the default handler scroll the listbox content, then sync
+         the scrollbar thumb position.  The default handler calls
+         ListBox_SetTopIndex internally but does not update the
+         manually managed scrollbar. */
+      int old_top = ListBox_GetTopIndex(hwnd);
+      LRESULT result = CallWindowProc(lpfnDefStatListProc, hwnd, message, wParam, lParam);
+      int new_top = ListBox_GetTopIndex(hwnd);
+      if (new_top != old_top)
+      {
+         StatsListUpdateScrollPos(hwnd, new_top);
+         InvalidateRect(hList, NULL, TRUE);
+      }
+      return result;
+   }
 
       HANDLE_MSG(hwnd, WM_VSCROLL, StatsListVScroll);
 
@@ -452,7 +485,7 @@ void StatsListVScroll(HWND hwnd, HWND hwndCtl, UINT code, int pos)
 
    if (new_top != old_top)
    {
-      SetScrollPos(hwnd, SB_VERT, new_top, TRUE); 
+      StatsListUpdateScrollPos(hwnd, new_top);
 
       WindowBeginUpdate(hwnd);
       ListBox_SetTopIndex(hwnd, new_top);
@@ -485,7 +518,7 @@ bool StatListKey(HWND hwnd, UINT key, bool fDown, int cRepeat, UINT flags)
        new_top = new_pos;
      ListBox_SetTopIndex(hwnd, new_top);
      ListBox_SetCurSel(hwnd, new_pos);
-     SetScrollPos(hwnd, SB_VERT, new_top, TRUE); 
+     StatsListUpdateScrollPos(hwnd, new_top);
      WindowEndUpdate(hwnd);
      return true;
 
@@ -496,7 +529,7 @@ bool StatListKey(HWND hwnd, UINT key, bool fDown, int cRepeat, UINT flags)
        new_top = new_pos - num_visible;
      ListBox_SetTopIndex(hwnd, new_top);
      ListBox_SetCurSel(hwnd, new_pos);
-     SetScrollPos(hwnd, SB_VERT, new_top, TRUE); 
+     StatsListUpdateScrollPos(hwnd, new_top);
      WindowEndUpdate(hwnd);
      return true;
 
@@ -506,7 +539,7 @@ bool StatListKey(HWND hwnd, UINT key, bool fDown, int cRepeat, UINT flags)
      new_top = new_pos;
      ListBox_SetTopIndex(hwnd, new_top);
      ListBox_SetCurSel(hwnd, new_pos);
-     SetScrollPos(hwnd, SB_VERT, new_top, TRUE); 
+     StatsListUpdateScrollPos(hwnd, new_top);
      WindowEndUpdate(hwnd);
      return true;
 
@@ -516,7 +549,7 @@ bool StatListKey(HWND hwnd, UINT key, bool fDown, int cRepeat, UINT flags)
      new_top = new_pos - num_visible;
      ListBox_SetTopIndex(hwnd, new_top);
      ListBox_SetCurSel(hwnd, new_pos);
-     SetScrollPos(hwnd, SB_VERT, new_top, TRUE); 
+     StatsListUpdateScrollPos(hwnd, new_top);
      WindowEndUpdate(hwnd);
      return true;
 


### PR DESCRIPTION
## What

- Scrollbar thumb in the spells/skills list is now proportional to content size
- Mouse wheel scrolling now moves the scrollbar thumb

>[!NOTE]
> This only affects the spells/skills listbox (`statlist.c`). The inventory and statistics panes use standalone scrollbar controls and will need a separate follow-on PR.

## Why

- `SetScrollRange`/`SetScrollPos` do not support page size, so Windows draws a
  fixed-size thumb regardless of how many items are visible vs total
- The existing `WM_MOUSEWHEEL` handler in `StatsListProc` invalidated the listbox
  for repaint but did not update the scrollbar position, so the thumb stayed put
  while content scrolled

## How

The listbox background is drawn with a tiled texture that must stay aligned to the main window. Windows' default scroll mechanism shifts existing pixels, which would break the texture alignment. So the code manages scrolling manually,
which means it must also update the scrollbar position manually.

The old flow was:

```
scroll event  --> SetScrollPos (position only, no page size)
              --> ListBox_SetTopIndex
              --> repaint

WM_MOUSEWHEEL --> InvalidateRect (no scrollbar update)
```

The new flow is:

```
scroll event  --> StatsListUpdateScrollPos (SetScrollInfo with SIF_POS)
              --> ListBox_SetTopIndex
              --> repaint

WM_MOUSEWHEEL --> default handler scrolls content
              --> StatsListUpdateScrollPos (sync thumb to new top index)
              --> InvalidateRect
```

`StatsListResize` now sets `SIF_RANGE | SIF_PAGE | SIF_POS` via `SetScrollInfo` so Windows knows the page size and draws a proportional thumb.

A new `StatsListUpdateScrollPos` helper wraps the `SetScrollInfo` call for position updates. This replaces 6 inline `SetScrollPos` calls across `StatsListVScroll`, `StatListKey` (Up, Down, Page Up, Page Down), and the `WM_MOUSEWHEEL` handler.

The `WM_MOUSEWHEEL` handler only repaints when the top index actually changed, preventing flashes when scrolling past the start or end of the list.

> [!Note]
> Mouse wheel scrolling is slightly less smooth than thumb dragging because each wheel notch jumps by the system scroll line count (typically 3 items), whereas thumb dragging sends `SB_THUMBTRACK` on every pixel. This matches standard Windows behavior.

## Example
<img width="1401" height="690" alt="Meridian_mKLQWso7Rw" src="https://github.com/user-attachments/assets/0754c34a-c0a6-4291-9e1f-31bf61dfcc83" />

### Before
- Scrollbar thumb is a fixed size regardless of list length
- Mouse wheel scrolls the list content but the thumb stays in place

### After
- Scrollbar thumb is proportional (e.g. roughly 1/3 of the track when 10 of 30 spells are visible)
- Mouse wheel scrolls the list and the thumb follows along

