### PR TITLE
docs: remove Miles Sound System references from README, add OpenAL Soft

### DIFF
--- a/README
+++ b/README
@@ -23,9 +23,8 @@ the original source so that everyone can benefit.
 WHAT'S INCLUDED AND NOT INCLUDED
 
 The source to the client, server, game code, Blakod compiler, room
-editor, and all associated tools are included.  The source code to the
-Miles Sound System audio library is not included.  Client builds that you 
-make will use the fallback waveplay audio library instead.
+editor, and all associated tools are included.  Audio is handled by
+OpenAL Soft, whose prebuilt binaries are included in external/.
 
 
 BUILD INSTRUCTIONS
@@ -88,7 +87,9 @@ The blakserv.cfg file requires some manual changes to run on Linux.
 
 THIRD-PARTY CODE
 
-Meridian uses zlib, libpng, libarchive.  All three are built from source.
+Meridian uses zlib, libpng, libarchive, and OpenAL Soft.  zlib, libpng,
+and libarchive are built from source.  OpenAL Soft is included as a
+prebuilt binary (LGPL; see external/openal-soft/ for license details).
 libarchive was configured via cmake with the following cmake environment
 variables set to use zlib:
 


### PR DESCRIPTION
## What

- Removed stale references to the Miles Sound System and the waveplay fallback from the README; replaced with accurate mentions of OpenAL Soft.

## Why

- The README stated that MSS source was not included and that builds would fall back to waveplay.  Both statements are no longer true after the OpenAL migration (PR #1293).