### PR TITLE
Refactor d3drender.c

### DIFF
--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -100,6 +100,7 @@ M59EXPORT void _cdecl dprintf(const char *fmt,...);
 #include <string>
 #include <vector>
 #include <algorithm>
+#include <bit>
 
 #include "resource.h"
 #include "proto.h"

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -73,7 +73,6 @@ static D3DMATRIX view, mat, rot, trans, proj;
 // External Globals //
 //////////////////////
 extern long				viewer_height;
-extern PDIB				background;         /* Pointer to background bitmap */
 extern ObjectRange		visible_objects[];    /* Where objects are on screen */
 extern int				num_visible_objects;
 extern DrawItem			drawdata[];
@@ -81,13 +80,9 @@ extern long				nitems;
 extern int				sector_depths[];
 extern BYTE				*gBits;
 extern BYTE				*gBufferBits;
-extern D3DPRESENT_PARAMETERS	gPresentParam;
-extern long				stretchfactor;
 extern ViewElement		ViewElements[];
 extern HDC				gBitsDC;
 
-extern void			DrawItemsD3D();
-extern bool			ComputePlayerOverlayArea(PDIB pdib, char hotspot, AREA *obj_area);
 extern void			UpdateRoom3D(room_type *room, Draw3DParams *params);
 
 /////////////////////////
@@ -104,12 +99,12 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 {
 	// Ask for a bigger font to reduce aliasing, then scale the texture
 	// down by the same amount.
-	static constexpr float fontScale = 3.0;
-	HFONT hScaledFont = FontsGetScaledFont(hFont, fontScale);
+	static constexpr float FONT_SCALE = 3.0;
+	HFONT hScaledFont = FontsGetScaledFont(hFont, FONT_SCALE);
 	assert(hScaledFont);
-      
+	
 	pFont->fontHeight = GetFontHeight(hScaledFont);
-	pFont->texScale = fontScale;
+	pFont->texScale = FONT_SCALE;
    
 	if (pFont->fontHeight > 40)
 		pFont->texWidth = pFont->texHeight = 1024;
@@ -117,7 +112,7 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 		pFont->texWidth = pFont->texHeight = 512;
 	else
 		pFont->texWidth = pFont->texHeight = 256;
-
+	
 	D3DCAPS9 d3dCaps;
 	gpD3DDevice->GetDeviceCaps(&d3dCaps);
   
@@ -126,13 +121,13 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 		pFont->texScale *= static_cast<float>(pFont->texWidth) / static_cast<float>(d3dCaps.MaxTextureWidth);
 		pFont->texHeight = pFont->texWidth = d3dCaps.MaxTextureWidth;
 	}
-  
+	
 	if (pFont->pTexture)
 		pFont->pTexture->Release();
-   
+	
 	gpD3DDevice->CreateTexture(pFont->texWidth, pFont->texHeight, 1, 0, D3DFMT_A4R4G4B4,
 									D3DPOOL_MANAGED, &pFont->pTexture, nullptr);
-   
+	
 	BITMAPINFO bmi;
 	memset(&bmi.bmiHeader, 0, sizeof(BITMAPINFOHEADER));
 	bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
@@ -141,21 +136,21 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 	bmi.bmiHeader.biPlanes = 1;
 	bmi.bmiHeader.biCompression = BI_RGB;
 	bmi.bmiHeader.biBitCount = 32;
-
+	
 	HDC hDC = CreateCompatibleDC(gBitsDC);
 	DWORD *pBitmapBits;
 	HBITMAP hbmBitmap = CreateDIBSection(hDC, &bmi, DIB_RGB_COLORS, reinterpret_cast<void**>(&pBitmapBits), nullptr, 0);
 	SetMapMode(hDC, MM_TEXT);
-  
+	
 	SelectObject(hDC, hbmBitmap);
 	SelectObject(hDC, hScaledFont);
-   
+	
 	// Set text properties
 	SetTextColor(hDC, RGB(255,255,255));
 	SetBkColor(hDC, 0);
 	SetBkMode(hDC, TRANSPARENT);
 	SetTextAlign(hDC, TA_TOP);
-
+	
 	TCHAR str[2] = _T("x");
 	long x = 0;
 	long y = 0;
@@ -574,9 +569,6 @@ HRESULT D3DRenderInit(HWND hWnd)
 	gD3DEnabled = D3DDriverProfileInit();
 	if (!gD3DEnabled)
 		return E_FAIL;
-
-	D3DDISPLAYMODE displayMode;
-	gpD3D->GetAdapterDisplayMode(D3DADAPTER_DEFAULT, &displayMode);
 
 	gFrame = 0;
 	

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -218,7 +218,7 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 	for (int y = 0; y < pFont->texHeight; y++)
 	{
 		WORD *pDst16 = reinterpret_cast<WORD*>(pDstRow);
-		for(int x = 0; x < pFont->texWidth; x++)
+		for (int x = 0; x < pFont->texWidth; x++)
 		{
 			// Extract 4-bit alpha from 8-bit source.
 			BYTE bAlpha = static_cast<BYTE>( (pBitmapBits[pFont->texWidth * y + x] & 0xff) >> 4 );

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -11,15 +11,17 @@
 extern int main_viewport_width;
 extern int main_viewport_height;
 
-// Define field of views with magic numbers for tuning
+// Defines field of views
 float FovHorizontal(long width)
 {
-	return width / static_cast<float>(main_viewport_width) * (-PI / 3.78f);
+	static constexpr float HORIZONTAL_TUNING_FACTOR  = (-PI / 3.78f);
+	return width / static_cast<float>(main_viewport_width) * HORIZONTAL_TUNING_FACTOR ;
 }
 
 float FovVertical(long height)
 {
-	return height / static_cast<float>(main_viewport_height) * (PI / 5.88f);
+	static constexpr float VERTICAL_TUNING_FACTOR = (PI / 5.88f);
+	return height / static_cast<float>(main_viewport_height) * VERTICAL_TUNING_FACTOR;
 }
 
 // Helper function to determine if an object should be rendered in the current pass based on transparency.
@@ -77,7 +79,7 @@ RECT					gD3DRect;
 BYTE					gViewerLight = 0;
 int						gNumObjects;
 int						gNumDPCalls;
-static PALETTEENTRY		gPalette[256];  // Legacy 8-bit color palette, aka 256 colors.
+static PALETTEENTRY		gPalette[NUM_COLORS];
 
 static unsigned int		gFrame = 0;
 
@@ -247,13 +249,10 @@ HRESULT D3DRenderInit(HWND hWnd)
 	IDirect3DDevice9_GetDeviceCaps(gpD3DDevice, &gD3DCaps);
 
 	gFrame = 0;
-   
-	gViewport.X = 0;
-	gViewport.Y = 0;
-	gViewport.Width = gScreenWidth;
-	gViewport.Height = gScreenHeight;
-	gViewport.MinZ = 0.0f;
-	gViewport.MaxZ = 1.0f;
+	
+	// Initializes D3D viewport to match current screen dimensions.
+	// Defines screen dimensions (X, Y, Width, Height) and depth range (MinZ, MaxZ).
+	gViewport = { 0, 0, static_cast<DWORD>(gScreenWidth), static_cast<DWORD>(gScreenHeight), 0.0f, 1.0f};
 
 	IDirect3DDevice9_SetViewport(gpD3DDevice, &gViewport);
 
@@ -448,12 +447,7 @@ void D3DRenderShutDown(void)
 
 void D3DRenderBegin(room_type *room, Draw3DParams *params)
 {
-	int	curPacket = 0;
-	int	curIndex = 0;
 	room_contents_node *pRNode = nullptr;
-
-	long timeOverall = timeGetTime();
-	long timeSetup = timeGetTime();
 
 	// Static variable to track the player's previous ability to see. Initialize it only once.
 	static bool can_see = !effects.blind;
@@ -557,8 +551,6 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 		static_cast<float>(params->viewer_height)
 	};
 
-	timeSetup = timeGetTime() - timeSetup;
-
 	if (draw_sky) // Render the skybox first
 	{
 		SkyboxRenderParams skyboxRenderParams(decl1dc, gD3DDriverProfile, gWorldPool, gWorldCacheSystem);
@@ -633,7 +625,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	if (draw_world)
 	{
-		long timeWorld = D3DRenderWorld(worldRenderParams, worldPropertyParams, lightAndTextureParams);
+		D3DRenderWorld(worldRenderParams, worldPropertyParams, lightAndTextureParams);
 
 		// DEBUG: Draw circles at static light positions
 		if (D3DLightsDebugPositionsEnabled() && config.bDynamicLighting)
@@ -663,7 +655,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 		PlayerViewParams playerViewParams(gScreenWidth, gScreenHeight, main_viewport_width, main_viewport_height, gD3DRect);
 
-		long timeObjects = D3DRenderObjects(objectsRenderParams, gameObjectDataParams, lightAndTextureParams, fontTextureParams, playerViewParams);
+		D3DRenderObjects(objectsRenderParams, gameObjectDataParams, lightAndTextureParams, fontTextureParams, playerViewParams);
 	}
 
 	// Transparent walls are drawn LAST so that sprites/monsters behind them show
@@ -705,7 +697,6 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 		D3DFxBlurWaver(fxRenderSystemStructure);
 	}
 
-	long timeComplete = timeGetTime();
 	// view elements (e.g. viewport corners)
 	D3DRender_SetColorStage(1, D3DTOP_DISABLE, 0, 0);
 	D3DRender_SetAlphaStage(1, D3DTOP_DISABLE, 0, 0);
@@ -733,11 +724,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	IDirect3DDevice9_EndScene(gpD3DDevice);
 	
-	RECT rect;
-	rect.top = 0;
-	rect.bottom = gScreenHeight;
-	rect.left = 0;
-	rect.right = gScreenWidth;
+	RECT rect = GetScreenRect();
 
 	HRESULT hr = IDirect3DDevice9_Present(gpD3DDevice, &rect, &gD3DRect, nullptr, nullptr);
 
@@ -757,8 +744,6 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	if ((gFrame & 255) == 255)
 		debug(("number of vertices = %d\nnumber of dp calls = %d\n", gNumVertices, gNumDPCalls));
 
-	timeComplete = timeGetTime() - timeComplete;
-	timeOverall = timeGetTime() - timeOverall;
 }
 
 void D3DRenderResizeDisplay(int left, int top, int right, int bottom)
@@ -787,10 +772,6 @@ int D3DRenderIsEnabled(void)
 
 void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 {
-	D3DCAPS9		d3dCaps;
-	DWORD			*pBitmapBits;
-	BITMAPINFO		bmi;
-
    // Ask for a bigger font to reduce aliasing, then scale the texture
    // down by the same amount.
    float fontScale = 3.0;
@@ -807,6 +788,7 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 	else
 		pFont->texWidth = pFont->texHeight = 256;
 
+	D3DCAPS9 d3dCaps;
 	IDirect3DDevice9_GetDeviceCaps(gpD3DDevice, &d3dCaps);
   
 	if ( pFont->texWidth > static_cast<long>(d3dCaps.MaxTextureWidth) )
@@ -823,6 +805,7 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
       pFont->texHeight, 1, 0, D3DFMT_A4R4G4B4,
       D3DPOOL_MANAGED, &pFont->pTexture, nullptr);
    
+   BITMAPINFO bmi;
    memset(&bmi.bmiHeader, 0, sizeof(BITMAPINFOHEADER));
    bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
    bmi.bmiHeader.biWidth = static_cast<int>(pFont->texWidth);
@@ -832,6 +815,7 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
    bmi.bmiHeader.biBitCount = 32;
    
    HDC hDC = CreateCompatibleDC(gBitsDC);
+   DWORD *pBitmapBits;
    HBITMAP hbmBitmap = CreateDIBSection(hDC, &bmi, DIB_RGB_COLORS, (VOID**)&pBitmapBits, nullptr, 0 );
    SetMapMode(hDC, MM_TEXT);
   
@@ -1076,21 +1060,18 @@ d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDI
 
 void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool)
 {
-   // Render view elements (such as the main viewport yellow ui corners)
-   int offset = 0;
-
    float screenW = static_cast<float>(gD3DRect.right - gD3DRect.left) / static_cast<float>(gScreenWidth);
    float screenH = static_cast<float>(gD3DRect.bottom - gD3DRect.top) / static_cast<float>(gScreenHeight);
 
-   if (GetFocus() == hMain)
-      offset = 4;
-
+   // Render view elements (such as the main viewport yellow ui corners).
+   int offset = (GetFocus() == hMain) ? 4 : 0;
+   
    // 0 = top-left
    // 1 = top-right
    // 2 = bottom-left
    // 3 = bottom-right
-
-   for (int i = 0; i < 4; ++i)
+   static constexpr int NUM_CORNERS = 4;
+   for (int i = 0; i < NUM_CORNERS; ++i)
    {
       float width = static_cast<float>(ViewElements[i + offset].width) / screenW;
       float height = static_cast<float>(ViewElements[i + offset].height) / screenH;
@@ -1143,11 +1124,12 @@ void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool)
       pChunk->xyz[2] = { right, VIEW_ELEMENT_Z, bottom };
       pChunk->xyz[3] = { right, VIEW_ELEMENT_Z, top };	  
 
-      for (int j = 0; j < 4; j++)
+      for (auto& color : pChunk->bgra)
       {
-         pChunk->bgra[j] = {255, 255, 255, 255};
+         color = {255, 255, 255, 255}; // Solid white (no tinting)
       }
 
+      // Half-pixel offset to prevent texture bleeding.
       static constexpr float foffset = 1.0f / 64.0f;
       pChunk->st0[0] = { foffset, foffset };
       pChunk->st0[1] = { foffset, (1.0f - foffset) };
@@ -1180,10 +1162,7 @@ LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
 
 	POINT pnt = { 0, 0 };
 	
-	RECT rect;
-	rect.left = rect.top = 0;
-	rect.right = gScreenWidth;
-	rect.bottom = gScreenHeight;
+	RECT rect = GetScreenRect();
 
 	// copy framebuffer to texture
 	IDirect3DDevice9_StretchRect(gpD3DDevice, pSrc, &rect, pDest[0], &rect, D3DTEXF_NONE);

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -157,7 +157,7 @@ void					*D3DRenderMalloc(unsigned int bytes);
 void SetZBias(LPDIRECT3DDEVICE9 device, int z_bias)
 {
    float bias = z_bias * -0.00001f;
-   IDirect3DDevice9_SetRenderState(device, D3DRS_DEPTHBIAS, *((DWORD *) &bias));
+   device->SetRenderState(D3DRS_DEPTHBIAS, *((DWORD *) &bias));
 }
 
 int getD3dRenderThreshold()
@@ -244,9 +244,9 @@ HRESULT D3DRenderInit(HWND hWnd)
 		return E_FAIL;
 
 	D3DDISPLAYMODE displayMode;
-	IDirect3D9_GetAdapterDisplayMode(gpD3D, D3DADAPTER_DEFAULT, &displayMode);
+	gpD3D->GetAdapterDisplayMode(D3DADAPTER_DEFAULT, &displayMode);
 
-	IDirect3DDevice9_GetDeviceCaps(gpD3DDevice, &gD3DCaps);
+	gpD3DDevice->GetDeviceCaps(&gD3DCaps);
 
 	gFrame = 0;
 	
@@ -254,22 +254,22 @@ HRESULT D3DRenderInit(HWND hWnd)
 	// Defines screen dimensions (X, Y, Width, Height) and depth range (MinZ, MaxZ).
 	gViewport = { 0, 0, static_cast<DWORD>(gScreenWidth), static_cast<DWORD>(gScreenHeight), 0.0f, 1.0f};
 
-	IDirect3DDevice9_SetViewport(gpD3DDevice, &gViewport);
+	gpD3DDevice->SetViewport(&gViewport);
 
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_CULLMODE, D3DCULL_NONE);
+	gpD3DDevice->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
 
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_LIGHTING, FALSE);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_CLIPPING, FALSE);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZENABLE, TRUE);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZFUNC, D3DCMP_LESSEQUAL);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, TRUE);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_DITHERENABLE, FALSE);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_STENCILENABLE, FALSE);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF, TEMP_ALPHA_REF);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAFUNC, D3DCMP_GREATEREQUAL);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_LASTPIXEL, TRUE);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FILLMODE, D3DFILL_SOLID);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_COLORWRITEENABLE,
+	gpD3DDevice->SetRenderState(D3DRS_LIGHTING, FALSE);
+	gpD3DDevice->SetRenderState(D3DRS_CLIPPING, FALSE);
+	gpD3DDevice->SetRenderState(D3DRS_ZENABLE, TRUE);
+	gpD3DDevice->SetRenderState(D3DRS_ZFUNC, D3DCMP_LESSEQUAL);
+	gpD3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, TRUE);
+	gpD3DDevice->SetRenderState(D3DRS_DITHERENABLE, FALSE);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILENABLE, FALSE);
+	gpD3DDevice->SetRenderState(D3DRS_ALPHAREF, TEMP_ALPHA_REF);
+	gpD3DDevice->SetRenderState(D3DRS_ALPHAFUNC, D3DCMP_GREATEREQUAL);
+	gpD3DDevice->SetRenderState(D3DRS_LASTPIXEL, TRUE);
+	gpD3DDevice->SetRenderState(D3DRS_FILLMODE, D3DFILL_SOLID);
+	gpD3DDevice->SetRenderState(D3DRS_COLORWRITEENABLE,
 		D3DCOLORWRITEENABLE_ALPHA | D3DCOLORWRITEENABLE_RED | D3DCOLORWRITEENABLE_GREEN |
 		D3DCOLORWRITEENABLE_BLUE);
 
@@ -301,25 +301,25 @@ HRESULT D3DRenderInit(HWND hWnd)
 	gEffectPool.pMaterialFctn = &D3DMaterialEffectPool;
 	gParticlePool.pMaterialFctn = &D3DMaterialParticlePool;
    
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MINFILTER, gD3DDriverProfile.minFilter);
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MIPFILTER, D3DTEXF_NONE);
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAXANISOTROPY, gD3DDriverProfile.maxAnisotropy);
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_MINFILTER, gD3DDriverProfile.minFilter);
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_MIPFILTER, D3DTEXF_NONE);
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_MAXANISOTROPY, gD3DDriverProfile.maxAnisotropy);
    
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MINFILTER, gD3DDriverProfile.minFilter);
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MIPFILTER, D3DTEXF_NONE);
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MAXANISOTROPY, gD3DDriverProfile.maxAnisotropy);
+	gpD3DDevice->SetSamplerState(1, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);
+	gpD3DDevice->SetSamplerState(1, D3DSAMP_MINFILTER, gD3DDriverProfile.minFilter);
+	gpD3DDevice->SetSamplerState(1, D3DSAMP_MIPFILTER, D3DTEXF_NONE);
+	gpD3DDevice->SetSamplerState(1, D3DSAMP_MAXANISOTROPY, gD3DDriverProfile.maxAnisotropy);
 
 	/***************************************************************************/
 	/*                    VERTEX DECLARATIONS                                  */
 	/***************************************************************************/
 	
-	IDirect3DDevice9_CreateVertexDeclaration(gpD3DDevice, decl0, &decl0dc);
-	IDirect3DDevice9_CreateVertexDeclaration(gpD3DDevice, decl1, &decl1dc);
-	IDirect3DDevice9_CreateVertexDeclaration(gpD3DDevice, decl2, &decl2dc);
+	gpD3DDevice->CreateVertexDeclaration(decl0, &decl0dc);
+	gpD3DDevice->CreateVertexDeclaration(decl1, &decl1dc);
+	gpD3DDevice->CreateVertexDeclaration(decl2, &decl2dc);
 
-   SetZBias(gpD3DDevice, 0);
+	SetZBias(gpD3DDevice, 0);
 
 	D3DRenderLMapsBuild();
 
@@ -331,23 +331,20 @@ HRESULT D3DRenderInit(HWND hWnd)
 		float	end = 50000.8f;
 		DWORD	mode = D3DFOG_LINEAR;
 
-		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGENABLE, TRUE);
-		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGCOLOR, 0);
-		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGTABLEMODE,
-                                      mode);
-		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGSTART,
-                                      *(DWORD *)(&start));
-		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGEND,
-                                      *(DWORD *)(&end));
+		gpD3DDevice->SetRenderState(D3DRS_FOGENABLE, TRUE);
+		gpD3DDevice->SetRenderState(D3DRS_FOGCOLOR, 0);
+		gpD3DDevice->SetRenderState(D3DRS_FOGTABLEMODE, mode);
+		gpD3DDevice->SetRenderState(D3DRS_FOGSTART, *(DWORD *)(&start));
+		gpD3DDevice->SetRenderState(D3DRS_FOGEND, *(DWORD *)(&end));
 	}
 
 	// create framebuffer textures
    for (int i = 0; i < MAX_RENDER_TARGET_POOL; i++)
-      IDirect3DDevice9_CreateTexture(gpD3DDevice, gSmallTextureSize, gSmallTextureSize, 1,
+      gpD3DDevice->CreateTexture(gSmallTextureSize, gSmallTextureSize, 1,
                                      D3DUSAGE_RENDERTARGET, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT,
                                      &gpBackBufferTex[i], nullptr);
    
-   IDirect3DDevice9_CreateTexture(gpD3DDevice, gFullTextureSize, gFullTextureSize, 1,
+   gpD3DDevice->CreateTexture(gFullTextureSize, gFullTextureSize, 1,
                                   D3DUSAGE_RENDERTARGET, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT,
                                   &gpBackBufferTexFull, nullptr);
 
@@ -393,25 +390,30 @@ void D3DRenderShutDown(void)
 
 		if (gpNoLookThrough)
 		{
-			IDirect3DTexture9_Release(gpNoLookThrough);
+			gpNoLookThrough->Release();
 			gpNoLookThrough = nullptr;
 		}
 		if (gpBackBufferTexFull)
 		{
-			IDirect3DTexture9_Release(gpBackBufferTexFull);
+			gpBackBufferTexFull->Release();
 			gpBackBufferTexFull = nullptr;
 		}
 
 		if (gFont.pTexture)
 		{
-         IDirect3DTexture9_Release(gFont.pTexture);
-         delete [] gFont.kerningPairs;
-         gFont.pTexture = nullptr;
+			gFont.pTexture->Release();
+			gFont.pTexture = nullptr;
+		}
+		
+		if (gFont.kerningPairs)
+		{
+			delete[] gFont.kerningPairs;
+			gFont.kerningPairs = nullptr;
 		}
 
 		for (int i = 0; i < MAX_RENDER_TARGET_POOL; i++)
 		{
-         IDirect3DTexture9_Release(gpBackBufferTex[i]);
+			gpBackBufferTex[i]->Release();
 			gpBackBufferTex[i] = nullptr;
 		}
 
@@ -421,7 +423,7 @@ void D3DRenderShutDown(void)
 		{
 			if (gpViewElements[i])
 			{
-				IDirect3DDevice9_Release(gpViewElements[i]);
+				gpViewElements[i]->Release();
 				gpViewElements[i] = nullptr;
 			}
 		}
@@ -430,17 +432,17 @@ void D3DRenderShutDown(void)
 		/*                       VERTEX DECLARATIONS                               */
 		/***************************************************************************/
 		
-		if (decl0dc) IDirect3DDevice9_Release(decl0dc);
-		if (decl1dc) IDirect3DDevice9_Release(decl1dc);
-		if (decl2dc) IDirect3DDevice9_Release(decl2dc);
-
+		if (decl0dc) decl0dc->Release();
+		if (decl1dc) decl1dc->Release();
+		if (decl2dc) decl2dc->Release();
 		decl0dc = nullptr;
 		decl1dc = nullptr;
 		decl2dc = nullptr;
       
-      IDirect3DDevice9_Release(gpD3DDevice);
+		gpD3DDevice->Release();
 		gpD3DDevice = nullptr;
-      IDirect3D9_Release(gpD3D);
+		
+		gpD3D->Release();
 		gpD3D = nullptr;
 	}
 }
@@ -498,14 +500,12 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	LightCacheUpdateParams lightCacheParams{&gDLightCache, &gDLightCacheDynamic, gD3DRedrawAll};
 	D3DLMapsStaticGet(room, lightCacheParams);
 
-	IDirect3DDevice9_Clear(gpD3DDevice, 0, nullptr, D3DCLEAR_TARGET |
-		D3DCLEAR_ZBUFFER | D3DCLEAR_STENCIL,
-		D3DCOLOR_ARGB(0, 0, 0, 0), 1.0, 0);
+	gpD3DDevice->Clear(0, nullptr, (D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER | D3DCLEAR_STENCIL), D3DCOLOR_ARGB(0, 0, 0, 0), 1.0, 0);
 
-	IDirect3DDevice9_BeginScene(gpD3DDevice);
+	gpD3DDevice->BeginScene();
 
 	MatrixIdentity(&mat);
-	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_WORLD, &mat);
+	gpD3DDevice->SetTransform(D3DTS_WORLD, &mat);
 
 	// A full 360-degree circle is 4096 game units. Player camera rotation is offset
 	// by 270 degrees (3072 game units) to align it with the legacy engine orientation.
@@ -521,15 +521,14 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	MatrixTranslate(&trans, -static_cast<float>(params->viewer_x), -static_cast<float>(params->viewer_height), -static_cast<float>(params->viewer_y));
 	MatrixMultiply(&view, &trans, &rot);
 
-	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_VIEW, &view);
+	gpD3DDevice->SetTransform(D3DTS_VIEW, &view);
 
 	XformMatrixPerspective(&proj, FovHorizontal(gD3DRect.right - gD3DRect.left), FovVertical(gD3DRect.bottom - gD3DRect.top), 100.0f, Z_RANGE);
-	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_PROJECTION, &proj);
+	gpD3DDevice->SetTransform(D3DTS_PROJECTION, &proj);
 
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_COLORWRITEENABLE,
-		D3DCOLORWRITEENABLE_RED | D3DCOLORWRITEENABLE_GREEN | D3DCOLORWRITEENABLE_BLUE);
+	gpD3DDevice->SetRenderState(D3DRS_COLORWRITEENABLE, D3DCOLORWRITEENABLE_RED | D3DCOLORWRITEENABLE_GREEN | D3DCOLORWRITEENABLE_BLUE);
 
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_CULLMODE, D3DCULL_CW);
+	gpD3DDevice->SetRenderState(D3DRS_CULLMODE, D3DCULL_CW);
 
 	D3DCacheSystemReset(&gObjectCacheSystem);
 	D3DCacheSystemReset(&gLMapCacheSystem);
@@ -589,15 +588,15 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 			D3DRenderPoolReset(&gWorldPoolStatic, &D3DMaterialWorldPool);
 			D3DRenderPoolReset(&gWallMaskPool, &D3DMaterialWallMaskPool);
 
-			IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, TRUE);
-			IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHABLENDENABLE, FALSE);
-			IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, FALSE);
+			gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+			gpD3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
+			gpD3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
 			D3DGeometryBuildNew(worldRenderParams, worldPropertyParams, lightAndTextureParams, false);
 
 			// Second pass: render transparent objects
-			IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHABLENDENABLE, TRUE);
-			IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, TRUE);
-			IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, FALSE);  // Disable depth writing
+			gpD3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
+			gpD3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, TRUE);
+			gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);  // Disable depth writing
 
 			D3DGeometryBuildNew(worldRenderParams, worldPropertyParams, lightAndTextureParams, true);
 
@@ -635,7 +634,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 		}
 	}
 
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_CULLMODE, D3DCULL_NONE);
+	gpD3DDevice->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
 	SetZBias(gpD3DDevice, 1);
 
 	if (draw_particles)
@@ -671,14 +670,14 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	SetZBias(gpD3DDevice, ZBIAS_DEFAULT);
 
-	IDirect3DDevice9_SetVertexShader(gpD3DDevice, nullptr);
-	IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, decl0dc);
+	gpD3DDevice->SetVertexShader(nullptr);
+	gpD3DDevice->SetVertexDeclaration(decl0dc);
 
 	// Set up orthographic projection for drawing overlays
 	MatrixIdentity(&mat);
-	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_WORLD, &mat);
-	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_VIEW, &mat);
-	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_PROJECTION, &mat);
+	gpD3DDevice->SetTransform(D3DTS_WORLD, &mat);
+	gpD3DDevice->SetTransform(D3DTS_VIEW, &mat);
+	gpD3DDevice->SetTransform(D3DTS_PROJECTION, &mat);
 
 	FxRenderSystemStructure fxRenderSystemStructure(decl1dc, &gObjectPool, &gObjectCacheSystem, 
 		&gEffectPool, &gEffectCacheSystem, gpBackBufferTex, gpBackBufferTexFull, 
@@ -704,14 +703,14 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	D3DRender_SetAlphaTestState(TRUE, TEMP_ALPHA_REF, D3DCMP_GREATEREQUAL);
 	D3DRender_SetAlphaBlendState(TRUE, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA);
 
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAGFILTER, D3DTEXF_POINT);
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MINFILTER, D3DTEXF_POINT);
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_MAGFILTER, D3DTEXF_POINT);
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_MINFILTER, D3DTEXF_POINT);
 
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_ADDRESSU, D3DTADDRESS_CLAMP);
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_ADDRESSV, D3DTADDRESS_CLAMP);
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSU, D3DTADDRESS_CLAMP);
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_CLAMP);
 
-	IDirect3DDevice9_SetVertexShader(gpD3DDevice, nullptr);
-	IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, decl1dc);
+	gpD3DDevice->SetVertexShader(nullptr);
+	gpD3DDevice->SetVertexDeclaration(decl1dc);
 
 	D3DRenderPoolReset(&gObjectPool, &D3DMaterialObjectPool);
 	D3DCacheSystemReset(&gObjectCacheSystem);
@@ -719,19 +718,19 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	D3DCacheFill(&gObjectCacheSystem, &gObjectPool, 1);
 	D3DCacheFlush(&gObjectCacheSystem, &gObjectPool, 1, D3DPT_TRIANGLESTRIP);
 
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);	
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MINFILTER, gD3DDriverProfile.minFilter);
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);	
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_MINFILTER, gD3DDriverProfile.minFilter);
 
-	IDirect3DDevice9_EndScene(gpD3DDevice);
+	gpD3DDevice->EndScene();
 	
 	RECT rect = GetScreenRect();
 
-	HRESULT hr = IDirect3DDevice9_Present(gpD3DDevice, &rect, &gD3DRect, nullptr, nullptr);
+	HRESULT hr = gpD3DDevice->Present(&rect, &gD3DRect, nullptr, nullptr);
 
 	if (hr == D3DERR_DEVICELOST)
 	{
 		while (hr == D3DERR_DEVICELOST)
-			hr = IDirect3DDevice9_TestCooperativeLevel(gpD3DDevice);
+			hr = gpD3DDevice->TestCooperativeLevel();
 
 		if (hr == D3DERR_DEVICENOTRESET)
 		{
@@ -789,7 +788,7 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 		pFont->texWidth = pFont->texHeight = 256;
 
 	D3DCAPS9 d3dCaps;
-	IDirect3DDevice9_GetDeviceCaps(gpD3DDevice, &d3dCaps);
+	gpD3DDevice->GetDeviceCaps(&d3dCaps);
   
 	if ( pFont->texWidth > static_cast<long>(d3dCaps.MaxTextureWidth) )
 	{
@@ -800,10 +799,7 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 	if (pFont->pTexture)
 		IDirect3DTexture9_Release(pFont->pTexture);
    
-   IDirect3DDevice9_CreateTexture(
-      gpD3DDevice, pFont->texWidth,
-      pFont->texHeight, 1, 0, D3DFMT_A4R4G4B4,
-      D3DPOOL_MANAGED, &pFont->pTexture, nullptr);
+   gpD3DDevice->CreateTexture(pFont->texWidth, pFont->texHeight, 1, 0, D3DFMT_A4R4G4B4, D3DPOOL_MANAGED, &pFont->pTexture, nullptr);
    
    BITMAPINFO bmi;
    memset(&bmi.bmiHeader, 0, sizeof(BITMAPINFOHEADER));
@@ -1153,31 +1149,31 @@ LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
 	D3DRenderPoolReset(&gEffectPool, &D3DMaterialEffectPool);
 
 	// get pointer to backbuffer surface and z/stencil surface
-	IDirect3DDevice9_GetRenderTarget(gpD3DDevice, 0, &pSrc);
-	IDirect3DDevice9_GetDepthStencilSurface(gpD3DDevice, &pZBuf);
-
+	gpD3DDevice->GetRenderTarget(0, &pSrc);
+	gpD3DDevice->GetDepthStencilSurface(&pZBuf);
+	
 	// get pointer to texture surface for rendering
-	IDirect3DTexture9_GetSurfaceLevel(pTex0, 0, &pDest[0]);
-	IDirect3DTexture9_GetSurfaceLevel(pTex1, 0, &pDest[1]);
+	pTex0->GetSurfaceLevel(0, &pDest[0]);
+	pTex1->GetSurfaceLevel(0, &pDest[1]);
 
 	POINT pnt = { 0, 0 };
 	
 	RECT rect = GetScreenRect();
 
 	// copy framebuffer to texture
-	IDirect3DDevice9_StretchRect(gpD3DDevice, pSrc, &rect, pDest[0], &rect, D3DTEXF_NONE);
+	gpD3DDevice->StretchRect(pSrc, &rect, pDest[0], &rect, D3DTEXF_NONE);
    
 	// clear local->screen transforms
 	D3DMATRIX mat;
 	MatrixIdentity(&mat);
-	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_WORLD, &mat);
-	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_VIEW, &mat);
-	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_PROJECTION, &mat);
+	gpD3DDevice->SetTransform(D3DTS_WORLD, &mat);
+	gpD3DDevice->SetTransform(D3DTS_VIEW, &mat);
+	gpD3DDevice->SetTransform(D3DTS_PROJECTION, &mat);
 
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, FALSE);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, FALSE);
+	gpD3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
+	gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
 
-	IDirect3DDevice9_SetRenderTarget(gpD3DDevice, 0, pDest[1]);
+	gpD3DDevice->SetRenderTarget(0, pDest[1]);
 
 	d3d_render_packet_new *pPacket = D3DRenderPacketNew(&gEffectPool);
 	
@@ -1220,14 +1216,14 @@ LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
 	D3DCacheFlush(&gEffectCacheSystem, &gEffectPool, 1, D3DPT_TRIANGLESTRIP);
 
 	// restore render target to backbuffer
-	HRESULT hr = IDirect3DDevice9_SetRenderTarget(gpD3DDevice, 0, pSrc);
-	hr = IDirect3DDevice9_SetDepthStencilSurface(gpD3DDevice, pZBuf);
-	hr = IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, TRUE);
+	HRESULT hr = gpD3DDevice->SetRenderTarget(0, pSrc);
+	hr = gpD3DDevice->SetDepthStencilSurface(pZBuf);
+	hr = gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
    
-	IDirect3DSurface9_Release(pSrc);
-	IDirect3DSurface9_Release(pZBuf);
-	IDirect3DSurface9_Release(pDest[0]);
-	IDirect3DSurface9_Release(pDest[1]);
+	pSrc->Release();
+	pZBuf->Release();
+	pDest[0]->Release();
+	pDest[1]->Release();
 
 	return pTex1;
 }

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -7,38 +7,15 @@
 // Meridian is a registered trademark.
 #include "client.h"
 
-// Main client windows current viewport area
-extern int main_viewport_width;
-extern int main_viewport_height;
 
-// Defines field of views
-float FovHorizontal(long width)
-{
-	static constexpr float HORIZONTAL_TUNING_FACTOR  = (-PI / 3.78f);
-	return width / static_cast<float>(main_viewport_width) * HORIZONTAL_TUNING_FACTOR ;
-}
+///////////////
+// Variables //
+///////////////
 
-float FovVertical(long height)
-{
-	static constexpr float VERTICAL_TUNING_FACTOR = (PI / 5.88f);
-	return height / static_cast<float>(main_viewport_height) * VERTICAL_TUNING_FACTOR;
-}
-
-// Helper function to determine if an object should be rendered in the current pass based on transparency.
-bool ShouldRenderInCurrentPass(bool transparent_pass, bool isTransparent)
-{
-	return transparent_pass == isTransparent;
-}
-
-// Pool of textures used for off-screen rendering (drawing to memory instead of on screen).
-// These are used for intermediate passes for things like dynamic lighting.
-static constexpr int MAX_RENDER_TARGET_POOL = 16;
-
-d3d_render_packet_new	*gpPacket;
+d3d_render_packet_new	*gpPacket = nullptr;
 
 LPDIRECT3DTEXTURE9		gpNoLookThrough = nullptr;
-LPDIRECT3DTEXTURE9		gpBackBufferTex[MAX_RENDER_TARGET_POOL];
-LPDIRECT3DTEXTURE9		gpBackBufferTexFull;
+
 LPDIRECT3DTEXTURE9		gpViewElements[NUM_VIEW_ELEMENTS];
 
 D3DVIEWPORT9			gViewport;
@@ -73,23 +50,18 @@ d3d_render_pool_new		gParticlePool;
 custom_xyz				playerOldPos;
 custom_xyz				playerDeltaPos;
 
-font_3d					gFont;
-
 RECT					gD3DRect;
 BYTE					gViewerLight = 0;
-int						gNumObjects;
-int						gNumDPCalls;
-static PALETTEENTRY		gPalette[NUM_COLORS];
+int						gNumObjects = 0;
+int						gNumDPCalls = 0;
 
 static unsigned int		gFrame = 0;
 
 // The size of the main full size render buffer and also a smaller buffer for effects.
 // The smaller buffer is used for effects that don't need full resolution.
 // As per the original specification, the smaller buffer is 1/4 the size of the full buffer.
-int						gFullTextureSize;
-int						gSmallTextureSize;
-
-int						d3dRenderTextureThreshold;
+int						gFullTextureSize = 0;
+int						gSmallTextureSize = 0;
 
 D3DVERTEXELEMENT9		decl0[] = {
 	{0, 0, D3DDECLTYPE_FLOAT3,	 D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_POSITION, 0},
@@ -119,17 +91,20 @@ LPDIRECT3DVERTEXDECLARATION9 decl2dc;
 AREA					gD3DView;
 int						gD3DRedrawAll = 0;
 int						gTemp = 0;
-bool					gWireframe;		// this is really bad, I'm sorry
+
+D3DMATRIX view, mat, rot, trans, proj;
+
+//////////////////////
+// External Globals //
+//////////////////////
 
 extern long				viewer_height;
-extern Color			base_palette[NUM_COLORS];
 extern PDIB				background;         /* Pointer to background bitmap */
 extern ObjectRange		visible_objects[];    /* Where objects are on screen */
 extern int				num_visible_objects;
 extern DrawItem			drawdata[];
 extern long				nitems;
 extern int				sector_depths[];
-extern d3d_driver_profile	gD3DDriverProfile;
 extern BYTE				*gBits;
 extern BYTE				*gBufferBits;
 extern D3DPRESENT_PARAMETERS	gPresentParam;
@@ -137,96 +112,482 @@ extern long				stretchfactor;
 extern ViewElement		ViewElements[];
 extern HDC				gBitsDC;
 
-D3DMATRIX view, mat, rot, trans, proj;
-
-// new render stuff
-void					D3DRenderPoolInit(d3d_render_pool_new *pPool, int size, int packetSize);
-void					D3DRenderPoolShutdown(d3d_render_pool_new *pPool);
-void					D3DRenderPoolReset(d3d_render_pool_new *pPool, void *pMaterialFunc);
-d3d_render_packet_new	*D3DRenderPacketNew(d3d_render_pool_new *pPool);
-void					D3DRenderPacketInit(d3d_render_packet_new *pPacket);
-d3d_render_chunk_new	*D3DRenderChunkNew(d3d_render_packet_new *pPacket);
-void					D3DRenderChunkInit(d3d_render_chunk_new *pChunk);
-d3d_render_packet_new	*D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDIRECT3DTEXTURE9 pTexture,
-												PDIB pDib, BYTE xLat0, BYTE xLat1, int effect);
-
-void					D3DRenderViewElementsDraw(d3d_render_pool_new *pPool);
-
-void					*D3DRenderMalloc(unsigned int bytes);
-
-void SetZBias(LPDIRECT3DDEVICE9 device, int z_bias)
-{
-   float bias = z_bias * -0.00001f;
-   device->SetRenderState(D3DRS_DEPTHBIAS, *((DWORD *) &bias));
-}
-
-int getD3dRenderThreshold()
-{
-	return d3dRenderTextureThreshold;
-}
-
-bool isManagedTexturesEnabled() {
-    return gD3DDriverProfile.bManagedTextures;
-}
-
-bool isFogEnabled()
-{
-	return gD3DDriverProfile.bFogEnable;
-}
-
-void setWireframeMode(bool isEnabled)
-{
-	gWireframe = isEnabled;
-}
-
-PALETTEENTRY* getPalette()
-{
-    return gPalette;
-}
-
-const Color(&getBasePalette())[NUM_COLORS]
-{
-	return base_palette;
-}
-
-bool isWireframeMode()
-{
-	return gWireframe;
-}
-
-const font_3d& getFont3d()
-{
-	return gFont;
-}
-
-const LPDIRECT3DTEXTURE9 getWhiteLightTexture()
-{
-	return D3DRenderLightsGetWhite();
-}
-
-const LPDIRECT3DTEXTURE9 getBackBufferTextureZero()
-{
-	return gpBackBufferTex[0];
-}
-
-// externed stuff
 extern void			DrawItemsD3D();
 extern bool			ComputePlayerOverlayArea(PDIB pdib, char hotspot, AREA *obj_area);
 extern void			UpdateRoom3D(room_type *room, Draw3DParams *params);
 
-int DistanceGet(int x, int y)
-{
-	float xf = static_cast<float>(x);
-	float yf = static_cast<float>(y);
-	int distance = sqrt((xf * xf) + (yf * yf));
+/////////////////////////
+// Internal Prototypes //
+/////////////////////////
 
-	return static_cast<int>(distance);
+void D3DRenderPacketInit(d3d_render_packet_new *pPacket);
+void D3DRenderChunkInit(d3d_render_chunk_new *pChunk);
+void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool);
+
+//////////////////////////////
+// Main Rendering Interface //
+//////////////////////////////
+
+void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
+{
+   // Ask for a bigger font to reduce aliasing, then scale the texture
+   // down by the same amount.
+   static constexpr float fontScale = 3.0;
+   HFONT hScaledFont = FontsGetScaledFont(hFont, fontScale);
+   assert(hScaledFont);
+      
+   pFont->fontHeight = GetFontHeight(hScaledFont);
+   pFont->texScale = fontScale;
+   
+	if (pFont->fontHeight > 40)
+		pFont->texWidth = pFont->texHeight = 1024;
+	else if (pFont->fontHeight > 20)
+		pFont->texWidth = pFont->texHeight = 512;
+	else
+		pFont->texWidth = pFont->texHeight = 256;
+
+	D3DCAPS9 d3dCaps;
+	gpD3DDevice->GetDeviceCaps(&d3dCaps);
+  
+	if ( pFont->texWidth > static_cast<long>(d3dCaps.MaxTextureWidth) )
+	{
+		pFont->texScale *= static_cast<float>(pFont->texWidth) / static_cast<float>(d3dCaps.MaxTextureWidth);
+		pFont->texHeight = pFont->texWidth = d3dCaps.MaxTextureWidth;
+	}
+  
+	if (pFont->pTexture)
+		IDirect3DTexture9_Release(pFont->pTexture);
+   
+   gpD3DDevice->CreateTexture(pFont->texWidth, pFont->texHeight, 1, 0, D3DFMT_A4R4G4B4, D3DPOOL_MANAGED, &pFont->pTexture, nullptr);
+   
+   BITMAPINFO bmi;
+   memset(&bmi.bmiHeader, 0, sizeof(BITMAPINFOHEADER));
+   bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+   bmi.bmiHeader.biWidth = static_cast<int>(pFont->texWidth);
+   bmi.bmiHeader.biHeight = -static_cast<int>(pFont->texHeight);
+   bmi.bmiHeader.biPlanes = 1;
+   bmi.bmiHeader.biCompression = BI_RGB;
+   bmi.bmiHeader.biBitCount = 32;
+   
+   HDC hDC = CreateCompatibleDC(gBitsDC);
+   DWORD *pBitmapBits;
+   HBITMAP hbmBitmap = CreateDIBSection(hDC, &bmi, DIB_RGB_COLORS, (VOID**)&pBitmapBits, nullptr, 0 );
+   SetMapMode(hDC, MM_TEXT);
+  
+   SelectObject(hDC, hbmBitmap);
+   SelectObject(hDC, hScaledFont);
+   
+   // Set text properties
+   SetTextColor(hDC, RGB(255,255,255));
+   SetBkColor(hDC, 0);
+   SetBkMode(hDC, TRANSPARENT);
+   SetTextAlign(hDC, TA_TOP);
+   
+   TCHAR str[2] = _T("x");
+   long x = 0;
+   long y = 0;
+   for(TCHAR c = 32; c < 127; c++ )
+   {
+      int index = c - 32;
+      
+      str[0] = c;
+	  
+	  SIZE size;
+      GetTextExtentPoint32(hDC, str, 1, &size);
+      
+      if (!GetCharABCWidths(hDC, c, c, &pFont->abc[index]))
+	  {
+         pFont->abc[index].abcA = 0;
+         pFont->abc[index].abcB = size.cx;
+         pFont->abc[index].abcC = 0;
+      }
+
+      size.cx = pFont->abc[index].abcB;
+
+      // Is this row of the texture filled up?
+      if (x + size.cx >= pFont->texWidth)
+      {
+         x = 0;
+         y += size.cy + 1;
+      }
+      
+      int left_offset = pFont->abc[index].abcA;
+      ExtTextOut(hDC, x - left_offset, y+0, 0, nullptr, str, 1, nullptr);
+      
+      pFont->texST[index][0].s = ((FLOAT)(x+0)) / pFont->texWidth;
+      pFont->texST[index][0].t = ((FLOAT)(y+0)) / pFont->texHeight;
+      pFont->texST[index][1].s = ((FLOAT)(x+0 + size.cx)) / pFont->texWidth;
+      pFont->texST[index][1].t = ((FLOAT)(y+0 + size.cy)) / pFont->texHeight;
+
+      // Leave +1 space so bilinear filtering doesn't pick up neighboring character
+      x += size.cx+1;  
+   }
+   
+   D3DLOCKED_RECT d3dlr;
+   IDirect3DTexture9_LockRect(pFont->pTexture, 0, &d3dlr, 0, 0);
+   
+   BYTE *pDstRow = (BYTE*)d3dlr.pBits;
+   
+   for(y = 0; y < pFont->texHeight; y++)
+   {
+      WORD *pDst16 = (WORD *)pDstRow;
+      for(x = 0; x < pFont->texWidth; x++)
+      {
+         BYTE bAlpha = static_cast<BYTE>( (pBitmapBits[pFont->texWidth * y + x] & 0xff) >> 4 );
+         if (bAlpha > 0)
+         {
+            *pDst16++ = (bAlpha << 12) | 0x0fff;
+         }
+         else
+         {
+            *pDst16++ = 0x0000;
+         }
+      }
+      pDstRow += d3dlr.Pitch;
+   }
+   
+   IDirect3DTexture9_UnlockRect(pFont->pTexture, 0);
+
+   // Get kerning pairs for font
+   pFont->numKerningPairs = GetKerningPairs(hDC, 0, nullptr);
+   pFont->kerningPairs = new KERNINGPAIR[pFont->numKerningPairs];
+   GetKerningPairs(hDC, pFont->numKerningPairs, pFont->kerningPairs);
+   
+   DeleteObject(hbmBitmap);
+   DeleteObject(hScaledFont);
+   DeleteDC(hDC);
 }
 
-void *D3DRenderMalloc(unsigned int bytes)
+void D3DRenderPoolInit(d3d_render_pool_new *pPool, int size, int packetSize)
 {
-	return malloc(bytes);
+	pPool->size = size;
+	pPool->curPacket = 0;
+	d3d_render_packet_new *pPacket = (d3d_render_packet_new *)D3DRenderMalloc(sizeof(d3d_render_packet_new) * size);
+	assert(pPacket);
+	pPool->renderPacketList = list_create(pPacket);
+	pPool->packetSize = packetSize;
+
+	D3DRenderPoolReset(pPool, nullptr);
+
+	for (u_int i = 0; i < pPool->size; i++)
+	{
+		pPacket->size = packetSize;
+	}
 }
+
+void D3DRenderPoolShutdown(d3d_render_pool_new *pPool)
+{
+	list_destroy(pPool->renderPacketList);
+	memset(pPool, 0, sizeof(d3d_render_pool_new));
+}
+
+void D3DRenderPoolReset(d3d_render_pool_new *pPool, void *pMaterialFunc)
+{
+	pPool->curPacket = 0;
+	pPool->numLists = 0;
+	pPool->curPacketList = pPool->renderPacketList;
+	pPool->pMaterialFctn = (MaterialFctn) pMaterialFunc;
+}
+
+d3d_render_packet_new *D3DRenderPacketNew(d3d_render_pool_new *pPool)
+{
+	d3d_render_packet_new *pPacket;
+
+	if (pPool->curPacket >= pPool->size)
+	{
+		if (pPool->curPacketList->next == nullptr)
+		{
+			pPacket = (d3d_render_packet_new *)D3DRenderMalloc(sizeof(d3d_render_packet_new) * pPool->size);
+			assert(pPacket);
+			list_add_item(pPool->renderPacketList, pPacket);
+		}
+		else
+			pPacket = (d3d_render_packet_new *)pPool->curPacketList->next->data;
+
+		pPool->curPacketList = pPool->curPacketList->next;
+		pPool->curPacket = 1;
+		pPool->numLists++;
+
+		pPacket = (d3d_render_packet_new *)pPool->curPacketList->data;
+	}
+	else
+	{
+		pPacket = (d3d_render_packet_new *)pPool->curPacketList->data;
+		pPacket += pPool->curPacket;
+
+		if (pPool->curPacket == 12)
+			gpPacket = pPacket;
+
+		pPool->curPacket++;
+	}
+
+	D3DRenderPacketInit(pPacket);
+	return pPacket;
+}
+
+void D3DRenderPacketInit(d3d_render_packet_new *pPacket)
+{
+	pPacket->curChunk = 0;
+	pPacket->effect = 0;
+	pPacket->flags = 0;
+	pPacket->pDib = nullptr;
+	pPacket->pMaterialFctn = nullptr;
+	pPacket->pTexture = nullptr;
+	pPacket->xLat0 = 0;
+	pPacket->xLat1 = 0;
+}
+
+d3d_render_chunk_new *D3DRenderChunkNew(d3d_render_packet_new *pPacket)
+{
+	if (pPacket->curChunk >= (pPacket->size - 1))
+		return nullptr;
+	else
+	{
+		pPacket->curChunk++;
+		D3DRenderChunkInit(&pPacket->renderChunks[pPacket->curChunk - 1]);
+		return &pPacket->renderChunks[pPacket->curChunk - 1];
+	}
+}
+
+void D3DRenderChunkInit(d3d_render_chunk_new *pChunk)
+{
+	pChunk->curIndex = 0;
+	pChunk->drawn = 0;
+	pChunk->flags = 0;
+	pChunk->zBias = 0;
+	pChunk->isTargeted = FALSE;
+	pChunk->numIndices = 0;
+	pChunk->xLat0 = 0;
+	pChunk->xLat1 = 0;
+	pChunk->pSector = nullptr;
+	pChunk->pSectorNeg = nullptr;
+	pChunk->pSectorPos = nullptr;
+	pChunk->pSideDef = nullptr;
+	pChunk->pMaterialFctn = nullptr;
+	pChunk->pRenderCache = nullptr;
+}
+
+d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDIRECT3DTEXTURE9 pTexture,
+												PDIB pDib, BYTE xLat0, BYTE xLat1, int effect)
+{
+	d3d_render_packet_new *pPacket;
+	
+	for (list_type list = pPool->renderPacketList; list != pPool->curPacketList->next; list = list->next)
+	{
+		pPacket = (d3d_render_packet_new *)list->data;
+
+		u_int numPackets;
+		if (list == pPool->curPacketList)
+			numPackets = pPool->curPacket;
+		else
+			numPackets = pPool->size;
+
+		// for each packet
+		for (u_int count = 0; count < numPackets; count++, pPacket++)
+		{
+			// if we find a match that isn't full already, return it
+			if ((pPacket->pDib == pDib) && (pPacket->pTexture == pTexture) &&
+				(pPacket->xLat0 == xLat0) && (pPacket->xLat1 == xLat1) &&
+				(pPacket->effect == effect))
+			{
+				if (pPacket->curChunk < (pPacket->size - 1))
+					return pPacket;
+			}
+		}
+	}
+
+	// otherwise, return a new one (or NULL if no more remain)
+	pPacket = D3DRenderPacketNew(pPool);
+
+	if (pPacket)
+	{
+		pPacket->pDib = pDib;
+		pPacket->pTexture = pTexture;
+		pPacket->xLat0 = xLat0;
+		pPacket->xLat1 = xLat1;
+		pPacket->effect = effect;
+		pPacket->size = pPool->packetSize;
+	}
+
+	return pPacket;
+}
+
+void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool)
+{
+   float screenW = static_cast<float>(gD3DRect.right - gD3DRect.left) / static_cast<float>(gScreenWidth);
+   float screenH = static_cast<float>(gD3DRect.bottom - gD3DRect.top) / static_cast<float>(gScreenHeight);
+
+   // Render view elements (such as the main viewport yellow ui corners).
+   int offset = (GetFocus() == hMain) ? 4 : 0;
+   
+   // 0 = top-left
+   // 1 = top-right
+   // 2 = bottom-left
+   // 3 = bottom-right
+   static constexpr int NUM_CORNERS = 4;
+   for (int i = 0; i < NUM_CORNERS; ++i)
+   {
+      float width = static_cast<float>(ViewElements[i + offset].width) / screenW;
+      float height = static_cast<float>(ViewElements[i + offset].height) / screenH;
+
+      float left, right, top, bottom;
+	  
+      if (i % 2 == 0)  // left side
+      {
+         left = D3DRENDER_SCREEN_TO_CLIP_X(0, gScreenWidth);
+         right = D3DRENDER_SCREEN_TO_CLIP_X(width, gScreenWidth);
+      }
+      else  // right side
+      {
+         left = D3DRENDER_SCREEN_TO_CLIP_X(gScreenWidth - width, gScreenWidth);
+         right = D3DRENDER_SCREEN_TO_CLIP_X(gScreenWidth, gScreenWidth);
+      }
+
+      if (i < 2)  // top side
+      {
+         top = D3DRENDER_SCREEN_TO_CLIP_Y(0, gScreenHeight);
+         bottom = D3DRENDER_SCREEN_TO_CLIP_Y(height, gScreenHeight);
+      }
+      else  // bottom side
+      {
+         top = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight - height, gScreenHeight);
+         bottom = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight, gScreenHeight);
+      }
+
+      d3d_render_packet_new *pPacket = D3DRenderPacketNew(pPool);
+      pPacket->pDib = nullptr;
+      pPacket->pTexture = gpViewElements[i + offset];
+      pPacket->xLat0 = 0;
+      pPacket->xLat1 = 0;
+      pPacket->effect = 0;
+      pPacket->size = pPool->packetSize;
+
+      d3d_render_chunk_new *pChunk = D3DRenderChunkNew(pPacket);
+      pChunk->flags = 0;
+      pChunk->numIndices = 4;
+      pChunk->numVertices = 4;
+      pChunk->numPrimitives = pChunk->numVertices - 2;
+      pChunk->xLat0 = 0;
+      pChunk->xLat1 = 0;
+
+      pPacket->pMaterialFctn = D3DMaterialObjectPacket;
+      pChunk->pMaterialFctn = D3DMaterialNone;
+
+      pChunk->xyz[0] = { left, VIEW_ELEMENT_Z, top };
+      pChunk->xyz[1] = { left, VIEW_ELEMENT_Z, bottom };	  
+      pChunk->xyz[2] = { right, VIEW_ELEMENT_Z, bottom };
+      pChunk->xyz[3] = { right, VIEW_ELEMENT_Z, top };	  
+
+      for (auto& color : pChunk->bgra)
+      {
+         color = {255, 255, 255, 255}; // Solid white (no tinting)
+      }
+
+      // Half-pixel offset to prevent texture bleeding.
+      static constexpr float foffset = 1.0f / 64.0f;
+      pChunk->st0[0] = { foffset, foffset };
+      pChunk->st0[1] = { foffset, (1.0f - foffset) };
+      pChunk->st0[2] = { (1.0f - foffset), (1.0f - foffset) };
+      pChunk->st0[3] = { (1.0f - foffset), foffset };
+
+      pChunk->indices[0] = 1;
+      pChunk->indices[1] = 2;
+      pChunk->indices[2] = 0;
+      pChunk->indices[3] = 3;
+   }
+}
+
+// Captures current rendered frame as a texture for post-processing effects.
+LPDIRECT3DTEXTURE9 D3DRender_CaptureEffect(LPDIRECT3DTEXTURE9 pTex0, LPDIRECT3DTEXTURE9 pTex1)
+{
+	LPDIRECT3DSURFACE9 pSrc, pDest[2], pZBuf;
+
+	D3DCacheSystemReset(&gEffectCacheSystem);
+	D3DRenderPoolReset(&gEffectPool, &D3DMaterialEffectPool);
+
+	// get pointer to backbuffer surface and z/stencil surface
+	gpD3DDevice->GetRenderTarget(0, &pSrc);
+	gpD3DDevice->GetDepthStencilSurface(&pZBuf);
+	
+	// get pointer to texture surface for rendering
+	pTex0->GetSurfaceLevel(0, &pDest[0]);
+	pTex1->GetSurfaceLevel(0, &pDest[1]);
+
+	POINT pnt = { 0, 0 };
+	
+	RECT rect = GetScreenRect();
+
+	// copy framebuffer to texture
+	gpD3DDevice->StretchRect(pSrc, &rect, pDest[0], &rect, D3DTEXF_NONE);
+   
+	// clear local->screen transforms
+	D3DMATRIX mat;
+	MatrixIdentity(&mat);
+	gpD3DDevice->SetTransform(D3DTS_WORLD, &mat);
+	gpD3DDevice->SetTransform(D3DTS_VIEW, &mat);
+	gpD3DDevice->SetTransform(D3DTS_PROJECTION, &mat);
+
+	gpD3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
+	gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+	gpD3DDevice->SetRenderTarget(0, pDest[1]);
+
+	d3d_render_packet_new *pPacket = D3DRenderPacketNew(&gEffectPool);
+	
+	if (nullptr == pPacket)
+		return nullptr;
+	
+	d3d_render_chunk_new *pChunk = D3DRenderChunkNew(pPacket);
+	pPacket->pMaterialFctn = D3DMaterialEffectPacket;
+	pChunk->pMaterialFctn = D3DMaterialEffectChunk;
+	pPacket->pTexture = pTex0;
+	pChunk->numIndices = pChunk->numVertices = 4;
+	pChunk->numPrimitives = pChunk->numVertices - 2;
+	MatrixIdentity(&pChunk->xForm);
+
+	CHUNK_XYZ_SET(pChunk, 0, D3DRENDER_SCREEN_TO_CLIP_X(0, gSmallTextureSize),
+		0, D3DRENDER_SCREEN_TO_CLIP_Y(0, gSmallTextureSize));
+	CHUNK_XYZ_SET(pChunk, 1, D3DRENDER_SCREEN_TO_CLIP_X(0, gSmallTextureSize),
+		0, D3DRENDER_SCREEN_TO_CLIP_Y(gSmallTextureSize, gSmallTextureSize));
+	CHUNK_XYZ_SET(pChunk, 2, D3DRENDER_SCREEN_TO_CLIP_X(gSmallTextureSize, gSmallTextureSize),
+		0, D3DRENDER_SCREEN_TO_CLIP_Y(gSmallTextureSize, gSmallTextureSize));
+	CHUNK_XYZ_SET(pChunk, 3, D3DRENDER_SCREEN_TO_CLIP_X(gSmallTextureSize, gSmallTextureSize),
+		0, D3DRENDER_SCREEN_TO_CLIP_Y(0, gSmallTextureSize));
+
+	CHUNK_ST0_SET(pChunk, 0, 0.0f, 0.0f);
+	CHUNK_ST0_SET(pChunk, 1, 0.0f, gScreenHeight / static_cast<float>(gFullTextureSize));
+	CHUNK_ST0_SET(pChunk, 2, gScreenWidth / static_cast<float>(gFullTextureSize), gScreenHeight / static_cast<float>(gFullTextureSize));
+	CHUNK_ST0_SET(pChunk, 3, gScreenWidth / static_cast<float>(gFullTextureSize), 0.0f);
+
+	CHUNK_BGRA_SET(pChunk, 0, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
+	CHUNK_BGRA_SET(pChunk, 1, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
+	CHUNK_BGRA_SET(pChunk, 2, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
+	CHUNK_BGRA_SET(pChunk, 3, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
+
+	CHUNK_INDEX_SET(pChunk, 0, 1);
+	CHUNK_INDEX_SET(pChunk, 1, 2);
+	CHUNK_INDEX_SET(pChunk, 2, 0);
+	CHUNK_INDEX_SET(pChunk, 3, 3);
+
+	D3DCacheFill(&gEffectCacheSystem, &gEffectPool, 1);
+	D3DCacheFlush(&gEffectCacheSystem, &gEffectPool, 1, D3DPT_TRIANGLESTRIP);
+
+	// restore render target to backbuffer
+	HRESULT hr = gpD3DDevice->SetRenderTarget(0, pSrc);
+	hr = gpD3DDevice->SetDepthStencilSurface(pZBuf);
+	hr = gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+   
+	pSrc->Release();
+	pZBuf->Release();
+	pDest[0]->Release();
+	pDest[1]->Release();
+
+	return pTex1;
+}
+
+//////////////////////
+// Public Functions //
+//////////////////////
 
 /************************************************************************************
 *
@@ -458,7 +819,8 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	bool can_see_now = !effects.blind;
 
 	// Trigger a redraw only if the player was blind, but now can see.
-	if (!can_see && can_see_now) {
+	if (!can_see && can_see_now)
+	{
 		gD3DRedrawAll |= D3DRENDER_REDRAW_ALL;
 	}
 
@@ -742,15 +1104,11 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	}
 	if ((gFrame & 255) == 255)
 		debug(("number of vertices = %d\nnumber of dp calls = %d\n", gNumVertices, gNumDPCalls));
-
 }
 
 void D3DRenderResizeDisplay(int left, int top, int right, int bottom)
 {
-	gD3DRect.left = left;
-	gD3DRect.right = left + right;
-	gD3DRect.top = top;
-	gD3DRect.bottom = top + bottom;
+	gD3DRect = {static_cast<LONG>(left), static_cast<LONG>(top), static_cast<LONG>(left + right), static_cast<LONG>(top + bottom)};
 }
 
 void D3DRenderEnableToggle(void)
@@ -762,470 +1120,6 @@ void D3DRenderEnableToggle(void)
 		memset(gBits, 0, MAXX * MAXY);
 		memset(gBufferBits, 0, MAXX * 2 * MAXY * 2);
 	}
-}
-
-int D3DRenderIsEnabled(void)
-{
-	return gD3DEnabled;
-}
-
-void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
-{
-   // Ask for a bigger font to reduce aliasing, then scale the texture
-   // down by the same amount.
-   float fontScale = 3.0;
-   HFONT hScaledFont = FontsGetScaledFont(hFont, fontScale);
-   assert(hScaledFont);
-      
-   pFont->fontHeight = GetFontHeight(hScaledFont);
-   pFont->texScale = fontScale;
-   
-	if (pFont->fontHeight > 40)
-		pFont->texWidth = pFont->texHeight = 1024;
-	else if (pFont->fontHeight > 20)
-		pFont->texWidth = pFont->texHeight = 512;
-	else
-		pFont->texWidth = pFont->texHeight = 256;
-
-	D3DCAPS9 d3dCaps;
-	gpD3DDevice->GetDeviceCaps(&d3dCaps);
-  
-	if ( pFont->texWidth > static_cast<long>(d3dCaps.MaxTextureWidth) )
-	{
-		pFont->texScale *= static_cast<float>(pFont->texWidth) / static_cast<float>(d3dCaps.MaxTextureWidth);
-		pFont->texHeight = pFont->texWidth = d3dCaps.MaxTextureWidth;
-	}
-  
-	if (pFont->pTexture)
-		IDirect3DTexture9_Release(pFont->pTexture);
-   
-   gpD3DDevice->CreateTexture(pFont->texWidth, pFont->texHeight, 1, 0, D3DFMT_A4R4G4B4, D3DPOOL_MANAGED, &pFont->pTexture, nullptr);
-   
-   BITMAPINFO bmi;
-   memset(&bmi.bmiHeader, 0, sizeof(BITMAPINFOHEADER));
-   bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
-   bmi.bmiHeader.biWidth = static_cast<int>(pFont->texWidth);
-   bmi.bmiHeader.biHeight = -static_cast<int>(pFont->texHeight);
-   bmi.bmiHeader.biPlanes = 1;
-   bmi.bmiHeader.biCompression = BI_RGB;
-   bmi.bmiHeader.biBitCount = 32;
-   
-   HDC hDC = CreateCompatibleDC(gBitsDC);
-   DWORD *pBitmapBits;
-   HBITMAP hbmBitmap = CreateDIBSection(hDC, &bmi, DIB_RGB_COLORS, (VOID**)&pBitmapBits, nullptr, 0 );
-   SetMapMode(hDC, MM_TEXT);
-  
-   SelectObject(hDC, hbmBitmap);
-   SelectObject(hDC, hScaledFont);
-   
-   // Set text properties
-   SetTextColor(hDC, RGB(255,255,255));
-   SetBkColor(hDC, 0);
-   SetBkMode(hDC, TRANSPARENT);
-   SetTextAlign(hDC, TA_TOP);
-   
-   TCHAR str[2] = _T("x");
-   long x = 0;
-   long y = 0;
-   for(TCHAR c = 32; c < 127; c++ )
-   {
-      int index = c - 32;
-      
-      str[0] = c;
-	  
-	  SIZE size;
-      GetTextExtentPoint32(hDC, str, 1, &size);
-      
-      if (!GetCharABCWidths(hDC, c, c, &pFont->abc[index]))
-	  {
-         pFont->abc[index].abcA = 0;
-         pFont->abc[index].abcB = size.cx;
-         pFont->abc[index].abcC = 0;
-      }
-
-      size.cx = pFont->abc[index].abcB;
-
-      // Is this row of the texture filled up?
-      if (x + size.cx >= pFont->texWidth)
-      {
-         x = 0;
-         y += size.cy + 1;
-      }
-      
-      int left_offset = pFont->abc[index].abcA;
-      ExtTextOut(hDC, x - left_offset, y+0, 0, nullptr, str, 1, nullptr);
-      
-      pFont->texST[index][0].s = ((FLOAT)(x+0)) / pFont->texWidth;
-      pFont->texST[index][0].t = ((FLOAT)(y+0)) / pFont->texHeight;
-      pFont->texST[index][1].s = ((FLOAT)(x+0 + size.cx)) / pFont->texWidth;
-      pFont->texST[index][1].t = ((FLOAT)(y+0 + size.cy)) / pFont->texHeight;
-
-      // Leave +1 space so bilinear filtering doesn't pick up neighboring character
-      x += size.cx+1;  
-   }
-   
-   D3DLOCKED_RECT d3dlr;
-   IDirect3DTexture9_LockRect(pFont->pTexture, 0, &d3dlr, 0, 0);
-   
-   BYTE *pDstRow = (BYTE*)d3dlr.pBits;
-   
-   for(y = 0; y < pFont->texHeight; y++)
-   {
-      WORD *pDst16 = (WORD *)pDstRow;
-      for(x = 0; x < pFont->texWidth; x++)
-      {
-         BYTE bAlpha = static_cast<BYTE>( (pBitmapBits[pFont->texWidth * y + x] & 0xff) >> 4 );
-         if (bAlpha > 0)
-         {
-            *pDst16++ = (bAlpha << 12) | 0x0fff;
-         }
-         else
-         {
-            *pDst16++ = 0x0000;
-         }
-      }
-      pDstRow += d3dlr.Pitch;
-   }
-   
-   IDirect3DTexture9_UnlockRect(pFont->pTexture, 0);
-
-   // Get kerning pairs for font
-   pFont->numKerningPairs = GetKerningPairs(hDC, 0, nullptr);
-   pFont->kerningPairs = new KERNINGPAIR[pFont->numKerningPairs];
-   GetKerningPairs(hDC, pFont->numKerningPairs, pFont->kerningPairs);
-   
-   DeleteObject(hbmBitmap);
-   DeleteObject(hScaledFont);
-   DeleteDC(hDC);
-}
-
-// new render stuff
-void D3DRenderPoolInit(d3d_render_pool_new *pPool, int size, int packetSize)
-{
-	pPool->size = size;
-	pPool->curPacket = 0;
-	d3d_render_packet_new *pPacket = (d3d_render_packet_new *)D3DRenderMalloc(sizeof(d3d_render_packet_new) * size);
-	assert(pPacket);
-	pPool->renderPacketList = list_create(pPacket);
-	pPool->packetSize = packetSize;
-
-	D3DRenderPoolReset(pPool, nullptr);
-
-	for (u_int i = 0; i < pPool->size; i++)
-	{
-		pPacket->size = packetSize;
-	}
-}
-
-void D3DRenderPoolShutdown(d3d_render_pool_new *pPool)
-{
-	list_destroy(pPool->renderPacketList);
-	memset(pPool, 0, sizeof(d3d_render_pool_new));
-}
-
-void D3DRenderPoolReset(d3d_render_pool_new *pPool, void *pMaterialFunc)
-{
-	pPool->curPacket = 0;
-	pPool->numLists = 0;
-	pPool->curPacketList = pPool->renderPacketList;
-	pPool->pMaterialFctn = (MaterialFctn) pMaterialFunc;
-}
-
-d3d_render_packet_new *D3DRenderPacketNew(d3d_render_pool_new *pPool)
-{
-	d3d_render_packet_new *pPacket;
-
-	if (pPool->curPacket >= pPool->size)
-	{
-		if (pPool->curPacketList->next == nullptr)
-		{
-			pPacket = (d3d_render_packet_new *)D3DRenderMalloc(sizeof(d3d_render_packet_new) * pPool->size);
-			assert(pPacket);
-			list_add_item(pPool->renderPacketList, pPacket);
-		}
-		else
-			pPacket = (d3d_render_packet_new *)pPool->curPacketList->next->data;
-
-		pPool->curPacketList = pPool->curPacketList->next;
-		pPool->curPacket = 1;
-		pPool->numLists++;
-
-		pPacket = (d3d_render_packet_new *)pPool->curPacketList->data;
-	}
-	else
-	{
-		pPacket = (d3d_render_packet_new *)pPool->curPacketList->data;
-		pPacket += pPool->curPacket;
-
-		if (pPool->curPacket == 12)
-			gpPacket = pPacket;
-
-		pPool->curPacket++;
-	}
-
-	D3DRenderPacketInit(pPacket);
-	return pPacket;
-}
-
-void D3DRenderPacketInit(d3d_render_packet_new *pPacket)
-{
-	pPacket->curChunk = 0;
-	pPacket->effect = 0;
-	pPacket->flags = 0;
-	pPacket->pDib = nullptr;
-	pPacket->pMaterialFctn = nullptr;
-	pPacket->pTexture = nullptr;
-	pPacket->xLat0 = 0;
-	pPacket->xLat1 = 0;
-}
-
-d3d_render_chunk_new *D3DRenderChunkNew(d3d_render_packet_new *pPacket)
-{
-	if (pPacket->curChunk >= (pPacket->size - 1))
-		return nullptr;
-	else
-	{
-		pPacket->curChunk++;
-		D3DRenderChunkInit(&pPacket->renderChunks[pPacket->curChunk - 1]);
-		return &pPacket->renderChunks[pPacket->curChunk - 1];
-	}
-}
-
-void D3DRenderChunkInit(d3d_render_chunk_new *pChunk)
-{
-	pChunk->curIndex = 0;
-	pChunk->drawn = 0;
-	pChunk->flags = 0;
-	pChunk->zBias = 0;
-	pChunk->isTargeted = FALSE;
-	pChunk->numIndices = 0;
-	pChunk->xLat0 = 0;
-	pChunk->xLat1 = 0;
-	pChunk->pSector = nullptr;
-	pChunk->pSectorNeg = nullptr;
-	pChunk->pSectorPos = nullptr;
-	pChunk->pSideDef = nullptr;
-	pChunk->pMaterialFctn = nullptr;
-	pChunk->pRenderCache = nullptr;
-}
-
-d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDIRECT3DTEXTURE9 pTexture,
-												PDIB pDib, BYTE xLat0, BYTE xLat1, int effect)
-{
-	d3d_render_packet_new *pPacket;
-	
-	for (list_type list = pPool->renderPacketList; list != pPool->curPacketList->next; list = list->next)
-	{
-		pPacket = (d3d_render_packet_new *)list->data;
-
-		u_int numPackets;
-		if (list == pPool->curPacketList)
-			numPackets = pPool->curPacket;
-		else
-			numPackets = pPool->size;
-
-		// for each packet
-		for (u_int count = 0; count < numPackets; count++, pPacket++)
-		{
-			// if we find a match that isn't full already, return it
-			if ((pPacket->pDib == pDib) && (pPacket->pTexture == pTexture) &&
-				(pPacket->xLat0 == xLat0) && (pPacket->xLat1 == xLat1) &&
-				(pPacket->effect == effect))
-			{
-				if (pPacket->curChunk < (pPacket->size - 1))
-					return pPacket;
-			}
-		}
-	}
-
-	// otherwise, return a new one (or NULL if no more remain)
-	pPacket = D3DRenderPacketNew(pPool);
-
-	if (pPacket)
-	{
-		pPacket->pDib = pDib;
-		pPacket->pTexture = pTexture;
-		pPacket->xLat0 = xLat0;
-		pPacket->xLat1 = xLat1;
-		pPacket->effect = effect;
-		pPacket->size = pPool->packetSize;
-	}
-
-	return pPacket;
-}
-
-void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool)
-{
-   float screenW = static_cast<float>(gD3DRect.right - gD3DRect.left) / static_cast<float>(gScreenWidth);
-   float screenH = static_cast<float>(gD3DRect.bottom - gD3DRect.top) / static_cast<float>(gScreenHeight);
-
-   // Render view elements (such as the main viewport yellow ui corners).
-   int offset = (GetFocus() == hMain) ? 4 : 0;
-   
-   // 0 = top-left
-   // 1 = top-right
-   // 2 = bottom-left
-   // 3 = bottom-right
-   static constexpr int NUM_CORNERS = 4;
-   for (int i = 0; i < NUM_CORNERS; ++i)
-   {
-      float width = static_cast<float>(ViewElements[i + offset].width) / screenW;
-      float height = static_cast<float>(ViewElements[i + offset].height) / screenH;
-
-      float left, right, top, bottom;
-	  
-      if (i % 2 == 0)  // left side
-      {
-         left = D3DRENDER_SCREEN_TO_CLIP_X(0, gScreenWidth);
-         right = D3DRENDER_SCREEN_TO_CLIP_X(width, gScreenWidth);
-      }
-      else  // right side
-      {
-         left = D3DRENDER_SCREEN_TO_CLIP_X(gScreenWidth - width, gScreenWidth);
-         right = D3DRENDER_SCREEN_TO_CLIP_X(gScreenWidth, gScreenWidth);
-      }
-
-      if (i < 2)  // top side
-      {
-         top = D3DRENDER_SCREEN_TO_CLIP_Y(0, gScreenHeight);
-         bottom = D3DRENDER_SCREEN_TO_CLIP_Y(height, gScreenHeight);
-      }
-      else  // bottom side
-      {
-         top = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight - height, gScreenHeight);
-         bottom = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight, gScreenHeight);
-      }
-
-      d3d_render_packet_new *pPacket = D3DRenderPacketNew(pPool);
-      pPacket->pDib = nullptr;
-      pPacket->pTexture = gpViewElements[i + offset];
-      pPacket->xLat0 = 0;
-      pPacket->xLat1 = 0;
-      pPacket->effect = 0;
-      pPacket->size = pPool->packetSize;
-
-      d3d_render_chunk_new *pChunk = D3DRenderChunkNew(pPacket);
-      pChunk->flags = 0;
-      pChunk->numIndices = 4;
-      pChunk->numVertices = 4;
-      pChunk->numPrimitives = pChunk->numVertices - 2;
-      pChunk->xLat0 = 0;
-      pChunk->xLat1 = 0;
-
-      pPacket->pMaterialFctn = D3DMaterialObjectPacket;
-      pChunk->pMaterialFctn = D3DMaterialNone;
-
-      pChunk->xyz[0] = { left, VIEW_ELEMENT_Z, top };
-      pChunk->xyz[1] = { left, VIEW_ELEMENT_Z, bottom };	  
-      pChunk->xyz[2] = { right, VIEW_ELEMENT_Z, bottom };
-      pChunk->xyz[3] = { right, VIEW_ELEMENT_Z, top };	  
-
-      for (auto& color : pChunk->bgra)
-      {
-         color = {255, 255, 255, 255}; // Solid white (no tinting)
-      }
-
-      // Half-pixel offset to prevent texture bleeding.
-      static constexpr float foffset = 1.0f / 64.0f;
-      pChunk->st0[0] = { foffset, foffset };
-      pChunk->st0[1] = { foffset, (1.0f - foffset) };
-      pChunk->st0[2] = { (1.0f - foffset), (1.0f - foffset) };
-      pChunk->st0[3] = { (1.0f - foffset), foffset };
-
-      pChunk->indices[0] = 1;
-      pChunk->indices[1] = 2;
-      pChunk->indices[2] = 0;
-      pChunk->indices[3] = 3;
-   }
-}
-
-LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
-													 LPDIRECT3DTEXTURE9	pTex1,
-													 float width, float height)
-{
-	LPDIRECT3DSURFACE9	pSrc, pDest[2], pZBuf;
-
-	D3DCacheSystemReset(&gEffectCacheSystem);
-	D3DRenderPoolReset(&gEffectPool, &D3DMaterialEffectPool);
-
-	// get pointer to backbuffer surface and z/stencil surface
-	gpD3DDevice->GetRenderTarget(0, &pSrc);
-	gpD3DDevice->GetDepthStencilSurface(&pZBuf);
-	
-	// get pointer to texture surface for rendering
-	pTex0->GetSurfaceLevel(0, &pDest[0]);
-	pTex1->GetSurfaceLevel(0, &pDest[1]);
-
-	POINT pnt = { 0, 0 };
-	
-	RECT rect = GetScreenRect();
-
-	// copy framebuffer to texture
-	gpD3DDevice->StretchRect(pSrc, &rect, pDest[0], &rect, D3DTEXF_NONE);
-   
-	// clear local->screen transforms
-	D3DMATRIX mat;
-	MatrixIdentity(&mat);
-	gpD3DDevice->SetTransform(D3DTS_WORLD, &mat);
-	gpD3DDevice->SetTransform(D3DTS_VIEW, &mat);
-	gpD3DDevice->SetTransform(D3DTS_PROJECTION, &mat);
-
-	gpD3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
-	gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
-
-	gpD3DDevice->SetRenderTarget(0, pDest[1]);
-
-	d3d_render_packet_new *pPacket = D3DRenderPacketNew(&gEffectPool);
-	
-	if (nullptr == pPacket)
-		return nullptr;
-	
-	d3d_render_chunk_new *pChunk = D3DRenderChunkNew(pPacket);
-	pPacket->pMaterialFctn = D3DMaterialEffectPacket;
-	pChunk->pMaterialFctn = D3DMaterialEffectChunk;
-	pPacket->pTexture = pTex0;
-	pChunk->numIndices = pChunk->numVertices = 4;
-	pChunk->numPrimitives = pChunk->numVertices - 2;
-	MatrixIdentity(&pChunk->xForm);
-
-	CHUNK_XYZ_SET(pChunk, 0, D3DRENDER_SCREEN_TO_CLIP_X(0, gSmallTextureSize),
-		0, D3DRENDER_SCREEN_TO_CLIP_Y(0, gSmallTextureSize));
-	CHUNK_XYZ_SET(pChunk, 1, D3DRENDER_SCREEN_TO_CLIP_X(0, gSmallTextureSize),
-		0, D3DRENDER_SCREEN_TO_CLIP_Y(gSmallTextureSize, gSmallTextureSize));
-	CHUNK_XYZ_SET(pChunk, 2, D3DRENDER_SCREEN_TO_CLIP_X(gSmallTextureSize, gSmallTextureSize),
-		0, D3DRENDER_SCREEN_TO_CLIP_Y(gSmallTextureSize, gSmallTextureSize));
-	CHUNK_XYZ_SET(pChunk, 3, D3DRENDER_SCREEN_TO_CLIP_X(gSmallTextureSize, gSmallTextureSize),
-		0, D3DRENDER_SCREEN_TO_CLIP_Y(0, gSmallTextureSize));
-
-	CHUNK_ST0_SET(pChunk, 0, 0.0f, 0.0f);
-	CHUNK_ST0_SET(pChunk, 1, 0.0f, gScreenHeight / static_cast<float>(gFullTextureSize));
-	CHUNK_ST0_SET(pChunk, 2, gScreenWidth / static_cast<float>(gFullTextureSize), gScreenHeight / static_cast<float>(gFullTextureSize));
-	CHUNK_ST0_SET(pChunk, 3, gScreenWidth / static_cast<float>(gFullTextureSize), 0.0f);
-
-	CHUNK_BGRA_SET(pChunk, 0, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
-	CHUNK_BGRA_SET(pChunk, 1, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
-	CHUNK_BGRA_SET(pChunk, 2, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
-	CHUNK_BGRA_SET(pChunk, 3, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
-
-	CHUNK_INDEX_SET(pChunk, 0, 1);
-	CHUNK_INDEX_SET(pChunk, 1, 2);
-	CHUNK_INDEX_SET(pChunk, 2, 0);
-	CHUNK_INDEX_SET(pChunk, 3, 3);
-
-	D3DCacheFill(&gEffectCacheSystem, &gEffectPool, 1);
-	D3DCacheFlush(&gEffectCacheSystem, &gEffectPool, 1, D3DPT_TRIANGLESTRIP);
-
-	// restore render target to backbuffer
-	HRESULT hr = gpD3DDevice->SetRenderTarget(0, pSrc);
-	hr = gpD3DDevice->SetDepthStencilSurface(pZBuf);
-	hr = gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
-   
-	pSrc->Release();
-	pZBuf->Release();
-	pDest[0]->Release();
-	pDest[1]->Release();
-
-	return pTex1;
 }
 
 // Controls alpha testing, which is a 'pass/fail' check for pixels based on their transparency.

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -11,7 +11,6 @@
 ///////////////
 // Variables //
 ///////////////
-
 d3d_render_packet_new	*gpPacket = nullptr;
 
 LPDIRECT3DTEXTURE9		gpNoLookThrough = nullptr;
@@ -47,10 +46,10 @@ d3d_render_pool_new		gWallMaskPool;
 d3d_render_pool_new		gEffectPool;
 d3d_render_pool_new		gParticlePool;
 
-custom_xyz				playerOldPos;
-custom_xyz				playerDeltaPos;
+custom_xyz				playerOldPos = {0.0f, 0.0f, 0.0f};
+custom_xyz				playerDeltaPos = {0.0f, 0.0f, 0.0f};
 
-RECT					gD3DRect;
+RECT					gD3DRect = {0, 0, 0, 0};
 BYTE					gViewerLight = 0;
 int						gNumObjects = 0;
 int						gNumDPCalls = 0;
@@ -97,7 +96,6 @@ D3DMATRIX view, mat, rot, trans, proj;
 //////////////////////
 // External Globals //
 //////////////////////
-
 extern long				viewer_height;
 extern PDIB				background;         /* Pointer to background bitmap */
 extern ObjectRange		visible_objects[];    /* Where objects are on screen */
@@ -119,7 +117,6 @@ extern void			UpdateRoom3D(room_type *room, Draw3DParams *params);
 /////////////////////////
 // Internal Prototypes //
 /////////////////////////
-
 void D3DRenderPacketInit(d3d_render_packet_new *pPacket);
 void D3DRenderChunkInit(d3d_render_chunk_new *pChunk);
 void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool);
@@ -127,17 +124,16 @@ void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool);
 //////////////////////////////
 // Main Rendering Interface //
 //////////////////////////////
-
 void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 {
-   // Ask for a bigger font to reduce aliasing, then scale the texture
-   // down by the same amount.
-   static constexpr float fontScale = 3.0;
-   HFONT hScaledFont = FontsGetScaledFont(hFont, fontScale);
-   assert(hScaledFont);
+	// Ask for a bigger font to reduce aliasing, then scale the texture
+	// down by the same amount.
+	static constexpr float fontScale = 3.0;
+	HFONT hScaledFont = FontsGetScaledFont(hFont, fontScale);
+	assert(hScaledFont);
       
-   pFont->fontHeight = GetFontHeight(hScaledFont);
-   pFont->texScale = fontScale;
+	pFont->fontHeight = GetFontHeight(hScaledFont);
+	pFont->texScale = fontScale;
    
 	if (pFont->fontHeight > 40)
 		pFont->texWidth = pFont->texHeight = 1024;
@@ -156,113 +152,113 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 	}
   
 	if (pFont->pTexture)
-		IDirect3DTexture9_Release(pFont->pTexture);
+		pFont->pTexture->Release();
    
-   gpD3DDevice->CreateTexture(pFont->texWidth, pFont->texHeight, 1, 0, D3DFMT_A4R4G4B4, D3DPOOL_MANAGED, &pFont->pTexture, nullptr);
+	gpD3DDevice->CreateTexture(pFont->texWidth, pFont->texHeight, 1, 0, D3DFMT_A4R4G4B4,
+									D3DPOOL_MANAGED, &pFont->pTexture, nullptr);
    
-   BITMAPINFO bmi;
-   memset(&bmi.bmiHeader, 0, sizeof(BITMAPINFOHEADER));
-   bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
-   bmi.bmiHeader.biWidth = static_cast<int>(pFont->texWidth);
-   bmi.bmiHeader.biHeight = -static_cast<int>(pFont->texHeight);
-   bmi.bmiHeader.biPlanes = 1;
-   bmi.bmiHeader.biCompression = BI_RGB;
-   bmi.bmiHeader.biBitCount = 32;
-   
-   HDC hDC = CreateCompatibleDC(gBitsDC);
-   DWORD *pBitmapBits;
-   HBITMAP hbmBitmap = CreateDIBSection(hDC, &bmi, DIB_RGB_COLORS, (VOID**)&pBitmapBits, nullptr, 0 );
-   SetMapMode(hDC, MM_TEXT);
+	BITMAPINFO bmi;
+	memset(&bmi.bmiHeader, 0, sizeof(BITMAPINFOHEADER));
+	bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+	bmi.bmiHeader.biWidth = static_cast<int>(pFont->texWidth);
+	bmi.bmiHeader.biHeight = -static_cast<int>(pFont->texHeight);
+	bmi.bmiHeader.biPlanes = 1;
+	bmi.bmiHeader.biCompression = BI_RGB;
+	bmi.bmiHeader.biBitCount = 32;
+
+	HDC hDC = CreateCompatibleDC(gBitsDC);
+	DWORD *pBitmapBits;
+	HBITMAP hbmBitmap = CreateDIBSection(hDC, &bmi, DIB_RGB_COLORS, (VOID**)&pBitmapBits, nullptr, 0 );
+	SetMapMode(hDC, MM_TEXT);
   
-   SelectObject(hDC, hbmBitmap);
-   SelectObject(hDC, hScaledFont);
+	SelectObject(hDC, hbmBitmap);
+	SelectObject(hDC, hScaledFont);
    
-   // Set text properties
-   SetTextColor(hDC, RGB(255,255,255));
-   SetBkColor(hDC, 0);
-   SetBkMode(hDC, TRANSPARENT);
-   SetTextAlign(hDC, TA_TOP);
-   
-   TCHAR str[2] = _T("x");
-   long x = 0;
-   long y = 0;
-   for(TCHAR c = 32; c < 127; c++ )
-   {
-      int index = c - 32;
+	// Set text properties
+	SetTextColor(hDC, RGB(255,255,255));
+	SetBkColor(hDC, 0);
+	SetBkMode(hDC, TRANSPARENT);
+	SetTextAlign(hDC, TA_TOP);
+
+	TCHAR str[2] = _T("x");
+	long x = 0;
+	long y = 0;
+	for(TCHAR c = 32; c < 127; c++ )
+	{
+		int index = c - 32;
+		
+		str[0] = c;
+		
+		SIZE size;
+		GetTextExtentPoint32(hDC, str, 1, &size);
+		
+		if (!GetCharABCWidths(hDC, c, c, &pFont->abc[index]))
+		{
+			pFont->abc[index] = { 0, static_cast<UINT>(size.cx), 0 };
+		}
+
+		size.cx = pFont->abc[index].abcB;
+
+		// Is this row of the texture filled up?
+		if (x + size.cx >= pFont->texWidth)
+		{
+			x = 0;
+			y += (size.cy + 1);
+		}
       
-      str[0] = c;
+		int left_offset = pFont->abc[index].abcA;
+		ExtTextOut(hDC, x - left_offset, y, 0, nullptr, str, 1, nullptr);
+      
+		pFont->texST[index][0] = {(static_cast<float>(x) / pFont->texWidth), 
+									(static_cast<float>(y) / pFont->texHeight)};
 	  
-	  SIZE size;
-      GetTextExtentPoint32(hDC, str, 1, &size);
-      
-      if (!GetCharABCWidths(hDC, c, c, &pFont->abc[index]))
-	  {
-         pFont->abc[index].abcA = 0;
-         pFont->abc[index].abcB = size.cx;
-         pFont->abc[index].abcC = 0;
-      }
+		pFont->texST[index][1] = {(static_cast<float>(x + size.cx) / pFont->texWidth),
+									(static_cast<float>(y + size.cy) / pFont->texHeight)};
 
-      size.cx = pFont->abc[index].abcB;
+		// Leave +1 space so bilinear filtering doesn't pick up neighboring character
+		x += (size.cx + 1);  
+	}
+   
+	D3DLOCKED_RECT d3dlr;
+	pFont->pTexture->LockRect(0, &d3dlr, 0, 0);
+   
+	BYTE *pDstRow = reinterpret_cast<BYTE*>(d3dlr.pBits);
+   
+	// Convert a texture bitmask into a 16-bit pixel format.
+	for (y = 0; y < pFont->texHeight; y++)
+	{
+		WORD *pDst16 = reinterpret_cast<WORD*>(pDstRow);
+		for(x = 0; x < pFont->texWidth; x++)
+		{
+			// Extract 4-bit alpha from 8-bit source.
+			BYTE bAlpha = static_cast<BYTE>( (pBitmapBits[pFont->texWidth * y + x] & 0xff) >> 4 );
+			
+			// If there's any alpha, set color to white with alpha. Otherwise it's transparent.
+			*pDst16++ = (bAlpha > 0)	? (static_cast<WORD>(bAlpha << 12) | 0x0FFF)
+										: 0x0000;
+		}
+		pDstRow += d3dlr.Pitch;
+	}
+	
+	pFont->pTexture->UnlockRect(0);
 
-      // Is this row of the texture filled up?
-      if (x + size.cx >= pFont->texWidth)
-      {
-         x = 0;
-         y += size.cy + 1;
-      }
-      
-      int left_offset = pFont->abc[index].abcA;
-      ExtTextOut(hDC, x - left_offset, y+0, 0, nullptr, str, 1, nullptr);
-      
-      pFont->texST[index][0].s = ((FLOAT)(x+0)) / pFont->texWidth;
-      pFont->texST[index][0].t = ((FLOAT)(y+0)) / pFont->texHeight;
-      pFont->texST[index][1].s = ((FLOAT)(x+0 + size.cx)) / pFont->texWidth;
-      pFont->texST[index][1].t = ((FLOAT)(y+0 + size.cy)) / pFont->texHeight;
-
-      // Leave +1 space so bilinear filtering doesn't pick up neighboring character
-      x += size.cx+1;  
-   }
-   
-   D3DLOCKED_RECT d3dlr;
-   IDirect3DTexture9_LockRect(pFont->pTexture, 0, &d3dlr, 0, 0);
-   
-   BYTE *pDstRow = (BYTE*)d3dlr.pBits;
-   
-   for(y = 0; y < pFont->texHeight; y++)
-   {
-      WORD *pDst16 = (WORD *)pDstRow;
-      for(x = 0; x < pFont->texWidth; x++)
-      {
-         BYTE bAlpha = static_cast<BYTE>( (pBitmapBits[pFont->texWidth * y + x] & 0xff) >> 4 );
-         if (bAlpha > 0)
-         {
-            *pDst16++ = (bAlpha << 12) | 0x0fff;
-         }
-         else
-         {
-            *pDst16++ = 0x0000;
-         }
-      }
-      pDstRow += d3dlr.Pitch;
-   }
-   
-   IDirect3DTexture9_UnlockRect(pFont->pTexture, 0);
-
-   // Get kerning pairs for font
-   pFont->numKerningPairs = GetKerningPairs(hDC, 0, nullptr);
-   pFont->kerningPairs = new KERNINGPAIR[pFont->numKerningPairs];
-   GetKerningPairs(hDC, pFont->numKerningPairs, pFont->kerningPairs);
-   
-   DeleteObject(hbmBitmap);
-   DeleteObject(hScaledFont);
-   DeleteDC(hDC);
+	// Get kerning pairs for font
+	pFont->numKerningPairs = GetKerningPairs(hDC, 0, nullptr);
+	pFont->kerningPairs = new KERNINGPAIR[pFont->numKerningPairs];
+	GetKerningPairs(hDC, pFont->numKerningPairs, pFont->kerningPairs);
+	
+	DeleteObject(hbmBitmap);
+	DeleteObject(hScaledFont);
+	DeleteDC(hDC);
 }
 
 void D3DRenderPoolInit(d3d_render_pool_new *pPool, int size, int packetSize)
 {
 	pPool->size = size;
 	pPool->curPacket = 0;
-	d3d_render_packet_new *pPacket = (d3d_render_packet_new *)D3DRenderMalloc(sizeof(d3d_render_packet_new) * size);
+	
+	d3d_render_packet_new *pPacket = reinterpret_cast<d3d_render_packet_new*>
+										(D3DRenderMalloc(sizeof(d3d_render_packet_new) * size));
 	assert(pPacket);
 	pPool->renderPacketList = list_create(pPacket);
 	pPool->packetSize = packetSize;
@@ -286,7 +282,7 @@ void D3DRenderPoolReset(d3d_render_pool_new *pPool, void *pMaterialFunc)
 	pPool->curPacket = 0;
 	pPool->numLists = 0;
 	pPool->curPacketList = pPool->renderPacketList;
-	pPool->pMaterialFctn = (MaterialFctn) pMaterialFunc;
+	pPool->pMaterialFctn = reinterpret_cast<MaterialFctn>(pMaterialFunc);
 }
 
 d3d_render_packet_new *D3DRenderPacketNew(d3d_render_pool_new *pPool)
@@ -297,22 +293,24 @@ d3d_render_packet_new *D3DRenderPacketNew(d3d_render_pool_new *pPool)
 	{
 		if (pPool->curPacketList->next == nullptr)
 		{
-			pPacket = (d3d_render_packet_new *)D3DRenderMalloc(sizeof(d3d_render_packet_new) * pPool->size);
+			pPacket = reinterpret_cast<d3d_render_packet_new*>(D3DRenderMalloc(sizeof(d3d_render_packet_new) * pPool->size));
 			assert(pPacket);
 			list_add_item(pPool->renderPacketList, pPacket);
 		}
 		else
-			pPacket = (d3d_render_packet_new *)pPool->curPacketList->next->data;
+		{
+			reinterpret_cast<d3d_render_packet_new*>(pPool->curPacketList->next->data);
+		}
 
 		pPool->curPacketList = pPool->curPacketList->next;
 		pPool->curPacket = 1;
 		pPool->numLists++;
 
-		pPacket = (d3d_render_packet_new *)pPool->curPacketList->data;
+		pPacket = reinterpret_cast<d3d_render_packet_new*>(pPool->curPacketList->data);
 	}
 	else
 	{
-		pPacket = (d3d_render_packet_new *)pPool->curPacketList->data;
+		pPacket = reinterpret_cast<d3d_render_packet_new*>(pPool->curPacketList->data);
 		pPacket += pPool->curPacket;
 
 		if (pPool->curPacket == 12)
@@ -414,87 +412,87 @@ d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDI
 
 void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool)
 {
-   float screenW = static_cast<float>(gD3DRect.right - gD3DRect.left) / static_cast<float>(gScreenWidth);
-   float screenH = static_cast<float>(gD3DRect.bottom - gD3DRect.top) / static_cast<float>(gScreenHeight);
+	float screenW = static_cast<float>(gD3DRect.right - gD3DRect.left) / static_cast<float>(gScreenWidth);
+	float screenH = static_cast<float>(gD3DRect.bottom - gD3DRect.top) / static_cast<float>(gScreenHeight);
 
-   // Render view elements (such as the main viewport yellow ui corners).
-   int offset = (GetFocus() == hMain) ? 4 : 0;
-   
-   // 0 = top-left
-   // 1 = top-right
-   // 2 = bottom-left
-   // 3 = bottom-right
-   static constexpr int NUM_CORNERS = 4;
-   for (int i = 0; i < NUM_CORNERS; ++i)
-   {
-      float width = static_cast<float>(ViewElements[i + offset].width) / screenW;
-      float height = static_cast<float>(ViewElements[i + offset].height) / screenH;
+	// Render view elements (such as the main viewport yellow ui corners).
+	int offset = (GetFocus() == hMain) ? 4 : 0;
 
-      float left, right, top, bottom;
+	// 0 = top-left
+	// 1 = top-right
+	// 2 = bottom-left
+	// 3 = bottom-right
+	static constexpr int NUM_CORNERS = 4;
+	for (int i = 0; i < NUM_CORNERS; ++i)
+	{
+		float width = static_cast<float>(ViewElements[i + offset].width) / screenW;
+		float height = static_cast<float>(ViewElements[i + offset].height) / screenH;
+		
+		float left, right, top, bottom;
 	  
-      if (i % 2 == 0)  // left side
-      {
-         left = D3DRENDER_SCREEN_TO_CLIP_X(0, gScreenWidth);
-         right = D3DRENDER_SCREEN_TO_CLIP_X(width, gScreenWidth);
-      }
-      else  // right side
-      {
-         left = D3DRENDER_SCREEN_TO_CLIP_X(gScreenWidth - width, gScreenWidth);
-         right = D3DRENDER_SCREEN_TO_CLIP_X(gScreenWidth, gScreenWidth);
-      }
+		if (i % 2 == 0)  // left side
+		{
+			left = D3DRENDER_SCREEN_TO_CLIP_X(0, gScreenWidth);
+			right = D3DRENDER_SCREEN_TO_CLIP_X(width, gScreenWidth);
+		}
+		else  // right side
+		{
+			left = D3DRENDER_SCREEN_TO_CLIP_X(gScreenWidth - width, gScreenWidth);
+			right = D3DRENDER_SCREEN_TO_CLIP_X(gScreenWidth, gScreenWidth);
+		}
 
-      if (i < 2)  // top side
-      {
-         top = D3DRENDER_SCREEN_TO_CLIP_Y(0, gScreenHeight);
-         bottom = D3DRENDER_SCREEN_TO_CLIP_Y(height, gScreenHeight);
-      }
-      else  // bottom side
-      {
-         top = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight - height, gScreenHeight);
-         bottom = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight, gScreenHeight);
-      }
+		if (i < 2)  // top side
+		{
+		 top = D3DRENDER_SCREEN_TO_CLIP_Y(0, gScreenHeight);
+		 bottom = D3DRENDER_SCREEN_TO_CLIP_Y(height, gScreenHeight);
+		}
+		else  // bottom side
+		{
+		 top = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight - height, gScreenHeight);
+		 bottom = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight, gScreenHeight);
+		}
 
-      d3d_render_packet_new *pPacket = D3DRenderPacketNew(pPool);
-      pPacket->pDib = nullptr;
-      pPacket->pTexture = gpViewElements[i + offset];
-      pPacket->xLat0 = 0;
-      pPacket->xLat1 = 0;
-      pPacket->effect = 0;
-      pPacket->size = pPool->packetSize;
+		d3d_render_packet_new *pPacket = D3DRenderPacketNew(pPool);
+		pPacket->pDib = nullptr;
+		pPacket->pTexture = gpViewElements[i + offset];
+		pPacket->xLat0 = 0;
+		pPacket->xLat1 = 0;
+		pPacket->effect = 0;
+		pPacket->size = pPool->packetSize;
 
-      d3d_render_chunk_new *pChunk = D3DRenderChunkNew(pPacket);
-      pChunk->flags = 0;
-      pChunk->numIndices = 4;
-      pChunk->numVertices = 4;
-      pChunk->numPrimitives = pChunk->numVertices - 2;
-      pChunk->xLat0 = 0;
-      pChunk->xLat1 = 0;
+		d3d_render_chunk_new *pChunk = D3DRenderChunkNew(pPacket);
+		pChunk->flags = 0;
+		pChunk->numIndices = 4;
+		pChunk->numVertices = 4;
+		pChunk->numPrimitives = pChunk->numVertices - 2;
+		pChunk->xLat0 = 0;
+		pChunk->xLat1 = 0;
 
-      pPacket->pMaterialFctn = D3DMaterialObjectPacket;
-      pChunk->pMaterialFctn = D3DMaterialNone;
+		pPacket->pMaterialFctn = D3DMaterialObjectPacket;
+		pChunk->pMaterialFctn = D3DMaterialNone;
 
-      pChunk->xyz[0] = { left, VIEW_ELEMENT_Z, top };
-      pChunk->xyz[1] = { left, VIEW_ELEMENT_Z, bottom };	  
-      pChunk->xyz[2] = { right, VIEW_ELEMENT_Z, bottom };
-      pChunk->xyz[3] = { right, VIEW_ELEMENT_Z, top };	  
+		pChunk->xyz[0] = { left, VIEW_ELEMENT_Z, top };
+		pChunk->xyz[1] = { left, VIEW_ELEMENT_Z, bottom };	  
+		pChunk->xyz[2] = { right, VIEW_ELEMENT_Z, bottom };
+		pChunk->xyz[3] = { right, VIEW_ELEMENT_Z, top };	  
 
-      for (auto& color : pChunk->bgra)
-      {
-         color = {255, 255, 255, 255}; // Solid white (no tinting)
-      }
+		for (auto& color : pChunk->bgra)
+		{
+		 color = {255, 255, 255, 255}; // Solid white (no tinting)
+		}
 
-      // Half-pixel offset to prevent texture bleeding.
-      static constexpr float foffset = 1.0f / 64.0f;
-      pChunk->st0[0] = { foffset, foffset };
-      pChunk->st0[1] = { foffset, (1.0f - foffset) };
-      pChunk->st0[2] = { (1.0f - foffset), (1.0f - foffset) };
-      pChunk->st0[3] = { (1.0f - foffset), foffset };
+		// Half-pixel offset to prevent texture bleeding.
+		static constexpr float foffset = 1.0f / 64.0f;
+		pChunk->st0[0] = { foffset, foffset };
+		pChunk->st0[1] = { foffset, (1.0f - foffset) };
+		pChunk->st0[2] = { (1.0f - foffset), (1.0f - foffset) };
+		pChunk->st0[3] = { (1.0f - foffset), foffset };
 
-      pChunk->indices[0] = 1;
-      pChunk->indices[1] = 2;
-      pChunk->indices[2] = 0;
-      pChunk->indices[3] = 3;
-   }
+		pChunk->indices[0] = 1;
+		pChunk->indices[1] = 2;
+		pChunk->indices[2] = 0;
+		pChunk->indices[3] = 3;
+	}
 }
 
 // Captures current rendered frame as a texture for post-processing effects.
@@ -514,7 +512,6 @@ LPDIRECT3DTEXTURE9 D3DRender_CaptureEffect(LPDIRECT3DTEXTURE9 pTex0, LPDIRECT3DT
 	pTex1->GetSurfaceLevel(0, &pDest[1]);
 
 	POINT pnt = { 0, 0 };
-	
 	RECT rect = GetScreenRect();
 
 	// copy framebuffer to texture
@@ -545,29 +542,33 @@ LPDIRECT3DTEXTURE9 D3DRender_CaptureEffect(LPDIRECT3DTEXTURE9 pTex0, LPDIRECT3DT
 	pChunk->numPrimitives = pChunk->numVertices - 2;
 	MatrixIdentity(&pChunk->xForm);
 
-	CHUNK_XYZ_SET(pChunk, 0, D3DRENDER_SCREEN_TO_CLIP_X(0, gSmallTextureSize),
-		0, D3DRENDER_SCREEN_TO_CLIP_Y(0, gSmallTextureSize));
-	CHUNK_XYZ_SET(pChunk, 1, D3DRENDER_SCREEN_TO_CLIP_X(0, gSmallTextureSize),
-		0, D3DRENDER_SCREEN_TO_CLIP_Y(gSmallTextureSize, gSmallTextureSize));
-	CHUNK_XYZ_SET(pChunk, 2, D3DRENDER_SCREEN_TO_CLIP_X(gSmallTextureSize, gSmallTextureSize),
-		0, D3DRENDER_SCREEN_TO_CLIP_Y(gSmallTextureSize, gSmallTextureSize));
-	CHUNK_XYZ_SET(pChunk, 3, D3DRENDER_SCREEN_TO_CLIP_X(gSmallTextureSize, gSmallTextureSize),
-		0, D3DRENDER_SCREEN_TO_CLIP_Y(0, gSmallTextureSize));
+	pChunk->xyz[0] = { D3DRENDER_SCREEN_TO_CLIP_X(0, gSmallTextureSize),
+							0, D3DRENDER_SCREEN_TO_CLIP_Y(0, gSmallTextureSize) };
+						
+	pChunk->xyz[1] = { D3DRENDER_SCREEN_TO_CLIP_X(0, gSmallTextureSize),
+							0, D3DRENDER_SCREEN_TO_CLIP_Y(gSmallTextureSize, gSmallTextureSize) };
+						
+	pChunk->xyz[2] = { D3DRENDER_SCREEN_TO_CLIP_X(gSmallTextureSize, gSmallTextureSize),
+							0, D3DRENDER_SCREEN_TO_CLIP_Y(gSmallTextureSize, gSmallTextureSize) };
+						
+	pChunk->xyz[3] = { D3DRENDER_SCREEN_TO_CLIP_X(gSmallTextureSize, gSmallTextureSize),
+							0, D3DRENDER_SCREEN_TO_CLIP_Y(0, gSmallTextureSize) };
 
-	CHUNK_ST0_SET(pChunk, 0, 0.0f, 0.0f);
-	CHUNK_ST0_SET(pChunk, 1, 0.0f, gScreenHeight / static_cast<float>(gFullTextureSize));
-	CHUNK_ST0_SET(pChunk, 2, gScreenWidth / static_cast<float>(gFullTextureSize), gScreenHeight / static_cast<float>(gFullTextureSize));
-	CHUNK_ST0_SET(pChunk, 3, gScreenWidth / static_cast<float>(gFullTextureSize), 0.0f);
+	const float texSize = static_cast<float>(gFullTextureSize);
+	pChunk->st0[0] = { 0.0f, 0.0f };
+	pChunk->st0[1] = { 0.0f, (gScreenHeight / texSize) };
+	pChunk->st0[2] = { (gScreenWidth / texSize), (gScreenHeight / texSize) };
+	pChunk->st0[3] = { (gScreenWidth / texSize), 0.0f };
 
-	CHUNK_BGRA_SET(pChunk, 0, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
-	CHUNK_BGRA_SET(pChunk, 1, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
-	CHUNK_BGRA_SET(pChunk, 2, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
-	CHUNK_BGRA_SET(pChunk, 3, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
+	for (int i = 0; i < 4; i++)
+	{
+		pChunk->bgra[i] = {COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX};
+	}
 
-	CHUNK_INDEX_SET(pChunk, 0, 1);
-	CHUNK_INDEX_SET(pChunk, 1, 2);
-	CHUNK_INDEX_SET(pChunk, 2, 0);
-	CHUNK_INDEX_SET(pChunk, 3, 3);
+	pChunk->indices[0] = 1;
+	pChunk->indices[1] = 2;
+	pChunk->indices[2] = 0;
+	pChunk->indices[3] = 3;
 
 	D3DCacheFill(&gEffectCacheSystem, &gEffectPool, 1);
 	D3DCacheFlush(&gEffectCacheSystem, &gEffectPool, 1, D3DPT_TRIANGLESTRIP);
@@ -680,7 +681,7 @@ HRESULT D3DRenderInit(HWND hWnd)
 	gpD3DDevice->CreateVertexDeclaration(decl1, &decl1dc);
 	gpD3DDevice->CreateVertexDeclaration(decl2, &decl2dc);
 
-	SetZBias(gpD3DDevice, 0);
+	SetZBias(0);
 
 	D3DRenderLMapsBuild();
 
@@ -688,26 +689,24 @@ HRESULT D3DRenderInit(HWND hWnd)
 
 	if (gD3DDriverProfile.bFogEnable)
 	{
-		float	start = 0.0f;
-		float	end = 50000.8f;
-		DWORD	mode = D3DFOG_LINEAR;
+		static constexpr float start = 0.0f;
+		static constexpr float end = 50000.8f;
+		DWORD mode = D3DFOG_LINEAR;
 
 		gpD3DDevice->SetRenderState(D3DRS_FOGENABLE, TRUE);
 		gpD3DDevice->SetRenderState(D3DRS_FOGCOLOR, 0);
 		gpD3DDevice->SetRenderState(D3DRS_FOGTABLEMODE, mode);
-		gpD3DDevice->SetRenderState(D3DRS_FOGSTART, *(DWORD *)(&start));
-		gpD3DDevice->SetRenderState(D3DRS_FOGEND, *(DWORD *)(&end));
+		gpD3DDevice->SetRenderState(D3DRS_FOGSTART, std::bit_cast<DWORD>(start));
+		gpD3DDevice->SetRenderState(D3DRS_FOGEND, std::bit_cast<DWORD>(end));
 	}
 
 	// create framebuffer textures
-   for (int i = 0; i < MAX_RENDER_TARGET_POOL; i++)
-      gpD3DDevice->CreateTexture(gSmallTextureSize, gSmallTextureSize, 1,
-                                     D3DUSAGE_RENDERTARGET, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT,
-                                     &gpBackBufferTex[i], nullptr);
+	for (int i = 0; i < MAX_RENDER_TARGET_POOL; i++)
+	gpD3DDevice->CreateTexture(gSmallTextureSize, gSmallTextureSize, 1,D3DUSAGE_RENDERTARGET, D3DFMT_A8R8G8B8,
+									D3DPOOL_DEFAULT, &gpBackBufferTex[i], nullptr);
    
-   gpD3DDevice->CreateTexture(gFullTextureSize, gFullTextureSize, 1,
-                                  D3DUSAGE_RENDERTARGET, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT,
-                                  &gpBackBufferTexFull, nullptr);
+	gpD3DDevice->CreateTexture(gFullTextureSize, gFullTextureSize, 1, D3DUSAGE_RENDERTARGET, D3DFMT_A8R8G8B8,
+									D3DPOOL_DEFAULT, &gpBackBufferTexFull, nullptr);
 
 	/***************************************************************************/
 	/*                                FONT                                     */
@@ -723,89 +722,89 @@ HRESULT D3DRenderInit(HWND hWnd)
 
 void D3DRenderShutDown(void)
 {
-	if (!gD3DDriverProfile.bSoftwareRenderer)
+	if (gD3DDriverProfile.bSoftwareRenderer)
+		return;
+	
+	if (config.bDynamicLighting)
 	{
-		if (config.bDynamicLighting)
-		{
-			D3DCacheSystemShutdown(&gLMapCacheSystem);
-			D3DCacheSystemShutdown(&gLMapCacheSystemStatic);
-			D3DRenderPoolShutdown(&gLMapPool);
-			D3DRenderPoolShutdown(&gLMapPoolStatic);
-		}
-
-		D3DCacheSystemShutdown(&gObjectCacheSystem);
-		D3DCacheSystemShutdown(&gWorldCacheSystem);
-		D3DCacheSystemShutdown(&gWorldCacheSystemStatic);
-		D3DCacheSystemShutdown(&gWallMaskCacheSystem);
-		D3DCacheSystemShutdown(&gEffectCacheSystem);
-		D3DCacheSystemShutdown(&gParticleCacheSystem);
-
-		D3DRenderPoolShutdown(&gObjectPool);
-		D3DRenderPoolShutdown(&gWorldPool);
-		D3DRenderPoolShutdown(&gWorldPoolStatic);
-		D3DRenderPoolShutdown(&gWallMaskPool);
-		D3DRenderPoolShutdown(&gEffectPool);
-		D3DRenderPoolShutdown(&gParticlePool);
-
-		D3DRenderLightsShutdown();
-
-		if (gpNoLookThrough)
-		{
-			gpNoLookThrough->Release();
-			gpNoLookThrough = nullptr;
-		}
-		if (gpBackBufferTexFull)
-		{
-			gpBackBufferTexFull->Release();
-			gpBackBufferTexFull = nullptr;
-		}
-
-		if (gFont.pTexture)
-		{
-			gFont.pTexture->Release();
-			gFont.pTexture = nullptr;
-		}
-		
-		if (gFont.kerningPairs)
-		{
-			delete[] gFont.kerningPairs;
-			gFont.kerningPairs = nullptr;
-		}
-
-		for (int i = 0; i < MAX_RENDER_TARGET_POOL; i++)
-		{
-			gpBackBufferTex[i]->Release();
-			gpBackBufferTex[i] = nullptr;
-		}
-
-		D3DRenderSkyBoxShutdown();
-
-		for (int i = 0; i < NUM_VIEW_ELEMENTS; i++)
-		{
-			if (gpViewElements[i])
-			{
-				gpViewElements[i]->Release();
-				gpViewElements[i] = nullptr;
-			}
-		}
-      
-		/***************************************************************************/
-		/*                       VERTEX DECLARATIONS                               */
-		/***************************************************************************/
-		
-		if (decl0dc) decl0dc->Release();
-		if (decl1dc) decl1dc->Release();
-		if (decl2dc) decl2dc->Release();
-		decl0dc = nullptr;
-		decl1dc = nullptr;
-		decl2dc = nullptr;
-      
-		gpD3DDevice->Release();
-		gpD3DDevice = nullptr;
-		
-		gpD3D->Release();
-		gpD3D = nullptr;
+		D3DCacheSystemShutdown(&gLMapCacheSystem);
+		D3DCacheSystemShutdown(&gLMapCacheSystemStatic);
+		D3DRenderPoolShutdown(&gLMapPool);
+		D3DRenderPoolShutdown(&gLMapPoolStatic);
 	}
+
+	D3DCacheSystemShutdown(&gObjectCacheSystem);
+	D3DCacheSystemShutdown(&gWorldCacheSystem);
+	D3DCacheSystemShutdown(&gWorldCacheSystemStatic);
+	D3DCacheSystemShutdown(&gWallMaskCacheSystem);
+	D3DCacheSystemShutdown(&gEffectCacheSystem);
+	D3DCacheSystemShutdown(&gParticleCacheSystem);
+
+	D3DRenderPoolShutdown(&gObjectPool);
+	D3DRenderPoolShutdown(&gWorldPool);
+	D3DRenderPoolShutdown(&gWorldPoolStatic);
+	D3DRenderPoolShutdown(&gWallMaskPool);
+	D3DRenderPoolShutdown(&gEffectPool);
+	D3DRenderPoolShutdown(&gParticlePool);
+
+	D3DRenderLightsShutdown();
+
+	if (gpNoLookThrough)
+	{
+		gpNoLookThrough->Release();
+		gpNoLookThrough = nullptr;
+	}
+	if (gpBackBufferTexFull)
+	{
+		gpBackBufferTexFull->Release();
+		gpBackBufferTexFull = nullptr;
+	}
+
+	if (gFont.pTexture)
+	{
+		gFont.pTexture->Release();
+		gFont.pTexture = nullptr;
+	}
+	
+	if (gFont.kerningPairs)
+	{
+		delete[] gFont.kerningPairs;
+		gFont.kerningPairs = nullptr;
+	}
+
+	for (int i = 0; i < MAX_RENDER_TARGET_POOL; i++)
+	{
+		gpBackBufferTex[i]->Release();
+		gpBackBufferTex[i] = nullptr;
+	}
+
+	D3DRenderSkyBoxShutdown();
+
+	for (int i = 0; i < NUM_VIEW_ELEMENTS; i++)
+	{
+		if (gpViewElements[i])
+		{
+			gpViewElements[i]->Release();
+			gpViewElements[i] = nullptr;
+		}
+	}
+  
+	/***************************************************************************/
+	/*                       VERTEX DECLARATIONS                               */
+	/***************************************************************************/
+	
+	if (decl0dc) decl0dc->Release();
+	if (decl1dc) decl1dc->Release();
+	if (decl2dc) decl2dc->Release();
+	decl0dc = nullptr;
+	decl1dc = nullptr;
+	decl2dc = nullptr;
+  
+	gpD3DDevice->Release();
+	gpD3DDevice = nullptr;
+	
+	gpD3D->Release();
+	gpD3D = nullptr;
 }
 
 void D3DRenderBegin(room_type *room, Draw3DParams *params)
@@ -844,8 +843,8 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	{
 		for (int i = 0; i < NUM_VIEW_ELEMENTS; i++)
 		{
-			gpViewElements[i] = D3DRenderTextureCreateFromResource(ViewElements[i].bits,
-				ViewElements[i].width, ViewElements[i].height);
+			gpViewElements[i] = D3DRenderTextureCreateFromResource(ViewElements[i].bits, ViewElements[i].width, 
+																	ViewElements[i].height);
 		}
 	}
 
@@ -862,7 +861,8 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	LightCacheUpdateParams lightCacheParams{&gDLightCache, &gDLightCacheDynamic, gD3DRedrawAll};
 	D3DLMapsStaticGet(room, lightCacheParams);
 
-	gpD3DDevice->Clear(0, nullptr, (D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER | D3DCLEAR_STENCIL), D3DCOLOR_ARGB(0, 0, 0, 0), 1.0, 0);
+	gpD3DDevice->Clear(0, nullptr, (D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER | D3DCLEAR_STENCIL),
+							D3DCOLOR_ARGB(0, 0, 0, 0), 1.0, 0);
 
 	gpD3DDevice->BeginScene();
 
@@ -880,15 +880,20 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	MatrixRotateY(&rot, static_cast<float>(angleHeading) * 360.0f / 4096.0f * PI / 180.0f);
 	MatrixRotateX(&mat, static_cast<float>(anglePitch) * 45.0f / 414.0f * PI / 180.0f);
 	MatrixMultiply(&rot, &rot, &mat);
-	MatrixTranslate(&trans, -static_cast<float>(params->viewer_x), -static_cast<float>(params->viewer_height), -static_cast<float>(params->viewer_y));
+	MatrixTranslate(&trans, -static_cast<float>(params->viewer_x), 
+							-static_cast<float>(params->viewer_height), 
+							-static_cast<float>(params->viewer_y));
 	MatrixMultiply(&view, &trans, &rot);
 
 	gpD3DDevice->SetTransform(D3DTS_VIEW, &view);
 
-	XformMatrixPerspective(&proj, FovHorizontal(gD3DRect.right - gD3DRect.left), FovVertical(gD3DRect.bottom - gD3DRect.top), 100.0f, Z_RANGE);
+	XformMatrixPerspective(&proj, FovHorizontal(gD3DRect.right - gD3DRect.left), 
+									FovVertical(gD3DRect.bottom - gD3DRect.top), 100.0f, Z_RANGE);
 	gpD3DDevice->SetTransform(D3DTS_PROJECTION, &proj);
 
-	gpD3DDevice->SetRenderState(D3DRS_COLORWRITEENABLE, D3DCOLORWRITEENABLE_RED | D3DCOLORWRITEENABLE_GREEN | D3DCOLORWRITEENABLE_BLUE);
+	gpD3DDevice->SetRenderState(D3DRS_COLORWRITEENABLE, D3DCOLORWRITEENABLE_RED | 
+														D3DCOLORWRITEENABLE_GREEN | 
+														D3DCOLORWRITEENABLE_BLUE);
 
 	gpD3DDevice->SetRenderState(D3DRS_CULLMODE, D3DCULL_CW);
 
@@ -896,7 +901,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	D3DCacheSystemReset(&gLMapCacheSystem);
 	D3DCacheSystemReset(&gWorldCacheSystem);
 
-	SetZBias(gpD3DDevice, ZBIAS_DEFAULT);
+	SetZBias(ZBIAS_DEFAULT);
 
 	UpdateRoom3D(room, params);
 
@@ -925,8 +930,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	WorldPoolParams worldPoolParams(&gWorldPool, &gWorldPoolStatic, &gLMapPool, &gLMapPoolStatic, &gWallMaskPool);
 		
-	WorldRenderParams worldRenderParams(decl1dc, decl2dc, gD3DDriverProfile, worldCacheSystemParams, worldPoolParams, 
-		view, proj);
+	WorldRenderParams worldRenderParams(decl1dc, decl2dc, gD3DDriverProfile, worldCacheSystemParams, worldPoolParams, view, proj);
 
 	LightAndTextureParams lightAndTextureParams(&gDLightCache, &gDLightCacheDynamic, gSmallTextureSize, sector_depths);
 
@@ -979,8 +983,9 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	if (draw_background_overlays)
 	{
 		BackgroundOverlaysRenderStateParams bgoRenderStateParams(decl1dc, gD3DDriverProfile, &gWorldPool, &gWorldCacheSystem, 
-			view, mat, gD3DRect);
-		BackgroundOverlaysSceneParams bgoSceneParams(&num_visible_objects, visible_objects, angleHeading, anglePitch, room, params);
+																	view, mat, gD3DRect);
+		BackgroundOverlaysSceneParams bgoSceneParams(&num_visible_objects, visible_objects, 
+														angleHeading, anglePitch, room, params);
 		D3DRenderBackgroundOverlays(bgoRenderStateParams, bgoSceneParams);
 	}
 
@@ -997,7 +1002,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	}
 
 	gpD3DDevice->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
-	SetZBias(gpD3DDevice, 1);
+	SetZBias(1);
 
 	if (draw_particles)
 	{
@@ -1007,7 +1012,8 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	if (draw_objects)
 	{
-		ObjectsRenderParams objectsRenderParams(decl1dc, decl2dc, gD3DDriverProfile, &gObjectPool, &gObjectCacheSystem, view, proj, room, params);
+		ObjectsRenderParams objectsRenderParams(decl1dc, decl2dc, gD3DDriverProfile, &gObjectPool, &gObjectCacheSystem,
+													view, proj, room, params);
 
 		GameObjectDataParams gameObjectDataParams(nitems, &num_visible_objects, &gNumObjects, drawdata, visible_objects, 
 			gpBackBufferTexFull, gpBackBufferTex);
@@ -1030,7 +1036,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	D3DRender_SetColorStage(1, D3DTOP_DISABLE, D3DTA_CURRENT, D3DTA_TEXTURE);
 	D3DRender_SetAlphaStage(1, D3DTOP_DISABLE, D3DTA_CURRENT, D3DTA_TEXTURE);
 
-	SetZBias(gpD3DDevice, ZBIAS_DEFAULT);
+	SetZBias(ZBIAS_DEFAULT);
 
 	gpD3DDevice->SetVertexShader(nullptr);
 	gpD3DDevice->SetVertexDeclaration(decl0dc);
@@ -1092,8 +1098,10 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	if (hr == D3DERR_DEVICELOST)
 	{
 		while (hr == D3DERR_DEVICELOST)
+		{
 			hr = gpD3DDevice->TestCooperativeLevel();
-
+		}
+		
 		if (hr == D3DERR_DEVICENOTRESET)
 		{
 			D3DRenderShutDown();
@@ -1108,7 +1116,8 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 void D3DRenderResizeDisplay(int left, int top, int right, int bottom)
 {
-	gD3DRect = {static_cast<LONG>(left), static_cast<LONG>(top), static_cast<LONG>(left + right), static_cast<LONG>(top + bottom)};
+	gD3DRect = {static_cast<LONG>(left), static_cast<LONG>(top),
+				static_cast<LONG>(left + right), static_cast<LONG>(top + bottom)};
 }
 
 void D3DRenderEnableToggle(void)
@@ -1156,21 +1165,21 @@ void D3DRender_SetStencilMark(DWORD refValue)
 // Filters drawing based on stencil buffer comparison.  Doesn't modify the buffer.
 void D3DRender_SetStencilTest(D3DCMPFUNC comparisonFunc, DWORD refValue)
 {
-    if (!gpD3DDevice) return;
-    gpD3DDevice->SetRenderState(D3DRS_STENCILENABLE, TRUE);
-    gpD3DDevice->SetRenderState(D3DRS_STENCILFUNC, comparisonFunc);
-    gpD3DDevice->SetRenderState(D3DRS_STENCILREF, refValue);
+	if (!gpD3DDevice) return;
+	gpD3DDevice->SetRenderState(D3DRS_STENCILENABLE, TRUE);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILFUNC, comparisonFunc);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILREF, refValue);
 	// Don't change the stencil buffer during the test.
-    gpD3DDevice->SetRenderState(D3DRS_STENCILPASS, D3DSTENCILOP_KEEP);
-    gpD3DDevice->SetRenderState(D3DRS_STENCILFAIL, D3DSTENCILOP_KEEP);
-    gpD3DDevice->SetRenderState(D3DRS_STENCILZFAIL, D3DSTENCILOP_KEEP);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILPASS, D3DSTENCILOP_KEEP);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILFAIL, D3DSTENCILOP_KEEP);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILZFAIL, D3DSTENCILOP_KEEP);
 }
 
 // Disable stencil testing for subsequent rendering.
 void D3DRender_DisableStencil()
 {
-    if (!gpD3DDevice) return;
-    gpD3DDevice->SetRenderState(D3DRS_STENCILENABLE, FALSE);
+	if (!gpD3DDevice) return;
+	gpD3DDevice->SetRenderState(D3DRS_STENCILENABLE, FALSE);
 }
 
 // Controls how textures and colors are mathematically combined, whether it's 2D sprites or 3D surfaces.

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -91,7 +91,8 @@ AREA					gD3DView;
 int						gD3DRedrawAll = 0;
 int						gTemp = 0;
 
-D3DMATRIX view, mat, rot, trans, proj;
+// Transformation matrices for the current frame's pipeline.
+static D3DMATRIX view, mat, rot, trans, proj;
 
 //////////////////////
 // External Globals //
@@ -518,11 +519,11 @@ LPDIRECT3DTEXTURE9 D3DRender_CaptureEffect(LPDIRECT3DTEXTURE9 pTex0, LPDIRECT3DT
 	gpD3DDevice->StretchRect(pSrc, &rect, pDest[0], &rect, D3DTEXF_NONE);
    
 	// clear local->screen transforms
-	D3DMATRIX mat;
-	MatrixIdentity(&mat);
-	gpD3DDevice->SetTransform(D3DTS_WORLD, &mat);
-	gpD3DDevice->SetTransform(D3DTS_VIEW, &mat);
-	gpD3DDevice->SetTransform(D3DTS_PROJECTION, &mat);
+	D3DMATRIX tempMat;
+	MatrixIdentity(&tempMat);
+	gpD3DDevice->SetTransform(D3DTS_WORLD, &tempMat);
+	gpD3DDevice->SetTransform(D3DTS_VIEW, &tempMat);
+	gpD3DDevice->SetTransform(D3DTS_PROJECTION, &tempMat);
 
 	gpD3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
 	gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -7,23 +7,17 @@
 // Meridian is a registered trademark.
 #include "client.h"
 
+static constexpr int TEX_CACHE_MAX_WALLMASK = 2000000;
+static constexpr int TEX_CACHE_MAX_EFFECT = 1000000;
+static constexpr int TEX_CACHE_MAX_PARTICLE = 1000000;
 
 ///////////////
 // Variables //
 ///////////////
-d3d_render_packet_new	*gpPacket = nullptr;
-
 LPDIRECT3DTEXTURE9		gpNoLookThrough = nullptr;
-
 LPDIRECT3DTEXTURE9		gpViewElements[NUM_VIEW_ELEMENTS];
 
 D3DVIEWPORT9			gViewport;
-D3DCAPS9				gD3DCaps;
-
-d3d_render_cache		gObjectCache;
-d3d_render_cache		gWorldCache;
-d3d_render_cache		gWorldCacheStatic;
-d3d_render_cache		gLMapCacheStatic;
 
 d3d_render_cache_system	gObjectCacheSystem;
 d3d_render_cache_system	gWorldCacheSystem;
@@ -50,8 +44,9 @@ custom_xyz				playerOldPos = {0.0f, 0.0f, 0.0f};
 custom_xyz				playerDeltaPos = {0.0f, 0.0f, 0.0f};
 
 RECT					gD3DRect = {0, 0, 0, 0};
-BYTE					gViewerLight = 0;
 int						gNumObjects = 0;
+
+// Incremented in d3dcache.c to track total DrawPrimitive calls per frame.
 int						gNumDPCalls = 0;
 
 static unsigned int		gFrame = 0;
@@ -87,9 +82,7 @@ LPDIRECT3DVERTEXDECLARATION9 decl0dc;
 LPDIRECT3DVERTEXDECLARATION9 decl1dc;
 LPDIRECT3DVERTEXDECLARATION9 decl2dc;
 
-AREA					gD3DView;
 int						gD3DRedrawAll = 0;
-int						gTemp = 0;
 
 // Transformation matrices for the current frame's pipeline.
 static D3DMATRIX view, mat, rot, trans, proj;
@@ -169,7 +162,7 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 
 	HDC hDC = CreateCompatibleDC(gBitsDC);
 	DWORD *pBitmapBits;
-	HBITMAP hbmBitmap = CreateDIBSection(hDC, &bmi, DIB_RGB_COLORS, (VOID**)&pBitmapBits, nullptr, 0 );
+	HBITMAP hbmBitmap = CreateDIBSection(hDC, &bmi, DIB_RGB_COLORS, reinterpret_cast<void**>(&pBitmapBits), nullptr, 0);
 	SetMapMode(hDC, MM_TEXT);
   
 	SelectObject(hDC, hbmBitmap);
@@ -184,7 +177,7 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 	TCHAR str[2] = _T("x");
 	long x = 0;
 	long y = 0;
-	for(TCHAR c = 32; c < 127; c++ )
+	for(TCHAR c = 32; c < 127; c++)
 	{
 		int index = c - 32;
 		
@@ -235,8 +228,7 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 			BYTE bAlpha = static_cast<BYTE>( (pBitmapBits[pFont->texWidth * y + x] & 0xff) >> 4 );
 			
 			// If there's any alpha, set color to white with alpha. Otherwise it's transparent.
-			*pDst16++ = (bAlpha > 0)	? (static_cast<WORD>(bAlpha << 12) | 0x0FFF)
-										: 0x0000;
+			*pDst16++ = (bAlpha > 0) ? (static_cast<WORD>(bAlpha << 12) | 0x0FFF) : 0x0000;
 		}
 		pDstRow += d3dlr.Pitch;
 	}
@@ -313,10 +305,6 @@ d3d_render_packet_new *D3DRenderPacketNew(d3d_render_pool_new *pPool)
 	{
 		pPacket = reinterpret_cast<d3d_render_packet_new*>(pPool->curPacketList->data);
 		pPacket += pPool->curPacket;
-
-		if (pPool->curPacket == 12)
-			gpPacket = pPacket;
-
 		pPool->curPacket++;
 	}
 
@@ -340,12 +328,9 @@ d3d_render_chunk_new *D3DRenderChunkNew(d3d_render_packet_new *pPacket)
 {
 	if (pPacket->curChunk >= (pPacket->size - 1))
 		return nullptr;
-	else
-	{
-		pPacket->curChunk++;
-		D3DRenderChunkInit(&pPacket->renderChunks[pPacket->curChunk - 1]);
-		return &pPacket->renderChunks[pPacket->curChunk - 1];
-	}
+	pPacket->curChunk++;
+	D3DRenderChunkInit(&pPacket->renderChunks[pPacket->curChunk - 1]);
+	return &pPacket->renderChunks[pPacket->curChunk - 1];
 }
 
 void D3DRenderChunkInit(d3d_render_chunk_new *pChunk)
@@ -444,13 +429,13 @@ void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool)
 
 		if (i < 2)  // top side
 		{
-		 top = D3DRENDER_SCREEN_TO_CLIP_Y(0, gScreenHeight);
-		 bottom = D3DRENDER_SCREEN_TO_CLIP_Y(height, gScreenHeight);
+			top = D3DRENDER_SCREEN_TO_CLIP_Y(0, gScreenHeight);
+			bottom = D3DRENDER_SCREEN_TO_CLIP_Y(height, gScreenHeight);
 		}
 		else  // bottom side
 		{
-		 top = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight - height, gScreenHeight);
-		 bottom = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight, gScreenHeight);
+			top = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight - height, gScreenHeight);
+			bottom = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight, gScreenHeight);
 		}
 
 		d3d_render_packet_new *pPacket = D3DRenderPacketNew(pPool);
@@ -561,9 +546,9 @@ LPDIRECT3DTEXTURE9 D3DRender_CaptureEffect(LPDIRECT3DTEXTURE9 pTex0, LPDIRECT3DT
 	pChunk->st0[2] = { (gScreenWidth / texSize), (gScreenHeight / texSize) };
 	pChunk->st0[3] = { (gScreenWidth / texSize), 0.0f };
 
-	for (int i = 0; i < 4; i++)
+	for (auto& color : pChunk->bgra)
 	{
-		pChunk->bgra[i] = {COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX};
+		color = {COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX};
 	}
 
 	pChunk->indices[0] = 1;
@@ -609,8 +594,6 @@ HRESULT D3DRenderInit(HWND hWnd)
 	D3DDISPLAYMODE displayMode;
 	gpD3D->GetAdapterDisplayMode(D3DADAPTER_DEFAULT, &displayMode);
 
-	gpD3DDevice->GetDeviceCaps(&gD3DCaps);
-
 	gFrame = 0;
 	
 	// Initializes D3D viewport to match current screen dimensions.
@@ -644,9 +627,9 @@ HRESULT D3DRenderInit(HWND hWnd)
 	D3DCacheSystemInit(&gObjectCacheSystem, gD3DDriverProfile.texMemObjects);
 	D3DCacheSystemInit(&gWorldCacheSystem, gD3DDriverProfile.texMemWorldDynamic);
 	D3DCacheSystemInit(&gWorldCacheSystemStatic, gD3DDriverProfile.texMemWorldStatic);
-	D3DCacheSystemInit(&gWallMaskCacheSystem, 2000000);
-	D3DCacheSystemInit(&gEffectCacheSystem, 1000000);
-	D3DCacheSystemInit(&gParticleCacheSystem, 1000000);
+	D3DCacheSystemInit(&gWallMaskCacheSystem, TEX_CACHE_MAX_WALLMASK);
+	D3DCacheSystemInit(&gEffectCacheSystem, TEX_CACHE_MAX_EFFECT);
+	D3DCacheSystemInit(&gParticleCacheSystem, TEX_CACHE_MAX_PARTICLE);
 
 	D3DRenderPoolInit(&gObjectPool, POOL_SIZE, PACKET_SIZE);
 	D3DRenderPoolInit(&gWorldPool, POOL_SIZE, PACKET_SIZE);
@@ -692,11 +675,9 @@ HRESULT D3DRenderInit(HWND hWnd)
 	{
 		static constexpr float start = 0.0f;
 		static constexpr float end = 50000.8f;
-		DWORD mode = D3DFOG_LINEAR;
-
 		gpD3DDevice->SetRenderState(D3DRS_FOGENABLE, TRUE);
 		gpD3DDevice->SetRenderState(D3DRS_FOGCOLOR, 0);
-		gpD3DDevice->SetRenderState(D3DRS_FOGTABLEMODE, mode);
+		gpD3DDevice->SetRenderState(D3DRS_FOGTABLEMODE, D3DFOG_LINEAR);
 		gpD3DDevice->SetRenderState(D3DRS_FOGSTART, std::bit_cast<DWORD>(start));
 		gpD3DDevice->SetRenderState(D3DRS_FOGEND, std::bit_cast<DWORD>(end));
 	}
@@ -937,38 +918,31 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	WorldPropertyParams worldPropertyParams(gpNoLookThrough, D3DRenderLightsGetOrange());
 
-	if (gD3DRedrawAll & D3DRENDER_REDRAW_ALL)
+	// Perform a requested static cache rebuild only if invert effect isn't active.
+	// GetLightPaletteIndex returns PALETTE_INVERT during the flash effect, which would
+	// cause incorrect lighting values to be baked into the static geometry cache.
+	// Keep gD3DRedrawAll set so rebuild happens after the invert effect ends.
+	if ((gD3DRedrawAll & D3DRENDER_REDRAW_ALL) && (effects.invert <= 0))
 	{
-		// Defer static cache rebuild while invert effect is active.
-		// GetLightPaletteIndex returns PALETTE_INVERT during the flash effect, which would
-		// cause incorrect lighting values to be baked into the static geometry cache.
-		// Keep gD3DRedrawAll set so rebuild happens after the invert effect ends.
-		if (effects.invert > 0)
-		{
-			// Skip rebuild this frame - will be processed when invert effect ends
-		}
-		else
-		{
-			D3DCacheSystemReset(&gWorldCacheSystemStatic);
-			D3DCacheSystemReset(&gWallMaskCacheSystem);
+		D3DCacheSystemReset(&gWorldCacheSystemStatic);
+		D3DCacheSystemReset(&gWallMaskCacheSystem);
 
-			D3DRenderPoolReset(&gWorldPoolStatic, &D3DMaterialWorldPool);
-			D3DRenderPoolReset(&gWallMaskPool, &D3DMaterialWallMaskPool);
+		D3DRenderPoolReset(&gWorldPoolStatic, &D3DMaterialWorldPool);
+		D3DRenderPoolReset(&gWallMaskPool, &D3DMaterialWallMaskPool);
 
-			gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
-			gpD3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
-			gpD3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
-			D3DGeometryBuildNew(worldRenderParams, worldPropertyParams, lightAndTextureParams, false);
+		gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+		gpD3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
+		gpD3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
+		D3DGeometryBuildNew(worldRenderParams, worldPropertyParams, lightAndTextureParams, false);
 
-			// Second pass: render transparent objects
-			gpD3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
-			gpD3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, TRUE);
-			gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);  // Disable depth writing
+		// Second pass: render transparent objects
+		gpD3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
+		gpD3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, TRUE);
+		gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);  // Disable depth writing
 
-			D3DGeometryBuildNew(worldRenderParams, worldPropertyParams, lightAndTextureParams, true);
+		D3DGeometryBuildNew(worldRenderParams, worldPropertyParams, lightAndTextureParams, true);
 
-			gD3DRedrawAll = FALSE;
-		}
+		gD3DRedrawAll = FALSE;
 	}
 	else if (gD3DRedrawAll & D3DRENDER_REDRAW_UPDATE)
 	{

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -7,13 +7,6 @@
 // Meridian is a registered trademark.
 #include "client.h"
 
-#define	TEX_CACHE_MAX_OBJECT	8000000
-#define	TEX_CACHE_MAX_WORLD		8000000
-#define	TEX_CACHE_MAX_LMAP		8000000
-#define	TEX_CACHE_MAX_WALLMASK	2000000
-#define	TEX_CACHE_MAX_EFFECT	2000000
-#define	TEX_CACHE_MAX_PARTICLE	1000000
-
 // Main client windows current viewport area
 extern int main_viewport_width;
 extern int main_viewport_height;
@@ -21,12 +14,12 @@ extern int main_viewport_height;
 // Define field of views with magic numbers for tuning
 float FovHorizontal(long width)
 {
-	return width / (float)(main_viewport_width) * (-PI / 3.78f);
+	return width / static_cast<float>(main_viewport_width) * (-PI / 3.78f);
 }
 
 float FovVertical(long height)
 {
-	return height / (float)(main_viewport_height) * (PI / 5.88f);
+	return height / static_cast<float>(main_viewport_height) * (PI / 5.88f);
 }
 
 // Helper function to determine if an object should be rendered in the current pass based on transparency.
@@ -35,10 +28,14 @@ bool ShouldRenderInCurrentPass(bool transparent_pass, bool isTransparent)
 	return transparent_pass == isTransparent;
 }
 
+// Pool of textures used for off-screen rendering (drawing to memory instead of on screen).
+// These are used for intermediate passes for things like dynamic lighting.
+static constexpr int MAX_RENDER_TARGET_POOL = 16;
+
 d3d_render_packet_new	*gpPacket;
 
-LPDIRECT3DTEXTURE9		gpNoLookThrough = NULL;
-LPDIRECT3DTEXTURE9		gpBackBufferTex[16];
+LPDIRECT3DTEXTURE9		gpNoLookThrough = nullptr;
+LPDIRECT3DTEXTURE9		gpBackBufferTex[MAX_RENDER_TARGET_POOL];
 LPDIRECT3DTEXTURE9		gpBackBufferTexFull;
 LPDIRECT3DTEXTURE9		gpViewElements[NUM_VIEW_ELEMENTS];
 
@@ -80,7 +77,7 @@ RECT					gD3DRect;
 BYTE					gViewerLight = 0;
 int						gNumObjects;
 int						gNumDPCalls;
-static PALETTEENTRY		gPalette[256];
+static PALETTEENTRY		gPalette[256];  // Legacy 8-bit color palette, aka 256 colors.
 
 static unsigned int		gFrame = 0;
 
@@ -155,10 +152,10 @@ void					D3DRenderViewElementsDraw(d3d_render_pool_new *pPool);
 
 void					*D3DRenderMalloc(unsigned int bytes);
 
-void SetZBias(LPDIRECT3DDEVICE9 device, int z_bias) {
+void SetZBias(LPDIRECT3DDEVICE9 device, int z_bias)
+{
    float bias = z_bias * -0.00001f;
-   IDirect3DDevice9_SetRenderState(device, D3DRS_DEPTHBIAS,
-                                   *((DWORD *) &bias));
+   IDirect3DDevice9_SetRenderState(device, D3DRS_DEPTHBIAS, *((DWORD *) &bias));
 }
 
 int getD3dRenderThreshold()
@@ -217,15 +214,11 @@ extern void			UpdateRoom3D(room_type *room, Draw3DParams *params);
 
 int DistanceGet(int x, int y)
 {
-	int	distance;
-	float	xf, yf;
+	float xf = static_cast<float>(x);
+	float yf = static_cast<float>(y);
+	int distance = sqrt((xf * xf) + (yf * yf));
 
-	xf = (float)x;
-	yf = (float)y;
-
-	distance = sqrt((double)(xf * xf) + (double)(yf * yf));
-
-	return (int)distance;
+	return static_cast<int>(distance);
 }
 
 void *D3DRenderMalloc(unsigned int bytes)
@@ -241,20 +234,19 @@ void *D3DRenderMalloc(unsigned int bytes)
 ************************************************************************************/
 HRESULT D3DRenderInit(HWND hWnd)
 {
-	D3DDISPLAYMODE			displayMode;
-
-	if (NULL == (gpD3D = Direct3DCreate9(D3D_SDK_VERSION)))
+	if (nullptr == (gpD3D = Direct3DCreate9(D3D_SDK_VERSION)))
 		return E_FAIL;
 
 	gD3DEnabled = D3DDriverProfileInit();
 	if (!gD3DEnabled)
 		return E_FAIL;
 
+	D3DDISPLAYMODE displayMode;
 	IDirect3D9_GetAdapterDisplayMode(gpD3D, D3DADAPTER_DEFAULT, &displayMode);
 
 	IDirect3DDevice9_GetDeviceCaps(gpD3DDevice, &gD3DCaps);
 
-   gFrame = 0;
+	gFrame = 0;
    
 	gViewport.X = 0;
 	gViewport.Y = 0;
@@ -282,46 +274,43 @@ HRESULT D3DRenderInit(HWND hWnd)
 		D3DCOLORWRITEENABLE_ALPHA | D3DCOLORWRITEENABLE_RED | D3DCOLORWRITEENABLE_GREEN |
 		D3DCOLORWRITEENABLE_BLUE);
 
-	{
-
     D3DCacheSystemInit(&gLMapCacheSystem, gD3DDriverProfile.texMemLMapDynamic);
     D3DCacheSystemInit(&gLMapCacheSystemStatic, gD3DDriverProfile.texMemLMapStatic);
     D3DRenderPoolInit(&gLMapPool, POOL_SIZE, PACKET_SIZE);
     D3DRenderPoolInit(&gLMapPoolStatic, POOL_SIZE, PACKET_SIZE);
 
-		D3DCacheSystemInit(&gObjectCacheSystem, gD3DDriverProfile.texMemObjects);
-		D3DCacheSystemInit(&gWorldCacheSystem, gD3DDriverProfile.texMemWorldDynamic);
-		D3DCacheSystemInit(&gWorldCacheSystemStatic, gD3DDriverProfile.texMemWorldStatic);
-		D3DCacheSystemInit(&gWallMaskCacheSystem, 2000000);
-		D3DCacheSystemInit(&gEffectCacheSystem, 1000000);
-		D3DCacheSystemInit(&gParticleCacheSystem, 1000000);
+	D3DCacheSystemInit(&gObjectCacheSystem, gD3DDriverProfile.texMemObjects);
+	D3DCacheSystemInit(&gWorldCacheSystem, gD3DDriverProfile.texMemWorldDynamic);
+	D3DCacheSystemInit(&gWorldCacheSystemStatic, gD3DDriverProfile.texMemWorldStatic);
+	D3DCacheSystemInit(&gWallMaskCacheSystem, 2000000);
+	D3DCacheSystemInit(&gEffectCacheSystem, 1000000);
+	D3DCacheSystemInit(&gParticleCacheSystem, 1000000);
 
-		D3DRenderPoolInit(&gObjectPool, POOL_SIZE, PACKET_SIZE);
-		D3DRenderPoolInit(&gWorldPool, POOL_SIZE, PACKET_SIZE);
-		D3DRenderPoolInit(&gWorldPoolStatic, POOL_SIZE, PACKET_SIZE);
-		D3DRenderPoolInit(&gWallMaskPool, POOL_SIZE / 2, PACKET_SIZE);
-		D3DRenderPoolInit(&gEffectPool, POOL_SIZE / 8, PACKET_SIZE);
-		D3DRenderPoolInit(&gParticlePool, POOL_SIZE, PACKET_SIZE);
+	D3DRenderPoolInit(&gObjectPool, POOL_SIZE, PACKET_SIZE);
+	D3DRenderPoolInit(&gWorldPool, POOL_SIZE, PACKET_SIZE);
+	D3DRenderPoolInit(&gWorldPoolStatic, POOL_SIZE, PACKET_SIZE);
+	D3DRenderPoolInit(&gWallMaskPool, POOL_SIZE / 2, PACKET_SIZE);
+	D3DRenderPoolInit(&gEffectPool, POOL_SIZE / 8, PACKET_SIZE);
+	D3DRenderPoolInit(&gParticlePool, POOL_SIZE, PACKET_SIZE);
 
-		gWorldPool.pMaterialFctn = &D3DMaterialWorldPool;
-		gWorldPoolStatic.pMaterialFctn = &D3DMaterialWorldPool;
-		gLMapPool.pMaterialFctn = &D3DMaterialLMapDynamicPool;
-		gObjectPool.pMaterialFctn = &D3DMaterialObjectPool;
-		gLMapPoolStatic.pMaterialFctn = &D3DMaterialLMapDynamicPool;
-		gWallMaskPool.pMaterialFctn = &D3DMaterialWallMaskPool;
-		gEffectPool.pMaterialFctn = &D3DMaterialEffectPool;
-		gParticlePool.pMaterialFctn = &D3DMaterialParticlePool;
-	}
+	gWorldPool.pMaterialFctn = &D3DMaterialWorldPool;
+	gWorldPoolStatic.pMaterialFctn = &D3DMaterialWorldPool;
+	gLMapPool.pMaterialFctn = &D3DMaterialLMapDynamicPool;
+	gObjectPool.pMaterialFctn = &D3DMaterialObjectPool;
+	gLMapPoolStatic.pMaterialFctn = &D3DMaterialLMapDynamicPool;
+	gWallMaskPool.pMaterialFctn = &D3DMaterialWallMaskPool;
+	gEffectPool.pMaterialFctn = &D3DMaterialEffectPool;
+	gParticlePool.pMaterialFctn = &D3DMaterialParticlePool;
    
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MINFILTER, gD3DDriverProfile.minFilter);
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MIPFILTER, D3DTEXF_NONE);
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAXANISOTROPY, gD3DDriverProfile.maxAnisotropy);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MINFILTER, gD3DDriverProfile.minFilter);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MIPFILTER, D3DTEXF_NONE);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAXANISOTROPY, gD3DDriverProfile.maxAnisotropy);
    
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MINFILTER, gD3DDriverProfile.minFilter);
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MIPFILTER, D3DTEXF_NONE);
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MAXANISOTROPY, gD3DDriverProfile.maxAnisotropy);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MINFILTER, gD3DDriverProfile.minFilter);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MIPFILTER, D3DTEXF_NONE);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MAXANISOTROPY, gD3DDriverProfile.maxAnisotropy);
 
 	/***************************************************************************/
 	/*                    VERTEX DECLARATIONS                                  */
@@ -354,14 +343,14 @@ HRESULT D3DRenderInit(HWND hWnd)
 	}
 
 	// create framebuffer textures
-   for (int i = 0; i <= 15; i++)
+   for (int i = 0; i < MAX_RENDER_TARGET_POOL; i++)
       IDirect3DDevice9_CreateTexture(gpD3DDevice, gSmallTextureSize, gSmallTextureSize, 1,
                                      D3DUSAGE_RENDERTARGET, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT,
-                                     &gpBackBufferTex[i], NULL);
+                                     &gpBackBufferTex[i], nullptr);
    
    IDirect3DDevice9_CreateTexture(gpD3DDevice, gFullTextureSize, gFullTextureSize, 1,
                                   D3DUSAGE_RENDERTARGET, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT,
-                                  &gpBackBufferTexFull, NULL);
+                                  &gpBackBufferTexFull, nullptr);
 
 	/***************************************************************************/
 	/*                                FONT                                     */
@@ -370,17 +359,13 @@ HRESULT D3DRenderInit(HWND hWnd)
 	// This will call D3DRenderFontInit to make sure the font texture is created
 	GraphicsResetFont();
 
-	playerOldPos.x = 0;
-	playerOldPos.y = 0;
-	playerOldPos.z = 0;
+	playerOldPos = { 0, 0, 0 };
 
 	return S_OK;
 }
 
 void D3DRenderShutDown(void)
 {
-	int	i;
-
 	if (!gD3DDriverProfile.bSoftwareRenderer)
 	{
 		if (config.bDynamicLighting)
@@ -410,35 +395,35 @@ void D3DRenderShutDown(void)
 		if (gpNoLookThrough)
 		{
 			IDirect3DTexture9_Release(gpNoLookThrough);
-			gpNoLookThrough = NULL;
+			gpNoLookThrough = nullptr;
 		}
 		if (gpBackBufferTexFull)
 		{
 			IDirect3DTexture9_Release(gpBackBufferTexFull);
-			gpBackBufferTexFull = NULL;
+			gpBackBufferTexFull = nullptr;
 		}
 
 		if (gFont.pTexture)
 		{
          IDirect3DTexture9_Release(gFont.pTexture);
          delete [] gFont.kerningPairs;
-         gFont.pTexture = NULL;
+         gFont.pTexture = nullptr;
 		}
 
-		for (i = 0; i < 16; i++)
+		for (int i = 0; i < MAX_RENDER_TARGET_POOL; i++)
 		{
          IDirect3DTexture9_Release(gpBackBufferTex[i]);
-			gpBackBufferTex[i] = NULL;
+			gpBackBufferTex[i] = nullptr;
 		}
 
 		D3DRenderSkyBoxShutdown();
 
-		for (i = 0; i < NUM_VIEW_ELEMENTS; i++)
+		for (int i = 0; i < NUM_VIEW_ELEMENTS; i++)
 		{
 			if (gpViewElements[i])
 			{
 				IDirect3DDevice9_Release(gpViewElements[i]);
-				gpViewElements[i] = NULL;
+				gpViewElements[i] = nullptr;
 			}
 		}
       
@@ -450,28 +435,25 @@ void D3DRenderShutDown(void)
 		if (decl1dc) IDirect3DDevice9_Release(decl1dc);
 		if (decl2dc) IDirect3DDevice9_Release(decl2dc);
 
-		decl0dc = NULL;
-		decl1dc = NULL;
-		decl2dc = NULL;
+		decl0dc = nullptr;
+		decl1dc = nullptr;
+		decl2dc = nullptr;
       
       IDirect3DDevice9_Release(gpD3DDevice);
-		gpD3DDevice = NULL;
+		gpD3DDevice = nullptr;
       IDirect3D9_Release(gpD3D);
-		gpD3D = NULL;
+		gpD3D = nullptr;
 	}
 }
 
 void D3DRenderBegin(room_type *room, Draw3DParams *params)
 {
-	int			angleHeading, anglePitch;
-	int			curPacket = 0;
-	int			curIndex = 0;
+	int	curPacket = 0;
+	int	curIndex = 0;
 	room_contents_node *pRNode = nullptr;
 
-	long		timeOverall, timeWorld, timeObjects, timeLMaps, timeSkybox, timeSetup, timeComplete;
-
-	timeOverall = timeGetTime();
-	timeSetup = timeGetTime();
+	long timeOverall = timeGetTime();
+	long timeSetup = timeGetTime();
 
 	// Static variable to track the player's previous ability to see. Initialize it only once.
 	static bool can_see = !effects.blind;
@@ -502,9 +484,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	// view element textures
 	if (gFrame == 0)
 	{
-		int	i;
-
-		for (i = 0; i < NUM_VIEW_ELEMENTS; i++)
+		for (int i = 0; i < NUM_VIEW_ELEMENTS; i++)
 		{
 			gpViewElements[i] = D3DRenderTextureCreateFromResource(ViewElements[i].bits,
 				ViewElements[i].width, ViewElements[i].height);
@@ -512,8 +492,6 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	}
 
 	gFrame++;
-
-	timeWorld = timeObjects = timeLMaps = timeSkybox = timeComplete = 0;
 
 	gNumObjects = 0;
 	gNumVertices = 0;
@@ -526,7 +504,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	LightCacheUpdateParams lightCacheParams{&gDLightCache, &gDLightCacheDynamic, gD3DRedrawAll};
 	D3DLMapsStaticGet(room, lightCacheParams);
 
-	IDirect3DDevice9_Clear(gpD3DDevice, 0, NULL, D3DCLEAR_TARGET |
+	IDirect3DDevice9_Clear(gpD3DDevice, 0, nullptr, D3DCLEAR_TARGET |
 		D3DCLEAR_ZBUFFER | D3DCLEAR_STENCIL,
 		D3DCOLOR_ARGB(0, 0, 0, 0), 1.0, 0);
 
@@ -535,16 +513,18 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	MatrixIdentity(&mat);
 	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_WORLD, &mat);
 
-	angleHeading = params->viewer_angle + 3072;
+	// A full 360-degree circle is 4096 game units. Player camera rotation is offset
+	// by 270 degrees (3072 game units) to align it with the legacy engine orientation.
+	int angleHeading = params->viewer_angle + 3072;
 	if (angleHeading >= 4096)
 		angleHeading -= 4096;
 
-	anglePitch = PlayerGetHeightOffset();
+	int anglePitch = PlayerGetHeightOffset();
 
-	MatrixRotateY(&rot, (float)angleHeading * 360.0f / 4096.0f * PI / 180.0f);
-	MatrixRotateX(&mat, (float)anglePitch * 45.0f / 414.0f * PI / 180.0f);
+	MatrixRotateY(&rot, static_cast<float>(angleHeading) * 360.0f / 4096.0f * PI / 180.0f);
+	MatrixRotateX(&mat, static_cast<float>(anglePitch) * 45.0f / 414.0f * PI / 180.0f);
 	MatrixMultiply(&rot, &rot, &mat);
-	MatrixTranslate(&trans, -(float)params->viewer_x, -(float)params->viewer_height, -(float)params->viewer_y);
+	MatrixTranslate(&trans, -static_cast<float>(params->viewer_x), -static_cast<float>(params->viewer_height), -static_cast<float>(params->viewer_y));
 	MatrixMultiply(&view, &trans, &rot);
 
 	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_VIEW, &view);
@@ -565,13 +545,17 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	UpdateRoom3D(room, params);
 
-	playerDeltaPos.x = params->viewer_x - playerOldPos.x;
-	playerDeltaPos.y = params->viewer_y - playerOldPos.y;
-	playerDeltaPos.z = params->viewer_height - playerOldPos.z;
-
-	playerOldPos.x = params->viewer_x;
-	playerOldPos.y = params->viewer_y;
-	playerOldPos.z = params->viewer_height;
+	playerDeltaPos = { 
+		static_cast<float>(params->viewer_x) - playerOldPos.x, 
+		static_cast<float>(params->viewer_y) - playerOldPos.y, 
+		static_cast<float>(params->viewer_height) - playerOldPos.z 
+	};
+	
+	playerOldPos = { 
+		static_cast<float>(params->viewer_x),
+		static_cast<float>(params->viewer_y),
+		static_cast<float>(params->viewer_height)
+	};
 
 	timeSetup = timeGetTime() - timeSetup;
 
@@ -649,7 +633,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	if (draw_world)
 	{
-		timeWorld = D3DRenderWorld(worldRenderParams, worldPropertyParams, lightAndTextureParams);
+		long timeWorld = D3DRenderWorld(worldRenderParams, worldPropertyParams, lightAndTextureParams);
 
 		// DEBUG: Draw circles at static light positions
 		if (D3DLightsDebugPositionsEnabled() && config.bDynamicLighting)
@@ -679,7 +663,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 		PlayerViewParams playerViewParams(gScreenWidth, gScreenHeight, main_viewport_width, main_viewport_height, gD3DRect);
 
-		timeObjects = D3DRenderObjects(objectsRenderParams, gameObjectDataParams, lightAndTextureParams, fontTextureParams, playerViewParams);
+		long timeObjects = D3DRenderObjects(objectsRenderParams, gameObjectDataParams, lightAndTextureParams, fontTextureParams, playerViewParams);
 	}
 
 	// Transparent walls are drawn LAST so that sprites/monsters behind them show
@@ -695,7 +679,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	SetZBias(gpD3DDevice, ZBIAS_DEFAULT);
 
-	IDirect3DDevice9_SetVertexShader(gpD3DDevice, NULL);
+	IDirect3DDevice9_SetVertexShader(gpD3DDevice, nullptr);
 	IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, decl0dc);
 
 	// Set up orthographic projection for drawing overlays
@@ -721,7 +705,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 		D3DFxBlurWaver(fxRenderSystemStructure);
 	}
 
-	timeComplete = timeGetTime();
+	long timeComplete = timeGetTime();
 	// view elements (e.g. viewport corners)
 	D3DRender_SetColorStage(1, D3DTOP_DISABLE, 0, 0);
 	D3DRender_SetAlphaStage(1, D3DTOP_DISABLE, 0, 0);
@@ -735,7 +719,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
    IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_ADDRESSU, D3DTADDRESS_CLAMP);
    IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_ADDRESSV, D3DTADDRESS_CLAMP);
 
-	IDirect3DDevice9_SetVertexShader(gpD3DDevice, NULL);
+	IDirect3DDevice9_SetVertexShader(gpD3DDevice, nullptr);
 	IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, decl1dc);
 
 	D3DRenderPoolReset(&gObjectPool, &D3DMaterialObjectPool);
@@ -745,20 +729,17 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	D3DCacheFlush(&gObjectCacheSystem, &gObjectPool, 1, D3DPT_TRIANGLESTRIP);
 
 	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);	
-
-
-
 	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MINFILTER, gD3DDriverProfile.minFilter);
 
 	IDirect3DDevice9_EndScene(gpD3DDevice);
+	
 	RECT rect;
-
 	rect.top = 0;
 	rect.bottom = gScreenHeight;
 	rect.left = 0;
 	rect.right = gScreenWidth;
 
-	HRESULT hr = IDirect3DDevice9_Present(gpD3DDevice, &rect, &gD3DRect, NULL, NULL);
+	HRESULT hr = IDirect3DDevice9_Present(gpD3DDevice, &rect, &gD3DRect, nullptr, nullptr);
 
 	if (hr == D3DERR_DEVICELOST)
 	{
@@ -778,9 +759,6 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	timeComplete = timeGetTime() - timeComplete;
 	timeOverall = timeGetTime() - timeOverall;
-
-	//debug(("overall = %d lightmaps = %d world = %d objects = %d skybox = %d num vertices = %d setup = %d completion = %d (%d, %d, %d)\n"
-	//, timeOverall, timeLMaps, timeWorld, timeObjects, timeSkybox, gNumVertices, timeComplete));
 }
 
 void D3DRenderResizeDisplay(int left, int top, int right, int bottom)
@@ -810,18 +788,8 @@ int D3DRenderIsEnabled(void)
 void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 {
 	D3DCAPS9		d3dCaps;
-	HDC				hDC;
-   HBITMAP			hbmBitmap;
 	DWORD			*pBitmapBits;
-   BITMAPINFO		bmi;
-   long x = 0;
-   long y = 0;
-   TCHAR			str[2] = _T("x");
-	TCHAR			c;
-   SIZE			size;
-	D3DLOCKED_RECT	d3dlr;
-   WORD			*pDst16;
-   BYTE			bAlpha;
+	BITMAPINFO		bmi;
 
    // Ask for a bigger font to reduce aliasing, then scale the texture
    // down by the same amount.
@@ -841,9 +809,9 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 
 	IDirect3DDevice9_GetDeviceCaps(gpD3DDevice, &d3dCaps);
   
-	if (pFont->texWidth > (long) d3dCaps.MaxTextureWidth)
+	if ( pFont->texWidth > static_cast<long>(d3dCaps.MaxTextureWidth) )
 	{
-		pFont->texScale *= (float)pFont->texWidth / (float)d3dCaps.MaxTextureWidth;
+		pFont->texScale *= static_cast<float>(pFont->texWidth) / static_cast<float>(d3dCaps.MaxTextureWidth);
 		pFont->texHeight = pFont->texWidth = d3dCaps.MaxTextureWidth;
 	}
   
@@ -853,18 +821,18 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
    IDirect3DDevice9_CreateTexture(
       gpD3DDevice, pFont->texWidth,
       pFont->texHeight, 1, 0, D3DFMT_A4R4G4B4,
-      D3DPOOL_MANAGED, &pFont->pTexture, NULL);
+      D3DPOOL_MANAGED, &pFont->pTexture, nullptr);
    
    memset(&bmi.bmiHeader, 0, sizeof(BITMAPINFOHEADER));
    bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
-   bmi.bmiHeader.biWidth = (int)pFont->texWidth;
-   bmi.bmiHeader.biHeight = -(int)pFont->texHeight;
+   bmi.bmiHeader.biWidth = static_cast<int>(pFont->texWidth);
+   bmi.bmiHeader.biHeight = -static_cast<int>(pFont->texHeight);
    bmi.bmiHeader.biPlanes = 1;
    bmi.bmiHeader.biCompression = BI_RGB;
    bmi.bmiHeader.biBitCount = 32;
    
-   hDC = CreateCompatibleDC(gBitsDC);
-   hbmBitmap = CreateDIBSection(hDC, &bmi, DIB_RGB_COLORS, (VOID**)&pBitmapBits, NULL, 0 );
+   HDC hDC = CreateCompatibleDC(gBitsDC);
+   HBITMAP hbmBitmap = CreateDIBSection(hDC, &bmi, DIB_RGB_COLORS, (VOID**)&pBitmapBits, nullptr, 0 );
    SetMapMode(hDC, MM_TEXT);
   
    SelectObject(hDC, hbmBitmap);
@@ -876,14 +844,20 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
    SetBkMode(hDC, TRANSPARENT);
    SetTextAlign(hDC, TA_TOP);
    
-   for(c = 32; c < 127; c++ )
+   TCHAR str[2] = _T("x");
+   long x = 0;
+   long y = 0;
+   for(TCHAR c = 32; c < 127; c++ )
    {
-      int index = c-32;
+      int index = c - 32;
       
       str[0] = c;
+	  
+	  SIZE size;
       GetTextExtentPoint32(hDC, str, 1, &size);
       
-      if (!GetCharABCWidths(hDC, c, c, &pFont->abc[index])) {
+      if (!GetCharABCWidths(hDC, c, c, &pFont->abc[index]))
+	  {
          pFont->abc[index].abcA = 0;
          pFont->abc[index].abcB = size.cx;
          pFont->abc[index].abcC = 0;
@@ -899,7 +873,7 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
       }
       
       int left_offset = pFont->abc[index].abcA;
-      ExtTextOut(hDC, x - left_offset, y+0, 0, NULL, str, 1, NULL);
+      ExtTextOut(hDC, x - left_offset, y+0, 0, nullptr, str, 1, nullptr);
       
       pFont->texST[index][0].s = ((FLOAT)(x+0)) / pFont->texWidth;
       pFont->texST[index][0].t = ((FLOAT)(y+0)) / pFont->texHeight;
@@ -910,16 +884,17 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
       x += size.cx+1;  
    }
    
+   D3DLOCKED_RECT d3dlr;
    IDirect3DTexture9_LockRect(pFont->pTexture, 0, &d3dlr, 0, 0);
    
    BYTE *pDstRow = (BYTE*)d3dlr.pBits;
    
    for(y = 0; y < pFont->texHeight; y++)
    {
-      pDst16 = (WORD *)pDstRow;
+      WORD *pDst16 = (WORD *)pDstRow;
       for(x = 0; x < pFont->texWidth; x++)
       {
-         bAlpha = (BYTE)((pBitmapBits[pFont->texWidth * y + x] & 0xff) >> 4);
+         BYTE bAlpha = static_cast<BYTE>( (pBitmapBits[pFont->texWidth * y + x] & 0xff) >> 4 );
          if (bAlpha > 0)
          {
             *pDst16++ = (bAlpha << 12) | 0x0fff;
@@ -935,7 +910,7 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
    IDirect3DTexture9_UnlockRect(pFont->pTexture, 0);
 
    // Get kerning pairs for font
-   pFont->numKerningPairs = GetKerningPairs(hDC, 0, NULL);
+   pFont->numKerningPairs = GetKerningPairs(hDC, 0, nullptr);
    pFont->kerningPairs = new KERNINGPAIR[pFont->numKerningPairs];
    GetKerningPairs(hDC, pFont->numKerningPairs, pFont->kerningPairs);
    
@@ -947,19 +922,16 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 // new render stuff
 void D3DRenderPoolInit(d3d_render_pool_new *pPool, int size, int packetSize)
 {
-	d3d_render_packet_new	*pPacket = NULL;
-	u_int	i;
-
 	pPool->size = size;
 	pPool->curPacket = 0;
-	pPacket = (d3d_render_packet_new *)D3DRenderMalloc(sizeof(d3d_render_packet_new) * size);
+	d3d_render_packet_new *pPacket = (d3d_render_packet_new *)D3DRenderMalloc(sizeof(d3d_render_packet_new) * size);
 	assert(pPacket);
 	pPool->renderPacketList = list_create(pPacket);
 	pPool->packetSize = packetSize;
 
-	D3DRenderPoolReset(pPool, NULL);
+	D3DRenderPoolReset(pPool, nullptr);
 
-	for (i = 0; i < pPool->size; i++)
+	for (u_int i = 0; i < pPool->size; i++)
 	{
 		pPacket->size = packetSize;
 	}
@@ -981,11 +953,11 @@ void D3DRenderPoolReset(d3d_render_pool_new *pPool, void *pMaterialFunc)
 
 d3d_render_packet_new *D3DRenderPacketNew(d3d_render_pool_new *pPool)
 {
-	d3d_render_packet_new	*pPacket;
+	d3d_render_packet_new *pPacket;
 
 	if (pPool->curPacket >= pPool->size)
 	{
-		if (pPool->curPacketList->next == NULL)
+		if (pPool->curPacketList->next == nullptr)
 		{
 			pPacket = (d3d_render_packet_new *)D3DRenderMalloc(sizeof(d3d_render_packet_new) * pPool->size);
 			assert(pPacket);
@@ -1020,9 +992,9 @@ void D3DRenderPacketInit(d3d_render_packet_new *pPacket)
 	pPacket->curChunk = 0;
 	pPacket->effect = 0;
 	pPacket->flags = 0;
-	pPacket->pDib = NULL;
-	pPacket->pMaterialFctn = NULL;
-	pPacket->pTexture = NULL;
+	pPacket->pDib = nullptr;
+	pPacket->pMaterialFctn = nullptr;
+	pPacket->pTexture = nullptr;
 	pPacket->xLat0 = 0;
 	pPacket->xLat1 = 0;
 }
@@ -1030,7 +1002,7 @@ void D3DRenderPacketInit(d3d_render_packet_new *pPacket)
 d3d_render_chunk_new *D3DRenderChunkNew(d3d_render_packet_new *pPacket)
 {
 	if (pPacket->curChunk >= (pPacket->size - 1))
-		return NULL;
+		return nullptr;
 	else
 	{
 		pPacket->curChunk++;
@@ -1049,32 +1021,31 @@ void D3DRenderChunkInit(d3d_render_chunk_new *pChunk)
 	pChunk->numIndices = 0;
 	pChunk->xLat0 = 0;
 	pChunk->xLat1 = 0;
-	pChunk->pSector = NULL;
-	pChunk->pSectorNeg = NULL;
-	pChunk->pSectorPos = NULL;
-	pChunk->pSideDef = NULL;
-	pChunk->pMaterialFctn = NULL;
-	pChunk->pRenderCache = NULL;
+	pChunk->pSector = nullptr;
+	pChunk->pSectorNeg = nullptr;
+	pChunk->pSectorPos = nullptr;
+	pChunk->pSideDef = nullptr;
+	pChunk->pMaterialFctn = nullptr;
+	pChunk->pRenderCache = nullptr;
 }
 
 d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDIRECT3DTEXTURE9 pTexture,
 												PDIB pDib, BYTE xLat0, BYTE xLat1, int effect)
 {
-	u_int						count, numPackets;
-	d3d_render_packet_new	*pPacket;
-	list_type				list;
-
-	for (list = pPool->renderPacketList; list != pPool->curPacketList->next; list = list->next)
+	d3d_render_packet_new *pPacket;
+	
+	for (list_type list = pPool->renderPacketList; list != pPool->curPacketList->next; list = list->next)
 	{
 		pPacket = (d3d_render_packet_new *)list->data;
 
+		u_int numPackets;
 		if (list == pPool->curPacketList)
 			numPackets = pPool->curPacket;
 		else
 			numPackets = pPool->size;
 
 		// for each packet
-		for (count = 0; count < numPackets; count++, pPacket++)
+		for (u_int count = 0; count < numPackets; count++, pPacket++)
 		{
 			// if we find a match that isn't full already, return it
 			if ((pPacket->pDib == pDib) && (pPacket->pTexture == pTexture) &&
@@ -1106,32 +1077,26 @@ d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDI
 void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool)
 {
    // Render view elements (such as the main viewport yellow ui corners)
-   int i, j;
-   float screenW, screenH, foffset;
    int offset = 0;
-   d3d_render_packet_new *pPacket;
-   d3d_render_chunk_new *pChunk;
 
-   screenW = (float) (gD3DRect.right - gD3DRect.left) / (float) gScreenWidth;
-   screenH = (float) (gD3DRect.bottom - gD3DRect.top) / (float) gScreenHeight;
+   float screenW = static_cast<float>(gD3DRect.right - gD3DRect.left) / static_cast<float>(gScreenWidth);
+   float screenH = static_cast<float>(gD3DRect.bottom - gD3DRect.top) / static_cast<float>(gScreenHeight);
 
    if (GetFocus() == hMain)
       offset = 4;
-
-   foffset = 1.0f / 64.0f;
 
    // 0 = top-left
    // 1 = top-right
    // 2 = bottom-left
    // 3 = bottom-right
 
-   for (i = 0; i < 4; ++i)
+   for (int i = 0; i < 4; ++i)
    {
+      float width = static_cast<float>(ViewElements[i + offset].width) / screenW;
+      float height = static_cast<float>(ViewElements[i + offset].height) / screenH;
+
       float left, right, top, bottom;
-
-      float width = (float)ViewElements[i + offset].width / screenW;
-      float height = (float)ViewElements[i + offset].height / screenH;
-
+	  
       if (i % 2 == 0)  // left side
       {
          left = D3DRENDER_SCREEN_TO_CLIP_X(0, gScreenWidth);
@@ -1154,15 +1119,15 @@ void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool)
          bottom = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight, gScreenHeight);
       }
 
-      pPacket = D3DRenderPacketNew(pPool);
-      pPacket->pDib = NULL;
+      d3d_render_packet_new *pPacket = D3DRenderPacketNew(pPool);
+      pPacket->pDib = nullptr;
       pPacket->pTexture = gpViewElements[i + offset];
       pPacket->xLat0 = 0;
       pPacket->xLat1 = 0;
       pPacket->effect = 0;
       pPacket->size = pPool->packetSize;
 
-      pChunk = D3DRenderChunkNew(pPacket);
+      d3d_render_chunk_new *pChunk = D3DRenderChunkNew(pPacket);
       pChunk->flags = 0;
       pChunk->numIndices = 4;
       pChunk->numVertices = 4;
@@ -1173,35 +1138,21 @@ void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool)
       pPacket->pMaterialFctn = D3DMaterialObjectPacket;
       pChunk->pMaterialFctn = D3DMaterialNone;
 
-      pChunk->xyz[0].x = left;
-      pChunk->xyz[0].z = top;
-      pChunk->xyz[0].y = VIEW_ELEMENT_Z;
-      pChunk->xyz[1].x = left;
-      pChunk->xyz[1].z = bottom;
-      pChunk->xyz[1].y = VIEW_ELEMENT_Z;
-      pChunk->xyz[2].x = right;
-      pChunk->xyz[2].z = bottom;
-      pChunk->xyz[2].y = VIEW_ELEMENT_Z;
-      pChunk->xyz[3].x = right;
-      pChunk->xyz[3].z = top;
-      pChunk->xyz[3].y = VIEW_ELEMENT_Z;
+      pChunk->xyz[0] = { left, VIEW_ELEMENT_Z, top };
+      pChunk->xyz[1] = { left, VIEW_ELEMENT_Z, bottom };	  
+      pChunk->xyz[2] = { right, VIEW_ELEMENT_Z, bottom };
+      pChunk->xyz[3] = { right, VIEW_ELEMENT_Z, top };	  
 
-      for (j = 0; j < 4; j++)
+      for (int j = 0; j < 4; j++)
       {
-         pChunk->bgra[j].b = 255;
-         pChunk->bgra[j].g = 255;
-         pChunk->bgra[j].r = 255;
-         pChunk->bgra[j].a = 255;
+         pChunk->bgra[j] = {255, 255, 255, 255};
       }
 
-      pChunk->st0[0].s = foffset;
-      pChunk->st0[0].t = foffset;
-      pChunk->st0[1].s = foffset;
-      pChunk->st0[1].t = 1.0f - foffset;
-      pChunk->st0[2].s = 1.0f - foffset;
-      pChunk->st0[2].t = 1.0f - foffset;
-      pChunk->st0[3].s = 1.0f - foffset;
-      pChunk->st0[3].t = foffset;
+      static constexpr float foffset = 1.0f / 64.0f;
+      pChunk->st0[0] = { foffset, foffset };
+      pChunk->st0[1] = { foffset, (1.0f - foffset) };
+      pChunk->st0[2] = { (1.0f - foffset), (1.0f - foffset) };
+      pChunk->st0[3] = { (1.0f - foffset), foffset };
 
       pChunk->indices[0] = 1;
       pChunk->indices[1] = 2;
@@ -1215,12 +1166,6 @@ LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
 													 float width, float height)
 {
 	LPDIRECT3DSURFACE9	pSrc, pDest[2], pZBuf;
-	RECT				rect;
-	POINT				pnt;
-	D3DMATRIX			mat;
-	d3d_render_packet_new	*pPacket;
-	d3d_render_chunk_new	*pChunk;
-   HRESULT hr;
 
 	D3DCacheSystemReset(&gEffectCacheSystem);
 	D3DRenderPoolReset(&gEffectPool, &D3DMaterialEffectPool);
@@ -1233,8 +1178,9 @@ LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
 	IDirect3DTexture9_GetSurfaceLevel(pTex0, 0, &pDest[0]);
 	IDirect3DTexture9_GetSurfaceLevel(pTex1, 0, &pDest[1]);
 
-	pnt.x = 0;
-	pnt.y = 0;
+	POINT pnt = { 0, 0 };
+	
+	RECT rect;
 	rect.left = rect.top = 0;
 	rect.right = gScreenWidth;
 	rect.bottom = gScreenHeight;
@@ -1243,6 +1189,7 @@ LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
 	IDirect3DDevice9_StretchRect(gpD3DDevice, pSrc, &rect, pDest[0], &rect, D3DTEXF_NONE);
    
 	// clear local->screen transforms
+	D3DMATRIX mat;
 	MatrixIdentity(&mat);
 	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_WORLD, &mat);
 	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_VIEW, &mat);
@@ -1253,10 +1200,12 @@ LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
 
 	IDirect3DDevice9_SetRenderTarget(gpD3DDevice, 0, pDest[1]);
 
-	pPacket = D3DRenderPacketNew(&gEffectPool);
-	if (NULL == pPacket)
-		return NULL;
-	pChunk = D3DRenderChunkNew(pPacket);
+	d3d_render_packet_new *pPacket = D3DRenderPacketNew(&gEffectPool);
+	
+	if (nullptr == pPacket)
+		return nullptr;
+	
+	d3d_render_chunk_new *pChunk = D3DRenderChunkNew(pPacket);
 	pPacket->pMaterialFctn = D3DMaterialEffectPacket;
 	pChunk->pMaterialFctn = D3DMaterialEffectChunk;
 	pPacket->pTexture = pTex0;
@@ -1274,9 +1223,9 @@ LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
 		0, D3DRENDER_SCREEN_TO_CLIP_Y(0, gSmallTextureSize));
 
 	CHUNK_ST0_SET(pChunk, 0, 0.0f, 0.0f);
-	CHUNK_ST0_SET(pChunk, 1, 0.0f, gScreenHeight / (float)gFullTextureSize);
-	CHUNK_ST0_SET(pChunk, 2, gScreenWidth / (float)gFullTextureSize, gScreenHeight / (float)gFullTextureSize);
-	CHUNK_ST0_SET(pChunk, 3, gScreenWidth / (float)gFullTextureSize, 0.0f);
+	CHUNK_ST0_SET(pChunk, 1, 0.0f, gScreenHeight / static_cast<float>(gFullTextureSize));
+	CHUNK_ST0_SET(pChunk, 2, gScreenWidth / static_cast<float>(gFullTextureSize), gScreenHeight / static_cast<float>(gFullTextureSize));
+	CHUNK_ST0_SET(pChunk, 3, gScreenWidth / static_cast<float>(gFullTextureSize), 0.0f);
 
 	CHUNK_BGRA_SET(pChunk, 0, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
 	CHUNK_BGRA_SET(pChunk, 1, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
@@ -1292,7 +1241,7 @@ LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
 	D3DCacheFlush(&gEffectCacheSystem, &gEffectPool, 1, D3DPT_TRIANGLESTRIP);
 
 	// restore render target to backbuffer
-	hr = IDirect3DDevice9_SetRenderTarget(gpD3DDevice, 0, pSrc);
+	HRESULT hr = IDirect3DDevice9_SetRenderTarget(gpD3DDevice, 0, pSrc);
 	hr = IDirect3DDevice9_SetDepthStencilSurface(gpD3DDevice, pZBuf);
 	hr = IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, TRUE);
    

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -105,15 +105,22 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 	
 	pFont->fontHeight = GetFontHeight(hScaledFont);
 	pFont->texScale = FONT_SCALE;
-   
-	if (pFont->fontHeight > 40)
-		pFont->texWidth = pFont->texHeight = 1024;
-	else if (pFont->fontHeight > 20)
-		pFont->texWidth = pFont->texHeight = 512;
-	else
-		pFont->texWidth = pFont->texHeight = 256;
 	
-	D3DCAPS9 d3dCaps;
+	static constexpr int LARGE_FONT_THRESHOLD = 40;
+	static constexpr int MEDIUM_FONT_THRESHOLD = 20;
+	
+	static constexpr int FONT_TEXTURE_SIZE_LARGE = 1024;
+	static constexpr int FONT_TEXTURE_SIZE_MEDIUM = 512;
+	static constexpr int FONT_TEXTURE_SIZE_SMALL = 256;
+	
+	if (pFont->fontHeight > LARGE_FONT_THRESHOLD)
+		pFont->texWidth = pFont->texHeight = FONT_TEXTURE_SIZE_LARGE;
+	else if (pFont->fontHeight > MEDIUM_FONT_THRESHOLD)
+		pFont->texWidth = pFont->texHeight = FONT_TEXTURE_SIZE_MEDIUM;
+	else
+		pFont->texWidth = pFont->texHeight = FONT_TEXTURE_SIZE_SMALL;
+	
+	D3DCAPS9 d3dCaps = {};
 	gpD3DDevice->GetDeviceCaps(&d3dCaps);
   
 	if ( pFont->texWidth > static_cast<long>(d3dCaps.MaxTextureWidth) )
@@ -128,78 +135,90 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 	gpD3DDevice->CreateTexture(pFont->texWidth, pFont->texHeight, 1, 0, D3DFMT_A4R4G4B4,
 									D3DPOOL_MANAGED, &pFont->pTexture, nullptr);
 	
-	BITMAPINFO bmi;
-	memset(&bmi.bmiHeader, 0, sizeof(BITMAPINFOHEADER));
-	bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
-	bmi.bmiHeader.biWidth = static_cast<int>(pFont->texWidth);
-	bmi.bmiHeader.biHeight = -static_cast<int>(pFont->texHeight);
-	bmi.bmiHeader.biPlanes = 1;
-	bmi.bmiHeader.biCompression = BI_RGB;
-	bmi.bmiHeader.biBitCount = 32;
+	static constexpr int BITMAP_PLANES = 1;
+	static constexpr int BITMAP_BIT_DEPTH = 32;
 	
-	HDC hDC = CreateCompatibleDC(gBitsDC);
-	DWORD *pBitmapBits;
-	HBITMAP hbmBitmap = CreateDIBSection(hDC, &bmi, DIB_RGB_COLORS, reinterpret_cast<void**>(&pBitmapBits), nullptr, 0);
-	SetMapMode(hDC, MM_TEXT);
+	// Initialize bitmap info. Top-down DIBs (negative height) match D3D's coordinate system.
+	BITMAPINFO bitmapInfo = {};
+	bitmapInfo.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+	bitmapInfo.bmiHeader.biWidth = static_cast<int>(pFont->texWidth);
+	bitmapInfo.bmiHeader.biHeight = -static_cast<int>(pFont->texHeight);
+	bitmapInfo.bmiHeader.biPlanes = BITMAP_PLANES;
+	bitmapInfo.bmiHeader.biCompression = BI_RGB;
+	bitmapInfo.bmiHeader.biBitCount = BITMAP_BIT_DEPTH;
 	
-	SelectObject(hDC, hbmBitmap);
-	SelectObject(hDC, hScaledFont);
+	// Handle to Device Context for fonts.
+	HDC fontDC = CreateCompatibleDC(gBitsDC);
+	DWORD *pBitmapBits = nullptr;
+	HBITMAP fontBitmap = CreateDIBSection(fontDC, &bitmapInfo, DIB_RGB_COLORS, reinterpret_cast<void**>(&pBitmapBits), nullptr, 0);
+	SetMapMode(fontDC, MM_TEXT);
+	
+	SelectObject(fontDC, fontBitmap);
+	SelectObject(fontDC, hScaledFont);
 	
 	// Set text properties
-	SetTextColor(hDC, RGB(255,255,255));
-	SetBkColor(hDC, 0);
-	SetBkMode(hDC, TRANSPARENT);
-	SetTextAlign(hDC, TA_TOP);
+	SetTextColor(fontDC, RGB(255,255,255));
+	SetBkColor(fontDC, 0);
+	SetBkMode(fontDC, TRANSPARENT);
+	SetTextAlign(fontDC, TA_TOP);
 	
+	// Temporary string that holds both a character and a null terminator.
 	TCHAR str[2] = _T("x");
-	long x = 0;
-	long y = 0;
-	for(TCHAR c = 32; c < 127; c++)
+	
+	// Tracks next available pixel position in the texture atlas.
+	long atlasX = 0;
+	long atlasY = 0;
+	
+	// Iterate through printable ASCII characters.
+	for (int i = 0; i < NUM_CHARS; i++)
 	{
-		int index = c - 32;
+		// Skip the first 32 non-printable characters.
+		TCHAR c = static_cast<TCHAR>(i + 32);
 		
 		str[0] = c;
 		
-		SIZE size;
-		GetTextExtentPoint32(hDC, str, 1, &size);
+		SIZE size = {};
+		GetTextExtentPoint32(fontDC, str, 1, &size);
 		
-		if (!GetCharABCWidths(hDC, c, c, &pFont->abc[index]))
+		if (!GetCharABCWidths(fontDC, c, c, &pFont->abc[i]))
 		{
-			pFont->abc[index] = { 0, static_cast<UINT>(size.cx), 0 };
+			// If font isn't TrueType, fallback to basic width (abcB).
+			pFont->abc[i] = { 0, static_cast<UINT>(size.cx), 0 };
 		}
 
-		size.cx = pFont->abc[index].abcB;
+		// Use the 'B' width (actual character body) for layout.
+		size.cx = pFont->abc[i].abcB;
 
 		// Is this row of the texture filled up?
-		if (x + size.cx >= pFont->texWidth)
+		if (atlasX + size.cx >= pFont->texWidth)
 		{
-			x = 0;
-			y += (size.cy + 1);
+			atlasX = 0;
+			atlasY += (size.cy + 1);
 		}
       
-		int left_offset = pFont->abc[index].abcA;
-		ExtTextOut(hDC, x - left_offset, y, 0, nullptr, str, 1, nullptr);
+		int left_offset = pFont->abc[i].abcA;
+		ExtTextOut(fontDC, (atlasX - left_offset), atlasY, 0, nullptr, str, 1, nullptr);
       
-		pFont->texST[index][0] = {(static_cast<float>(x) / pFont->texWidth), 
-									(static_cast<float>(y) / pFont->texHeight)};
+		pFont->texST[i][0] = {(static_cast<float>(atlasX) / pFont->texWidth), 
+									(static_cast<float>(atlasY) / pFont->texHeight)};
 	  
-		pFont->texST[index][1] = {(static_cast<float>(x + size.cx) / pFont->texWidth),
-									(static_cast<float>(y + size.cy) / pFont->texHeight)};
+		pFont->texST[i][1] = {(static_cast<float>(atlasX + size.cx) / pFont->texWidth),
+									(static_cast<float>(atlasY + size.cy) / pFont->texHeight)};
 
 		// Leave +1 space so bilinear filtering doesn't pick up neighboring character
-		x += (size.cx + 1);  
+		atlasX += (size.cx + 1);  
 	}
    
-	D3DLOCKED_RECT d3dlr;
+	D3DLOCKED_RECT d3dlr = {};
 	pFont->pTexture->LockRect(0, &d3dlr, 0, 0);
    
 	BYTE *pDstRow = reinterpret_cast<BYTE*>(d3dlr.pBits);
    
 	// Convert a texture bitmask into a 16-bit pixel format.
-	for (y = 0; y < pFont->texHeight; y++)
+	for (int y = 0; y < pFont->texHeight; y++)
 	{
 		WORD *pDst16 = reinterpret_cast<WORD*>(pDstRow);
-		for(x = 0; x < pFont->texWidth; x++)
+		for(int x = 0; x < pFont->texWidth; x++)
 		{
 			// Extract 4-bit alpha from 8-bit source.
 			BYTE bAlpha = static_cast<BYTE>( (pBitmapBits[pFont->texWidth * y + x] & 0xff) >> 4 );
@@ -213,13 +232,13 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 	pFont->pTexture->UnlockRect(0);
 
 	// Get kerning pairs for font
-	pFont->numKerningPairs = GetKerningPairs(hDC, 0, nullptr);
+	pFont->numKerningPairs = GetKerningPairs(fontDC, 0, nullptr);
 	pFont->kerningPairs = new KERNINGPAIR[pFont->numKerningPairs];
-	GetKerningPairs(hDC, pFont->numKerningPairs, pFont->kerningPairs);
+	GetKerningPairs(fontDC, pFont->numKerningPairs, pFont->kerningPairs);
 	
-	DeleteObject(hbmBitmap);
+	DeleteObject(fontBitmap);
 	DeleteObject(hScaledFont);
-	DeleteDC(hDC);
+	DeleteDC(fontDC);
 }
 
 void D3DRenderPoolInit(d3d_render_pool_new *pPool, int size, int packetSize)

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -14,8 +14,8 @@ static constexpr int TEX_CACHE_MAX_PARTICLE = 1000000;
 ///////////////
 // Variables //
 ///////////////
-LPDIRECT3DTEXTURE9		gpNoLookThrough = nullptr;
-LPDIRECT3DTEXTURE9		gpViewElements[NUM_VIEW_ELEMENTS];
+IDirect3DTexture9*		gpNoLookThrough = nullptr;
+IDirect3DTexture9*		gpViewElements[NUM_VIEW_ELEMENTS];
 
 D3DVIEWPORT9			gViewport;
 
@@ -57,30 +57,12 @@ static unsigned int		gFrame = 0;
 int						gFullTextureSize = 0;
 int						gSmallTextureSize = 0;
 
-D3DVERTEXELEMENT9		decl0[] = {
-	{0, 0, D3DDECLTYPE_FLOAT3,	 D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_POSITION, 0},
-	{1, 0, D3DDECLTYPE_D3DCOLOR, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_COLOR, 0},
-	D3DDECL_END()
-	};
-
-D3DVERTEXELEMENT9		decl1[] = {
-	{0, 0, D3DDECLTYPE_FLOAT3,	 D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_POSITION, 0},
-	{1, 0, D3DDECLTYPE_D3DCOLOR, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_COLOR, 0},
-	{2, 0, D3DDECLTYPE_FLOAT2,	 D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_TEXCOORD, 0},
-	D3DDECL_END()
-	};
-
-D3DVERTEXELEMENT9		decl2[] = {
-	{0, 0, D3DDECLTYPE_FLOAT3,	 D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_POSITION, 0},
-	{1, 0, D3DDECLTYPE_D3DCOLOR, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_COLOR, 0},
-	{2, 0, D3DDECLTYPE_FLOAT2,	 D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_TEXCOORD, 0},
-	{3, 0, D3DDECLTYPE_FLOAT2,	 D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_TEXCOORD, 1},
-	D3DDECL_END()
-	};
-
-LPDIRECT3DVERTEXDECLARATION9 decl0dc;
-LPDIRECT3DVERTEXDECLARATION9 decl1dc;
-LPDIRECT3DVERTEXDECLARATION9 decl2dc;
+// Basic layout: Position and diffuse color.  Used for simple geometry and UI.
+IDirect3DVertexDeclaration9* g_pVertexDecl_PosColor;
+// Standard layout: Position, color, and one UV. Used for most world textures, sprites, and particles.
+IDirect3DVertexDeclaration9* g_pVertexDecl_PosColorTex1;
+// Multi-textured layout: Position, color, and two UVs. Used for lightmapped surfaces.
+IDirect3DVertexDeclaration9* g_pVertexDecl_PosColorTex2;
 
 int						gD3DRedrawAll = 0;
 
@@ -351,7 +333,7 @@ void D3DRenderChunkInit(d3d_render_chunk_new *pChunk)
 	pChunk->pRenderCache = nullptr;
 }
 
-d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDIRECT3DTEXTURE9 pTexture,
+d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, IDirect3DTexture9* pTexture,
 												PDIB pDib, BYTE xLat0, BYTE xLat1, int effect)
 {
 	d3d_render_packet_new *pPacket;
@@ -482,9 +464,11 @@ void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool)
 }
 
 // Captures current rendered frame as a texture for post-processing effects.
-LPDIRECT3DTEXTURE9 D3DRender_CaptureEffect(LPDIRECT3DTEXTURE9 pTex0, LPDIRECT3DTEXTURE9 pTex1)
+IDirect3DTexture9* D3DRender_CaptureEffect(IDirect3DTexture9* pTex0, IDirect3DTexture9* pTex1)
 {
-	LPDIRECT3DSURFACE9 pSrc, pDest[2], pZBuf;
+	IDirect3DSurface9* pSrc = nullptr;
+	IDirect3DSurface9* pDest[2]{};
+	IDirect3DSurface9* pZBuf = nullptr;
 
 	D3DCacheSystemReset(&gEffectCacheSystem);
 	D3DRenderPoolReset(&gEffectPool, &D3DMaterialEffectPool);
@@ -660,10 +644,34 @@ HRESULT D3DRenderInit(HWND hWnd)
 	/***************************************************************************/
 	/*                    VERTEX DECLARATIONS                                  */
 	/***************************************************************************/
-	
-	gpD3DDevice->CreateVertexDeclaration(decl0, &decl0dc);
-	gpD3DDevice->CreateVertexDeclaration(decl1, &decl1dc);
-	gpD3DDevice->CreateVertexDeclaration(decl2, &decl2dc);
+
+	// Vertex layout for non-textured geometry.
+	static constexpr D3DVERTEXELEMENT9 VERTEX_LAYOUT_POS_COLOR[] = {
+		{0, 0, D3DDECLTYPE_FLOAT3,	 D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_POSITION, 0},
+		{1, 0, D3DDECLTYPE_D3DCOLOR, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_COLOR, 0},
+		D3DDECL_END()
+		};
+
+	// Vertex layout for standard texturing.
+	static constexpr D3DVERTEXELEMENT9 VERTEX_LAYOUT_POS_COLOR_TEX1[] = {
+		{0, 0, D3DDECLTYPE_FLOAT3,	 D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_POSITION, 0},
+		{1, 0, D3DDECLTYPE_D3DCOLOR, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_COLOR, 0},
+		{2, 0, D3DDECLTYPE_FLOAT2,	 D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_TEXCOORD, 0},
+		D3DDECL_END()
+		};
+
+	// Vertex layout for multi-texturing (lightmaps).
+	static constexpr D3DVERTEXELEMENT9 VERTEX_LAYOUT_POS_COLOR_TEX2[] = {
+		{0, 0, D3DDECLTYPE_FLOAT3,	 D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_POSITION, 0},
+		{1, 0, D3DDECLTYPE_D3DCOLOR, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_COLOR, 0},
+		{2, 0, D3DDECLTYPE_FLOAT2,	 D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_TEXCOORD, 0},
+		{3, 0, D3DDECLTYPE_FLOAT2,	 D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_TEXCOORD, 1},
+		D3DDECL_END()
+		};
+
+	gpD3DDevice->CreateVertexDeclaration(VERTEX_LAYOUT_POS_COLOR, &g_pVertexDecl_PosColor);
+	gpD3DDevice->CreateVertexDeclaration(VERTEX_LAYOUT_POS_COLOR_TEX1, &g_pVertexDecl_PosColorTex1);
+	gpD3DDevice->CreateVertexDeclaration(VERTEX_LAYOUT_POS_COLOR_TEX2, &g_pVertexDecl_PosColorTex2);
 
 	SetZBias(0);
 
@@ -775,12 +783,12 @@ void D3DRenderShutDown(void)
 	/*                       VERTEX DECLARATIONS                               */
 	/***************************************************************************/
 	
-	if (decl0dc) decl0dc->Release();
-	if (decl1dc) decl1dc->Release();
-	if (decl2dc) decl2dc->Release();
-	decl0dc = nullptr;
-	decl1dc = nullptr;
-	decl2dc = nullptr;
+	if (g_pVertexDecl_PosColor) g_pVertexDecl_PosColor->Release();
+	if (g_pVertexDecl_PosColorTex1) g_pVertexDecl_PosColorTex1->Release();
+	if (g_pVertexDecl_PosColorTex2) g_pVertexDecl_PosColorTex2->Release();
+	g_pVertexDecl_PosColor = nullptr;
+	g_pVertexDecl_PosColorTex1 = nullptr;
+	g_pVertexDecl_PosColorTex2 = nullptr;
   
 	gpD3DDevice->Release();
 	gpD3DDevice = nullptr;
@@ -901,7 +909,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	if (draw_sky) // Render the skybox first
 	{
-		SkyboxRenderParams skyboxRenderParams(decl1dc, gD3DDriverProfile, gWorldPool, gWorldCacheSystem);
+		SkyboxRenderParams skyboxRenderParams(g_pVertexDecl_PosColorTex1, gD3DDriverProfile, gWorldPool, gWorldCacheSystem);
 		D3DRenderSkyBox(params, angleHeading, anglePitch, view, skyboxRenderParams);
 	}
 
@@ -912,7 +920,8 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	WorldPoolParams worldPoolParams(&gWorldPool, &gWorldPoolStatic, &gLMapPool, &gLMapPoolStatic, &gWallMaskPool);
 		
-	WorldRenderParams worldRenderParams(decl1dc, decl2dc, gD3DDriverProfile, worldCacheSystemParams, worldPoolParams, view, proj);
+	WorldRenderParams worldRenderParams(g_pVertexDecl_PosColorTex1, g_pVertexDecl_PosColorTex2,
+											gD3DDriverProfile, worldCacheSystemParams, worldPoolParams, view, proj);
 
 	LightAndTextureParams lightAndTextureParams(&gDLightCache, &gDLightCacheDynamic, gSmallTextureSize, sector_depths);
 
@@ -957,7 +966,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	// background overlays (e.g. the Sun & Moon)
 	if (draw_background_overlays)
 	{
-		BackgroundOverlaysRenderStateParams bgoRenderStateParams(decl1dc, gD3DDriverProfile, &gWorldPool, &gWorldCacheSystem, 
+		BackgroundOverlaysRenderStateParams bgoRenderStateParams(g_pVertexDecl_PosColorTex1, gD3DDriverProfile, &gWorldPool, &gWorldCacheSystem, 
 																	view, mat, gD3DRect);
 		BackgroundOverlaysSceneParams bgoSceneParams(&num_visible_objects, visible_objects, 
 														angleHeading, anglePitch, room, params);
@@ -981,13 +990,13 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	if (draw_particles)
 	{
-		ParticleSystemStructure particleSystemStructure(decl1dc, playerDeltaPos, &gParticlePool, &gParticleCacheSystem);
+		ParticleSystemStructure particleSystemStructure(g_pVertexDecl_PosColorTex1, playerDeltaPos, &gParticlePool, &gParticleCacheSystem);
 		D3DRenderParticles(particleSystemStructure);
 	}
 
 	if (draw_objects)
 	{
-		ObjectsRenderParams objectsRenderParams(decl1dc, decl2dc, gD3DDriverProfile, &gObjectPool, &gObjectCacheSystem,
+		ObjectsRenderParams objectsRenderParams(g_pVertexDecl_PosColorTex1, g_pVertexDecl_PosColorTex2, gD3DDriverProfile, &gObjectPool, &gObjectCacheSystem,
 													view, proj, room, params);
 
 		GameObjectDataParams gameObjectDataParams(nitems, &num_visible_objects, &gNumObjects, drawdata, visible_objects, 
@@ -1014,7 +1023,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	SetZBias(ZBIAS_DEFAULT);
 
 	gpD3DDevice->SetVertexShader(nullptr);
-	gpD3DDevice->SetVertexDeclaration(decl0dc);
+	gpD3DDevice->SetVertexDeclaration(g_pVertexDecl_PosColor);
 
 	// Set up orthographic projection for drawing overlays
 	MatrixIdentity(&mat);
@@ -1022,7 +1031,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	gpD3DDevice->SetTransform(D3DTS_VIEW, &mat);
 	gpD3DDevice->SetTransform(D3DTS_PROJECTION, &mat);
 
-	FxRenderSystemStructure fxRenderSystemStructure(decl1dc, &gObjectPool, &gObjectCacheSystem, 
+	FxRenderSystemStructure fxRenderSystemStructure(g_pVertexDecl_PosColorTex1, &gObjectPool, &gObjectCacheSystem, 
 		&gEffectPool, &gEffectCacheSystem, gpBackBufferTex, gpBackBufferTexFull, 
 		gFullTextureSize, gSmallTextureSize, mat, gFrame, gScreenWidth, gScreenHeight);
 
@@ -1053,7 +1062,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_CLAMP);
 
 	gpD3DDevice->SetVertexShader(nullptr);
-	gpD3DDevice->SetVertexDeclaration(decl1dc);
+	gpD3DDevice->SetVertexDeclaration(g_pVertexDecl_PosColorTex1);
 
 	D3DRenderPoolReset(&gObjectPool, &D3DMaterialObjectPool);
 	D3DCacheSystemReset(&gObjectCacheSystem);

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -115,6 +115,12 @@ inline bool D3DRender_InBounds(float coordinate, float range)
 	return fabs(coordinate) < range;
 }
 
+inline RECT GetScreenRect()
+{
+	// RECT struct is set in this order: Left -> Top -> Right -> Bottom
+	return { 0, 0, gScreenWidth, gScreenHeight};
+}
+
 /////////////////////////
 // Function Prototypes //
 /////////////////////////

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -99,14 +99,14 @@ inline LPDIRECT3DTEXTURE9 gpBackBufferTexFull;
 inline static PALETTEENTRY gPalette[NUM_COLORS];
 
 // Main client windows current viewport area
-// Derived from graphics.c
+// Defined in graphics.c
 extern int main_viewport_width;
 extern int main_viewport_height;
 
 // Defined in d3ddriver.c
 extern d3d_driver_profile gD3DDriverProfile;
 
-// Derived from palette.c
+// Defined in palette.c
 extern Color base_palette[NUM_COLORS];
 
 //////////////////////

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -245,13 +245,13 @@ void				D3DRenderBegin(room_type *room, Draw3DParams *params);
 void				D3DRenderResizeDisplay(int left, int top, int right, int bottom);
 void				D3DRenderEnableToggle(void);
 int					D3DRenderObjectGetLight(BSPnode *tree, room_contents_node *pRNode);
-d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDIRECT3DTEXTURE9 pTexture,
+d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, IDirect3DTexture9* pTexture,
 												PDIB pDib, BYTE xLat0, BYTE xLat1, int effect);												
 d3d_render_packet_new *D3DRenderPacketNew(d3d_render_pool_new *pPool);
 d3d_render_chunk_new *D3DRenderChunkNew(d3d_render_packet_new *pPacket);
 void				D3DRenderPoolReset(d3d_render_pool_new *pPool, void *pMaterialFunc);
 void				D3DRenderFontInit(font_3d *pFont, HFONT hFont);
-LPDIRECT3DTEXTURE9  D3DRender_CaptureEffect(LPDIRECT3DTEXTURE9 pTex0, LPDIRECT3DTEXTURE9 pTex1);
+IDirect3DTexture9*  D3DRender_CaptureEffect(IDirect3DTexture9* pTex0, IDirect3DTexture9* pTex1);
 
 // D3D State Functions
 void D3DRender_SetAlphaTestState(BOOL enable, DWORD alphaRef, D3DCMPFUNC comparisonFunc);

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -71,10 +71,10 @@ struct font_3d
 	long				 texHeight;
 	float				 texScale;
 	custom_st	   texST[NUM_CHARS][2];
-  // Deal with underhanging and overhanging characters
-  ABC          abc[NUM_CHARS];
-  int          numKerningPairs;
-  KERNINGPAIR *kerningPairs;
+	// Deal with underhanging and overhanging characters
+	ABC          abc[NUM_CHARS];
+	int          numKerningPairs;
+	KERNINGPAIR *kerningPairs;
 };
 
 /////////////
@@ -88,15 +88,7 @@ inline int gD3DEnabled = 0;
 inline int gScreenWidth = 0;
 inline int gScreenHeight = 0;
 
-// Main client windows current viewport area
-// These varaibles exist in graphics.c
-extern int main_viewport_width;
-extern int main_viewport_height;
-
 inline int d3dRenderTextureThreshold;
-
-// Defined in d3ddriver.c
-extern d3d_driver_profile gD3DDriverProfile;
 
 inline bool gWireframe = false;
 inline font_3d gFont;
@@ -105,6 +97,16 @@ inline LPDIRECT3DTEXTURE9 gpBackBufferTex[MAX_RENDER_TARGET_POOL];
 inline LPDIRECT3DTEXTURE9 gpBackBufferTexFull;
 
 inline static PALETTEENTRY gPalette[NUM_COLORS];
+
+// Main client windows current viewport area
+// Derived from graphics.c
+extern int main_viewport_width;
+extern int main_viewport_height;
+
+// Defined in d3ddriver.c
+extern d3d_driver_profile gD3DDriverProfile;
+
+// Derived from palette.c
 extern Color base_palette[NUM_COLORS];
 
 //////////////////////
@@ -141,7 +143,7 @@ inline bool D3DRender_InBounds(float coordinate, float range)
 inline RECT GetScreenRect()
 {
 	// RECT struct is set in this order: Left -> Top -> Right -> Bottom
-	return { 0, 0, gScreenWidth, gScreenHeight};
+	return { 0, 0, gScreenWidth, gScreenHeight };
 }
 
 inline int D3DRenderIsEnabled()
@@ -154,10 +156,10 @@ inline void *D3DRenderMalloc(unsigned int bytes)
 	return malloc(bytes);
 }
 
-inline void SetZBias(LPDIRECT3DDEVICE9 device, int z_bias)
+inline void SetZBias(int z_bias)
 {
    float bias = z_bias * -0.00001f;
-   device->SetRenderState(D3DRS_DEPTHBIAS, *((DWORD *) &bias));
+   gpD3DDevice->SetRenderState(D3DRS_DEPTHBIAS, std::bit_cast<DWORD>(bias));
 }
 
 inline int DistanceGet(int x, int y)
@@ -248,7 +250,6 @@ d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDI
 d3d_render_packet_new *D3DRenderPacketNew(d3d_render_pool_new *pPool);
 d3d_render_chunk_new *D3DRenderChunkNew(d3d_render_packet_new *pPacket);
 void				D3DRenderPoolReset(d3d_render_pool_new *pPool, void *pMaterialFunc);
-void				*D3DRenderMalloc(unsigned int bytes);
 void				D3DRenderFontInit(font_3d *pFont, HFONT hFont);
 LPDIRECT3DTEXTURE9  D3DRender_CaptureEffect(LPDIRECT3DTEXTURE9 pTex0, LPDIRECT3DTEXTURE9 pTex1);
 

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -66,7 +66,7 @@ struct font_3d
 	TCHAR        strFontName[80];
 	long         fontHeight;
 
-	LPDIRECT3DTEXTURE9	pTexture;
+	IDirect3DTexture9*	pTexture;
 	long				 texWidth;
 	long				 texHeight;
 	float				 texScale;
@@ -93,8 +93,8 @@ inline int d3dRenderTextureThreshold;
 inline bool gWireframe = false;
 inline font_3d gFont;
 
-inline LPDIRECT3DTEXTURE9 gpBackBufferTex[MAX_RENDER_TARGET_POOL];
-inline LPDIRECT3DTEXTURE9 gpBackBufferTexFull;
+inline IDirect3DTexture9* gpBackBufferTex[MAX_RENDER_TARGET_POOL];
+inline IDirect3DTexture9* gpBackBufferTexFull;
 
 inline static PALETTEENTRY gPalette[NUM_COLORS];
 
@@ -177,13 +177,13 @@ inline bool ShouldRenderInCurrentPass(bool transparent_pass, bool isTransparent)
 inline float FovHorizontal(long width)
 {
 	static constexpr float HORIZONTAL_TUNING_FACTOR  = (-PI / 3.78f);
-	return width / static_cast<float>(main_viewport_width) * HORIZONTAL_TUNING_FACTOR ;
+	return (width / static_cast<float>(main_viewport_width)) * HORIZONTAL_TUNING_FACTOR ;
 }
 
 inline float FovVertical(long height)
 {
 	static constexpr float VERTICAL_TUNING_FACTOR = (PI / 5.88f);
-	return height / static_cast<float>(main_viewport_height) * VERTICAL_TUNING_FACTOR;
+	return (height / static_cast<float>(main_viewport_height)) * VERTICAL_TUNING_FACTOR;
 }
 
 // Retrieve the threshold value for determining whether to round up the dimensions of a texture.
@@ -217,7 +217,7 @@ inline const font_3d& getFont3d()
 	return gFont;
 }
 
-inline const LPDIRECT3DTEXTURE9 getBackBufferTextureZero()
+inline const IDirect3DTexture9* getBackBufferTextureZero()
 {
 	return gpBackBufferTex[0];
 }

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -36,16 +36,9 @@ static constexpr float Z_RANGE = 200000.0f;
 // Standard ASCII table, minus the first 32 non-printable control characters.
 static constexpr int NUM_CHARS = 128 - 32;
 
-/////////////
-// Globals //
-/////////////
-inline IDirect3D9* gpD3D = nullptr;
-inline IDirect3DDevice9* gpD3DDevice = nullptr;
-
-inline int gNumVertices = 0;
-inline int gD3DEnabled = 0;
-inline int gScreenWidth = 0;
-inline int gScreenHeight = 0;
+// Pool of textures used for off-screen rendering (drawing to memory instead of on screen).
+// These are used for intermediate passes for things like dynamic lighting.
+static constexpr int MAX_RENDER_TARGET_POOL = 16;
 
 ////////////////
 // Structures //
@@ -84,6 +77,36 @@ struct font_3d
   KERNINGPAIR *kerningPairs;
 };
 
+/////////////
+// Globals //
+/////////////
+inline IDirect3D9* gpD3D = nullptr;
+inline IDirect3DDevice9* gpD3DDevice = nullptr;
+
+inline int gNumVertices = 0;
+inline int gD3DEnabled = 0;
+inline int gScreenWidth = 0;
+inline int gScreenHeight = 0;
+
+// Main client windows current viewport area
+// These varaibles exist in graphics.c
+extern int main_viewport_width;
+extern int main_viewport_height;
+
+inline int d3dRenderTextureThreshold;
+
+// Defined in d3ddriver.c
+extern d3d_driver_profile gD3DDriverProfile;
+
+inline bool gWireframe = false;
+inline font_3d gFont;
+
+inline LPDIRECT3DTEXTURE9 gpBackBufferTex[MAX_RENDER_TARGET_POOL];
+inline LPDIRECT3DTEXTURE9 gpBackBufferTexFull;
+
+inline static PALETTEENTRY gPalette[NUM_COLORS];
+extern Color base_palette[NUM_COLORS];
+
 //////////////////////
 // Helper Functions //
 //////////////////////
@@ -121,6 +144,96 @@ inline RECT GetScreenRect()
 	return { 0, 0, gScreenWidth, gScreenHeight};
 }
 
+inline int D3DRenderIsEnabled()
+{
+	return gD3DEnabled;
+}
+
+inline void *D3DRenderMalloc(unsigned int bytes)
+{
+	return malloc(bytes);
+}
+
+inline void SetZBias(LPDIRECT3DDEVICE9 device, int z_bias)
+{
+   float bias = z_bias * -0.00001f;
+   device->SetRenderState(D3DRS_DEPTHBIAS, *((DWORD *) &bias));
+}
+
+inline int DistanceGet(int x, int y)
+{
+	return static_cast<int>(sqrtf(static_cast<float>(x * x + y * y)));
+}
+
+// Helper function to determine if an object should be rendered in the current pass based on transparency.
+inline bool ShouldRenderInCurrentPass(bool transparent_pass, bool isTransparent)
+{
+	return transparent_pass == isTransparent;
+}
+
+// Defines field of views
+inline float FovHorizontal(long width)
+{
+	static constexpr float HORIZONTAL_TUNING_FACTOR  = (-PI / 3.78f);
+	return width / static_cast<float>(main_viewport_width) * HORIZONTAL_TUNING_FACTOR ;
+}
+
+inline float FovVertical(long height)
+{
+	static constexpr float VERTICAL_TUNING_FACTOR = (PI / 5.88f);
+	return height / static_cast<float>(main_viewport_height) * VERTICAL_TUNING_FACTOR;
+}
+
+// Retrieve the threshold value for determining whether to round up the dimensions of a texture.
+inline int getD3dRenderThreshold()
+{
+	return d3dRenderTextureThreshold;
+}
+
+inline bool isManagedTexturesEnabled()
+{
+    return gD3DDriverProfile.bManagedTextures;
+}
+
+inline bool isFogEnabled()
+{
+	return gD3DDriverProfile.bFogEnable;
+}
+
+inline void setWireframeMode(bool isEnabled)
+{
+	gWireframe = isEnabled;
+}
+
+inline bool isWireframeMode()
+{
+	return gWireframe;
+}
+
+inline const font_3d& getFont3d()
+{
+	return gFont;
+}
+
+inline const LPDIRECT3DTEXTURE9 getBackBufferTextureZero()
+{
+	return gpBackBufferTex[0];
+}
+
+// Global palette array containing 256 color entries used for rendering textures in the current frame.
+// This palette is dynamically updated based on the current rendering context.
+inline PALETTEENTRY* getPalette()
+{
+    return gPalette;
+}
+
+// Base palette array containing predefined colors used as a reference for rendering effects.
+// This palette remains constant and is used for color lookups and transformations.
+inline const Color(&getBasePalette())[NUM_COLORS]
+{
+	return base_palette;
+}
+
 /////////////////////////
 // Function Prototypes //
 /////////////////////////
@@ -129,56 +242,15 @@ void				D3DRenderShutDown(void);
 void				D3DRenderBegin(room_type *room, Draw3DParams *params);
 void				D3DRenderResizeDisplay(int left, int top, int right, int bottom);
 void				D3DRenderEnableToggle(void);
-int					D3DRenderIsEnabled(void);
 int					D3DRenderObjectGetLight(BSPnode *tree, room_contents_node *pRNode);
 d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDIRECT3DTEXTURE9 pTexture,
-												PDIB pDib, BYTE xLat0, BYTE xLat1, int effect);
+												PDIB pDib, BYTE xLat0, BYTE xLat1, int effect);												
 d3d_render_packet_new *D3DRenderPacketNew(d3d_render_pool_new *pPool);
 d3d_render_chunk_new *D3DRenderChunkNew(d3d_render_packet_new *pPacket);
 void				D3DRenderPoolReset(d3d_render_pool_new *pPool, void *pMaterialFunc);
 void				*D3DRenderMalloc(unsigned int bytes);
 void				D3DRenderFontInit(font_3d *pFont, HFONT hFont);
-
-LPDIRECT3DTEXTURE9  D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9 pTex0, LPDIRECT3DTEXTURE9 pTex1, 
-	float width, float height);
-
-void SetZBias(LPDIRECT3DDEVICE9 device, int z_bias);
-int DistanceGet(int x, int y);
-
-int FindHotspotPdib(PDIB pdib, char hotspot, POINT* point);
-
-bool ShouldRenderInCurrentPass(bool transparent_pass, bool isTransparent);
-
-float FovHorizontal(long width);
-float FovVertical(long height);
-
-// Retrieve the threshold value for determining whether to round up the dimensions of a texture.
-int getD3dRenderThreshold();
-
-// Returns the max shading range (FINENESS-shade_amount) to FINENESS
-long getShadeAmount();
-
-bool isManagedTexturesEnabled();
-bool isFogEnabled();
-
-const Vector3D& getSunVector();
-
-void setWireframeMode(bool isEnabled);
-bool isWireframeMode();
-
-const font_3d& getFont3d();
-
-const LPDIRECT3DTEXTURE9 getWhiteLightTexture();
-
-const LPDIRECT3DTEXTURE9 getBackBufferTextureZero();
-
-// Global palette array containing 256 color entries used for rendering textures in the current frame.
-// This palette is dynamically updated based on the current rendering context.
-PALETTEENTRY* getPalette();
-
-// Base palette array containing predefined colors used as a reference for rendering effects.
-// This palette remains constant and is used for color lookups and transformations.
-const Color(&getBasePalette())[NUM_COLORS];
+LPDIRECT3DTEXTURE9  D3DRender_CaptureEffect(LPDIRECT3DTEXTURE9 pTex0, LPDIRECT3DTEXTURE9 pTex1);
 
 // D3D State Functions
 void D3DRender_SetAlphaTestState(BOOL enable, DWORD alphaRef, D3DCMPFUNC comparisonFunc);
@@ -193,5 +265,20 @@ void D3DRender_SetAlphaStage(DWORD stage, D3DTEXTUREOP alphaOp, DWORD arg1, DWOR
 
 void D3DRender_SetStreams(d3d_render_cache* pCache, int numStages);
 void D3DRender_ClearStreams(int numStages);
+
+////////////////////////
+// External Functions //
+////////////////////////
+
+// Defined in object3d.c
+int FindHotspotPdib(PDIB pdib, char hotspot, POINT* point);
+const Vector3D& getSunVector();
+
+// Defined in graphics.c
+// Returns the max shading range (FINENESS-shade_amount) to FINENESS.
+long getShadeAmount();
+
+// Defined in d3drender_lights.c
+LPDIRECT3DTEXTURE9 D3DRenderLightsGetWhite();
 
 #endif	// __D3DRENDER_H__

--- a/clientd3d/d3drender_fx.c
+++ b/clientd3d/d3drender_fx.c
@@ -690,8 +690,7 @@ void D3DFxBlurWaver(const FxRenderSystemStructure& fxRss)
 	IDirect3DDevice9_SetVertexShader(gpD3DDevice, NULL);
 	IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, fxRss.vertexDeclaration);
 
-	D3DRenderFramebufferTextureCreate(fxRss.backBufferTexFull, fxRss.backBufferTex[t],
-		fxRss.smallTextureSize, fxRss.smallTextureSize);
+	D3DRender_CaptureEffect(fxRss.backBufferTexFull, fxRss.backBufferTex[t]);
 
 	D3DCacheSystemReset(fxRss.effectCacheSystem);
 	D3DRenderPoolReset(fxRss.effectPool, &D3DMaterialBlurPool);

--- a/clientd3d/d3drender_materials.c
+++ b/clientd3d/d3drender_materials.c
@@ -224,7 +224,7 @@ bool D3DMaterialLMapDynamicPool(d3d_render_pool_new *pPool)
    IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP);
    IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP);
 
-   const auto &whiteLightTexture = getWhiteLightTexture();
+   const auto &whiteLightTexture = D3DRenderLightsGetWhite();
    IDirect3DDevice9_SetTexture(gpD3DDevice, 0, (IDirect3DBaseTexture9 *) whiteLightTexture);
 
    D3DRender_SetColorStage(0, D3DTOP_MODULATE, D3DTA_TEXTURE, D3DTA_DIFFUSE);

--- a/clientd3d/d3drender_materials.c
+++ b/clientd3d/d3drender_materials.c
@@ -78,14 +78,14 @@ bool D3DMaterialWorldDynamicChunk(d3d_render_chunk_new *pChunk)
 		if (pChunk->pSector)
 		{
 			if (pChunk->pSector->ceiling == current_room.sectors[0].ceiling)
-				SetZBias(gpD3DDevice, 0);
+				SetZBias(0);
 			else
-            SetZBias(gpD3DDevice, ZBIAS_WORLD);
+            SetZBias(ZBIAS_WORLD);
 		}
 	}
 	else
 	{
-		SetZBias(gpD3DDevice, ZBIAS_WORLD);
+		SetZBias(ZBIAS_WORLD);
 	}
 
 	// Clamp texture V axis if vertical tiling is disabled 
@@ -144,14 +144,14 @@ bool D3DMaterialWorldStaticChunk(d3d_render_chunk_new *pChunk)
 		if (pChunk->pSector)
 		{
 			if (pChunk->pSector->ceiling == current_room.sectors[0].ceiling)
-				SetZBias(gpD3DDevice, 0);
+				SetZBias(0);
 			else
-				SetZBias(gpD3DDevice, ZBIAS_WORLD);
+				SetZBias(ZBIAS_WORLD);
 		}
 	}
 	else
 	{
-		SetZBias(gpD3DDevice, ZBIAS_WORLD);
+		SetZBias(ZBIAS_WORLD);
 	}
 
 	// Clamp texture V axis if vertical tiling is disabled 
@@ -197,7 +197,7 @@ bool D3DMaterialMaskChunk(d3d_render_chunk_new *pChunk)
 	else
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_CULLMODE, D3DCULL_CW);
 
-	SetZBias(gpD3DDevice, pChunk->zBias);
+	SetZBias(pChunk->zBias);
 
 	return true;
 }
@@ -263,13 +263,13 @@ bool D3DMaterialLMapDynamicChunk(d3d_render_chunk_new *pChunk)
 		{
 			const auto& current_room = getCurrentRoom();
 			if (pChunk->pSector->ceiling == current_room.sectors[0].ceiling)
-				SetZBias(gpD3DDevice, 0);
+				SetZBias(0);
 			else
-				SetZBias(gpD3DDevice, ZBIAS_WORLD);
+				SetZBias(ZBIAS_WORLD);
 		}
 	}
 	else
-		SetZBias(gpD3DDevice, ZBIAS_WORLD);
+		SetZBias(ZBIAS_WORLD);
 
 	return true;
 }
@@ -286,13 +286,13 @@ bool D3DMaterialLMapStaticChunk(d3d_render_chunk_new *pChunk)
 		{
 			const auto& current_room = getCurrentRoom();
 			if (pChunk->pSector->ceiling == current_room.sectors[0].ceiling)
-				SetZBias(gpD3DDevice, 0);
+				SetZBias(0);
 			else
-				SetZBias(gpD3DDevice, ZBIAS_WORLD);
+				SetZBias(ZBIAS_WORLD);
 		}
 	}
 	else
-      SetZBias(gpD3DDevice, ZBIAS_WORLD);
+      SetZBias(ZBIAS_WORLD);
 
 	if (pChunk->pSector)
 		if (pChunk->pSector->flags & SF_HAS_ANIMATED)
@@ -352,7 +352,7 @@ bool D3DMaterialObjectChunk(d3d_render_chunk_new *pChunk)
 
 	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_WORLD, &pChunk->xForm);
 
-	SetZBias(gpD3DDevice, pChunk->zBias);
+	SetZBias(pChunk->zBias);
 
 	if (GetDrawingEffect(pChunk->flags) == OF_TRANSLUCENT25)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
@@ -452,7 +452,7 @@ bool D3DMaterialObjectInvisibleChunk(d3d_render_chunk_new *pChunk)
 {
 	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_WORLD, &pChunk->xForm);
 
-	SetZBias(gpD3DDevice, pChunk->zBias);
+	SetZBias(pChunk->zBias);
 
 	if (GetDrawingEffect(pChunk->flags) == OF_TRANSLUCENT25)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,

--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -250,7 +250,7 @@ long D3DRenderObjects(
 	D3DCacheFill(objectsRenderParams.cacheSystem, objectsRenderParams.renderPool, 1);
 	D3DCacheFlush(objectsRenderParams.cacheSystem, objectsRenderParams.renderPool, 1, D3DPT_TRIANGLESTRIP);
 
-	SetZBias(gpD3DDevice, ZBIAS_DEFAULT);
+	SetZBias(ZBIAS_DEFAULT);
 
 	D3DRender_CaptureEffect(gameObjectDataParams.backBufferTexFull, gameObjectDataParams.backBufferTex[0]);
 

--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -252,8 +252,7 @@ long D3DRenderObjects(
 
 	SetZBias(gpD3DDevice, ZBIAS_DEFAULT);
 
-	D3DRenderFramebufferTextureCreate(gameObjectDataParams.backBufferTexFull, gameObjectDataParams.backBufferTex[0],
-		fontTextureParams.smallTextureSize, fontTextureParams.smallTextureSize);
+	D3DRender_CaptureEffect(gameObjectDataParams.backBufferTexFull, gameObjectDataParams.backBufferTex[0]);
 
 	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_VIEW, &objectsRenderParams.view);
 	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_PROJECTION, &objectsRenderParams.proj);

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -163,7 +163,7 @@ void D3DRenderSkyBox(Draw3DParams* params, int angleHeading, int anglePitch, con
 {
 	// Set render states for skybox
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_CULLMODE, D3DCULL_NONE);
-	SetZBias(gpD3DDevice, 0);
+	SetZBias(0);
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, FALSE);
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZENABLE, FALSE);
 

--- a/clientd3d/d3drender_world.c
+++ b/clientd3d/d3drender_world.c
@@ -62,7 +62,7 @@ long D3DRenderWorld(const WorldRenderParams &worldRenderParams, const WorldPrope
    // all opaque objects and then rendering all transparent objects in a separate pass.
    // This technique is also applied to draw_world, draw_objects, and light maps.
 
-   SetZBias(gpD3DDevice, ZBIAS_WORLD);
+   SetZBias(ZBIAS_WORLD);
    IDirect3DDevice9_SetVertexShader(gpD3DDevice, NULL);
    IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, worldRenderParams.vertexDeclaration);
    IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_CULLMODE, D3DCULL_CW);
@@ -135,7 +135,7 @@ long D3DRenderWorld(const WorldRenderParams &worldRenderParams, const WorldPrope
    D3DRenderWorldLighting(worldRenderParams, lightAndTextureParams);
 
    IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_CULLMODE, D3DCULL_NONE);
-   SetZBias(gpD3DDevice, 1);
+   SetZBias(1);
 
    // Disable alpha testing
    D3DRender_SetAlphaTestState(FALSE, alpha_test_threshold, D3DCMP_GREATEREQUAL);
@@ -155,7 +155,7 @@ void D3DRenderWorldLighting(const WorldRenderParams &worldRenderParams,
       IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MAGFILTER, worldRenderParams.driverProfile.magFilter);
       IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MINFILTER, worldRenderParams.driverProfile.minFilter);
 
-      SetZBias(gpD3DDevice, ZBIAS_WORLD);
+      SetZBias(ZBIAS_WORLD);
       IDirect3DDevice9_SetVertexShader(gpD3DDevice, NULL);
       IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, worldRenderParams.vertexDeclarationSecondary);
 
@@ -414,7 +414,7 @@ void D3DRenderTransparentWallsPass(const WorldRenderParams &worldRenderParams)
    IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_WORLD, &matIdentity);
    IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_VIEW, &worldRenderParams.view);
    IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_PROJECTION, &worldRenderParams.proj);
-   SetZBias(gpD3DDevice, ZBIAS_WORLD);
+   SetZBias(ZBIAS_WORLD);
    IDirect3DDevice9_SetVertexShader(gpD3DDevice, NULL);
    IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, worldRenderParams.vertexDeclaration);
    IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_CULLMODE, D3DCULL_CW);

--- a/clientd3d/graphics.c
+++ b/clientd3d/graphics.c
@@ -19,8 +19,6 @@
 //	Duplicate of what is in merint\userarea.h.
 #define USERAREA_HEIGHT 64
 
-extern AREA	gD3DView;
-
 /* Set to true when the room should be redrawn at the first opportunity */
 static bool need_redraw = false;
 


### PR DESCRIPTION
This PR refactors `d3drender.c` to be cleaned up and organized.  This includes moving part of the code in the source file into the header file.  The goal is similar to the header file refactor: to help with readability, debugging, and type safety.  

There should be no functional changes.  This PR optimizes the code by removing unused variables and converting certain variables into `static constexpr`, and there's an -87 net reduction in lines.  The high line count is due to moving helper functions into the header, and rearranging and organizing where variables and functions were defined.  Many macros were replaced with their C++ equivalent, and the whitespace in `d3drender.c` was adjusted to tab-based spacing to be consistent with the rest of the source file.

For now, certain externs were left in since they may trigger a lot more line changes in other source files.  If necessary, replacing them can be done in this PR or in a separate PR.

Refactoring
- Reorganized `d3drender.h` and `d3drender.c`.
  - Certain global variables from the source file were moved into the header.
  - Helper functions in `d3drender.c` moved into `d3drender.h` as inline helper functions.  Also removed them from Prototypes section.
  - `d3drender.h` globals section moved below structures section.
  - Split off external functions into its own section at the end of the header.
- Remove unused variables and function parameters.
  - Removed unused texture cache limits from top of source file and replaced them `static constexpr` of the ones used in `D3DRenderInit()`.
  - Debug variables for tracking render time were removed from `D3DRenderBegin()`.
- Rect setup in `d3drender.c` is made into its own helper function `GetScreenRect()`
- Refactored font glyph loop in `D3DRenderFontInit()` to use `int i = 0` instead and have character offset derived from it.
- Decoupled `x` and `y` variables in `D3DRenderFontInit()` for separate tasks.

Code Cleanup
- Replaced `NULL` with `nullptr`.
- Replaced Direct3D's C-style macros with C++ equivalents.
- Moved function variables declarations from start of function to at point-of use.
- Changed C-style type casting to use `static_cast`, `reinterpret_cast`, and `std::bit_cast`.
- Removed some redundancy.
  - Renamed `D3DRenderFramebufferTextureCreate()` to `D3DRender_CaptureEffect()`.  Removed unused `width` and `height` parameters.
  - Removed `getWhiteLightTexture()`.  Updated `d3drender_materials.c` to use `D3DRenderLightsGetWhite()` directly.
- Fixed possible memory leak in `D3DRenderShutdown()` where `gFont.kerningPairs` only deleted if textures existed.
