### PR TITLE
fix: play monster swing sounds from the monster instead of the target

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -1616,7 +1616,7 @@ messages:
    {
       if vrSound_miss <> $
       {
-         Send(poOwner,@SomethingWaveRoom,#what=what,#wave_rsc=vrSound_miss,
+         Send(poOwner,@SomethingWaveRoom,#what=self,#wave_rsc=vrSound_miss,
               #flags=SOUND_RANDOM_PITCH);
          if (IsClass(what,&Player))
          {
@@ -1630,11 +1630,11 @@ messages:
 
    AssessMiss(what = $, stroke_obj = $)
    "This does the fallout of a miss, gives appropriate message, etc.  "
-   "Called on target when missing."
+   "Called on self when missing."
    {
       if vrSound_miss <> $
       {
-         Send(poOwner,@SomethingWaveRoom,#what=what,#wave_rsc=vrSound_miss,
+         Send(poOwner,@SomethingWaveRoom,#what=self,#wave_rsc=vrSound_miss,
               #flags=SOUND_RANDOM_PITCH);
       }
 


### PR DESCRIPTION
## What
- Plays the monster's swing sound from the monster instead of from the target getting hit

## Why
- A player attacked by a giant rat hears the rat's swing sound centered on themselves with no left/right pan, even when the rat is several tiles away
  - The rat's "I see you" sound (`vrSound_aware`) already comes from the rat's direction, so the contrast makes the swing sound feel obviously broken
- Other players in the room hear the swing coming from the target's tile, not from the rat
- `player.kod` already does this correctly for player attacks, monsters were the only thing playing swing sounds from the wrong place
- This needs to be merged before the attempted fix/feature for sounds tracking moving objects PR
  - Once sources update position every frame, a swing sound stuck on the target will actively chase the target around the room
  - Today the wrong position is just frozen in place, less noticeable

## Notes
- Ranged attacks are unaffected
  - `vrSound_miss` for a ranged monster belongs at the attacker's tile
  - There are no projectile flight or impact sounds in the game today, so this PR doesn't touch them
- Made a small correction to the docstring on `AssessMiss` to match the existing `AssessHit` docstring

## Example

### Before
- Player A is attacked by a giant rat 6 tiles away
  - Player A hears the swipe centered on themselves
  - Player B watching from across the room hears the swipe from Player A's position

### After
- Player A hears the swipe from the rat's direction
- Player B hears the swipe from the rat's position
- The ouch sound still plays from Player A's position