### PR TITLE
fix: restore soft falloff for one-shot positional sounds

### DIFF
--- a/clientd3d/audio_openal.c
+++ b/clientd3d/audio_openal.c
@@ -188,10 +188,8 @@ bool AudioInit(HWND hWnd)
    ALfloat listenerOri[] = { 0.0f, 0.0f, -1.0f, 0.0f, 1.0f, 0.0f }; // forward, up
    alListenerfv(AL_ORIENTATION, listenerOri);
 
-   /* Default distance model: linear clamped, used for SF_LOOP ambient
-    * emitters that should cut off at their kod-defined radius (fountains,
-    * firepits, etc.).  Per-source distance model is enabled below so that
-    * one-shot sounds can use an inverse curve instead (no hard cutoff). */
+   // Use linear falloff by default, but let each source pick its own
+   // curve so they don't all have to fade out the same way.
    alDistanceModel(AL_LINEAR_DISTANCE_CLAMPED);
    alEnable(AL_SOURCE_DISTANCE_MODEL);
 
@@ -1029,13 +1027,13 @@ bool SoundPlay(const char* filename, int volume, BYTE flags,
       alSourcei(source, AL_SOURCE_RELATIVE, AL_FALSE);
       alSource3f(source, AL_POSITION, -(float)src_col, 0.0f, (float)src_row);
 
-      /* Pick the distance attenuation curve:
- *   - If the Blakod set a radius, fade linearly from full volume
- *     at 1 tile to silence at that radius (hard cutoff).  Used
- *     for looping emitters and one-shots with an explicit range.
- *   - Otherwise use OpenAL's "inverse" model: a 1/distance curve
- *     that halves every time distance doubles and never reaches
- *     zero, so distant one-shots stay faintly audible. */
+      // Pick the distance attenuation curve:
+      //   - If the caller set a radius, fade linearly from full volume
+      //     at 1 tile to silence at that radius (hard cutoff).  Used
+      //     for looping sources and one-shots with an explicit range.
+      //   - Otherwise use OpenAL's "inverse" model: a 1/distance curve
+      //     that halves every time distance doubles and never reaches
+      //     zero, so distant one-shots stay faintly audible.
       ALenum model;
       float refDist, maxDist;
       if ((flags & SF_LOOP) || radius > 0)

--- a/clientd3d/audio_openal.c
+++ b/clientd3d/audio_openal.c
@@ -188,8 +188,12 @@ bool AudioInit(HWND hWnd)
    ALfloat listenerOri[] = { 0.0f, 0.0f, -1.0f, 0.0f, 1.0f, 0.0f }; // forward, up
    alListenerfv(AL_ORIENTATION, listenerOri);
 
-   // Use linear distance model for predictable 3D audio falloff
+   /* Default distance model: linear clamped, used for SF_LOOP ambient
+    * emitters that should cut off at their kod-defined radius (fountains,
+    * firepits, etc.).  Per-source distance model is enabled below so that
+    * one-shot sounds can use an inverse curve instead (no hard cutoff). */
    alDistanceModel(AL_LINEAR_DISTANCE_CLAMPED);
+   alEnable(AL_SOURCE_DISTANCE_MODEL);
 
    g_initialized = true;
 
@@ -1025,9 +1029,31 @@ bool SoundPlay(const char* filename, int volume, BYTE flags,
       alSourcei(source, AL_SOURCE_RELATIVE, AL_FALSE);
       alSource3f(source, AL_POSITION, -(float)src_col, 0.0f, (float)src_row);
 
-      // Distance attenuation: full volume within 1 tile, silent at radius
-      alSourcef(source, AL_REFERENCE_DISTANCE, 1.0f);
-      alSourcef(source, AL_MAX_DISTANCE, (float)radius);
+      /* Pick the distance attenuation curve:
+ *   - If the Blakod set a radius, fade linearly from full volume
+ *     at 1 tile to silence at that radius (hard cutoff).  Used
+ *     for looping emitters and one-shots with an explicit range.
+ *   - Otherwise use OpenAL's "inverse" model: a 1/distance curve
+ *     that halves every time distance doubles and never reaches
+ *     zero, so distant one-shots stay faintly audible. */
+      ALenum model;
+      float refDist, maxDist;
+      if ((flags & SF_LOOP) || radius > 0)
+      {
+         float r = (radius > 0) ? (float)radius : (float)VOLUME_CUTOFF_DISTANCE;
+         model   = AL_LINEAR_DISTANCE_CLAMPED;
+         refDist = 1.0f;
+         maxDist = r;
+      }
+      else
+      {
+         model   = AL_INVERSE_DISTANCE_CLAMPED;
+         refDist = 2.0f;
+         maxDist = 10000.0f;
+      }
+      alSourcei(source, AL_DISTANCE_MODEL, model);
+      alSourcef(source, AL_REFERENCE_DISTANCE, refDist);
+      alSourcef(source, AL_MAX_DISTANCE, maxDist);
       alSourcef(source, AL_ROLLOFF_FACTOR, 1.0f);
 
       float gain = (float)max_vol / (float)MAX_VOLUME;

--- a/clientd3d/game.c
+++ b/clientd3d/game.c
@@ -652,11 +652,8 @@ void GamePlaySound(ID sound_rsc, ID source_obj, BYTE flags, WORD y, WORD x, WORD
 	 volume = maxvolume - (distance * maxvolume / cutoff) ;
       }
    }
-   /* Pass raw radius (not the defaulted cutoff) so SoundPlay can tell
-    * whether the Blakod explicitly set a cutoff radius for this sound.  A
-    * Blakod-set radius means the author wants a hard cutoff at that
-    * distance; radius of 0 means "no opinion" and SoundPlay will use a
-    * soft inverse falloff. */
+   // Pass the raw radius so the audio layer can tell a caller-specified
+   // radius (radius > 0) apart from "use the default" (radius == 0).
    PlayWaveRsc(sound_rsc, volume, flags, src_row, src_col, radius, maxvolume);
 }
 /************************************************************************/

--- a/clientd3d/game.c
+++ b/clientd3d/game.c
@@ -652,7 +652,12 @@ void GamePlaySound(ID sound_rsc, ID source_obj, BYTE flags, WORD y, WORD x, WORD
 	 volume = maxvolume - (distance * maxvolume / cutoff) ;
       }
    }
-   PlayWaveRsc(sound_rsc, volume, flags, src_row, src_col, cutoff, maxvolume);
+   /* Pass raw radius (not the defaulted cutoff) so SoundPlay can tell
+    * whether the Blakod explicitly set a cutoff radius for this sound.  A
+    * Blakod-set radius means the author wants a hard cutoff at that
+    * distance; radius of 0 means "no opinion" and SoundPlay will use a
+    * soft inverse falloff. */
+   PlayWaveRsc(sound_rsc, volume, flags, src_row, src_col, radius, maxvolume);
 }
 /************************************************************************/
 void GameQuit(void)

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -232,10 +232,53 @@ played at equal volume in both stereo channels (no panning).
 
 ### Distance Model
 
-- **Model:** Linear distance clamped
-- **Reference distance:** 1 tile (full volume)
-- **Max distance:** Radius from server (silence beyond)
-- **Coordinate mapping:** Game coords to OpenAL coords (X negated for handedness)
+The client uses two different OpenAL distance models depending on whether a
+sound is a one-shot effect or a looping ambient emitter, and whether the
+Blakod explicitly specified a cutoff radius:
+
+| Sound type | Blakod-set radius? | Distance model | Reference distance | Max distance | Behavior |
+|------------|--------------------|----------------|--------------------|--------------|----------|
+| `SF_LOOP` ambient (fountain, firepit, forge) | yes (always) | `AL_LINEAR_DISTANCE_CLAMPED` | 1 tile | radius | Linear falloff to silence at the Blakod-defined radius |
+| One-shot with explicit radius (door, scripted area effect) | yes | `AL_LINEAR_DISTANCE_CLAMPED` | 1 tile | radius | Linear falloff to silence at the Blakod-defined radius |
+| One-shot with no radius (combat, spells, generic effects) | no | `AL_INVERSE_DISTANCE_CLAMPED` | 2 tiles | 10000 (effectively unbounded) | Smooth `1/d` falloff, never reaches silence |
+
+The Blakod communicates intent via the `cutoff_radius` parameter on
+`SomethingWaveRoom` / `WaveSendUser`:
+
+- `cutoff_radius = 0` (default in `user.kod`'s `WaveSendUser`):  no opinion.
+  One-shots get the soft inverse falloff so distant combat/spells stay
+  audible across the room, matching pre-OpenAL Miles Sound System behavior
+  where `GamePlaySound()` computed `volume = MAX_VOLUME * 2 / distance` and
+  never let a sound reach zero.
+- `cutoff_radius = N` (Blakod set it explicitly):  the Blakod author wants
+  a hard cutoff at N tiles.  Used by door open/close (radius=4) so a door
+  slam in one corner of a large hall does not bleed across the whole room.
+
+Loops always use the linear-clamped model with their Blakod-defined radius.
+Without the cutoff, every loaded ambient emitter (fountain in every room,
+firepit in every cave) would mix together forever with no way to bound CPU
+or audio mix complexity.  `fountain.kod` defaults `piSoundRadius = 40` and
+firepits typically use 5.
+
+Per-source distance models are enabled via `AL_EXT_source_distance_model`
+(`alEnable(AL_SOURCE_DISTANCE_MODEL)` at init), which lets each source pick
+its own model independently of the global default.
+
+```mermaid
+flowchart TD
+    A["SoundPlay called"] --> B{"Has positional<br/>coordinates?"}
+    B -->|"No"| C["Centered on local listener<br/>(SOURCE_RELATIVE, no falloff)<br/>Plays equally L/R for this client only"]
+    B -->|"Yes"| D{"SF_LOOP flag set?"}
+    D -->|"Yes (fountain, firepit)"| E["AL_LINEAR_DISTANCE_CLAMPED<br/>ref=1, max=radius<br/>Hard cutoff at radius"]
+    D -->|"No"| G{"Blakod-set radius?<br/>(radius > 0)"}
+    G -->|"Yes (door, area effect)"| H["AL_LINEAR_DISTANCE_CLAMPED<br/>ref=1, max=radius<br/>Hard cutoff at radius"]
+    G -->|"No (combat, spell)"| F["AL_INVERSE_DISTANCE_CLAMPED<br/>ref=2, max=10000<br/>Soft 1/d falloff, no cutoff"]
+
+    style C fill:#1864ab,color:#fff
+    style E fill:#2f9e44,color:#fff
+    style H fill:#2f9e44,color:#fff
+    style F fill:#2f9e44,color:#fff
+```
 
 ### Coordinate System
 

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -132,8 +132,7 @@ theme.mp3 -> theme.ogg
 
 This mapping happens in `ConvertLegacyMusicExtension()` in music.c.
 
-Sound effects also prefer .ogg over .wav. When a .wav file is requested, the audio
-system first checks if an .ogg version exists and uses that instead.
+Sound effects also prefer .ogg over .wav. When a .wav file is requested, the audio system first checks if an .ogg version exists and uses that instead.
 
 ### File Naming Convention
 
@@ -158,14 +157,11 @@ Sound effects are cached using an LRU (Least Recently Used) strategy:
 - **Protection:** Buffers currently playing are never evicted
 - **Lookup:** O(1) via case-insensitive hash map
 
-Music is NOT cached because tracks are large and typically don't repeat rapidly.
-Instead, music uses streaming playback (see below).
+Music is NOT cached because tracks are large and typically don't repeat rapidly. Instead, music uses streaming playback (see below).
 
 ## Music Streaming
 
-Music files are played via streaming rather than full-file decoding. This eliminates
-the loading hitch that occurred when decompressing entire OGG files (30-50 MB of
-decoded PCM from 2-7 MB OGG files) in a single blocking call on the main thread.
+Music files are played via streaming rather than full-file decoding. This eliminates the loading hitch that occurred when decompressing entire OGG files (30-50 MB of decoded PCM from 2-7 MB OGG files) in a single blocking call on the main thread.
 
 ### How It Works
 
@@ -180,14 +176,9 @@ chunks and fed to OpenAL through a ring buffer:
 | Memory per buffer | 16,384 bytes (stereo 16-bit) |
 | Total streaming memory | ~64 KB (vs 30-50 MB full decode) |
 
-Music streaming runs on a dedicated background thread (`MusicThreadProc`) started
-in `AudioInit()`. The thread decodes OGG data and rotates OpenAL buffers independently
-of the main thread, so buffer refills cannot be starved by UI activity.
+Music streaming runs on a dedicated background thread (`MusicThreadProc`) started in `AudioInit()`. The thread decodes OGG data and rotates OpenAL buffers independently of the main thread, so buffer refills cannot be starved by UI activity.
 
-`MusicPlay()`, `MusicStop()`, and `MusicSetVolume()` post commands to the thread
-and return immediately. `MusicStreamUpdate()` queries `AL_BUFFERS_PROCESSED` to find
-consumed buffers, decodes the next chunk, and re-queues. If the source underruns,
-it restarts automatically. Looping seeks the decoder back to the start at EOF.
+`MusicPlay()`, `MusicStop()`, and `MusicSetVolume()` post commands to the thread and return immediately. `MusicStreamUpdate()` queries `AL_BUFFERS_PROCESSED` to find consumed buffers, decodes the next chunk, and re-queues. If the source underruns, it restarts automatically. Looping seeks the decoder back to the start at EOF.
 
 ```mermaid
 graph LR
@@ -219,8 +210,7 @@ graph LR
 
 ### Which Sounds Are Positional?
 
-Not all sounds use 3D positioning. This matches the original MSS behavior where all sounds
-played at equal volume in both stereo channels (no panning).
+Not all sounds use 3D positioning. This matches the original MSS behavior where all sounds played at equal volume in both stereo channels (no panning).
 
 | Sound Type | Positional? | Rationale |
 |------------|-------------|----------|
@@ -232,9 +222,7 @@ played at equal volume in both stereo channels (no panning).
 
 ### Distance Model
 
-The client uses two different OpenAL distance models depending on whether a
-sound is a one-shot effect or a looping ambient emitter, and whether the
-Blakod explicitly specified a cutoff radius:
+The client uses two different OpenAL distance models depending on whether a sound is a one-shot effect or a looping ambient emitter, and whether the Blakod explicitly specified a cutoff radius:
 
 | Sound type | Blakod-set radius? | Distance model | Reference distance | Max distance | Behavior |
 |------------|--------------------|----------------|--------------------|--------------|----------|
@@ -242,27 +230,14 @@ Blakod explicitly specified a cutoff radius:
 | One-shot with explicit radius (door, scripted area effect) | yes | `AL_LINEAR_DISTANCE_CLAMPED` | 1 tile | radius | Linear falloff to silence at the Blakod-defined radius |
 | One-shot with no radius (combat, spells, generic effects) | no | `AL_INVERSE_DISTANCE_CLAMPED` | 2 tiles | 10000 (effectively unbounded) | Smooth `1/d` falloff, never reaches silence |
 
-The Blakod communicates intent via the `cutoff_radius` parameter on
-`SomethingWaveRoom` / `WaveSendUser`:
+The Blakod communicates intent via the `cutoff_radius` parameter on `SomethingWaveRoom` / `WaveSendUser`:
 
-- `cutoff_radius = 0` (default in `user.kod`'s `WaveSendUser`):  no opinion.
-  One-shots get the soft inverse falloff so distant combat/spells stay
-  audible across the room, matching pre-OpenAL Miles Sound System behavior
-  where `GamePlaySound()` computed `volume = MAX_VOLUME * 2 / distance` and
-  never let a sound reach zero.
-- `cutoff_radius = N` (Blakod set it explicitly):  the Blakod author wants
-  a hard cutoff at N tiles.  Used by door open/close (radius=4) so a door
-  slam in one corner of a large hall does not bleed across the whole room.
+- `cutoff_radius = 0` (default in `user.kod`'s `WaveSendUser`): no opinion. One-shots get the soft inverse falloff so distant combat/spells stay audible across the room, matching pre-OpenAL Miles Sound System behavior where `GamePlaySound()` computed `volume = MAX_VOLUME * 2 / distance` and never let a sound reach zero.
+- `cutoff_radius = N` (Blakod set it explicitly): the Blakod author wants a hard cutoff at N tiles. Used by door open/close (radius=4) so a door slam in one corner of a large hall does not bleed across the whole room.
 
-Loops always use the linear-clamped model with their Blakod-defined radius.
-Without the cutoff, every loaded ambient emitter (fountain in every room,
-firepit in every cave) would mix together forever with no way to bound CPU
-or audio mix complexity.  `fountain.kod` defaults `piSoundRadius = 40` and
-firepits typically use 5.
+Loops always use the linear-clamped model with their Blakod-defined radius. Without the cutoff, every loaded ambient emitter (fountain in every room, firepit in every cave) would mix together forever with no way to bound CPU or audio mix complexity. `fountain.kod` defaults `piSoundRadius = 40` and firepits typically use 5.
 
-Per-source distance models are enabled via `AL_EXT_source_distance_model`
-(`alEnable(AL_SOURCE_DISTANCE_MODEL)` at init), which lets each source pick
-its own model independently of the global default.
+Per-source distance models are enabled via `AL_EXT_source_distance_model` (`alEnable(AL_SOURCE_DISTANCE_MODEL)` at init), which lets each source pick its own model independently of the global default.
 
 ```mermaid
 flowchart TD
@@ -287,9 +262,7 @@ All audio positioning uses **tile coordinates** (coarse grid), not fine coordina
 - **Fine coords:** High precision (e.g., 39424, 56832), used for smooth player movement
 - **Tile coords:** Coarse grid (e.g., 56, 18), conversion: `tile = fine >> LOG_FINENESS`
 
-`GamePlaySound()` normalizes object positions (fine) to tile coords before calling audio.
-`UpdateLoopingSounds()` converts player position (fine) to tile coords for the listener.
-Server-provided ambient sound positions are already in tile coords.
+`GamePlaySound()` normalizes object positions (fine) to tile coords before calling audio. `UpdateLoopingSounds()` converts player position (fine) to tile coords for the listener. Server-provided ambient sound positions are already in tile coords.
 
 The listener position is updated each frame via `AudioUpdateListener()`.
 
@@ -315,12 +288,9 @@ When adding new sound files to the game, follow these guidelines for optimal pla
 
 ### Why Mono for 3D Audio?
 
-OpenAL uses the mono audio data and applies HRTF/panning based on the sound's position
-relative to the listener. With stereo files, OpenAL cannot determine how to spatialize
-the left vs right channels, so it plays them as-is (no 3D effect).
+OpenAL uses the mono audio data and applies HRTF/panning based on the sound's position relative to the listener. With stereo files, OpenAL cannot determine how to spatialize the left vs right channels, so it plays them as-is (no 3D effect).
 
-If you notice a sound effect is not panning correctly when you move around it in-game,
-check if the source file is stereo and convert it to mono.
+If you notice a sound effect is not panning correctly when you move around it in-game, check if the source file is stereo and convert it to mono.
 
 ## Configuration
 
@@ -339,8 +309,7 @@ OpenAL Soft supports multiple audio output modes configured via `alsoft.ini` (us
 
 ### HRTF (Headphone 3D Audio)
 
-Head-Related Transfer Function simulates 3D audio for headphone users by applying filters
-that mimic how sound reaches your ears from different directions.
+Head-Related Transfer Function simulates 3D audio for headphone users by applying filters that mimic how sound reaches your ears from different directions.
 
 To enable HRTF, create or edit `alsoft.ini`:
 
@@ -349,14 +318,11 @@ To enable HRTF, create or edit `alsoft.ini`:
 hrtf = true
 ```
 
-OpenAL Soft ships with built-in HRTF data. Additional HRTF profiles (.mhr files) can be
-placed in the OpenAL Soft data directory.
+OpenAL Soft ships with built-in HRTF data. Additional HRTF profiles (.mhr files) can be placed in the OpenAL Soft data directory.
 
 ### Surround Sound (5.1 / 7.1)
 
-OpenAL Soft automatically detects and uses your system's speaker configuration. For
-multi-channel setups (5.1, 7.1), 3D positional sounds will be correctly spatialized
-across all speakers.
+OpenAL Soft automatically detects and uses your system's speaker configuration. For multi-channel setups (5.1, 7.1), 3D positional sounds will be correctly spatialized across all speakers.
 
 To force a specific output mode in `alsoft.ini`:
 
@@ -365,8 +331,7 @@ To force a specific output mode in `alsoft.ini`:
 channels = surround51   ; Options: mono, stereo, quad, surround51, surround61, surround71
 ```
 
-No game configuration is required—OpenAL Soft handles speaker routing automatically
-based on your Windows audio device settings.
+No game configuration is required—OpenAL Soft handles speaker routing automatically based on your Windows audio device settings.
 
 ## Dependencies
 

--- a/module/merintr/statlist.c
+++ b/module/merintr/statlist.c
@@ -29,7 +29,6 @@ extern HWND hStats;
 static int num_visible;             // # of stats visible in list box
 
 static int StatListFindItem(int num);
-static void StatsListUpdateScrollPos(HWND hwnd, int pos);
 static LRESULT CALLBACK StatsListProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 static void StatsListDrawStat(const DRAWITEMSTRUCT *lpdis, bool selected);
 static int  StatsListGetItemHeight(void);
@@ -88,22 +87,13 @@ void StatsListResize(list_type stats)
 
    // Hide scrollbar if not needed
    num_visible = (stats_area.cy - y) / std::max(ListBox_GetItemHeight(hList, 0), 1);
-   SCROLLINFO si = { sizeof(si), SIF_RANGE | SIF_PAGE | SIF_POS };
    if (num_visible >= ListBox_GetCount(hList))
-   {
-      si.nMin = 0;
-      si.nMax = 0;
-      si.nPage = 0;
-      si.nPos = 0;
-   }
+     SetScrollRange(hList, SB_VERT, 0, 0, TRUE);
    else
-   {
-      si.nMin = 0;
-      si.nMax = ListBox_GetCount(hList) - 1;
-      si.nPage = num_visible;
-      si.nPos = ListBox_GetTopIndex(hList);
-   }
-   SetScrollInfo(hList, SB_VERT, &si, TRUE);
+     {
+       SetScrollRange(hList, SB_VERT, 0, ListBox_GetCount(hList) - num_visible, TRUE);
+       SetScrollPos(hList, SB_VERT, ListBox_GetTopIndex(hList), TRUE);
+     }
 
 	if( StatsGetCurrentGroup() != STATS_INVENTORY )			//	ajw
 		ShowWindow(hList, SW_NORMAL);
@@ -164,16 +154,6 @@ int StatListFindItem(int num)
 }
 /************************************************************************/
 /*
- * StatsListUpdateScrollPos:  Set the scrollbar thumb position.
- */
-void StatsListUpdateScrollPos(HWND hwnd, int pos)
-{
-   SCROLLINFO si = { sizeof(si), SIF_POS };
-   si.nPos = pos;
-   SetScrollInfo(hwnd, SB_VERT, &si, TRUE);
-}
-/************************************************************************/
-/*
  * StatsListProc:  Subclassed window procedure for list box.
  */
 LRESULT CALLBACK StatsListProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
@@ -186,21 +166,8 @@ LRESULT CALLBACK StatsListProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lP
       break;
 
    case WM_MOUSEWHEEL:
-   {
-      /* Let the default handler scroll the listbox content, then sync
-         the scrollbar thumb position.  The default handler calls
-         ListBox_SetTopIndex internally but does not update the
-         manually managed scrollbar. */
-      int old_top = ListBox_GetTopIndex(hwnd);
-      LRESULT result = CallWindowProc(lpfnDefStatListProc, hwnd, message, wParam, lParam);
-      int new_top = ListBox_GetTopIndex(hwnd);
-      if (new_top != old_top)
-      {
-         StatsListUpdateScrollPos(hwnd, new_top);
-         InvalidateRect(hList, NULL, TRUE);
-      }
-      return result;
-   }
+      InvalidateRect(hList, NULL, TRUE);
+      break;
 
       HANDLE_MSG(hwnd, WM_VSCROLL, StatsListVScroll);
 
@@ -485,7 +452,7 @@ void StatsListVScroll(HWND hwnd, HWND hwndCtl, UINT code, int pos)
 
    if (new_top != old_top)
    {
-      StatsListUpdateScrollPos(hwnd, new_top);
+      SetScrollPos(hwnd, SB_VERT, new_top, TRUE); 
 
       WindowBeginUpdate(hwnd);
       ListBox_SetTopIndex(hwnd, new_top);
@@ -518,7 +485,7 @@ bool StatListKey(HWND hwnd, UINT key, bool fDown, int cRepeat, UINT flags)
        new_top = new_pos;
      ListBox_SetTopIndex(hwnd, new_top);
      ListBox_SetCurSel(hwnd, new_pos);
-     StatsListUpdateScrollPos(hwnd, new_top);
+     SetScrollPos(hwnd, SB_VERT, new_top, TRUE); 
      WindowEndUpdate(hwnd);
      return true;
 
@@ -529,7 +496,7 @@ bool StatListKey(HWND hwnd, UINT key, bool fDown, int cRepeat, UINT flags)
        new_top = new_pos - num_visible;
      ListBox_SetTopIndex(hwnd, new_top);
      ListBox_SetCurSel(hwnd, new_pos);
-     StatsListUpdateScrollPos(hwnd, new_top);
+     SetScrollPos(hwnd, SB_VERT, new_top, TRUE); 
      WindowEndUpdate(hwnd);
      return true;
 
@@ -539,7 +506,7 @@ bool StatListKey(HWND hwnd, UINT key, bool fDown, int cRepeat, UINT flags)
      new_top = new_pos;
      ListBox_SetTopIndex(hwnd, new_top);
      ListBox_SetCurSel(hwnd, new_pos);
-     StatsListUpdateScrollPos(hwnd, new_top);
+     SetScrollPos(hwnd, SB_VERT, new_top, TRUE); 
      WindowEndUpdate(hwnd);
      return true;
 
@@ -549,7 +516,7 @@ bool StatListKey(HWND hwnd, UINT key, bool fDown, int cRepeat, UINT flags)
      new_top = new_pos - num_visible;
      ListBox_SetTopIndex(hwnd, new_top);
      ListBox_SetCurSel(hwnd, new_pos);
-     StatsListUpdateScrollPos(hwnd, new_top);
+     SetScrollPos(hwnd, SB_VERT, new_top, TRUE); 
      WindowEndUpdate(hwnd);
      return true;
 

--- a/module/merintr/statlist.c
+++ b/module/merintr/statlist.c
@@ -29,6 +29,7 @@ extern HWND hStats;
 static int num_visible;             // # of stats visible in list box
 
 static int StatListFindItem(int num);
+static void StatsListUpdateScrollPos(HWND hwnd, int pos);
 static LRESULT CALLBACK StatsListProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 static void StatsListDrawStat(const DRAWITEMSTRUCT *lpdis, bool selected);
 static int  StatsListGetItemHeight(void);
@@ -87,13 +88,22 @@ void StatsListResize(list_type stats)
 
    // Hide scrollbar if not needed
    num_visible = (stats_area.cy - y) / std::max(ListBox_GetItemHeight(hList, 0), 1);
+   SCROLLINFO si = { sizeof(si), SIF_RANGE | SIF_PAGE | SIF_POS };
    if (num_visible >= ListBox_GetCount(hList))
-     SetScrollRange(hList, SB_VERT, 0, 0, TRUE);
+   {
+      si.nMin = 0;
+      si.nMax = 0;
+      si.nPage = 0;
+      si.nPos = 0;
+   }
    else
-     {
-       SetScrollRange(hList, SB_VERT, 0, ListBox_GetCount(hList) - num_visible, TRUE);
-       SetScrollPos(hList, SB_VERT, ListBox_GetTopIndex(hList), TRUE);
-     }
+   {
+      si.nMin = 0;
+      si.nMax = ListBox_GetCount(hList) - 1;
+      si.nPage = num_visible;
+      si.nPos = ListBox_GetTopIndex(hList);
+   }
+   SetScrollInfo(hList, SB_VERT, &si, TRUE);
 
 	if( StatsGetCurrentGroup() != STATS_INVENTORY )			//	ajw
 		ShowWindow(hList, SW_NORMAL);
@@ -154,6 +164,16 @@ int StatListFindItem(int num)
 }
 /************************************************************************/
 /*
+ * StatsListUpdateScrollPos:  Set the scrollbar thumb position.
+ */
+void StatsListUpdateScrollPos(HWND hwnd, int pos)
+{
+   SCROLLINFO si = { sizeof(si), SIF_POS };
+   si.nPos = pos;
+   SetScrollInfo(hwnd, SB_VERT, &si, TRUE);
+}
+/************************************************************************/
+/*
  * StatsListProc:  Subclassed window procedure for list box.
  */
 LRESULT CALLBACK StatsListProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
@@ -166,8 +186,21 @@ LRESULT CALLBACK StatsListProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lP
       break;
 
    case WM_MOUSEWHEEL:
-      InvalidateRect(hList, NULL, TRUE);
-      break;
+   {
+      /* Let the default handler scroll the listbox content, then sync
+         the scrollbar thumb position.  The default handler calls
+         ListBox_SetTopIndex internally but does not update the
+         manually managed scrollbar. */
+      int old_top = ListBox_GetTopIndex(hwnd);
+      LRESULT result = CallWindowProc(lpfnDefStatListProc, hwnd, message, wParam, lParam);
+      int new_top = ListBox_GetTopIndex(hwnd);
+      if (new_top != old_top)
+      {
+         StatsListUpdateScrollPos(hwnd, new_top);
+         InvalidateRect(hList, NULL, TRUE);
+      }
+      return result;
+   }
 
       HANDLE_MSG(hwnd, WM_VSCROLL, StatsListVScroll);
 
@@ -452,7 +485,7 @@ void StatsListVScroll(HWND hwnd, HWND hwndCtl, UINT code, int pos)
 
    if (new_top != old_top)
    {
-      SetScrollPos(hwnd, SB_VERT, new_top, TRUE); 
+      StatsListUpdateScrollPos(hwnd, new_top);
 
       WindowBeginUpdate(hwnd);
       ListBox_SetTopIndex(hwnd, new_top);
@@ -485,7 +518,7 @@ bool StatListKey(HWND hwnd, UINT key, bool fDown, int cRepeat, UINT flags)
        new_top = new_pos;
      ListBox_SetTopIndex(hwnd, new_top);
      ListBox_SetCurSel(hwnd, new_pos);
-     SetScrollPos(hwnd, SB_VERT, new_top, TRUE); 
+     StatsListUpdateScrollPos(hwnd, new_top);
      WindowEndUpdate(hwnd);
      return true;
 
@@ -496,7 +529,7 @@ bool StatListKey(HWND hwnd, UINT key, bool fDown, int cRepeat, UINT flags)
        new_top = new_pos - num_visible;
      ListBox_SetTopIndex(hwnd, new_top);
      ListBox_SetCurSel(hwnd, new_pos);
-     SetScrollPos(hwnd, SB_VERT, new_top, TRUE); 
+     StatsListUpdateScrollPos(hwnd, new_top);
      WindowEndUpdate(hwnd);
      return true;
 
@@ -506,7 +539,7 @@ bool StatListKey(HWND hwnd, UINT key, bool fDown, int cRepeat, UINT flags)
      new_top = new_pos;
      ListBox_SetTopIndex(hwnd, new_top);
      ListBox_SetCurSel(hwnd, new_pos);
-     SetScrollPos(hwnd, SB_VERT, new_top, TRUE); 
+     StatsListUpdateScrollPos(hwnd, new_top);
      WindowEndUpdate(hwnd);
      return true;
 
@@ -516,7 +549,7 @@ bool StatListKey(HWND hwnd, UINT key, bool fDown, int cRepeat, UINT flags)
      new_top = new_pos - num_visible;
      ListBox_SetTopIndex(hwnd, new_top);
      ListBox_SetCurSel(hwnd, new_pos);
-     SetScrollPos(hwnd, SB_VERT, new_top, TRUE); 
+     StatsListUpdateScrollPos(hwnd, new_top);
      WindowEndUpdate(hwnd);
      return true;
 


### PR DESCRIPTION
## What

- Fixes a regression introduced in the OpenAL migration (PR #1293) where one-shot positional sounds (combat, spells, etc.) became silent past a hard ~16 tile cutoff
- Splits the 3D distance model in `SoundPlay()` into two cases: sounds with a Blakod-set radius (looping ambients and one-shots with an explicit range) keep their hard cutoff; sounds with no Blakod-set radius use a smooth inverse falloff that never hits zero
- Updated `audio.md` to reflect these changes and also removed the 80 char carriage returns in the file

## Why

- Players reported being unable to hear nearby combat or spells from sources more than ~16 tiles away after the OpenAL update
> Oof I need to test it out a bit more but I believe the 'dynamic drop off' on sound volume is quite steep. You can hear a sound, such as combat, getting quieter as you move away from it, and after quite a short distance - maybe battle bow range - you cannot hear it at all. zero volume. So a ton of sound information is being lost as to what is happening

> You can only hear anything happening about 10 feet away from your character at any given time. 

- Pre-OpenAL behavior used two separate paths:
  - one-shots: `volume = MAX_VOLUME * 2 / distance` (a 1/d curve, never reached zero, audible across the entire room)
  - looping ambients: hard linear cutoff at the Blakod-defined `iSoundRadius` (correct, this is the whole point of the radius parameter)
- The OpenAL refactor unified both paths into `AL_LINEAR_DISTANCE_CLAMPED` with `AL_MAX_DISTANCE = radius`, applying the loop-style hard cliff to one-shots too
- The server defaults `cutoff_radius = 0` for nearly every sound it sends in `WaveSendUser` (`user.kod`), so one-shots fell back to the client's `VOLUME_CUTOFF_DISTANCE = 16` and went silent past 16 tiles
- Some Blakod paths (door open/close in `room.kod`) deliberately set `cutoff_radius = 4` so a door slam in one corner of a large hall does not bleed across the whole room.  That intent was correct and must be preserved
- The hard cutoff is still required for ambient loops, without it every fountain in every loaded room would mix together forever

## How

- `clientd3d/game.c GamePlaySound()`: pass the raw `radius` parameter through to `PlayWaveRsc` instead of the defaulted `cutoff` value, so the audio layer can tell "the Blakod set a radius" (`radius > 0`) apart from "no opinion" (`radius == 0`).  The internal volume calc still uses `cutoff` for the legacy non-positional path
- `clientd3d/audio_openal.c AudioInit()`: enable `AL_EXT_source_distance_model` via `alEnable(AL_SOURCE_DISTANCE_MODEL)` so each source can pick its own distance model
- `clientd3d/audio_openal.c SoundPlay()`: the positional branch picks one of two attenuation curves:
  - Blakod gave us a radius (looping emitters and one-shots with an explicit range): `AL_LINEAR_DISTANCE_CLAMPED`, `ref=1`, `max=radius`.  Honors the Blakod author's intent and prevents one-shots from leaking across large rooms; loops fall back to `VOLUME_CUTOFF_DISTANCE` if radius is 0, which should not happen in practice
  - No Blakod radius (combat, spells, generic effects): `AL_INVERSE_DISTANCE_CLAMPED`, `ref=2`, `max=10000`, `rolloff=1`.  Smooth `1/d` falloff matching the old MSS curve, never reaches zero
- The global default model stays linear-clamped so any future code path that does not opt in still gets safe behavior
- Updated `docs/audio.md` Distance Model section to document the split and added a flowchart of the routing in `SoundPlay()`

```mermaid
flowchart TD
    A["SoundPlay called"] --> B{"Has positional<br/>coordinates?"}
    B -->|"No"| C["Centered on local listener<br/>(SOURCE_RELATIVE, no falloff)<br/>Plays equally L/R for this client only"]
    B -->|"Yes"| D{"SF_LOOP flag set?"}
    D -->|"Yes (fountain, firepit)"| E["AL_LINEAR_DISTANCE_CLAMPED<br/>ref=1, max=radius<br/>Hard cutoff at radius"]
    D -->|"No"| G{"Blakod-set radius?<br/>(radius > 0)"}
    G -->|"Yes (door, area effect)"| H["AL_LINEAR_DISTANCE_CLAMPED<br/>ref=1, max=radius<br/>Hard cutoff at radius"]
    G -->|"No (combat, spell)"| F["AL_INVERSE_DISTANCE_CLAMPED<br/>ref=2, max=10000<br/>Soft 1/d falloff, no cutoff"]

    style C fill:#1864ab,color:#fff
    style E fill:#2f9e44,color:#fff
    style H fill:#2f9e44,color:#fff
    style F fill:#2f9e44,color:#fff
```

## Example

### Before

Combat one-shot at varying distances (radius defaulted to 16):

| Distance from source (tiles) | Gain |
|------------------------------|------|
| 1                            | 1.00 |
| 4                            | 0.80 |
| 8                            | 0.53 |
| 16                           | 0.00 (silent) |
| 32                           | 0.00 (silent) |

A player casting a spell 20 tiles away in the same room is completely inaudible.

### After

Combat one-shot with no Blakod-set radius (inverse falloff):

| Distance from source (tiles) | Gain |
|------------------------------|------|
| 1                            | 1.00 |
| 4                            | 0.50 |
| 8                            | 0.25 |
| 16                           | 0.125 |
| 32                           | 0.0625 |

Door open/close with `cutoff_radius = 4` (linear clamped, unchanged from before):

| Distance from source (tiles) | Gain |
|------------------------------|------|
| 1                            | 1.00 |
| 2                            | 0.67 |
| 3                            | 0.33 |
| 4                            | 0.00 (silent) |

Distant combat is faintly audible across the room (matching pre-OpenAL behavior), while doors still cut off cleanly at 4 tiles so a busy corridor does not become a wall of door noise.
