### PR TITLE
fix: client proportional scrollbar thumb for inventory and stats panes

### DIFF
--- a/module/merintr/inventry.c
+++ b/module/merintr/inventry.c
@@ -332,7 +332,15 @@ void InventoryScrollRange(void)
 {
    /* Max is when last item is on bottom of list */
    if (cols != 0)
-      SetScrollRange(hwndInvScroll, SB_CTL, 0, (num_items + cols - 1) / cols - rows, TRUE);
+   {
+      int total_rows = (num_items + cols - 1) / cols;
+      SCROLLINFO si = { sizeof(si), SIF_RANGE | SIF_PAGE | SIF_POS };
+      si.nMin  = 0;
+      si.nMax  = total_rows - 1;
+      si.nPage = rows;
+      si.nPos  = top_row;
+      SetScrollInfo(hwndInvScroll, SB_CTL, &si, TRUE);
+   }
 }
 /************************************************************************/
 /*

--- a/module/merintr/statnum.c
+++ b/module/merintr/statnum.c
@@ -171,8 +171,12 @@ void StatsNumResize(list_type stats)
       MoveWindow(hStatsScroll, stats_area.cx - stats_scrollbar_width,
                y, stats_scrollbar_width, num_visible * height, FALSE);
       ShowWindow(hStatsScroll, SW_HIDE);
-      SetScrollRange(hStatsScroll, SB_CTL, 0, num_stats - num_visible, TRUE);
-      SetScrollPos(hStatsScroll, SB_CTL, top_stat, TRUE);
+      SCROLLINFO si = { sizeof(si), SIF_RANGE | SIF_PAGE | SIF_POS };
+      si.nMin  = 0;
+      si.nMax  = num_stats - 1;
+      si.nPage = num_visible;
+      si.nPos  = top_stat;
+      SetScrollInfo(hStatsScroll, SB_CTL, &si, TRUE);
       if (StatsGetCurrentGroup() != STATS_INVENTORY)  //	ajw
          ShowWindow(hStatsScroll, SW_SHOWNORMAL);
    }


### PR DESCRIPTION
## What

- Inventory and stats scrollbar thumbs are now proportional to content size, matching the spells/skills fix in PR #1405

## Why

- `SetScrollRange` does not carry a page size, so Windows draws a fixed-size thumb regardless of how many rows are visible vs total
- Inventory and stats panes use standalone scrollbar controls (separate from the listbox-based spells/skills pane), so the earlier fix did not cover them

## How

- `module/merintr/inventry.c InventoryScrollRange()`: replaced `SetScrollRange` with `SetScrollInfo` carrying `SIF_RANGE | SIF_PAGE | SIF_POS`, where `nPage = rows`
- `module/merintr/statnum.c` (numeric stats layout): replaced the `SetScrollRange` + `SetScrollPos` pair with a single `SetScrollInfo` call, where `nPage = num_visible`

## Example

<img width="812" height="550" alt="meridian_hG7o4HZ1IA" src="https://github.com/user-attachments/assets/b697258c-a4e1-4f90-84e2-c156f4fda180" />
Resizing the client adjusts the inventory thumb size based on the amount of visible items
