### PR TITLE
Reorganize D3DRender

### DIFF
--- a/clientd3d/bsp.h
+++ b/clientd3d/bsp.h
@@ -121,10 +121,12 @@ typedef struct
    float x, y;
 } Pnt, Pnt2D, Vector2D;
 
-typedef struct
+struct Vector3D
 {
    float x, y, z;
-} Pnt3D, Vector3D;
+};
+
+using Pnt3D = Vector3D;
 
 typedef struct ObjectData
 {

--- a/clientd3d/d3dcache.c
+++ b/clientd3d/d3dcache.c
@@ -127,7 +127,7 @@ LPDIRECT3DTEXTURE9 D3DCacheTextureLookupSwizzled(d3d_texture_cache *pTextureCach
 	if (NULL == pTexture)
 		return NULL;
 
-	pTexEntry = (d3d_texture_cache_entry *)D3DRenderMalloc(sizeof(d3d_texture_cache_entry));
+	pTexEntry = reinterpret_cast<d3d_texture_cache_entry*>( malloc(sizeof(d3d_texture_cache_entry)) );
 	assert(pTexEntry);
 
 	IDirect3DTexture9_GetLevelDesc(pTexture, 0, &surfDesc);
@@ -195,7 +195,7 @@ LPDIRECT3DTEXTURE9 D3DCacheTextureLookup(d3d_texture_cache *pTextureCache, d3d_r
 	if (NULL == pTexture)
 		return NULL;
 
-	pTexEntry = (d3d_texture_cache_entry *)D3DRenderMalloc(sizeof(d3d_texture_cache_entry));
+	pTexEntry = reinterpret_cast<d3d_texture_cache_entry*>( malloc(sizeof(d3d_texture_cache_entry)) );
 	assert(pTexEntry);
 
 	IDirect3DTexture9_GetLevelDesc(pTexture, 0, &surfDesc);
@@ -236,7 +236,7 @@ void D3DCacheSystemInit(d3d_render_cache_system *pCacheSystem, int texCacheSize)
 
 	memset(pCacheSystem, 0, sizeof(pCacheSystem));
 	
-	pRenderCache = (d3d_render_cache *)D3DRenderMalloc(sizeof(d3d_render_cache));
+	pRenderCache = reinterpret_cast<d3d_render_cache*>( malloc(sizeof(d3d_render_cache)) );
 
 	if (pRenderCache)
 	{
@@ -310,7 +310,7 @@ d3d_render_cache *D3DCacheSystemSwap(d3d_render_cache_system *pCacheSystem)
 	}
 	else
 	{
-		pRenderCache = (d3d_render_cache *)D3DRenderMalloc(sizeof(d3d_render_cache));
+		pRenderCache = reinterpret_cast<d3d_render_cache*>( malloc(sizeof(d3d_render_cache)) );
 
 		if (pRenderCache)
 		{

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -7,13 +7,9 @@
 // Meridian is a registered trademark.
 #include "client.h"
 
-#define	TEX_CACHE_MAX_OBJECT	8000000
-#define	TEX_CACHE_MAX_WORLD		8000000
-#define	TEX_CACHE_MAX_LMAP		8000000
-#define	TEX_CACHE_MAX_WALLMASK	2000000
-#define	TEX_CACHE_MAX_EFFECT	2000000
-#define	TEX_CACHE_MAX_PARTICLE	1000000
-
+///////////////
+// Variables //
+///////////////
 d3d_render_packet_new	*gpPacket;
 
 LPDIRECT3DTEXTURE9		gpNoLookThrough = NULL;
@@ -21,11 +17,6 @@ LPDIRECT3DTEXTURE9		gpViewElements[NUM_VIEW_ELEMENTS];
 
 D3DVIEWPORT9			gViewport;
 D3DCAPS9				gD3DCaps;
-
-d3d_render_cache		gObjectCache;
-d3d_render_cache		gWorldCache;
-d3d_render_cache		gWorldCacheStatic;
-d3d_render_cache		gLMapCacheStatic;
 
 d3d_render_cache_system	gObjectCacheSystem;
 d3d_render_cache_system	gWorldCacheSystem;
@@ -52,7 +43,6 @@ custom_xyz				playerOldPos;
 custom_xyz				playerDeltaPos;
 
 RECT					gD3DRect;
-BYTE					gViewerLight = 0;
 int						gNumObjects;
 int						gNumDPCalls;
 
@@ -89,12 +79,14 @@ LPDIRECT3DVERTEXDECLARATION9 decl0dc;
 LPDIRECT3DVERTEXDECLARATION9 decl1dc;
 LPDIRECT3DVERTEXDECLARATION9 decl2dc;
 
-AREA					gD3DView;
 int						gD3DRedrawAll = 0;
-int						gTemp = 0;
 
+D3DMATRIX view, mat, rot, trans, proj;
+
+//////////////////////
+// External Globals //
+//////////////////////
 extern long				viewer_height;
-extern PDIB				background;         /* Pointer to background bitmap */
 extern ObjectRange		visible_objects[];    /* Where objects are on screen */
 extern int				num_visible_objects;
 extern DrawItem			drawdata[];
@@ -102,30 +94,521 @@ extern long				nitems;
 extern int				sector_depths[];
 extern BYTE				*gBits;
 extern BYTE				*gBufferBits;
-extern D3DPRESENT_PARAMETERS	gPresentParam;
-extern long				stretchfactor;
 extern ViewElement		ViewElements[];
 extern HDC				gBitsDC;
 
-D3DMATRIX view, mat, rot, trans, proj;
+extern void			UpdateRoom3D(room_type *room, Draw3DParams *params);
+
+/////////////////////////
+// Internal Prototypes //
+/////////////////////////
+void D3DRenderPacketInit(d3d_render_packet_new *pPacket);
+void D3DRenderChunkInit(d3d_render_chunk_new *pChunk);
+void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool);
+
+/////////////////////////////
+// Internal Implementation //
+/////////////////////////////
+void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
+{
+	D3DCAPS9		d3dCaps;
+	HDC				hDC;
+   HBITMAP			hbmBitmap;
+	DWORD			*pBitmapBits;
+   BITMAPINFO		bmi;
+   long x = 0;
+   long y = 0;
+   TCHAR			str[2] = _T("x");
+	TCHAR			c;
+   SIZE			size;
+	D3DLOCKED_RECT	d3dlr;
+   WORD			*pDst16;
+   BYTE			bAlpha;
+
+   // Ask for a bigger font to reduce aliasing, then scale the texture
+   // down by the same amount.
+   float fontScale = 3.0;
+   HFONT hScaledFont = FontsGetScaledFont(hFont, fontScale);
+   assert(hScaledFont);
+      
+   pFont->fontHeight = GetFontHeight(hScaledFont);
+   pFont->texScale = fontScale;
+   
+	if (pFont->fontHeight > 40)
+		pFont->texWidth = pFont->texHeight = 1024;
+	else if (pFont->fontHeight > 20)
+		pFont->texWidth = pFont->texHeight = 512;
+	else
+		pFont->texWidth = pFont->texHeight = 256;
+
+	IDirect3DDevice9_GetDeviceCaps(gpD3DDevice, &d3dCaps);
+  
+	if (pFont->texWidth > (long) d3dCaps.MaxTextureWidth)
+	{
+		pFont->texScale *= (float)pFont->texWidth / (float)d3dCaps.MaxTextureWidth;
+		pFont->texHeight = pFont->texWidth = d3dCaps.MaxTextureWidth;
+	}
+  
+	if (pFont->pTexture)
+		IDirect3DTexture9_Release(pFont->pTexture);
+   
+   IDirect3DDevice9_CreateTexture(
+      gpD3DDevice, pFont->texWidth,
+      pFont->texHeight, 1, 0, D3DFMT_A4R4G4B4,
+      D3DPOOL_MANAGED, &pFont->pTexture, NULL);
+   
+   memset(&bmi.bmiHeader, 0, sizeof(BITMAPINFOHEADER));
+   bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+   bmi.bmiHeader.biWidth = (int)pFont->texWidth;
+   bmi.bmiHeader.biHeight = -(int)pFont->texHeight;
+   bmi.bmiHeader.biPlanes = 1;
+   bmi.bmiHeader.biCompression = BI_RGB;
+   bmi.bmiHeader.biBitCount = 32;
+   
+   hDC = CreateCompatibleDC(gBitsDC);
+   hbmBitmap = CreateDIBSection(hDC, &bmi, DIB_RGB_COLORS, (VOID**)&pBitmapBits, NULL, 0 );
+   SetMapMode(hDC, MM_TEXT);
+  
+   SelectObject(hDC, hbmBitmap);
+   SelectObject(hDC, hScaledFont);
+   
+   // Set text properties
+   SetTextColor(hDC, RGB(255,255,255));
+   SetBkColor(hDC, 0);
+   SetBkMode(hDC, TRANSPARENT);
+   SetTextAlign(hDC, TA_TOP);
+   
+   for(c = 32; c < 127; c++ )
+   {
+      int index = c-32;
+      
+      str[0] = c;
+      GetTextExtentPoint32(hDC, str, 1, &size);
+      
+      if (!GetCharABCWidths(hDC, c, c, &pFont->abc[index])) {
+         pFont->abc[index].abcA = 0;
+         pFont->abc[index].abcB = size.cx;
+         pFont->abc[index].abcC = 0;
+      }
+
+      size.cx = pFont->abc[index].abcB;
+
+      // Is this row of the texture filled up?
+      if (x + size.cx >= pFont->texWidth)
+      {
+         x = 0;
+         y += size.cy + 1;
+      }
+      
+      int left_offset = pFont->abc[index].abcA;
+      ExtTextOut(hDC, x - left_offset, y+0, 0, NULL, str, 1, NULL);
+      
+      pFont->texST[index][0].s = ((FLOAT)(x+0)) / pFont->texWidth;
+      pFont->texST[index][0].t = ((FLOAT)(y+0)) / pFont->texHeight;
+      pFont->texST[index][1].s = ((FLOAT)(x+0 + size.cx)) / pFont->texWidth;
+      pFont->texST[index][1].t = ((FLOAT)(y+0 + size.cy)) / pFont->texHeight;
+
+      // Leave +1 space so bilinear filtering doesn't pick up neighboring character
+      x += size.cx+1;  
+   }
+   
+   IDirect3DTexture9_LockRect(pFont->pTexture, 0, &d3dlr, 0, 0);
+   
+   BYTE *pDstRow = (BYTE*)d3dlr.pBits;
+   
+   for(y = 0; y < pFont->texHeight; y++)
+   {
+      pDst16 = (WORD *)pDstRow;
+      for(x = 0; x < pFont->texWidth; x++)
+      {
+         bAlpha = (BYTE)((pBitmapBits[pFont->texWidth * y + x] & 0xff) >> 4);
+         if (bAlpha > 0)
+         {
+            *pDst16++ = (bAlpha << 12) | 0x0fff;
+         }
+         else
+         {
+            *pDst16++ = 0x0000;
+         }
+      }
+      pDstRow += d3dlr.Pitch;
+   }
+   
+   IDirect3DTexture9_UnlockRect(pFont->pTexture, 0);
+
+   // Get kerning pairs for font
+   pFont->numKerningPairs = GetKerningPairs(hDC, 0, NULL);
+   pFont->kerningPairs = new KERNINGPAIR[pFont->numKerningPairs];
+   GetKerningPairs(hDC, pFont->numKerningPairs, pFont->kerningPairs);
+   
+   DeleteObject(hbmBitmap);
+   DeleteObject(hScaledFont);
+   DeleteDC(hDC);
+}
 
 // new render stuff
-void					D3DRenderPoolInit(d3d_render_pool_new *pPool, int size, int packetSize);
-void					D3DRenderPoolShutdown(d3d_render_pool_new *pPool);
-void					D3DRenderPoolReset(d3d_render_pool_new *pPool, void *pMaterialFunc);
-d3d_render_packet_new	*D3DRenderPacketNew(d3d_render_pool_new *pPool);
-void					D3DRenderPacketInit(d3d_render_packet_new *pPacket);
-d3d_render_chunk_new	*D3DRenderChunkNew(d3d_render_packet_new *pPacket);
-void					D3DRenderChunkInit(d3d_render_chunk_new *pChunk);
-d3d_render_packet_new	*D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDIRECT3DTEXTURE9 pTexture,
-												PDIB pDib, BYTE xLat0, BYTE xLat1, int effect);
+void D3DRenderPoolInit(d3d_render_pool_new *pPool, int size, int packetSize)
+{
+	d3d_render_packet_new	*pPacket = NULL;
+	u_int	i;
 
-void					D3DRenderViewElementsDraw(d3d_render_pool_new *pPool);
+	pPool->size = size;
+	pPool->curPacket = 0;
+	pPacket = (d3d_render_packet_new *)D3DRenderMalloc(sizeof(d3d_render_packet_new) * size);
+	assert(pPacket);
+	pPool->renderPacketList = list_create(pPacket);
+	pPool->packetSize = packetSize;
 
-// externed stuff
-extern void			DrawItemsD3D();
-extern bool			ComputePlayerOverlayArea(PDIB pdib, char hotspot, AREA *obj_area);
-extern void			UpdateRoom3D(room_type *room, Draw3DParams *params);
+	D3DRenderPoolReset(pPool, NULL);
+
+	for (i = 0; i < pPool->size; i++)
+	{
+		pPacket->size = packetSize;
+	}
+}
+
+void D3DRenderPoolShutdown(d3d_render_pool_new *pPool)
+{
+	list_destroy(pPool->renderPacketList);
+	memset(pPool, 0, sizeof(d3d_render_pool_new));
+}
+
+void D3DRenderPoolReset(d3d_render_pool_new *pPool, void *pMaterialFunc)
+{
+	pPool->curPacket = 0;
+	pPool->numLists = 0;
+	pPool->curPacketList = pPool->renderPacketList;
+	pPool->pMaterialFctn = (MaterialFctn) pMaterialFunc;
+}
+
+d3d_render_packet_new *D3DRenderPacketNew(d3d_render_pool_new *pPool)
+{
+	d3d_render_packet_new	*pPacket;
+
+	if (pPool->curPacket >= pPool->size)
+	{
+		if (pPool->curPacketList->next == NULL)
+		{
+			pPacket = (d3d_render_packet_new *)D3DRenderMalloc(sizeof(d3d_render_packet_new) * pPool->size);
+			assert(pPacket);
+			list_add_item(pPool->renderPacketList, pPacket);
+		}
+		else
+			pPacket = (d3d_render_packet_new *)pPool->curPacketList->next->data;
+
+		pPool->curPacketList = pPool->curPacketList->next;
+		pPool->curPacket = 1;
+		pPool->numLists++;
+
+		pPacket = (d3d_render_packet_new *)pPool->curPacketList->data;
+	}
+	else
+	{
+		pPacket = (d3d_render_packet_new *)pPool->curPacketList->data;
+		pPacket += pPool->curPacket;
+
+		if (pPool->curPacket == 12)
+			gpPacket = pPacket;
+
+		pPool->curPacket++;
+	}
+
+	D3DRenderPacketInit(pPacket);
+	return pPacket;
+}
+
+void D3DRenderPacketInit(d3d_render_packet_new *pPacket)
+{
+	pPacket->curChunk = 0;
+	pPacket->effect = 0;
+	pPacket->flags = 0;
+	pPacket->pDib = NULL;
+	pPacket->pMaterialFctn = NULL;
+	pPacket->pTexture = NULL;
+	pPacket->xLat0 = 0;
+	pPacket->xLat1 = 0;
+}
+
+d3d_render_chunk_new *D3DRenderChunkNew(d3d_render_packet_new *pPacket)
+{
+	if (pPacket->curChunk >= (pPacket->size - 1))
+		return NULL;
+	else
+	{
+		pPacket->curChunk++;
+		D3DRenderChunkInit(&pPacket->renderChunks[pPacket->curChunk - 1]);
+		return &pPacket->renderChunks[pPacket->curChunk - 1];
+	}
+}
+
+void D3DRenderChunkInit(d3d_render_chunk_new *pChunk)
+{
+	pChunk->curIndex = 0;
+	pChunk->drawn = 0;
+	pChunk->flags = 0;
+	pChunk->zBias = 0;
+	pChunk->isTargeted = FALSE;
+	pChunk->numIndices = 0;
+	pChunk->xLat0 = 0;
+	pChunk->xLat1 = 0;
+	pChunk->pSector = NULL;
+	pChunk->pSectorNeg = NULL;
+	pChunk->pSectorPos = NULL;
+	pChunk->pSideDef = NULL;
+	pChunk->pMaterialFctn = NULL;
+	pChunk->pRenderCache = NULL;
+}
+
+d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDIRECT3DTEXTURE9 pTexture,
+												PDIB pDib, BYTE xLat0, BYTE xLat1, int effect)
+{
+	u_int						count, numPackets;
+	d3d_render_packet_new	*pPacket;
+	list_type				list;
+
+	for (list = pPool->renderPacketList; list != pPool->curPacketList->next; list = list->next)
+	{
+		pPacket = (d3d_render_packet_new *)list->data;
+
+		if (list == pPool->curPacketList)
+			numPackets = pPool->curPacket;
+		else
+			numPackets = pPool->size;
+
+		// for each packet
+		for (count = 0; count < numPackets; count++, pPacket++)
+		{
+			// if we find a match that isn't full already, return it
+			if ((pPacket->pDib == pDib) && (pPacket->pTexture == pTexture) &&
+				(pPacket->xLat0 == xLat0) && (pPacket->xLat1 == xLat1) &&
+				(pPacket->effect == effect))
+			{
+				if (pPacket->curChunk < (pPacket->size - 1))
+					return pPacket;
+			}
+		}
+	}
+
+	// otherwise, return a new one (or NULL if no more remain)
+	pPacket = D3DRenderPacketNew(pPool);
+
+	if (pPacket)
+	{
+		pPacket->pDib = pDib;
+		pPacket->pTexture = pTexture;
+		pPacket->xLat0 = xLat0;
+		pPacket->xLat1 = xLat1;
+		pPacket->effect = effect;
+		pPacket->size = pPool->packetSize;
+	}
+
+	return pPacket;
+}
+
+void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool)
+{
+   // Render view elements (such as the main viewport yellow ui corners)
+   int i, j;
+   float screenW, screenH, foffset;
+   int offset = 0;
+   d3d_render_packet_new *pPacket;
+   d3d_render_chunk_new *pChunk;
+
+   screenW = (float) (gD3DRect.right - gD3DRect.left) / (float) gScreenWidth;
+   screenH = (float) (gD3DRect.bottom - gD3DRect.top) / (float) gScreenHeight;
+
+   if (GetFocus() == hMain)
+      offset = 4;
+
+   foffset = 1.0f / 64.0f;
+
+   // 0 = top-left
+   // 1 = top-right
+   // 2 = bottom-left
+   // 3 = bottom-right
+
+   for (i = 0; i < 4; ++i)
+   {
+      float left, right, top, bottom;
+
+      float width = (float)ViewElements[i + offset].width / screenW;
+      float height = (float)ViewElements[i + offset].height / screenH;
+
+      if (i % 2 == 0)  // left side
+      {
+         left = D3DRENDER_SCREEN_TO_CLIP_X(0, gScreenWidth);
+         right = D3DRENDER_SCREEN_TO_CLIP_X(width, gScreenWidth);
+      }
+      else  // right side
+      {
+         left = D3DRENDER_SCREEN_TO_CLIP_X(gScreenWidth - width, gScreenWidth);
+         right = D3DRENDER_SCREEN_TO_CLIP_X(gScreenWidth, gScreenWidth);
+      }
+
+      if (i < 2)  // top side
+      {
+         top = D3DRENDER_SCREEN_TO_CLIP_Y(0, gScreenHeight);
+         bottom = D3DRENDER_SCREEN_TO_CLIP_Y(height, gScreenHeight);
+      }
+      else  // bottom side
+      {
+         top = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight - height, gScreenHeight);
+         bottom = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight, gScreenHeight);
+      }
+
+      pPacket = D3DRenderPacketNew(pPool);
+      pPacket->pDib = NULL;
+      pPacket->pTexture = gpViewElements[i + offset];
+      pPacket->xLat0 = 0;
+      pPacket->xLat1 = 0;
+      pPacket->effect = 0;
+      pPacket->size = pPool->packetSize;
+
+      pChunk = D3DRenderChunkNew(pPacket);
+      pChunk->flags = 0;
+      pChunk->numIndices = 4;
+      pChunk->numVertices = 4;
+      pChunk->numPrimitives = pChunk->numVertices - 2;
+      pChunk->xLat0 = 0;
+      pChunk->xLat1 = 0;
+
+      pPacket->pMaterialFctn = D3DMaterialObjectPacket;
+      pChunk->pMaterialFctn = D3DMaterialNone;
+
+      pChunk->xyz[0].x = left;
+      pChunk->xyz[0].z = top;
+      pChunk->xyz[0].y = VIEW_ELEMENT_Z;
+      pChunk->xyz[1].x = left;
+      pChunk->xyz[1].z = bottom;
+      pChunk->xyz[1].y = VIEW_ELEMENT_Z;
+      pChunk->xyz[2].x = right;
+      pChunk->xyz[2].z = bottom;
+      pChunk->xyz[2].y = VIEW_ELEMENT_Z;
+      pChunk->xyz[3].x = right;
+      pChunk->xyz[3].z = top;
+      pChunk->xyz[3].y = VIEW_ELEMENT_Z;
+
+      for (j = 0; j < 4; j++)
+      {
+         pChunk->bgra[j].b = 255;
+         pChunk->bgra[j].g = 255;
+         pChunk->bgra[j].r = 255;
+         pChunk->bgra[j].a = 255;
+      }
+
+      pChunk->st0[0].s = foffset;
+      pChunk->st0[0].t = foffset;
+      pChunk->st0[1].s = foffset;
+      pChunk->st0[1].t = 1.0f - foffset;
+      pChunk->st0[2].s = 1.0f - foffset;
+      pChunk->st0[2].t = 1.0f - foffset;
+      pChunk->st0[3].s = 1.0f - foffset;
+      pChunk->st0[3].t = foffset;
+
+      pChunk->indices[0] = 1;
+      pChunk->indices[1] = 2;
+      pChunk->indices[2] = 0;
+      pChunk->indices[3] = 3;
+   }
+}
+
+LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
+													 LPDIRECT3DTEXTURE9	pTex1,
+													 float width, float height)
+{
+	LPDIRECT3DSURFACE9	pSrc, pDest[2], pZBuf;
+	RECT				rect;
+	POINT				pnt;
+	D3DMATRIX			mat;
+	d3d_render_packet_new	*pPacket;
+	d3d_render_chunk_new	*pChunk;
+   HRESULT hr;
+
+	D3DCacheSystemReset(&gEffectCacheSystem);
+	D3DRenderPoolReset(&gEffectPool, &D3DMaterialEffectPool);
+
+	// get pointer to backbuffer surface and z/stencil surface
+	IDirect3DDevice9_GetRenderTarget(gpD3DDevice, 0, &pSrc);
+	IDirect3DDevice9_GetDepthStencilSurface(gpD3DDevice, &pZBuf);
+
+	// get pointer to texture surface for rendering
+	IDirect3DTexture9_GetSurfaceLevel(pTex0, 0, &pDest[0]);
+	IDirect3DTexture9_GetSurfaceLevel(pTex1, 0, &pDest[1]);
+
+	pnt.x = 0;
+	pnt.y = 0;
+	rect.left = rect.top = 0;
+	rect.right = gScreenWidth;
+	rect.bottom = gScreenHeight;
+
+	// copy framebuffer to texture
+	IDirect3DDevice9_StretchRect(gpD3DDevice, pSrc, &rect, pDest[0], &rect, D3DTEXF_NONE);
+   
+	// clear local->screen transforms
+	MatrixIdentity(&mat);
+	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_WORLD, &mat);
+	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_VIEW, &mat);
+	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_PROJECTION, &mat);
+
+	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, FALSE);
+	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, FALSE);
+
+	IDirect3DDevice9_SetRenderTarget(gpD3DDevice, 0, pDest[1]);
+
+	pPacket = D3DRenderPacketNew(&gEffectPool);
+	if (NULL == pPacket)
+		return NULL;
+	pChunk = D3DRenderChunkNew(pPacket);
+	pPacket->pMaterialFctn = D3DMaterialEffectPacket;
+	pChunk->pMaterialFctn = D3DMaterialEffectChunk;
+	pPacket->pTexture = pTex0;
+	pChunk->numIndices = pChunk->numVertices = 4;
+	pChunk->numPrimitives = pChunk->numVertices - 2;
+	MatrixIdentity(&pChunk->xForm);
+
+	CHUNK_XYZ_SET(pChunk, 0, D3DRENDER_SCREEN_TO_CLIP_X(0, gSmallTextureSize),
+		0, D3DRENDER_SCREEN_TO_CLIP_Y(0, gSmallTextureSize));
+	CHUNK_XYZ_SET(pChunk, 1, D3DRENDER_SCREEN_TO_CLIP_X(0, gSmallTextureSize),
+		0, D3DRENDER_SCREEN_TO_CLIP_Y(gSmallTextureSize, gSmallTextureSize));
+	CHUNK_XYZ_SET(pChunk, 2, D3DRENDER_SCREEN_TO_CLIP_X(gSmallTextureSize, gSmallTextureSize),
+		0, D3DRENDER_SCREEN_TO_CLIP_Y(gSmallTextureSize, gSmallTextureSize));
+	CHUNK_XYZ_SET(pChunk, 3, D3DRENDER_SCREEN_TO_CLIP_X(gSmallTextureSize, gSmallTextureSize),
+		0, D3DRENDER_SCREEN_TO_CLIP_Y(0, gSmallTextureSize));
+
+	CHUNK_ST0_SET(pChunk, 0, 0.0f, 0.0f);
+	CHUNK_ST0_SET(pChunk, 1, 0.0f, gScreenHeight / (float)gFullTextureSize);
+	CHUNK_ST0_SET(pChunk, 2, gScreenWidth / (float)gFullTextureSize, gScreenHeight / (float)gFullTextureSize);
+	CHUNK_ST0_SET(pChunk, 3, gScreenWidth / (float)gFullTextureSize, 0.0f);
+
+	CHUNK_BGRA_SET(pChunk, 0, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
+	CHUNK_BGRA_SET(pChunk, 1, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
+	CHUNK_BGRA_SET(pChunk, 2, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
+	CHUNK_BGRA_SET(pChunk, 3, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
+
+	CHUNK_INDEX_SET(pChunk, 0, 1);
+	CHUNK_INDEX_SET(pChunk, 1, 2);
+	CHUNK_INDEX_SET(pChunk, 2, 0);
+	CHUNK_INDEX_SET(pChunk, 3, 3);
+
+	D3DCacheFill(&gEffectCacheSystem, &gEffectPool, 1);
+	D3DCacheFlush(&gEffectCacheSystem, &gEffectPool, 1, D3DPT_TRIANGLESTRIP);
+
+	// restore render target to backbuffer
+	hr = IDirect3DDevice9_SetRenderTarget(gpD3DDevice, 0, pSrc);
+	hr = IDirect3DDevice9_SetDepthStencilSurface(gpD3DDevice, pZBuf);
+	hr = IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, TRUE);
+   
+	IDirect3DSurface9_Release(pSrc);
+	IDirect3DSurface9_Release(pZBuf);
+	IDirect3DSurface9_Release(pDest[0]);
+	IDirect3DSurface9_Release(pDest[1]);
+
+	return pTex1;
+}
+
+//////////////////////
+// Public Functions //
+//////////////////////
 
 /************************************************************************************
 *
@@ -694,503 +1177,6 @@ void D3DRenderEnableToggle(void)
 		memset(gBits, 0, MAXX * MAXY);
 		memset(gBufferBits, 0, MAXX * 2 * MAXY * 2);
 	}
-}
-
-void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
-{
-	D3DCAPS9		d3dCaps;
-	HDC				hDC;
-   HBITMAP			hbmBitmap;
-	DWORD			*pBitmapBits;
-   BITMAPINFO		bmi;
-   long x = 0;
-   long y = 0;
-   TCHAR			str[2] = _T("x");
-	TCHAR			c;
-   SIZE			size;
-	D3DLOCKED_RECT	d3dlr;
-   WORD			*pDst16;
-   BYTE			bAlpha;
-
-   // Ask for a bigger font to reduce aliasing, then scale the texture
-   // down by the same amount.
-   float fontScale = 3.0;
-   HFONT hScaledFont = FontsGetScaledFont(hFont, fontScale);
-   assert(hScaledFont);
-      
-   pFont->fontHeight = GetFontHeight(hScaledFont);
-   pFont->texScale = fontScale;
-   
-	if (pFont->fontHeight > 40)
-		pFont->texWidth = pFont->texHeight = 1024;
-	else if (pFont->fontHeight > 20)
-		pFont->texWidth = pFont->texHeight = 512;
-	else
-		pFont->texWidth = pFont->texHeight = 256;
-
-	IDirect3DDevice9_GetDeviceCaps(gpD3DDevice, &d3dCaps);
-  
-	if (pFont->texWidth > (long) d3dCaps.MaxTextureWidth)
-	{
-		pFont->texScale *= (float)pFont->texWidth / (float)d3dCaps.MaxTextureWidth;
-		pFont->texHeight = pFont->texWidth = d3dCaps.MaxTextureWidth;
-	}
-  
-	if (pFont->pTexture)
-		IDirect3DTexture9_Release(pFont->pTexture);
-   
-   IDirect3DDevice9_CreateTexture(
-      gpD3DDevice, pFont->texWidth,
-      pFont->texHeight, 1, 0, D3DFMT_A4R4G4B4,
-      D3DPOOL_MANAGED, &pFont->pTexture, NULL);
-   
-   memset(&bmi.bmiHeader, 0, sizeof(BITMAPINFOHEADER));
-   bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
-   bmi.bmiHeader.biWidth = (int)pFont->texWidth;
-   bmi.bmiHeader.biHeight = -(int)pFont->texHeight;
-   bmi.bmiHeader.biPlanes = 1;
-   bmi.bmiHeader.biCompression = BI_RGB;
-   bmi.bmiHeader.biBitCount = 32;
-   
-   hDC = CreateCompatibleDC(gBitsDC);
-   hbmBitmap = CreateDIBSection(hDC, &bmi, DIB_RGB_COLORS, (VOID**)&pBitmapBits, NULL, 0 );
-   SetMapMode(hDC, MM_TEXT);
-  
-   SelectObject(hDC, hbmBitmap);
-   SelectObject(hDC, hScaledFont);
-   
-   // Set text properties
-   SetTextColor(hDC, RGB(255,255,255));
-   SetBkColor(hDC, 0);
-   SetBkMode(hDC, TRANSPARENT);
-   SetTextAlign(hDC, TA_TOP);
-   
-   for(c = 32; c < 127; c++ )
-   {
-      int index = c-32;
-      
-      str[0] = c;
-      GetTextExtentPoint32(hDC, str, 1, &size);
-      
-      if (!GetCharABCWidths(hDC, c, c, &pFont->abc[index])) {
-         pFont->abc[index].abcA = 0;
-         pFont->abc[index].abcB = size.cx;
-         pFont->abc[index].abcC = 0;
-      }
-
-      size.cx = pFont->abc[index].abcB;
-
-      // Is this row of the texture filled up?
-      if (x + size.cx >= pFont->texWidth)
-      {
-         x = 0;
-         y += size.cy + 1;
-      }
-      
-      int left_offset = pFont->abc[index].abcA;
-      ExtTextOut(hDC, x - left_offset, y+0, 0, NULL, str, 1, NULL);
-      
-      pFont->texST[index][0].s = ((FLOAT)(x+0)) / pFont->texWidth;
-      pFont->texST[index][0].t = ((FLOAT)(y+0)) / pFont->texHeight;
-      pFont->texST[index][1].s = ((FLOAT)(x+0 + size.cx)) / pFont->texWidth;
-      pFont->texST[index][1].t = ((FLOAT)(y+0 + size.cy)) / pFont->texHeight;
-
-      // Leave +1 space so bilinear filtering doesn't pick up neighboring character
-      x += size.cx+1;  
-   }
-   
-   IDirect3DTexture9_LockRect(pFont->pTexture, 0, &d3dlr, 0, 0);
-   
-   BYTE *pDstRow = (BYTE*)d3dlr.pBits;
-   
-   for(y = 0; y < pFont->texHeight; y++)
-   {
-      pDst16 = (WORD *)pDstRow;
-      for(x = 0; x < pFont->texWidth; x++)
-      {
-         bAlpha = (BYTE)((pBitmapBits[pFont->texWidth * y + x] & 0xff) >> 4);
-         if (bAlpha > 0)
-         {
-            *pDst16++ = (bAlpha << 12) | 0x0fff;
-         }
-         else
-         {
-            *pDst16++ = 0x0000;
-         }
-      }
-      pDstRow += d3dlr.Pitch;
-   }
-   
-   IDirect3DTexture9_UnlockRect(pFont->pTexture, 0);
-
-   // Get kerning pairs for font
-   pFont->numKerningPairs = GetKerningPairs(hDC, 0, NULL);
-   pFont->kerningPairs = new KERNINGPAIR[pFont->numKerningPairs];
-   GetKerningPairs(hDC, pFont->numKerningPairs, pFont->kerningPairs);
-   
-   DeleteObject(hbmBitmap);
-   DeleteObject(hScaledFont);
-   DeleteDC(hDC);
-}
-
-// new render stuff
-void D3DRenderPoolInit(d3d_render_pool_new *pPool, int size, int packetSize)
-{
-	d3d_render_packet_new	*pPacket = NULL;
-	u_int	i;
-
-	pPool->size = size;
-	pPool->curPacket = 0;
-	pPacket = (d3d_render_packet_new *)D3DRenderMalloc(sizeof(d3d_render_packet_new) * size);
-	assert(pPacket);
-	pPool->renderPacketList = list_create(pPacket);
-	pPool->packetSize = packetSize;
-
-	D3DRenderPoolReset(pPool, NULL);
-
-	for (i = 0; i < pPool->size; i++)
-	{
-		pPacket->size = packetSize;
-	}
-}
-
-void D3DRenderPoolShutdown(d3d_render_pool_new *pPool)
-{
-	list_destroy(pPool->renderPacketList);
-	memset(pPool, 0, sizeof(d3d_render_pool_new));
-}
-
-void D3DRenderPoolReset(d3d_render_pool_new *pPool, void *pMaterialFunc)
-{
-	pPool->curPacket = 0;
-	pPool->numLists = 0;
-	pPool->curPacketList = pPool->renderPacketList;
-	pPool->pMaterialFctn = (MaterialFctn) pMaterialFunc;
-}
-
-d3d_render_packet_new *D3DRenderPacketNew(d3d_render_pool_new *pPool)
-{
-	d3d_render_packet_new	*pPacket;
-
-	if (pPool->curPacket >= pPool->size)
-	{
-		if (pPool->curPacketList->next == NULL)
-		{
-			pPacket = (d3d_render_packet_new *)D3DRenderMalloc(sizeof(d3d_render_packet_new) * pPool->size);
-			assert(pPacket);
-			list_add_item(pPool->renderPacketList, pPacket);
-		}
-		else
-			pPacket = (d3d_render_packet_new *)pPool->curPacketList->next->data;
-
-		pPool->curPacketList = pPool->curPacketList->next;
-		pPool->curPacket = 1;
-		pPool->numLists++;
-
-		pPacket = (d3d_render_packet_new *)pPool->curPacketList->data;
-	}
-	else
-	{
-		pPacket = (d3d_render_packet_new *)pPool->curPacketList->data;
-		pPacket += pPool->curPacket;
-
-		if (pPool->curPacket == 12)
-			gpPacket = pPacket;
-
-		pPool->curPacket++;
-	}
-
-	D3DRenderPacketInit(pPacket);
-	return pPacket;
-}
-
-void D3DRenderPacketInit(d3d_render_packet_new *pPacket)
-{
-	pPacket->curChunk = 0;
-	pPacket->effect = 0;
-	pPacket->flags = 0;
-	pPacket->pDib = NULL;
-	pPacket->pMaterialFctn = NULL;
-	pPacket->pTexture = NULL;
-	pPacket->xLat0 = 0;
-	pPacket->xLat1 = 0;
-}
-
-d3d_render_chunk_new *D3DRenderChunkNew(d3d_render_packet_new *pPacket)
-{
-	if (pPacket->curChunk >= (pPacket->size - 1))
-		return NULL;
-	else
-	{
-		pPacket->curChunk++;
-		D3DRenderChunkInit(&pPacket->renderChunks[pPacket->curChunk - 1]);
-		return &pPacket->renderChunks[pPacket->curChunk - 1];
-	}
-}
-
-void D3DRenderChunkInit(d3d_render_chunk_new *pChunk)
-{
-	pChunk->curIndex = 0;
-	pChunk->drawn = 0;
-	pChunk->flags = 0;
-	pChunk->zBias = 0;
-	pChunk->isTargeted = FALSE;
-	pChunk->numIndices = 0;
-	pChunk->xLat0 = 0;
-	pChunk->xLat1 = 0;
-	pChunk->pSector = NULL;
-	pChunk->pSectorNeg = NULL;
-	pChunk->pSectorPos = NULL;
-	pChunk->pSideDef = NULL;
-	pChunk->pMaterialFctn = NULL;
-	pChunk->pRenderCache = NULL;
-}
-
-d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDIRECT3DTEXTURE9 pTexture,
-												PDIB pDib, BYTE xLat0, BYTE xLat1, int effect)
-{
-	u_int						count, numPackets;
-	d3d_render_packet_new	*pPacket;
-	list_type				list;
-
-	for (list = pPool->renderPacketList; list != pPool->curPacketList->next; list = list->next)
-	{
-		pPacket = (d3d_render_packet_new *)list->data;
-
-		if (list == pPool->curPacketList)
-			numPackets = pPool->curPacket;
-		else
-			numPackets = pPool->size;
-
-		// for each packet
-		for (count = 0; count < numPackets; count++, pPacket++)
-		{
-			// if we find a match that isn't full already, return it
-			if ((pPacket->pDib == pDib) && (pPacket->pTexture == pTexture) &&
-				(pPacket->xLat0 == xLat0) && (pPacket->xLat1 == xLat1) &&
-				(pPacket->effect == effect))
-			{
-				if (pPacket->curChunk < (pPacket->size - 1))
-					return pPacket;
-			}
-		}
-	}
-
-	// otherwise, return a new one (or NULL if no more remain)
-	pPacket = D3DRenderPacketNew(pPool);
-
-	if (pPacket)
-	{
-		pPacket->pDib = pDib;
-		pPacket->pTexture = pTexture;
-		pPacket->xLat0 = xLat0;
-		pPacket->xLat1 = xLat1;
-		pPacket->effect = effect;
-		pPacket->size = pPool->packetSize;
-	}
-
-	return pPacket;
-}
-
-void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool)
-{
-   // Render view elements (such as the main viewport yellow ui corners)
-   int i, j;
-   float screenW, screenH, foffset;
-   int offset = 0;
-   d3d_render_packet_new *pPacket;
-   d3d_render_chunk_new *pChunk;
-
-   screenW = (float) (gD3DRect.right - gD3DRect.left) / (float) gScreenWidth;
-   screenH = (float) (gD3DRect.bottom - gD3DRect.top) / (float) gScreenHeight;
-
-   if (GetFocus() == hMain)
-      offset = 4;
-
-   foffset = 1.0f / 64.0f;
-
-   // 0 = top-left
-   // 1 = top-right
-   // 2 = bottom-left
-   // 3 = bottom-right
-
-   for (i = 0; i < 4; ++i)
-   {
-      float left, right, top, bottom;
-
-      float width = (float)ViewElements[i + offset].width / screenW;
-      float height = (float)ViewElements[i + offset].height / screenH;
-
-      if (i % 2 == 0)  // left side
-      {
-         left = D3DRENDER_SCREEN_TO_CLIP_X(0, gScreenWidth);
-         right = D3DRENDER_SCREEN_TO_CLIP_X(width, gScreenWidth);
-      }
-      else  // right side
-      {
-         left = D3DRENDER_SCREEN_TO_CLIP_X(gScreenWidth - width, gScreenWidth);
-         right = D3DRENDER_SCREEN_TO_CLIP_X(gScreenWidth, gScreenWidth);
-      }
-
-      if (i < 2)  // top side
-      {
-         top = D3DRENDER_SCREEN_TO_CLIP_Y(0, gScreenHeight);
-         bottom = D3DRENDER_SCREEN_TO_CLIP_Y(height, gScreenHeight);
-      }
-      else  // bottom side
-      {
-         top = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight - height, gScreenHeight);
-         bottom = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight, gScreenHeight);
-      }
-
-      pPacket = D3DRenderPacketNew(pPool);
-      pPacket->pDib = NULL;
-      pPacket->pTexture = gpViewElements[i + offset];
-      pPacket->xLat0 = 0;
-      pPacket->xLat1 = 0;
-      pPacket->effect = 0;
-      pPacket->size = pPool->packetSize;
-
-      pChunk = D3DRenderChunkNew(pPacket);
-      pChunk->flags = 0;
-      pChunk->numIndices = 4;
-      pChunk->numVertices = 4;
-      pChunk->numPrimitives = pChunk->numVertices - 2;
-      pChunk->xLat0 = 0;
-      pChunk->xLat1 = 0;
-
-      pPacket->pMaterialFctn = D3DMaterialObjectPacket;
-      pChunk->pMaterialFctn = D3DMaterialNone;
-
-      pChunk->xyz[0].x = left;
-      pChunk->xyz[0].z = top;
-      pChunk->xyz[0].y = VIEW_ELEMENT_Z;
-      pChunk->xyz[1].x = left;
-      pChunk->xyz[1].z = bottom;
-      pChunk->xyz[1].y = VIEW_ELEMENT_Z;
-      pChunk->xyz[2].x = right;
-      pChunk->xyz[2].z = bottom;
-      pChunk->xyz[2].y = VIEW_ELEMENT_Z;
-      pChunk->xyz[3].x = right;
-      pChunk->xyz[3].z = top;
-      pChunk->xyz[3].y = VIEW_ELEMENT_Z;
-
-      for (j = 0; j < 4; j++)
-      {
-         pChunk->bgra[j].b = 255;
-         pChunk->bgra[j].g = 255;
-         pChunk->bgra[j].r = 255;
-         pChunk->bgra[j].a = 255;
-      }
-
-      pChunk->st0[0].s = foffset;
-      pChunk->st0[0].t = foffset;
-      pChunk->st0[1].s = foffset;
-      pChunk->st0[1].t = 1.0f - foffset;
-      pChunk->st0[2].s = 1.0f - foffset;
-      pChunk->st0[2].t = 1.0f - foffset;
-      pChunk->st0[3].s = 1.0f - foffset;
-      pChunk->st0[3].t = foffset;
-
-      pChunk->indices[0] = 1;
-      pChunk->indices[1] = 2;
-      pChunk->indices[2] = 0;
-      pChunk->indices[3] = 3;
-   }
-}
-
-LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
-													 LPDIRECT3DTEXTURE9	pTex1,
-													 float width, float height)
-{
-	LPDIRECT3DSURFACE9	pSrc, pDest[2], pZBuf;
-	RECT				rect;
-	POINT				pnt;
-	D3DMATRIX			mat;
-	d3d_render_packet_new	*pPacket;
-	d3d_render_chunk_new	*pChunk;
-   HRESULT hr;
-
-	D3DCacheSystemReset(&gEffectCacheSystem);
-	D3DRenderPoolReset(&gEffectPool, &D3DMaterialEffectPool);
-
-	// get pointer to backbuffer surface and z/stencil surface
-	IDirect3DDevice9_GetRenderTarget(gpD3DDevice, 0, &pSrc);
-	IDirect3DDevice9_GetDepthStencilSurface(gpD3DDevice, &pZBuf);
-
-	// get pointer to texture surface for rendering
-	IDirect3DTexture9_GetSurfaceLevel(pTex0, 0, &pDest[0]);
-	IDirect3DTexture9_GetSurfaceLevel(pTex1, 0, &pDest[1]);
-
-	pnt.x = 0;
-	pnt.y = 0;
-	rect.left = rect.top = 0;
-	rect.right = gScreenWidth;
-	rect.bottom = gScreenHeight;
-
-	// copy framebuffer to texture
-	IDirect3DDevice9_StretchRect(gpD3DDevice, pSrc, &rect, pDest[0], &rect, D3DTEXF_NONE);
-   
-	// clear local->screen transforms
-	MatrixIdentity(&mat);
-	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_WORLD, &mat);
-	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_VIEW, &mat);
-	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_PROJECTION, &mat);
-
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, FALSE);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, FALSE);
-
-	IDirect3DDevice9_SetRenderTarget(gpD3DDevice, 0, pDest[1]);
-
-	pPacket = D3DRenderPacketNew(&gEffectPool);
-	if (NULL == pPacket)
-		return NULL;
-	pChunk = D3DRenderChunkNew(pPacket);
-	pPacket->pMaterialFctn = D3DMaterialEffectPacket;
-	pChunk->pMaterialFctn = D3DMaterialEffectChunk;
-	pPacket->pTexture = pTex0;
-	pChunk->numIndices = pChunk->numVertices = 4;
-	pChunk->numPrimitives = pChunk->numVertices - 2;
-	MatrixIdentity(&pChunk->xForm);
-
-	CHUNK_XYZ_SET(pChunk, 0, D3DRENDER_SCREEN_TO_CLIP_X(0, gSmallTextureSize),
-		0, D3DRENDER_SCREEN_TO_CLIP_Y(0, gSmallTextureSize));
-	CHUNK_XYZ_SET(pChunk, 1, D3DRENDER_SCREEN_TO_CLIP_X(0, gSmallTextureSize),
-		0, D3DRENDER_SCREEN_TO_CLIP_Y(gSmallTextureSize, gSmallTextureSize));
-	CHUNK_XYZ_SET(pChunk, 2, D3DRENDER_SCREEN_TO_CLIP_X(gSmallTextureSize, gSmallTextureSize),
-		0, D3DRENDER_SCREEN_TO_CLIP_Y(gSmallTextureSize, gSmallTextureSize));
-	CHUNK_XYZ_SET(pChunk, 3, D3DRENDER_SCREEN_TO_CLIP_X(gSmallTextureSize, gSmallTextureSize),
-		0, D3DRENDER_SCREEN_TO_CLIP_Y(0, gSmallTextureSize));
-
-	CHUNK_ST0_SET(pChunk, 0, 0.0f, 0.0f);
-	CHUNK_ST0_SET(pChunk, 1, 0.0f, gScreenHeight / (float)gFullTextureSize);
-	CHUNK_ST0_SET(pChunk, 2, gScreenWidth / (float)gFullTextureSize, gScreenHeight / (float)gFullTextureSize);
-	CHUNK_ST0_SET(pChunk, 3, gScreenWidth / (float)gFullTextureSize, 0.0f);
-
-	CHUNK_BGRA_SET(pChunk, 0, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
-	CHUNK_BGRA_SET(pChunk, 1, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
-	CHUNK_BGRA_SET(pChunk, 2, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
-	CHUNK_BGRA_SET(pChunk, 3, COLOR_MAX, COLOR_MAX, COLOR_MAX, COLOR_MAX);
-
-	CHUNK_INDEX_SET(pChunk, 0, 1);
-	CHUNK_INDEX_SET(pChunk, 1, 2);
-	CHUNK_INDEX_SET(pChunk, 2, 0);
-	CHUNK_INDEX_SET(pChunk, 3, 3);
-
-	D3DCacheFill(&gEffectCacheSystem, &gEffectPool, 1);
-	D3DCacheFlush(&gEffectCacheSystem, &gEffectPool, 1, D3DPT_TRIANGLESTRIP);
-
-	// restore render target to backbuffer
-	hr = IDirect3DDevice9_SetRenderTarget(gpD3DDevice, 0, pSrc);
-	hr = IDirect3DDevice9_SetDepthStencilSurface(gpD3DDevice, pZBuf);
-	hr = IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, TRUE);
-   
-	IDirect3DSurface9_Release(pSrc);
-	IDirect3DSurface9_Release(pZBuf);
-	IDirect3DSurface9_Release(pDest[0]);
-	IDirect3DSurface9_Release(pDest[1]);
-
-	return pTex1;
 }
 
 // Controls alpha testing, which is a 'pass/fail' check for pixels based on their transparency.

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -13,6 +13,8 @@
 d3d_render_packet_new	*gpPacket;
 
 LPDIRECT3DTEXTURE9		gpNoLookThrough = NULL;
+LPDIRECT3DTEXTURE9		gpBackBufferTex[16];
+LPDIRECT3DTEXTURE9		gpBackBufferTexFull;
 LPDIRECT3DTEXTURE9		gpViewElements[NUM_VIEW_ELEMENTS];
 
 D3DVIEWPORT9			gViewport;
@@ -42,9 +44,12 @@ d3d_render_pool_new		gParticlePool;
 custom_xyz				playerOldPos;
 custom_xyz				playerDeltaPos;
 
+font_3d					gFont;
+
 RECT					gD3DRect;
 int						gNumObjects;
 int						gNumDPCalls;
+static PALETTEENTRY		gPalette[256];
 
 static unsigned int		gFrame = 0;
 
@@ -53,6 +58,8 @@ static unsigned int		gFrame = 0;
 // As per the original specification, the smaller buffer is 1/4 the size of the full buffer.
 int						gFullTextureSize;
 int						gSmallTextureSize;
+
+int 					d3dRenderTextureThreshold;
 
 D3DVERTEXELEMENT9		decl0[] = {
 	{0, 0, D3DDECLTYPE_FLOAT3,	 D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_POSITION, 0},
@@ -80,12 +87,25 @@ LPDIRECT3DVERTEXDECLARATION9 decl1dc;
 LPDIRECT3DVERTEXDECLARATION9 decl2dc;
 
 int						gD3DRedrawAll = 0;
+bool 					gWireframe;
 
 D3DMATRIX view, mat, rot, trans, proj;
 
-//////////////////////
-// External Globals //
-//////////////////////
+///////////////////////////
+// External Dependencies //
+///////////////////////////
+
+// Defined in graphics.c
+// Main client windows current viewport area
+extern int main_viewport_width;
+extern int main_viewport_height;
+
+// Defined in d3ddriver.c
+extern d3d_driver_profile gD3DDriverProfile;
+
+// Defined in palette.c
+extern Color base_palette[NUM_COLORS];
+
 extern long				viewer_height;
 extern ObjectRange		visible_objects[];    /* Where objects are on screen */
 extern int				num_visible_objects;
@@ -255,7 +275,7 @@ void D3DRenderPoolInit(d3d_render_pool_new *pPool, int size, int packetSize)
 
 	pPool->size = size;
 	pPool->curPacket = 0;
-	pPacket = (d3d_render_packet_new *)D3DRenderMalloc(sizeof(d3d_render_packet_new) * size);
+	pPacket = reinterpret_cast<d3d_render_packet_new*>( malloc(sizeof(d3d_render_packet_new) * size) );
 	assert(pPacket);
 	pPool->renderPacketList = list_create(pPacket);
 	pPool->packetSize = packetSize;
@@ -290,7 +310,7 @@ d3d_render_packet_new *D3DRenderPacketNew(d3d_render_pool_new *pPool)
 	{
 		if (pPool->curPacketList->next == NULL)
 		{
-			pPacket = (d3d_render_packet_new *)D3DRenderMalloc(sizeof(d3d_render_packet_new) * pPool->size);
+			pPacket = reinterpret_cast<d3d_render_packet_new*>( malloc(sizeof(d3d_render_packet_new) * pPool->size) );
 			assert(pPacket);
 			list_add_item(pPool->renderPacketList, pPacket);
 		}
@@ -610,6 +630,92 @@ LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
 //////////////////////
 // Public Functions //
 //////////////////////
+int D3DRenderIsEnabled(void)
+{
+	return gD3DEnabled;
+}
+
+void SetZBias(LPDIRECT3DDEVICE9 device, int z_bias) {
+   float bias = z_bias * -0.00001f;
+   IDirect3DDevice9_SetRenderState(device, D3DRS_DEPTHBIAS,
+                                   *((DWORD *) &bias));
+}
+
+int DistanceGet(int x, int y)
+{
+	int	distance;
+	float	xf, yf;
+
+	xf = (float)x;
+	yf = (float)y;
+
+	distance = sqrt((double)(xf * xf) + (double)(yf * yf));
+
+	return (int)distance;
+}
+
+// Helper function to determine if an object should be rendered in the current pass based on transparency.
+bool ShouldRenderInCurrentPass(bool transparent_pass, bool isTransparent)
+{
+	return transparent_pass == isTransparent;
+}
+
+// Define field of views with magic numbers for tuning
+float FovHorizontal(long width)
+{
+	return width / (float)(main_viewport_width) * (-PI / 3.78f);
+}
+
+float FovVertical(long height)
+{
+	return height / (float)(main_viewport_height) * (PI / 5.88f);
+}
+
+// Retrieve the threshold value for determining whether to round up the dimensions of a texture.
+int getD3dRenderThreshold()
+{
+	return d3dRenderTextureThreshold;
+}
+
+bool isManagedTexturesEnabled()
+{
+    return gD3DDriverProfile.bManagedTextures;
+}
+
+bool isFogEnabled()
+{
+	return gD3DDriverProfile.bFogEnable;
+}
+
+void setWireframeMode(bool isEnabled)
+{
+	gWireframe = isEnabled;
+}
+
+bool isWireframeMode()
+{
+	return gWireframe;
+}
+
+const font_3d& getFont3d()
+{
+	return gFont;
+}
+
+const LPDIRECT3DTEXTURE9 getBackBufferTextureZero()
+{
+	return gpBackBufferTex[0];
+}
+
+PALETTEENTRY* getPalette()
+{
+    return gPalette;
+}
+
+const Color(&getBasePalette())[NUM_COLORS]
+{
+	return base_palette;
+}
 
 /************************************************************************************
 *

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -97,7 +97,7 @@ extern BYTE				*gBufferBits;
 extern ViewElement		ViewElements[];
 extern HDC				gBitsDC;
 
-extern void			UpdateRoom3D(room_type *room, Draw3DParams *params);
+extern void UpdateRoom3D(room_type *room, Draw3DParams *params);
 
 /////////////////////////
 // Internal Prototypes //
@@ -113,27 +113,27 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 {
 	D3DCAPS9		d3dCaps;
 	HDC				hDC;
-   HBITMAP			hbmBitmap;
+	HBITMAP			hbmBitmap;
 	DWORD			*pBitmapBits;
-   BITMAPINFO		bmi;
-   long x = 0;
-   long y = 0;
-   TCHAR			str[2] = _T("x");
+	BITMAPINFO		bmi;
+	long x = 0;
+	long y = 0;
+	TCHAR			str[2] = _T("x");
 	TCHAR			c;
-   SIZE			size;
+	SIZE			size;
 	D3DLOCKED_RECT	d3dlr;
-   WORD			*pDst16;
-   BYTE			bAlpha;
+	WORD			*pDst16;
+	BYTE			bAlpha;
 
-   // Ask for a bigger font to reduce aliasing, then scale the texture
-   // down by the same amount.
-   float fontScale = 3.0;
-   HFONT hScaledFont = FontsGetScaledFont(hFont, fontScale);
-   assert(hScaledFont);
-      
-   pFont->fontHeight = GetFontHeight(hScaledFont);
-   pFont->texScale = fontScale;
-   
+	// Ask for a bigger font to reduce aliasing, then scale the texture
+	// down by the same amount.
+	float fontScale = 3.0;
+	HFONT hScaledFont = FontsGetScaledFont(hFont, fontScale);
+	assert(hScaledFont);
+
+	pFont->fontHeight = GetFontHeight(hScaledFont);
+	pFont->texScale = fontScale;
+
 	if (pFont->fontHeight > 40)
 		pFont->texWidth = pFont->texHeight = 1024;
 	else if (pFont->fontHeight > 20)
@@ -142,108 +142,109 @@ void D3DRenderFontInit(font_3d *pFont, HFONT hFont)
 		pFont->texWidth = pFont->texHeight = 256;
 
 	IDirect3DDevice9_GetDeviceCaps(gpD3DDevice, &d3dCaps);
-  
+
 	if (pFont->texWidth > (long) d3dCaps.MaxTextureWidth)
 	{
 		pFont->texScale *= (float)pFont->texWidth / (float)d3dCaps.MaxTextureWidth;
 		pFont->texHeight = pFont->texWidth = d3dCaps.MaxTextureWidth;
 	}
-  
+
 	if (pFont->pTexture)
 		IDirect3DTexture9_Release(pFont->pTexture);
-   
-   IDirect3DDevice9_CreateTexture(
-      gpD3DDevice, pFont->texWidth,
-      pFont->texHeight, 1, 0, D3DFMT_A4R4G4B4,
-      D3DPOOL_MANAGED, &pFont->pTexture, NULL);
-   
-   memset(&bmi.bmiHeader, 0, sizeof(BITMAPINFOHEADER));
-   bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
-   bmi.bmiHeader.biWidth = (int)pFont->texWidth;
-   bmi.bmiHeader.biHeight = -(int)pFont->texHeight;
-   bmi.bmiHeader.biPlanes = 1;
-   bmi.bmiHeader.biCompression = BI_RGB;
-   bmi.bmiHeader.biBitCount = 32;
-   
-   hDC = CreateCompatibleDC(gBitsDC);
-   hbmBitmap = CreateDIBSection(hDC, &bmi, DIB_RGB_COLORS, (VOID**)&pBitmapBits, NULL, 0 );
-   SetMapMode(hDC, MM_TEXT);
-  
-   SelectObject(hDC, hbmBitmap);
-   SelectObject(hDC, hScaledFont);
-   
-   // Set text properties
-   SetTextColor(hDC, RGB(255,255,255));
-   SetBkColor(hDC, 0);
-   SetBkMode(hDC, TRANSPARENT);
-   SetTextAlign(hDC, TA_TOP);
-   
-   for(c = 32; c < 127; c++ )
-   {
-      int index = c-32;
-      
-      str[0] = c;
-      GetTextExtentPoint32(hDC, str, 1, &size);
-      
-      if (!GetCharABCWidths(hDC, c, c, &pFont->abc[index])) {
-         pFont->abc[index].abcA = 0;
-         pFont->abc[index].abcB = size.cx;
-         pFont->abc[index].abcC = 0;
-      }
 
-      size.cx = pFont->abc[index].abcB;
+	IDirect3DDevice9_CreateTexture(
+		gpD3DDevice, pFont->texWidth,
+		pFont->texHeight, 1, 0, D3DFMT_A4R4G4B4,
+		D3DPOOL_MANAGED, &pFont->pTexture, NULL);
 
-      // Is this row of the texture filled up?
-      if (x + size.cx >= pFont->texWidth)
-      {
-         x = 0;
-         y += size.cy + 1;
-      }
-      
-      int left_offset = pFont->abc[index].abcA;
-      ExtTextOut(hDC, x - left_offset, y+0, 0, NULL, str, 1, NULL);
-      
-      pFont->texST[index][0].s = ((FLOAT)(x+0)) / pFont->texWidth;
-      pFont->texST[index][0].t = ((FLOAT)(y+0)) / pFont->texHeight;
-      pFont->texST[index][1].s = ((FLOAT)(x+0 + size.cx)) / pFont->texWidth;
-      pFont->texST[index][1].t = ((FLOAT)(y+0 + size.cy)) / pFont->texHeight;
+	memset(&bmi.bmiHeader, 0, sizeof(BITMAPINFOHEADER));
+	bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+	bmi.bmiHeader.biWidth = (int)pFont->texWidth;
+	bmi.bmiHeader.biHeight = -(int)pFont->texHeight;
+	bmi.bmiHeader.biPlanes = 1;
+	bmi.bmiHeader.biCompression = BI_RGB;
+	bmi.bmiHeader.biBitCount = 32;
 
-      // Leave +1 space so bilinear filtering doesn't pick up neighboring character
-      x += size.cx+1;  
-   }
-   
-   IDirect3DTexture9_LockRect(pFont->pTexture, 0, &d3dlr, 0, 0);
-   
-   BYTE *pDstRow = (BYTE*)d3dlr.pBits;
-   
-   for(y = 0; y < pFont->texHeight; y++)
-   {
-      pDst16 = (WORD *)pDstRow;
-      for(x = 0; x < pFont->texWidth; x++)
-      {
-         bAlpha = (BYTE)((pBitmapBits[pFont->texWidth * y + x] & 0xff) >> 4);
-         if (bAlpha > 0)
-         {
-            *pDst16++ = (bAlpha << 12) | 0x0fff;
-         }
-         else
-         {
-            *pDst16++ = 0x0000;
-         }
-      }
-      pDstRow += d3dlr.Pitch;
-   }
-   
-   IDirect3DTexture9_UnlockRect(pFont->pTexture, 0);
+	hDC = CreateCompatibleDC(gBitsDC);
+	hbmBitmap = CreateDIBSection(hDC, &bmi, DIB_RGB_COLORS, (VOID**)&pBitmapBits, NULL, 0 );
+	SetMapMode(hDC, MM_TEXT);
 
-   // Get kerning pairs for font
-   pFont->numKerningPairs = GetKerningPairs(hDC, 0, NULL);
-   pFont->kerningPairs = new KERNINGPAIR[pFont->numKerningPairs];
-   GetKerningPairs(hDC, pFont->numKerningPairs, pFont->kerningPairs);
-   
-   DeleteObject(hbmBitmap);
-   DeleteObject(hScaledFont);
-   DeleteDC(hDC);
+	SelectObject(hDC, hbmBitmap);
+	SelectObject(hDC, hScaledFont);
+
+	// Set text properties
+	SetTextColor(hDC, RGB(255,255,255));
+	SetBkColor(hDC, 0);
+	SetBkMode(hDC, TRANSPARENT);
+	SetTextAlign(hDC, TA_TOP);
+
+	for (c = 32; c < 127; c++ )
+	{
+		int index = c-32;
+
+		str[0] = c;
+		GetTextExtentPoint32(hDC, str, 1, &size);
+
+		if (!GetCharABCWidths(hDC, c, c, &pFont->abc[index]))
+		{
+			pFont->abc[index].abcA = 0;
+			pFont->abc[index].abcB = size.cx;
+			pFont->abc[index].abcC = 0;
+		}
+
+		size.cx = pFont->abc[index].abcB;
+
+		// Is this row of the texture filled up?
+		if (x + size.cx >= pFont->texWidth)
+		{
+			x = 0;
+			y += size.cy + 1;
+		}
+
+		int left_offset = pFont->abc[index].abcA;
+		ExtTextOut(hDC, x - left_offset, y+0, 0, NULL, str, 1, NULL);
+
+		pFont->texST[index][0].s = ((FLOAT)(x+0)) / pFont->texWidth;
+		pFont->texST[index][0].t = ((FLOAT)(y+0)) / pFont->texHeight;
+		pFont->texST[index][1].s = ((FLOAT)(x+0 + size.cx)) / pFont->texWidth;
+		pFont->texST[index][1].t = ((FLOAT)(y+0 + size.cy)) / pFont->texHeight;
+
+		// Leave +1 space so bilinear filtering doesn't pick up neighboring character
+		x += size.cx+1;
+	}
+
+	IDirect3DTexture9_LockRect(pFont->pTexture, 0, &d3dlr, 0, 0);
+
+	BYTE *pDstRow = (BYTE*)d3dlr.pBits;
+
+	for (y = 0; y < pFont->texHeight; y++)
+	{
+		pDst16 = (WORD *)pDstRow;
+		for (x = 0; x < pFont->texWidth; x++)
+		{
+			bAlpha = (BYTE)((pBitmapBits[pFont->texWidth * y + x] & 0xff) >> 4);
+			if (bAlpha > 0)
+			{
+				*pDst16++ = (bAlpha << 12) | 0x0fff;
+			}
+			else
+			{
+				*pDst16++ = 0x0000;
+			}
+		}
+		pDstRow += d3dlr.Pitch;
+	}
+
+	IDirect3DTexture9_UnlockRect(pFont->pTexture, 0);
+
+	// Get kerning pairs for font
+	pFont->numKerningPairs = GetKerningPairs(hDC, 0, NULL);
+	pFont->kerningPairs = new KERNINGPAIR[pFont->numKerningPairs];
+	GetKerningPairs(hDC, pFont->numKerningPairs, pFont->kerningPairs);
+
+	DeleteObject(hbmBitmap);
+	DeleteObject(hScaledFont);
+	DeleteDC(hDC);
 }
 
 // new render stuff
@@ -407,109 +408,109 @@ d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDI
 
 void D3DRenderViewElementsDraw(d3d_render_pool_new *pPool)
 {
-   // Render view elements (such as the main viewport yellow ui corners)
-   int i, j;
-   float screenW, screenH, foffset;
-   int offset = 0;
-   d3d_render_packet_new *pPacket;
-   d3d_render_chunk_new *pChunk;
+	// Render view elements (such as the main viewport yellow ui corners)
+	int i, j;
+	float screenW, screenH, foffset;
+	int offset = 0;
+	d3d_render_packet_new *pPacket;
+	d3d_render_chunk_new *pChunk;
 
-   screenW = (float) (gD3DRect.right - gD3DRect.left) / (float) gScreenWidth;
-   screenH = (float) (gD3DRect.bottom - gD3DRect.top) / (float) gScreenHeight;
+	screenW = (float) (gD3DRect.right - gD3DRect.left) / (float) gScreenWidth;
+	screenH = (float) (gD3DRect.bottom - gD3DRect.top) / (float) gScreenHeight;
 
-   if (GetFocus() == hMain)
-      offset = 4;
+	if (GetFocus() == hMain)
+		offset = 4;
 
-   foffset = 1.0f / 64.0f;
+	foffset = 1.0f / 64.0f;
 
-   // 0 = top-left
-   // 1 = top-right
-   // 2 = bottom-left
-   // 3 = bottom-right
+	// 0 = top-left
+	// 1 = top-right
+	// 2 = bottom-left
+	// 3 = bottom-right
 
-   for (i = 0; i < 4; ++i)
-   {
-      float left, right, top, bottom;
+	for (i = 0; i < 4; ++i)
+	{
+		float left, right, top, bottom;
 
-      float width = (float)ViewElements[i + offset].width / screenW;
-      float height = (float)ViewElements[i + offset].height / screenH;
+		float width = (float)ViewElements[i + offset].width / screenW;
+		float height = (float)ViewElements[i + offset].height / screenH;
 
-      if (i % 2 == 0)  // left side
-      {
-         left = D3DRENDER_SCREEN_TO_CLIP_X(0, gScreenWidth);
-         right = D3DRENDER_SCREEN_TO_CLIP_X(width, gScreenWidth);
-      }
-      else  // right side
-      {
-         left = D3DRENDER_SCREEN_TO_CLIP_X(gScreenWidth - width, gScreenWidth);
-         right = D3DRENDER_SCREEN_TO_CLIP_X(gScreenWidth, gScreenWidth);
-      }
+		if (i % 2 == 0)  // left side
+		{
+			left = D3DRENDER_SCREEN_TO_CLIP_X(0, gScreenWidth);
+			right = D3DRENDER_SCREEN_TO_CLIP_X(width, gScreenWidth);
+		}
+		else  // right side
+		{
+			left = D3DRENDER_SCREEN_TO_CLIP_X(gScreenWidth - width, gScreenWidth);
+			right = D3DRENDER_SCREEN_TO_CLIP_X(gScreenWidth, gScreenWidth);
+		}
 
-      if (i < 2)  // top side
-      {
-         top = D3DRENDER_SCREEN_TO_CLIP_Y(0, gScreenHeight);
-         bottom = D3DRENDER_SCREEN_TO_CLIP_Y(height, gScreenHeight);
-      }
-      else  // bottom side
-      {
-         top = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight - height, gScreenHeight);
-         bottom = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight, gScreenHeight);
-      }
+		if (i < 2)  // top side
+		{
+			top = D3DRENDER_SCREEN_TO_CLIP_Y(0, gScreenHeight);
+			bottom = D3DRENDER_SCREEN_TO_CLIP_Y(height, gScreenHeight);
+		}
+		else  // bottom side
+		{
+			top = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight - height, gScreenHeight);
+			bottom = D3DRENDER_SCREEN_TO_CLIP_Y(gScreenHeight, gScreenHeight);
+		}
 
-      pPacket = D3DRenderPacketNew(pPool);
-      pPacket->pDib = NULL;
-      pPacket->pTexture = gpViewElements[i + offset];
-      pPacket->xLat0 = 0;
-      pPacket->xLat1 = 0;
-      pPacket->effect = 0;
-      pPacket->size = pPool->packetSize;
+		pPacket = D3DRenderPacketNew(pPool);
+		pPacket->pDib = NULL;
+		pPacket->pTexture = gpViewElements[i + offset];
+		pPacket->xLat0 = 0;
+		pPacket->xLat1 = 0;
+		pPacket->effect = 0;
+		pPacket->size = pPool->packetSize;
 
-      pChunk = D3DRenderChunkNew(pPacket);
-      pChunk->flags = 0;
-      pChunk->numIndices = 4;
-      pChunk->numVertices = 4;
-      pChunk->numPrimitives = pChunk->numVertices - 2;
-      pChunk->xLat0 = 0;
-      pChunk->xLat1 = 0;
+		pChunk = D3DRenderChunkNew(pPacket);
+		pChunk->flags = 0;
+		pChunk->numIndices = 4;
+		pChunk->numVertices = 4;
+		pChunk->numPrimitives = pChunk->numVertices - 2;
+		pChunk->xLat0 = 0;
+		pChunk->xLat1 = 0;
 
-      pPacket->pMaterialFctn = D3DMaterialObjectPacket;
-      pChunk->pMaterialFctn = D3DMaterialNone;
+		pPacket->pMaterialFctn = D3DMaterialObjectPacket;
+		pChunk->pMaterialFctn = D3DMaterialNone;
 
-      pChunk->xyz[0].x = left;
-      pChunk->xyz[0].z = top;
-      pChunk->xyz[0].y = VIEW_ELEMENT_Z;
-      pChunk->xyz[1].x = left;
-      pChunk->xyz[1].z = bottom;
-      pChunk->xyz[1].y = VIEW_ELEMENT_Z;
-      pChunk->xyz[2].x = right;
-      pChunk->xyz[2].z = bottom;
-      pChunk->xyz[2].y = VIEW_ELEMENT_Z;
-      pChunk->xyz[3].x = right;
-      pChunk->xyz[3].z = top;
-      pChunk->xyz[3].y = VIEW_ELEMENT_Z;
+		pChunk->xyz[0].x = left;
+		pChunk->xyz[0].z = top;
+		pChunk->xyz[0].y = VIEW_ELEMENT_Z;
+		pChunk->xyz[1].x = left;
+		pChunk->xyz[1].z = bottom;
+		pChunk->xyz[1].y = VIEW_ELEMENT_Z;
+		pChunk->xyz[2].x = right;
+		pChunk->xyz[2].z = bottom;
+		pChunk->xyz[2].y = VIEW_ELEMENT_Z;
+		pChunk->xyz[3].x = right;
+		pChunk->xyz[3].z = top;
+		pChunk->xyz[3].y = VIEW_ELEMENT_Z;
 
-      for (j = 0; j < 4; j++)
-      {
-         pChunk->bgra[j].b = 255;
-         pChunk->bgra[j].g = 255;
-         pChunk->bgra[j].r = 255;
-         pChunk->bgra[j].a = 255;
-      }
+		for (j = 0; j < 4; j++)
+		{
+			pChunk->bgra[j].b = 255;
+			pChunk->bgra[j].g = 255;
+			pChunk->bgra[j].r = 255;
+			pChunk->bgra[j].a = 255;
+		}
 
-      pChunk->st0[0].s = foffset;
-      pChunk->st0[0].t = foffset;
-      pChunk->st0[1].s = foffset;
-      pChunk->st0[1].t = 1.0f - foffset;
-      pChunk->st0[2].s = 1.0f - foffset;
-      pChunk->st0[2].t = 1.0f - foffset;
-      pChunk->st0[3].s = 1.0f - foffset;
-      pChunk->st0[3].t = foffset;
+		pChunk->st0[0].s = foffset;
+		pChunk->st0[0].t = foffset;
+		pChunk->st0[1].s = foffset;
+		pChunk->st0[1].t = 1.0f - foffset;
+		pChunk->st0[2].s = 1.0f - foffset;
+		pChunk->st0[2].t = 1.0f - foffset;
+		pChunk->st0[3].s = 1.0f - foffset;
+		pChunk->st0[3].t = foffset;
 
-      pChunk->indices[0] = 1;
-      pChunk->indices[1] = 2;
-      pChunk->indices[2] = 0;
-      pChunk->indices[3] = 3;
-   }
+		pChunk->indices[0] = 1;
+		pChunk->indices[1] = 2;
+		pChunk->indices[2] = 0;
+		pChunk->indices[3] = 3;
+	}
 }
 
 LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
@@ -522,7 +523,7 @@ LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
 	D3DMATRIX			mat;
 	d3d_render_packet_new	*pPacket;
 	d3d_render_chunk_new	*pChunk;
-   HRESULT hr;
+	HRESULT hr;
 
 	D3DCacheSystemReset(&gEffectCacheSystem);
 	D3DRenderPoolReset(&gEffectPool, &D3DMaterialEffectPool);
@@ -543,7 +544,7 @@ LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
 
 	// copy framebuffer to texture
 	IDirect3DDevice9_StretchRect(gpD3DDevice, pSrc, &rect, pDest[0], &rect, D3DTEXF_NONE);
-   
+
 	// clear local->screen transforms
 	MatrixIdentity(&mat);
 	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_WORLD, &mat);
@@ -597,7 +598,7 @@ LPDIRECT3DTEXTURE9 D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9	pTex0,
 	hr = IDirect3DDevice9_SetRenderTarget(gpD3DDevice, 0, pSrc);
 	hr = IDirect3DDevice9_SetDepthStencilSurface(gpD3DDevice, pZBuf);
 	hr = IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, TRUE);
-   
+
 	IDirect3DSurface9_Release(pSrc);
 	IDirect3DSurface9_Release(pZBuf);
 	IDirect3DSurface9_Release(pDest[0]);
@@ -631,8 +632,8 @@ HRESULT D3DRenderInit(HWND hWnd)
 
 	IDirect3DDevice9_GetDeviceCaps(gpD3DDevice, &gD3DCaps);
 
-   gFrame = 0;
-   
+	gFrame = 0;
+
 	gViewport.X = 0;
 	gViewport.Y = 0;
 	gViewport.Width = gScreenWidth;
@@ -661,10 +662,10 @@ HRESULT D3DRenderInit(HWND hWnd)
 
 	{
 
-    D3DCacheSystemInit(&gLMapCacheSystem, gD3DDriverProfile.texMemLMapDynamic);
-    D3DCacheSystemInit(&gLMapCacheSystemStatic, gD3DDriverProfile.texMemLMapStatic);
-    D3DRenderPoolInit(&gLMapPool, POOL_SIZE, PACKET_SIZE);
-    D3DRenderPoolInit(&gLMapPoolStatic, POOL_SIZE, PACKET_SIZE);
+	D3DCacheSystemInit(&gLMapCacheSystem, gD3DDriverProfile.texMemLMapDynamic);
+	D3DCacheSystemInit(&gLMapCacheSystemStatic, gD3DDriverProfile.texMemLMapStatic);
+	D3DRenderPoolInit(&gLMapPool, POOL_SIZE, PACKET_SIZE);
+	D3DRenderPoolInit(&gLMapPoolStatic, POOL_SIZE, PACKET_SIZE);
 
 		D3DCacheSystemInit(&gObjectCacheSystem, gD3DDriverProfile.texMemObjects);
 		D3DCacheSystemInit(&gWorldCacheSystem, gD3DDriverProfile.texMemWorldDynamic);
@@ -689,26 +690,26 @@ HRESULT D3DRenderInit(HWND hWnd)
 		gEffectPool.pMaterialFctn = &D3DMaterialEffectPool;
 		gParticlePool.pMaterialFctn = &D3DMaterialParticlePool;
 	}
-   
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MINFILTER, gD3DDriverProfile.minFilter);
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MIPFILTER, D3DTEXF_NONE);
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAXANISOTROPY, gD3DDriverProfile.maxAnisotropy);
-   
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MINFILTER, gD3DDriverProfile.minFilter);
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MIPFILTER, D3DTEXF_NONE);
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MAXANISOTROPY, gD3DDriverProfile.maxAnisotropy);
+
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MINFILTER, gD3DDriverProfile.minFilter);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MIPFILTER, D3DTEXF_NONE);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAXANISOTROPY, gD3DDriverProfile.maxAnisotropy);
+
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MINFILTER, gD3DDriverProfile.minFilter);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MIPFILTER, D3DTEXF_NONE);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_MAXANISOTROPY, gD3DDriverProfile.maxAnisotropy);
 
 	/***************************************************************************/
 	/*                    VERTEX DECLARATIONS                                  */
 	/***************************************************************************/
-	
+
 	IDirect3DDevice9_CreateVertexDeclaration(gpD3DDevice, decl0, &decl0dc);
 	IDirect3DDevice9_CreateVertexDeclaration(gpD3DDevice, decl1, &decl1dc);
 	IDirect3DDevice9_CreateVertexDeclaration(gpD3DDevice, decl2, &decl2dc);
 
-   SetZBias(gpD3DDevice, 0);
+	SetZBias(gpD3DDevice, 0);
 
 	D3DRenderLMapsBuild();
 
@@ -722,23 +723,20 @@ HRESULT D3DRenderInit(HWND hWnd)
 
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGENABLE, TRUE);
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGCOLOR, 0);
-		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGTABLEMODE,
-                                      mode);
-		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGSTART,
-                                      *(DWORD *)(&start));
-		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGEND,
-                                      *(DWORD *)(&end));
+		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGTABLEMODE, mode);
+		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGSTART, *(DWORD *)(&start));
+		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGEND, *(DWORD *)(&end));
 	}
 
 	// create framebuffer textures
-   for (int i = 0; i <= 15; i++)
-      IDirect3DDevice9_CreateTexture(gpD3DDevice, gSmallTextureSize, gSmallTextureSize, 1,
-                                     D3DUSAGE_RENDERTARGET, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT,
-                                     &gpBackBufferTex[i], NULL);
-   
-   IDirect3DDevice9_CreateTexture(gpD3DDevice, gFullTextureSize, gFullTextureSize, 1,
-                                  D3DUSAGE_RENDERTARGET, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT,
-                                  &gpBackBufferTexFull, NULL);
+	for (int i = 0; i <= 15; i++)
+		IDirect3DDevice9_CreateTexture(gpD3DDevice, gSmallTextureSize, gSmallTextureSize, 1,
+										D3DUSAGE_RENDERTARGET, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT,
+										&gpBackBufferTex[i], NULL);
+
+	IDirect3DDevice9_CreateTexture(gpD3DDevice, gFullTextureSize, gFullTextureSize, 1,
+									D3DUSAGE_RENDERTARGET, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT,
+									&gpBackBufferTexFull, NULL);
 
 	/***************************************************************************/
 	/*                                FONT                                     */
@@ -818,11 +816,11 @@ void D3DRenderShutDown(void)
 				gpViewElements[i] = NULL;
 			}
 		}
-      
+
 		/***************************************************************************/
 		/*                       VERTEX DECLARATIONS                               */
 		/***************************************************************************/
-		
+
 		if (decl0dc) IDirect3DDevice9_Release(decl0dc);
 		if (decl1dc) IDirect3DDevice9_Release(decl1dc);
 		if (decl2dc) IDirect3DDevice9_Release(decl2dc);
@@ -830,10 +828,10 @@ void D3DRenderShutDown(void)
 		decl0dc = NULL;
 		decl1dc = NULL;
 		decl2dc = NULL;
-      
-      IDirect3DDevice9_Release(gpD3DDevice);
+
+		IDirect3DDevice9_Release(gpD3DDevice);
 		gpD3DDevice = NULL;
-      IDirect3D9_Release(gpD3D);
+		IDirect3D9_Release(gpD3D);
 		gpD3D = NULL;
 	}
 }
@@ -964,8 +962,8 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 		&gLMapCacheSystem, &gLMapCacheSystemStatic, &gWallMaskCacheSystem);
 
 	WorldPoolParams worldPoolParams(&gWorldPool, &gWorldPoolStatic, &gLMapPool, &gLMapPoolStatic, &gWallMaskPool);
-		
-	WorldRenderParams worldRenderParams(decl1dc, decl2dc, gD3DDriverProfile, worldCacheSystemParams, worldPoolParams, 
+
+	WorldRenderParams worldRenderParams(decl1dc, decl2dc, gD3DDriverProfile, worldCacheSystemParams, worldPoolParams,
 		view, proj);
 
 	LightAndTextureParams lightAndTextureParams(&gDLightCache, &gDLightCacheDynamic, gSmallTextureSize, sector_depths);
@@ -1018,7 +1016,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	// background overlays (e.g. the Sun & Moon)
 	if (draw_background_overlays)
 	{
-		BackgroundOverlaysRenderStateParams bgoRenderStateParams(decl1dc, gD3DDriverProfile, &gWorldPool, &gWorldCacheSystem, 
+		BackgroundOverlaysRenderStateParams bgoRenderStateParams(decl1dc, gD3DDriverProfile, &gWorldPool, &gWorldCacheSystem,
 			view, mat, gD3DRect);
 		BackgroundOverlaysSceneParams bgoSceneParams(&num_visible_objects, visible_objects, angleHeading, anglePitch, room, params);
 		D3DRenderBackgroundOverlays(bgoRenderStateParams, bgoSceneParams);
@@ -1049,7 +1047,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	{
 		ObjectsRenderParams objectsRenderParams(decl1dc, decl2dc, gD3DDriverProfile, &gObjectPool, &gObjectCacheSystem, view, proj, room, params);
 
-		GameObjectDataParams gameObjectDataParams(nitems, &num_visible_objects, &gNumObjects, drawdata, visible_objects, 
+		GameObjectDataParams gameObjectDataParams(nitems, &num_visible_objects, &gNumObjects, drawdata, visible_objects,
 			gpBackBufferTexFull, gpBackBufferTex);
 
 		FontTextureParams fontTextureParams(&gFont, gSmallTextureSize);
@@ -1081,8 +1079,8 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_VIEW, &mat);
 	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_PROJECTION, &mat);
 
-	FxRenderSystemStructure fxRenderSystemStructure(decl1dc, &gObjectPool, &gObjectCacheSystem, 
-		&gEffectPool, &gEffectCacheSystem, gpBackBufferTex, gpBackBufferTexFull, 
+	FxRenderSystemStructure fxRenderSystemStructure(decl1dc, &gObjectPool, &gObjectCacheSystem,
+		&gEffectPool, &gEffectCacheSystem, gpBackBufferTex, gpBackBufferTexFull,
 		gFullTextureSize, gSmallTextureSize, mat, gFrame, gScreenWidth, gScreenHeight);
 
 	// post overlay effects
@@ -1109,8 +1107,8 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAGFILTER, D3DTEXF_POINT);
 	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MINFILTER, D3DTEXF_POINT);
 
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_ADDRESSU, D3DTADDRESS_CLAMP);
-   IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_ADDRESSV, D3DTADDRESS_CLAMP);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_ADDRESSU, D3DTADDRESS_CLAMP);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_ADDRESSV, D3DTADDRESS_CLAMP);
 
 	IDirect3DDevice9_SetVertexShader(gpD3DDevice, NULL);
 	IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, decl1dc);
@@ -1121,7 +1119,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	D3DCacheFill(&gObjectCacheSystem, &gObjectPool, 1);
 	D3DCacheFlush(&gObjectCacheSystem, &gObjectPool, 1, D3DPT_TRIANGLESTRIP);
 
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);	
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_MAGFILTER, gD3DDriverProfile.magFilter);
 
 
 
@@ -1201,33 +1199,33 @@ void D3DRender_SetAlphaBlendState(BOOL enable, D3DBLEND srcBlend, D3DBLEND dstBl
 void D3DRender_SetStencilMark(DWORD refValue)
 {
 	if (!gpD3DDevice) return;
-    gpD3DDevice->SetRenderState(D3DRS_STENCILENABLE, TRUE);
-    gpD3DDevice->SetRenderState(D3DRS_STENCILFUNC, D3DCMP_ALWAYS);
-    gpD3DDevice->SetRenderState(D3DRS_STENCILREF, refValue);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILENABLE, TRUE);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILFUNC, D3DCMP_ALWAYS);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILREF, refValue);
 	// Only mark pixels that pass the depth test. And don't mark areas that are occluded.
-    gpD3DDevice->SetRenderState(D3DRS_STENCILPASS, D3DSTENCILOP_REPLACE);
-    gpD3DDevice->SetRenderState(D3DRS_STENCILFAIL, D3DSTENCILOP_KEEP);
-    gpD3DDevice->SetRenderState(D3DRS_STENCILZFAIL, D3DSTENCILOP_KEEP);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILPASS, D3DSTENCILOP_REPLACE);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILFAIL, D3DSTENCILOP_KEEP);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILZFAIL, D3DSTENCILOP_KEEP);
 }
 
 // Filters drawing based on stencil buffer comparison.  Doesn't modify the buffer.
 void D3DRender_SetStencilTest(D3DCMPFUNC comparisonFunc, DWORD refValue)
 {
-    if (!gpD3DDevice) return;
-    gpD3DDevice->SetRenderState(D3DRS_STENCILENABLE, TRUE);
-    gpD3DDevice->SetRenderState(D3DRS_STENCILFUNC, comparisonFunc);
-    gpD3DDevice->SetRenderState(D3DRS_STENCILREF, refValue);
+	if (!gpD3DDevice) return;
+	gpD3DDevice->SetRenderState(D3DRS_STENCILENABLE, TRUE);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILFUNC, comparisonFunc);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILREF, refValue);
 	// Don't change the stencil buffer during the test.
-    gpD3DDevice->SetRenderState(D3DRS_STENCILPASS, D3DSTENCILOP_KEEP);
-    gpD3DDevice->SetRenderState(D3DRS_STENCILFAIL, D3DSTENCILOP_KEEP);
-    gpD3DDevice->SetRenderState(D3DRS_STENCILZFAIL, D3DSTENCILOP_KEEP);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILPASS, D3DSTENCILOP_KEEP);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILFAIL, D3DSTENCILOP_KEEP);
+	gpD3DDevice->SetRenderState(D3DRS_STENCILZFAIL, D3DSTENCILOP_KEEP);
 }
 
 // Disable stencil testing for subsequent rendering.
 void D3DRender_DisableStencil()
 {
-    if (!gpD3DDevice) return;
-    gpD3DDevice->SetRenderState(D3DRS_STENCILENABLE, FALSE);
+	if (!gpD3DDevice) return;
+	gpD3DDevice->SetRenderState(D3DRS_STENCILENABLE, FALSE);
 }
 
 // Controls how textures and colors are mathematically combined, whether it's 2D sprites or 3D surfaces.
@@ -1252,18 +1250,18 @@ void D3DRender_SetAlphaStage(DWORD stage, D3DTEXTUREOP alphaOp, DWORD arg1, DWOR
 void D3DRender_SetStreams(d3d_render_cache* pCache, int numStages)
 {
 	if (!gpD3DDevice || !pCache) return;
-	
+
 	// Tracks current stream index to ensure buffers are bound in order.
 	int i = 0;
-	
+
 	gpD3DDevice->SetStreamSource(i++, pCache->xyzBuffer.pVBuffer, 0, sizeof(custom_xyz));
 	gpD3DDevice->SetStreamSource(i++, pCache->bgraBuffer.pVBuffer, 0, sizeof(custom_bgra));
-	
+
 	for (int j = 0; j < numStages; j++)
 	{
 		gpD3DDevice->SetStreamSource(i++, pCache->stBuffer[j].pVBuffer, 0, sizeof(custom_st));
 	}
-	
+
 	gpD3DDevice->SetIndices(pCache->indexBuffer.pIBuffer);
 }
 
@@ -1271,17 +1269,17 @@ void D3DRender_SetStreams(d3d_render_cache* pCache, int numStages)
 void D3DRender_ClearStreams(int numStages)
 {
 	if (!gpD3DDevice) return;
-	
+
 	// Tracks current stream index to ensure buffers are cleared in order.
 	int i = 0;
-	
+
 	gpD3DDevice->SetStreamSource(i++, nullptr, 0, 0);
 	gpD3DDevice->SetStreamSource(i++, nullptr, 0, 0);
-	
+
 	for (int j = 0; j < numStages; j++)
 	{
 		gpD3DDevice->SetStreamSource(i++, nullptr, 0, 0);
 	}
-	
+
 	gpD3DDevice->SetIndices(nullptr);
 }

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -14,32 +14,9 @@
 #define	TEX_CACHE_MAX_EFFECT	2000000
 #define	TEX_CACHE_MAX_PARTICLE	1000000
 
-// Main client windows current viewport area
-extern int main_viewport_width;
-extern int main_viewport_height;
-
-// Define field of views with magic numbers for tuning
-float FovHorizontal(long width)
-{
-	return width / (float)(main_viewport_width) * (-PI / 3.78f);
-}
-
-float FovVertical(long height)
-{
-	return height / (float)(main_viewport_height) * (PI / 5.88f);
-}
-
-// Helper function to determine if an object should be rendered in the current pass based on transparency.
-bool ShouldRenderInCurrentPass(bool transparent_pass, bool isTransparent)
-{
-	return transparent_pass == isTransparent;
-}
-
 d3d_render_packet_new	*gpPacket;
 
 LPDIRECT3DTEXTURE9		gpNoLookThrough = NULL;
-LPDIRECT3DTEXTURE9		gpBackBufferTex[16];
-LPDIRECT3DTEXTURE9		gpBackBufferTexFull;
 LPDIRECT3DTEXTURE9		gpViewElements[NUM_VIEW_ELEMENTS];
 
 D3DVIEWPORT9			gViewport;
@@ -74,13 +51,10 @@ d3d_render_pool_new		gParticlePool;
 custom_xyz				playerOldPos;
 custom_xyz				playerDeltaPos;
 
-font_3d					gFont;
-
 RECT					gD3DRect;
 BYTE					gViewerLight = 0;
 int						gNumObjects;
 int						gNumDPCalls;
-static PALETTEENTRY		gPalette[256];
 
 static unsigned int		gFrame = 0;
 
@@ -89,8 +63,6 @@ static unsigned int		gFrame = 0;
 // As per the original specification, the smaller buffer is 1/4 the size of the full buffer.
 int						gFullTextureSize;
 int						gSmallTextureSize;
-
-int						d3dRenderTextureThreshold;
 
 D3DVERTEXELEMENT9		decl0[] = {
 	{0, 0, D3DDECLTYPE_FLOAT3,	 D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_POSITION, 0},
@@ -120,17 +92,14 @@ LPDIRECT3DVERTEXDECLARATION9 decl2dc;
 AREA					gD3DView;
 int						gD3DRedrawAll = 0;
 int						gTemp = 0;
-bool					gWireframe;		// this is really bad, I'm sorry
 
 extern long				viewer_height;
-extern Color			base_palette[NUM_COLORS];
 extern PDIB				background;         /* Pointer to background bitmap */
 extern ObjectRange		visible_objects[];    /* Where objects are on screen */
 extern int				num_visible_objects;
 extern DrawItem			drawdata[];
 extern long				nitems;
 extern int				sector_depths[];
-extern d3d_driver_profile	gD3DDriverProfile;
 extern BYTE				*gBits;
 extern BYTE				*gBufferBits;
 extern D3DPRESENT_PARAMETERS	gPresentParam;
@@ -153,85 +122,10 @@ d3d_render_packet_new	*D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDI
 
 void					D3DRenderViewElementsDraw(d3d_render_pool_new *pPool);
 
-void					*D3DRenderMalloc(unsigned int bytes);
-
-void SetZBias(LPDIRECT3DDEVICE9 device, int z_bias) {
-   float bias = z_bias * -0.00001f;
-   IDirect3DDevice9_SetRenderState(device, D3DRS_DEPTHBIAS,
-                                   *((DWORD *) &bias));
-}
-
-int getD3dRenderThreshold()
-{
-	return d3dRenderTextureThreshold;
-}
-
-bool isManagedTexturesEnabled() {
-    return gD3DDriverProfile.bManagedTextures;
-}
-
-bool isFogEnabled()
-{
-	return gD3DDriverProfile.bFogEnable;
-}
-
-void setWireframeMode(bool isEnabled)
-{
-	gWireframe = isEnabled;
-}
-
-PALETTEENTRY* getPalette()
-{
-    return gPalette;
-}
-
-const Color(&getBasePalette())[NUM_COLORS]
-{
-	return base_palette;
-}
-
-bool isWireframeMode()
-{
-	return gWireframe;
-}
-
-const font_3d& getFont3d()
-{
-	return gFont;
-}
-
-const LPDIRECT3DTEXTURE9 getWhiteLightTexture()
-{
-	return D3DRenderLightsGetWhite();
-}
-
-const LPDIRECT3DTEXTURE9 getBackBufferTextureZero()
-{
-	return gpBackBufferTex[0];
-}
-
 // externed stuff
 extern void			DrawItemsD3D();
 extern bool			ComputePlayerOverlayArea(PDIB pdib, char hotspot, AREA *obj_area);
 extern void			UpdateRoom3D(room_type *room, Draw3DParams *params);
-
-int DistanceGet(int x, int y)
-{
-	int	distance;
-	float	xf, yf;
-
-	xf = (float)x;
-	yf = (float)y;
-
-	distance = sqrt((double)(xf * xf) + (double)(yf * yf));
-
-	return (int)distance;
-}
-
-void *D3DRenderMalloc(unsigned int bytes)
-{
-	return malloc(bytes);
-}
 
 /************************************************************************************
 *
@@ -800,11 +694,6 @@ void D3DRenderEnableToggle(void)
 		memset(gBits, 0, MAXX * MAXY);
 		memset(gBufferBits, 0, MAXX * 2 * MAXY * 2);
 	}
-}
-
-int D3DRenderIsEnabled(void)
-{
-	return gD3DEnabled;
 }
 
 void D3DRenderFontInit(font_3d *pFont, HFONT hFont)

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -36,6 +36,17 @@ static constexpr float Z_RANGE = 200000.0f;
 // Standard ASCII table, minus the first 32 non-printable control characters.
 static constexpr int NUM_CHARS = 128 - 32;
 
+/////////////
+// Globals //
+/////////////
+inline IDirect3D9* gpD3D = nullptr;
+inline IDirect3DDevice9* gpD3DDevice = nullptr;
+
+inline int gNumVertices = 0;
+inline int gD3DEnabled = 0;
+inline int gScreenWidth = 0;
+inline int gScreenHeight = 0;
+
 ////////////////
 // Structures //
 ////////////////
@@ -73,40 +84,6 @@ struct font_3d
   KERNINGPAIR *kerningPairs;
 };
 
-/////////////
-// Globals //
-/////////////
-inline IDirect3D9* gpD3D = nullptr;
-inline IDirect3DDevice9* gpD3DDevice = nullptr;
-
-inline int gNumVertices = 0;
-inline int gD3DEnabled = 0;
-inline int gScreenWidth = 0;
-inline int gScreenHeight = 0;
-
-inline int d3dRenderTextureThreshold;
-
-inline bool gWireframe;
-inline font_3d gFont;
-
-inline LPDIRECT3DTEXTURE9 gpBackBufferTex[16];
-inline LPDIRECT3DTEXTURE9 gpBackBufferTexFull;
-
-inline static PALETTEENTRY gPalette[256];
-
-// External dependencies required by inline helper functions below.
-
-// Defined in graphics.c
-// Main client windows current viewport area
-extern int main_viewport_width;
-extern int main_viewport_height;
-
-// Defined in d3ddriver.c
-extern d3d_driver_profile gD3DDriverProfile;
-
-// Defined in palette.c
-extern Color base_palette[NUM_COLORS];
-
 //////////////////////
 // Helper Functions //
 //////////////////////
@@ -138,105 +115,35 @@ inline bool D3DRender_InBounds(float coordinate, float range)
 	return fabs(coordinate) < range;
 }
 
-inline int D3DRenderIsEnabled(void)
-{
-	return gD3DEnabled;
-}
+////////////////
+// Prototypes //
+////////////////
 
-inline void *D3DRenderMalloc(unsigned int bytes)
-{
-	return malloc(bytes);
-}
-
-inline void SetZBias(LPDIRECT3DDEVICE9 device, int z_bias) {
-   float bias = z_bias * -0.00001f;
-   IDirect3DDevice9_SetRenderState(device, D3DRS_DEPTHBIAS,
-                                   *((DWORD *) &bias));
-}
-
-inline int DistanceGet(int x, int y)
-{
-	int	distance;
-	float	xf, yf;
-
-	xf = (float)x;
-	yf = (float)y;
-
-	distance = sqrt((double)(xf * xf) + (double)(yf * yf));
-
-	return (int)distance;
-}
-
-// Helper function to determine if an object should be rendered in the current pass based on transparency.
-inline bool ShouldRenderInCurrentPass(bool transparent_pass, bool isTransparent)
-{
-	return transparent_pass == isTransparent;
-}
-
-// Define field of views with magic numbers for tuning
-inline float FovHorizontal(long width)
-{
-	return width / (float)(main_viewport_width) * (-PI / 3.78f);
-}
-
-inline float FovVertical(long height)
-{
-	return height / (float)(main_viewport_height) * (PI / 5.88f);
-}
-
-// Retrieve the threshold value for determining whether to round up the dimensions of a texture.
-inline int getD3dRenderThreshold()
-{
-	return d3dRenderTextureThreshold;
-}
-
-inline bool isManagedTexturesEnabled()
-{
-    return gD3DDriverProfile.bManagedTextures;
-}
-
-inline bool isFogEnabled()
-{
-	return gD3DDriverProfile.bFogEnable;
-}
-
-inline void setWireframeMode(bool isEnabled)
-{
-	gWireframe = isEnabled;
-}
-
-inline bool isWireframeMode()
-{
-	return gWireframe;
-}
-
-inline const font_3d& getFont3d()
-{
-	return gFont;
-}
-
-inline const LPDIRECT3DTEXTURE9 getBackBufferTextureZero()
-{
-	return gpBackBufferTex[0];
-}
+// Helper Function Prototypes //
+int D3DRenderIsEnabled(void);
+void SetZBias(LPDIRECT3DDEVICE9 device, int z_bias);
+int DistanceGet(int x, int y);
+bool ShouldRenderInCurrentPass(bool transparent_pass, bool isTransparent);
+float FovHorizontal(long width);
+float FovVertical(long height);
+int getD3dRenderThreshold();
+bool isManagedTexturesEnabled();
+bool isFogEnabled();
+void setWireframeMode(bool isEnabled);
+bool isWireframeMode();
+const font_3d& getFont3d();
+const LPDIRECT3DTEXTURE9 getBackBufferTextureZero();
 
 // Global palette array containing 256 color entries used for rendering textures in the current frame.
 // This palette is dynamically updated based on the current rendering context.
-inline PALETTEENTRY* getPalette()
-{
-    return gPalette;
-}
+PALETTEENTRY* getPalette();
 
 // Base palette array containing predefined colors used as a reference for rendering effects.
 // This palette remains constant and is used for color lookups and transformations.
-inline const Color(&getBasePalette())[NUM_COLORS]
-{
-	return base_palette;
-}
+const Color(&getBasePalette())[NUM_COLORS];
 
-/////////////////////////
-// Function Prototypes //
-/////////////////////////
+
+// Main Function Prototypes //
 HRESULT				D3DRenderInit(HWND hWnd);
 void				D3DRenderShutDown(void);
 void				D3DRenderBegin(room_type *room, Draw3DParams *params);
@@ -266,20 +173,5 @@ void D3DRender_SetAlphaStage(DWORD stage, D3DTEXTUREOP alphaOp, DWORD arg1, DWOR
 
 void D3DRender_SetStreams(d3d_render_cache* pCache, int numStages);
 void D3DRender_ClearStreams(int numStages);
-
-////////////////////////////
-// External Dependencies  //
-////////////////////////////
-
-// Defined in object3d.c
-int FindHotspotPdib(PDIB pdib, char hotspot, POINT* point);
-const Vector3D& getSunVector();
-
-// Defined in graphics.c
-// Returns the max shading range (FINENESS-shade_amount) to FINENESS
-long getShadeAmount();
-
-// Defined in d3drender_lights.c
-LPDIRECT3DTEXTURE9 D3DRenderLightsGetWhite();
 
 #endif	// __D3DRENDER_H__

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -36,17 +36,6 @@ static constexpr float Z_RANGE = 200000.0f;
 // Standard ASCII table, minus the first 32 non-printable control characters.
 static constexpr int NUM_CHARS = 128 - 32;
 
-/////////////
-// Globals //
-/////////////
-inline IDirect3D9* gpD3D = nullptr;
-inline IDirect3DDevice9* gpD3DDevice = nullptr;
-
-inline int gNumVertices = 0;
-inline int gD3DEnabled = 0;
-inline int gScreenWidth = 0;
-inline int gScreenHeight = 0;
-
 ////////////////
 // Structures //
 ////////////////
@@ -84,6 +73,40 @@ struct font_3d
   KERNINGPAIR *kerningPairs;
 };
 
+/////////////
+// Globals //
+/////////////
+inline IDirect3D9* gpD3D = nullptr;
+inline IDirect3DDevice9* gpD3DDevice = nullptr;
+
+inline int gNumVertices = 0;
+inline int gD3DEnabled = 0;
+inline int gScreenWidth = 0;
+inline int gScreenHeight = 0;
+
+inline int d3dRenderTextureThreshold;
+
+inline bool gWireframe;
+inline font_3d gFont;
+
+inline LPDIRECT3DTEXTURE9 gpBackBufferTex[16];
+inline LPDIRECT3DTEXTURE9 gpBackBufferTexFull;
+
+inline static PALETTEENTRY gPalette[256];
+
+// External dependencies required by inline helper functions below.
+
+// Defined in graphics.c
+// Main client windows current viewport area
+extern int main_viewport_width;
+extern int main_viewport_height;
+
+// Defined in d3ddriver.c
+extern d3d_driver_profile gD3DDriverProfile;
+
+// Defined in palette.c
+extern Color base_palette[NUM_COLORS];
+
 //////////////////////
 // Helper Functions //
 //////////////////////
@@ -115,6 +138,102 @@ inline bool D3DRender_InBounds(float coordinate, float range)
 	return fabs(coordinate) < range;
 }
 
+inline int D3DRenderIsEnabled(void)
+{
+	return gD3DEnabled;
+}
+
+inline void *D3DRenderMalloc(unsigned int bytes)
+{
+	return malloc(bytes);
+}
+
+inline void SetZBias(LPDIRECT3DDEVICE9 device, int z_bias) {
+   float bias = z_bias * -0.00001f;
+   IDirect3DDevice9_SetRenderState(device, D3DRS_DEPTHBIAS,
+                                   *((DWORD *) &bias));
+}
+
+inline int DistanceGet(int x, int y)
+{
+	int	distance;
+	float	xf, yf;
+
+	xf = (float)x;
+	yf = (float)y;
+
+	distance = sqrt((double)(xf * xf) + (double)(yf * yf));
+
+	return (int)distance;
+}
+
+// Helper function to determine if an object should be rendered in the current pass based on transparency.
+inline bool ShouldRenderInCurrentPass(bool transparent_pass, bool isTransparent)
+{
+	return transparent_pass == isTransparent;
+}
+
+// Define field of views with magic numbers for tuning
+inline float FovHorizontal(long width)
+{
+	return width / (float)(main_viewport_width) * (-PI / 3.78f);
+}
+
+inline float FovVertical(long height)
+{
+	return height / (float)(main_viewport_height) * (PI / 5.88f);
+}
+
+// Retrieve the threshold value for determining whether to round up the dimensions of a texture.
+inline int getD3dRenderThreshold()
+{
+	return d3dRenderTextureThreshold;
+}
+
+inline bool isManagedTexturesEnabled()
+{
+    return gD3DDriverProfile.bManagedTextures;
+}
+
+inline bool isFogEnabled()
+{
+	return gD3DDriverProfile.bFogEnable;
+}
+
+inline void setWireframeMode(bool isEnabled)
+{
+	gWireframe = isEnabled;
+}
+
+inline bool isWireframeMode()
+{
+	return gWireframe;
+}
+
+inline const font_3d& getFont3d()
+{
+	return gFont;
+}
+
+inline const LPDIRECT3DTEXTURE9 getBackBufferTextureZero()
+{
+	return gpBackBufferTex[0];
+}
+
+// Global palette array containing 256 color entries used for rendering textures in the current frame.
+// This palette is dynamically updated based on the current rendering context.
+inline PALETTEENTRY* getPalette()
+{
+    return gPalette;
+}
+
+// Base palette array containing predefined colors used as a reference for rendering effects.
+// This palette remains constant and is used for color lookups and transformations.
+inline const Color(&getBasePalette())[NUM_COLORS]
+{
+	return base_palette;
+}
+
 /////////////////////////
 // Function Prototypes //
 /////////////////////////
@@ -123,56 +242,16 @@ void				D3DRenderShutDown(void);
 void				D3DRenderBegin(room_type *room, Draw3DParams *params);
 void				D3DRenderResizeDisplay(int left, int top, int right, int bottom);
 void				D3DRenderEnableToggle(void);
-int					D3DRenderIsEnabled(void);
 int					D3DRenderObjectGetLight(BSPnode *tree, room_contents_node *pRNode);
 d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDIRECT3DTEXTURE9 pTexture,
 												PDIB pDib, BYTE xLat0, BYTE xLat1, int effect);
 d3d_render_packet_new *D3DRenderPacketNew(d3d_render_pool_new *pPool);
 d3d_render_chunk_new *D3DRenderChunkNew(d3d_render_packet_new *pPacket);
 void				D3DRenderPoolReset(d3d_render_pool_new *pPool, void *pMaterialFunc);
-void				*D3DRenderMalloc(unsigned int bytes);
 void				D3DRenderFontInit(font_3d *pFont, HFONT hFont);
 
 LPDIRECT3DTEXTURE9  D3DRenderFramebufferTextureCreate(LPDIRECT3DTEXTURE9 pTex0, LPDIRECT3DTEXTURE9 pTex1, 
 	float width, float height);
-
-void SetZBias(LPDIRECT3DDEVICE9 device, int z_bias);
-int DistanceGet(int x, int y);
-
-int FindHotspotPdib(PDIB pdib, char hotspot, POINT* point);
-
-bool ShouldRenderInCurrentPass(bool transparent_pass, bool isTransparent);
-
-float FovHorizontal(long width);
-float FovVertical(long height);
-
-// Retrieve the threshold value for determining whether to round up the dimensions of a texture.
-int getD3dRenderThreshold();
-
-// Returns the max shading range (FINENESS-shade_amount) to FINENESS
-long getShadeAmount();
-
-bool isManagedTexturesEnabled();
-bool isFogEnabled();
-
-const Vector3D& getSunVector();
-
-void setWireframeMode(bool isEnabled);
-bool isWireframeMode();
-
-const font_3d& getFont3d();
-
-const LPDIRECT3DTEXTURE9 getWhiteLightTexture();
-
-const LPDIRECT3DTEXTURE9 getBackBufferTextureZero();
-
-// Global palette array containing 256 color entries used for rendering textures in the current frame.
-// This palette is dynamically updated based on the current rendering context.
-PALETTEENTRY* getPalette();
-
-// Base palette array containing predefined colors used as a reference for rendering effects.
-// This palette remains constant and is used for color lookups and transformations.
-const Color(&getBasePalette())[NUM_COLORS];
 
 // D3D State Functions
 void D3DRender_SetAlphaTestState(BOOL enable, DWORD alphaRef, D3DCMPFUNC comparisonFunc);
@@ -187,5 +266,20 @@ void D3DRender_SetAlphaStage(DWORD stage, D3DTEXTUREOP alphaOp, DWORD arg1, DWOR
 
 void D3DRender_SetStreams(d3d_render_cache* pCache, int numStages);
 void D3DRender_ClearStreams(int numStages);
+
+////////////////////////////
+// External Dependencies  //
+////////////////////////////
+
+// Defined in object3d.c
+int FindHotspotPdib(PDIB pdib, char hotspot, POINT* point);
+const Vector3D& getSunVector();
+
+// Defined in graphics.c
+// Returns the max shading range (FINENESS-shade_amount) to FINENESS
+long getShadeAmount();
+
+// Defined in d3drender_lights.c
+LPDIRECT3DTEXTURE9 D3DRenderLightsGetWhite();
 
 #endif	// __D3DRENDER_H__

--- a/clientd3d/d3drender_lights.h
+++ b/clientd3d/d3drender_lights.h
@@ -71,4 +71,6 @@ float GetGlobalLightScale(void);
 // Report flicker performance stats (called from D3DRenderBegin).
 void D3DLightsReportFlickerPerf(void);
 
+LPDIRECT3DTEXTURE9 D3DRenderLightsGetWhite();
+
 #endif /* #ifndef _D3DRENDERLIGHTS_H */

--- a/clientd3d/d3drender_materials.c
+++ b/clientd3d/d3drender_materials.c
@@ -224,7 +224,7 @@ bool D3DMaterialLMapDynamicPool(d3d_render_pool_new *pPool)
    IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP);
    IDirect3DDevice9_SetSamplerState(gpD3DDevice, 1, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP);
 
-   const auto &whiteLightTexture = getWhiteLightTexture();
+   const auto &whiteLightTexture = D3DRenderLightsGetWhite();
    IDirect3DDevice9_SetTexture(gpD3DDevice, 0, (IDirect3DBaseTexture9 *) whiteLightTexture);
 
    D3DRender_SetColorStage(0, D3DTOP_MODULATE, D3DTA_TEXTURE, D3DTA_DIFFUSE);

--- a/clientd3d/draw3d.h
+++ b/clientd3d/draw3d.h
@@ -16,6 +16,10 @@
 
 #include "drawdefs.h"    // Basic constant definitions
 
+// Forward declaration of Vector3D required for getSunVector() to
+// avoid issues with include-order in client.h
+struct Vector3D;  
+
 /* a divided by b, rounded down */
 #define DIVDOWN(a,b) (a)/(b)
 /* a divided by b, rounded up (doesn't work for b<0!!!!) */
@@ -114,6 +118,7 @@ int  GetFlicker(room_contents_node *obj);
 const Draw3DParams& getDrawParams();
 void setDrawParams(Draw3DParams* newDrawParams);
 
+const Vector3D& getSunVector();
 
 #endif /* #ifndef _DRAW3D_H */
 

--- a/clientd3d/graphics.h
+++ b/clientd3d/graphics.h
@@ -49,5 +49,7 @@ bool GraphicsMouseCaptured(void);
 int GetFPS(void);
 int GetMSDrawFrame(void);
 
+long getShadeAmount();
+
 #endif
 

--- a/clientd3d/object3d.h
+++ b/clientd3d/object3d.h
@@ -62,5 +62,6 @@ bool GetObjectSize(ID icon_res, int group, int angle, list_type overlays, int *w
 void DrawObjectDecorations(DrawnObject *object);
 bool FindOverlayArea(PDIB pdib_ov, int angle, char hotspot, PDIB pdib_obj, 
 		     list_type overlays, int overlay_depth, AREA *overlay_area);
+int FindHotspotPdib(PDIB pdib, char hotspot, POINT* point);
 
 #endif /* #ifndef _OBJECT3D_H */


### PR DESCRIPTION
This PR is split off #1406 to help untangle the reorganization changes from the refactoring.

The PR strictly focuses on reorganization and cleanup for both `d3drender.c` and `d3drender.h` for better readability.  It also removes up unused variables and externs to help clarify which ones actually affect the renderer.  The refactoring of `d3drender.c` is planned for a separate PR after this one.

- Separated source file functions into two sections: Internal Implementation, and Public Functions
- Removed unused cache limits, global variables, and externs.
- Cleaned up redundant prototypes.  Grouped external functions at the bottom of the header file.
  - Removed `getWhiteLightTexture()`.  Updated `d3drender_materials.c` to use `D3DRenderLightsGetWhite()` directly.
  - Removed `D3DRenderMalloc()`.  Updated `d3drender.c` and `d3dcache.c` to instead use reinterpret_cast and malloc.
- Moved external function prototypes from `d3drender.h` to where they are defined.
  - Made `Vector3D` typedef  in `bsp.h` into a C++ struct to allow forward declarations in `draw3d.h` to resolve incomplete type error.
- Corrected whitespace by making space-based indentation into tab-based.  Also trimmed trailing whitespace.