### PR TITLE
feature: sounds follow moving objects

### DIFF
--- a/clientd3d/about.c
+++ b/clientd3d/about.c
@@ -302,7 +302,7 @@ void AboutTimer(HWND hwnd, UINT id)
 	       case ABOUT_RSC3: index = 5; break;
 	       default: index = rand() % num_sounds; break;
 	       }
-	       PlayWaveFile(hMain, sounds[index], MAX_VOLUME, SF_RANDOM_PITCH, 0, 0, 0, 0);
+	       PlayWaveFile(hMain, sounds[index], MAX_VOLUME, SF_RANDOM_PITCH, 0, 0, 0, 0, 0);
 	    }
 	 }
 		

--- a/clientd3d/audio_openal.c
+++ b/clientd3d/audio_openal.c
@@ -75,6 +75,16 @@ static std::list<CacheNode> g_cacheList;
 static std::unordered_map<std::string, std::list<CacheNode>::iterator,
                           CaseInsensitiveHash, CaseInsensitiveEqual> g_cacheMap;
 
+/*
+ * Tracked source registry: links a playing OpenAL source to a game object
+ * so the source's position can be refreshed each frame as the object moves.
+ */
+struct TrackedSource {
+   ALuint source;     // OpenAL source currently playing
+   ID     object_id;  // Game object whose position the source should follow
+};
+static std::vector<TrackedSource> g_trackedSources;
+
 // Music streaming state
 static const int STREAM_NUM_BUFFERS = 4;
 static const int STREAM_BUFFER_SAMPLES = 4096;
@@ -948,9 +958,13 @@ static ALuint LoadAudioBuffer(const char* filename)
 
 /*
  * SoundPlay: Returns true if sound started. Supports OGG/WAV, 3D positioning, looping.
+ *   When source_obj is non-zero and the sound is positional, the source is
+ *   registered so subsequent frames refresh its position from the object's
+ *   current location.
  */
 bool SoundPlay(const char* filename, int volume, BYTE flags,
-               int src_row, int src_col, int radius, int max_vol)
+               int src_row, int src_col, int radius, int max_vol,
+               ID source_obj)
 {
    if (!g_initialized)
       return false;
@@ -1096,6 +1110,14 @@ bool SoundPlay(const char* filename, int volume, BYTE flags,
       return false;
    }
 
+   // Register the source for per-frame position updates if it is a positional
+   // sound emitted by a known game object.  Non-positional sounds (UI, ambient
+   // loops at placeholder coords) ignore source_obj.
+   if (isPositional && source_obj != 0)
+   {
+      g_trackedSources.push_back({source, source_obj});
+   }
+
    return true;
 }
 
@@ -1124,6 +1146,8 @@ void SoundStopAll(void)
    {
       alSourceStop(g_sources[i]);
    }
+
+   g_trackedSources.clear();
 }
 
 /*
@@ -1166,7 +1190,50 @@ void Audio_StopSourcesForFilename(const char* filename)
       {
          alSourceStop(g_sources[i]);
          alSourcei(g_sources[i], AL_BUFFER, 0);
+
+         // Drop any tracked entries pointing at this source
+         auto end = std::remove_if(g_trackedSources.begin(), g_trackedSources.end(),
+            [src = g_sources[i]](const TrackedSource& t) { return t.source == src; });
+         g_trackedSources.erase(end, g_trackedSources.end());
       }
+   }
+}
+
+/*
+ * Audio_UpdateTrackedSources: Refresh OpenAL source positions for sounds
+ *   attached to moving game objects.  Drops entries whose source has stopped
+ *   or whose object is no longer in the room.
+ */
+void Audio_UpdateTrackedSources(void)
+{
+   if (!g_initialized || g_trackedSources.empty())
+      return;
+
+   for (auto it = g_trackedSources.begin(); it != g_trackedSources.end(); )
+   {
+      ALint state = AL_STOPPED;
+      alGetSourcei(it->source, AL_SOURCE_STATE, &state);
+      if (state != AL_PLAYING && state != AL_PAUSED)
+      {
+         it = g_trackedSources.erase(it);
+         continue;
+      }
+
+      room_contents_node *obj = GetRoomObjectById(it->object_id);
+      if (obj == NULL)
+      {
+         // Object left the room or was destroyed; stop the sound so it does
+         // not linger at a stale position.
+         alSourceStop(it->source);
+         it = g_trackedSources.erase(it);
+         continue;
+      }
+
+      int row = obj->motion.y >> LOG_FINENESS;
+      int col = obj->motion.x >> LOG_FINENESS;
+      // Negate X to match the listener's coordinate convention
+      alSource3f(it->source, AL_POSITION, -(float)col, 0.0f, (float)row);
+      ++it;
    }
 }
 

--- a/clientd3d/audio_openal.c
+++ b/clientd3d/audio_openal.c
@@ -1202,7 +1202,7 @@ void Audio_StopSourcesForFilename(const char* filename)
  *   attached to moving game objects.  Drops entries whose source has stopped
  *   or whose object is no longer in the room.
  */
-void Audio_UpdateTrackedSources(void)
+void AudioUpdateTrackedSources(void)
 {
    if (!g_initialized || g_trackedSources.empty())
       return;

--- a/clientd3d/audio_openal.c
+++ b/clientd3d/audio_openal.c
@@ -75,10 +75,8 @@ static std::list<CacheNode> g_cacheList;
 static std::unordered_map<std::string, std::list<CacheNode>::iterator,
                           CaseInsensitiveHash, CaseInsensitiveEqual> g_cacheMap;
 
-/*
- * Tracked source registry: links a playing OpenAL source to a game object
- * so the source's position can be refreshed each frame as the object moves.
- */
+// Tracked source registry: links a playing OpenAL source to a game object
+// so the source's position can be refreshed each frame as the object moves.
 struct TrackedSource {
    ALuint source;     // OpenAL source currently playing
    ID     object_id;  // Game object whose position the source should follow

--- a/clientd3d/audio_openal.c
+++ b/clientd3d/audio_openal.c
@@ -1204,7 +1204,7 @@ void Audio_StopSourcesForFilename(const char* filename)
  */
 void AudioUpdateTrackedSources(void)
 {
-   if (!g_initialized || g_trackedSources.empty())
+   if (!g_initialized)
       return;
 
    for (auto it = g_trackedSources.begin(); it != g_trackedSources.end(); )

--- a/clientd3d/audio_openal.c
+++ b/clientd3d/audio_openal.c
@@ -77,11 +77,9 @@ static std::unordered_map<std::string, std::list<CacheNode>::iterator,
 
 // Tracked source registry: links a playing OpenAL source to a game object
 // so the source's position can be refreshed each frame as the object moves.
-struct TrackedSource {
-   ALuint source;     // OpenAL source currently playing
-   ID     object_id;  // Game object whose position the source should follow
-};
-static std::vector<TrackedSource> g_trackedSources;
+// Key is the OpenAL source ID, value is the game object whose position the
+// source should follow.
+static std::unordered_map<ALuint, ID> g_trackedSources;
 
 // Music streaming state
 static const int STREAM_NUM_BUFFERS = 4;
@@ -1113,7 +1111,7 @@ bool SoundPlay(const char* filename, int volume, BYTE flags,
    // loops at placeholder coords) ignore source_obj.
    if (isPositional && source_obj != 0)
    {
-      g_trackedSources.push_back({source, source_obj});
+      g_trackedSources[source] = source_obj;
    }
 
    return true;
@@ -1188,11 +1186,7 @@ void Audio_StopSourcesForFilename(const char* filename)
       {
          alSourceStop(g_sources[i]);
          alSourcei(g_sources[i], AL_BUFFER, 0);
-
-         // Drop any tracked entries pointing at this source
-         auto end = std::remove_if(g_trackedSources.begin(), g_trackedSources.end(),
-            [src = g_sources[i]](const TrackedSource& t) { return t.source == src; });
-         g_trackedSources.erase(end, g_trackedSources.end());
+         g_trackedSources.erase(g_sources[i]);
       }
    }
 }
@@ -1209,20 +1203,23 @@ void AudioUpdateTrackedSources(void)
 
    for (auto it = g_trackedSources.begin(); it != g_trackedSources.end(); )
    {
+      ALuint source = it->first;
+      ID object_id = it->second;
+
       ALint state = AL_STOPPED;
-      alGetSourcei(it->source, AL_SOURCE_STATE, &state);
+      alGetSourcei(source, AL_SOURCE_STATE, &state);
       if (state != AL_PLAYING && state != AL_PAUSED)
       {
          it = g_trackedSources.erase(it);
          continue;
       }
 
-      room_contents_node *obj = GetRoomObjectById(it->object_id);
+      room_contents_node *obj = GetRoomObjectById(object_id);
       if (obj == NULL)
       {
          // Object left the room or was destroyed; stop the sound so it does
          // not linger at a stale position.
-         alSourceStop(it->source);
+         alSourceStop(source);
          it = g_trackedSources.erase(it);
          continue;
       }
@@ -1230,7 +1227,7 @@ void AudioUpdateTrackedSources(void)
       int row = obj->motion.y >> LOG_FINENESS;
       int col = obj->motion.x >> LOG_FINENESS;
       // Negate X to match the listener's coordinate convention
-      alSource3f(it->source, AL_POSITION, -(float)col, 0.0f, (float)row);
+      alSource3f(source, AL_POSITION, -(float)col, 0.0f, (float)row);
       ++it;
    }
 }

--- a/clientd3d/audio_openal.c
+++ b/clientd3d/audio_openal.c
@@ -1198,7 +1198,7 @@ void Audio_StopSourcesForFilename(const char* filename)
 }
 
 /*
- * Audio_UpdateTrackedSources: Refresh OpenAL source positions for sounds
+ * AudioUpdateTrackedSources: Refresh OpenAL source positions for sounds
  *   attached to moving game objects.  Drops entries whose source has stopped
  *   or whose object is no longer in the room.
  */

--- a/clientd3d/audio_openal.c
+++ b/clientd3d/audio_openal.c
@@ -1194,7 +1194,7 @@ void Audio_StopSourcesForFilename(const char* filename)
 /*
  * AudioUpdateTrackedSources: Refresh OpenAL source positions for sounds
  *   attached to moving game objects.  Drops entries whose source has stopped
- *   or whose object is no longer in the room.
+ *   or whose object can no longer be found by ID.
  */
 void AudioUpdateTrackedSources(void)
 {
@@ -1217,9 +1217,7 @@ void AudioUpdateTrackedSources(void)
       room_contents_node *obj = GetRoomObjectById(object_id);
       if (obj == NULL)
       {
-         // Object left the room or was destroyed; stop the sound so it does
-         // not linger at a stale position.
-         alSourceStop(source);
+         // Untrack but leave the source playing at its last position.
          it = g_trackedSources.erase(it);
          continue;
       }

--- a/clientd3d/audio_openal.h
+++ b/clientd3d/audio_openal.h
@@ -25,8 +25,11 @@ bool MusicIsPlaying(void);
 
 // Returns true if sound started successfully; supports OGG and WAV formats,
 // looping, and 3D positioning. Coordinates are in tile units.
+// source_obj is the ID of the game object that emits the sound (0 = none).
+// When non-zero, the source is registered for per-frame position updates.
 bool SoundPlay(const char* filename, int volume, BYTE flags, 
-               int src_row, int src_col, int radius, int max_vol);
+               int src_row, int src_col, int radius, int max_vol,
+               ID source_obj);
 
 void SoundStopAll(void);
 
@@ -35,6 +38,10 @@ void SoundStopLooping(void);
 
 // Stop any playing sources that are using the given filename's buffer
 void Audio_StopSourcesForFilename(const char* filename);
+
+// Update positions of sources tracked to a moving game object.  Call once
+// per frame.  Stopped sources and missing objects are pruned automatically.
+void Audio_UpdateTrackedSources(void);
 
 // Sets the listener's position and facing direction for 3D audio
 void AudioUpdateListener(float x, float y, float z, 

--- a/clientd3d/audio_openal.h
+++ b/clientd3d/audio_openal.h
@@ -41,7 +41,7 @@ void Audio_StopSourcesForFilename(const char* filename);
 
 // Update positions of sources tracked to a moving game object.  Call once
 // per frame.  Stopped sources and missing objects are pruned automatically.
-void Audio_UpdateTrackedSources(void);
+void AudioUpdateTrackedSources(void);
 
 // Sets the listener's position and facing direction for 3D audio
 void AudioUpdateListener(float x, float y, float z, 

--- a/clientd3d/game.c
+++ b/clientd3d/game.c
@@ -654,7 +654,9 @@ void GamePlaySound(ID sound_rsc, ID source_obj, BYTE flags, WORD y, WORD x, WORD
    }
    // Pass the raw radius so the audio layer can tell a caller-specified
    // radius (radius > 0) apart from "use the default" (radius == 0).
-   PlayWaveRsc(sound_rsc, volume, flags, src_row, src_col, radius, maxvolume);
+   // source_obj is forwarded so the audio layer can keep the source's
+   // position in sync if the emitter moves while the sound plays.
+   PlayWaveRsc(sound_rsc, volume, flags, src_row, src_col, radius, maxvolume, source_obj);
 }
 /************************************************************************/
 void GameQuit(void)

--- a/clientd3d/move.c
+++ b/clientd3d/move.c
@@ -433,7 +433,7 @@ void UserMovePlayer(int action)
        player_obj->motion.z <= z &&
        ((last_splash == 0xFFFFFFFF) || ((now - last_splash) > (DWORD)(500*depth))))
    {
-       PlayWaveRsc(effects.wadingsound, MAX_VOLUME, 0, 0, 0, 0, 0);
+       PlayWaveRsc(effects.wadingsound, MAX_VOLUME, 0, 0, 0, 0, 0, 0);
        last_splash = now;
    }
    if (depth == SF_DEPTH0)

--- a/clientd3d/sound.c
+++ b/clientd3d/sound.c
@@ -172,5 +172,5 @@ void UpdateLoopingSounds(int px, int py, int angle)
 	AudioUpdateListener((float)px, 0.0f, (float)py, forwardX, 0.0f, forwardZ);
 
 	// Refresh positions of sources attached to moving game objects
-	Audio_UpdateTrackedSources();
+	AudioUpdateTrackedSources();
 }

--- a/clientd3d/sound.c
+++ b/clientd3d/sound.c
@@ -86,7 +86,7 @@ void SoundInitialize(void)
  */
 M59EXPORT bool PlayWaveFile(HWND hwnd, const char *fname, int volume,
 							BYTE flags, int src_row, int src_col, int radius,
-							int max_vol)
+							int max_vol, ID source_obj)
 {
 	if (!fname || fname[0] == '\0')
 		return false;
@@ -99,21 +99,21 @@ M59EXPORT bool PlayWaveFile(HWND hwnd, const char *fname, int volume,
 	if (!fs::path(fname).has_parent_path())
 	{
 		std::string pathbuf = (fs::path(sound_dir) / fname).string();
-		played = SoundPlay(pathbuf.c_str(), volume, flags, src_row, src_col, radius, max_vol);
+		played = SoundPlay(pathbuf.c_str(), volume, flags, src_row, src_col, radius, max_vol, source_obj);
 		if (played)
 		{
 			actual_path = pathbuf;
 		}
 		else
 		{
-			played = SoundPlay(fname, volume, flags, src_row, src_col, radius, max_vol);
+			played = SoundPlay(fname, volume, flags, src_row, src_col, radius, max_vol, source_obj);
 			if (played)
 				actual_path = fname;
 		}
 	}
 	else
 	{
-		played = SoundPlay(fname, volume, flags, src_row, src_col, radius, max_vol);
+		played = SoundPlay(fname, volume, flags, src_row, src_col, radius, max_vol, source_obj);
 		if (played)
 			actual_path = fname;
 	}
@@ -128,7 +128,8 @@ M59EXPORT bool PlayWaveFile(HWND hwnd, const char *fname, int volume,
 	return played;
 }
 
-M59EXPORT void PlayWaveRsc(ID rsc, int volume, BYTE flags, int row, int col, int radius, int max_vol)
+M59EXPORT void PlayWaveRsc(ID rsc, int volume, BYTE flags, int row, int col,
+						   int radius, int max_vol, ID source_obj)
 {
 	char *name;
 
@@ -141,7 +142,7 @@ M59EXPORT void PlayWaveRsc(ID rsc, int volume, BYTE flags, int row, int col, int
 		return;
 
 	/* Forward to PlayWaveFile which handles path resolution and ambient tracking */
-	PlayWaveFile(hMain, name, volume, flags, row, col, radius, max_vol);
+	PlayWaveFile(hMain, name, volume, flags, row, col, radius, max_vol, source_obj);
 }
 
 M59EXPORT void SoundAbort(void)
@@ -169,4 +170,7 @@ void UpdateLoopingSounds(int px, int py, int angle)
 
 	// Update OpenAL listener position and orientation
 	AudioUpdateListener((float)px, 0.0f, (float)py, forwardX, 0.0f, forwardZ);
+
+	// Refresh positions of sources attached to moving game objects
+	Audio_UpdateTrackedSources();
 }

--- a/clientd3d/sound.h
+++ b/clientd3d/sound.h
@@ -18,9 +18,10 @@ void SoundInitialize(void);
 
 M59EXPORT bool PlayWaveFile(HWND hwnd, const char *fname, int volume,
                                      BYTE flags, int src_row, int src_col, int radius,
-                                     int max_vol);
+                                     int max_vol, ID source_obj);
 
-M59EXPORT void PlayWaveRsc(ID rsc, int volume, BYTE flags, int row, int col, int radius, int max_vol);
+M59EXPORT void PlayWaveRsc(ID rsc, int volume, BYTE flags, int row, int col,
+                                     int radius, int max_vol, ID source_obj);
 
 /* Marks all currently tracked looping sounds for potential cleanup. */
 void Sound_BeginLoopingSoundTransition(void);

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -87,6 +87,7 @@ graph TD
 | `SoundPlay(filename, volume, flags, ...)` | Play sound effect with optional 3D positioning |
 | `SoundStopAll()` | Stop all sound effects |
 | `AudioUpdateListener(x, y, z, ...)` | Update listener position for 3D audio |
+| `Audio_UpdateTrackedSources()` | Refresh positions of sources attached to moving game objects |
 
 ### Music API (music.c)
 
@@ -132,7 +133,8 @@ theme.mp3 -> theme.ogg
 
 This mapping happens in `ConvertLegacyMusicExtension()` in music.c.
 
-Sound effects also prefer .ogg over .wav. When a .wav file is requested, the audio system first checks if an .ogg version exists and uses that instead.
+Sound effects also prefer .ogg over .wav. When a .wav file is requested, the audio
+system first checks if an .ogg version exists and uses that instead.
 
 ### File Naming Convention
 
@@ -157,11 +159,14 @@ Sound effects are cached using an LRU (Least Recently Used) strategy:
 - **Protection:** Buffers currently playing are never evicted
 - **Lookup:** O(1) via case-insensitive hash map
 
-Music is NOT cached because tracks are large and typically don't repeat rapidly. Instead, music uses streaming playback (see below).
+Music is NOT cached because tracks are large and typically don't repeat rapidly.
+Instead, music uses streaming playback (see below).
 
 ## Music Streaming
 
-Music files are played via streaming rather than full-file decoding. This eliminates the loading hitch that occurred when decompressing entire OGG files (30-50 MB of decoded PCM from 2-7 MB OGG files) in a single blocking call on the main thread.
+Music files are played via streaming rather than full-file decoding. This eliminates
+the loading hitch that occurred when decompressing entire OGG files (30-50 MB of
+decoded PCM from 2-7 MB OGG files) in a single blocking call on the main thread.
 
 ### How It Works
 
@@ -176,9 +181,14 @@ chunks and fed to OpenAL through a ring buffer:
 | Memory per buffer | 16,384 bytes (stereo 16-bit) |
 | Total streaming memory | ~64 KB (vs 30-50 MB full decode) |
 
-Music streaming runs on a dedicated background thread (`MusicThreadProc`) started in `AudioInit()`. The thread decodes OGG data and rotates OpenAL buffers independently of the main thread, so buffer refills cannot be starved by UI activity.
+Music streaming runs on a dedicated background thread (`MusicThreadProc`) started
+in `AudioInit()`. The thread decodes OGG data and rotates OpenAL buffers independently
+of the main thread, so buffer refills cannot be starved by UI activity.
 
-`MusicPlay()`, `MusicStop()`, and `MusicSetVolume()` post commands to the thread and return immediately. `MusicStreamUpdate()` queries `AL_BUFFERS_PROCESSED` to find consumed buffers, decodes the next chunk, and re-queues. If the source underruns, it restarts automatically. Looping seeks the decoder back to the start at EOF.
+`MusicPlay()`, `MusicStop()`, and `MusicSetVolume()` post commands to the thread
+and return immediately. `MusicStreamUpdate()` queries `AL_BUFFERS_PROCESSED` to find
+consumed buffers, decodes the next chunk, and re-queues. If the source underruns,
+it restarts automatically. Looping seeks the decoder back to the start at EOF.
 
 ```mermaid
 graph LR
@@ -210,7 +220,8 @@ graph LR
 
 ### Which Sounds Are Positional?
 
-Not all sounds use 3D positioning. This matches the original MSS behavior where all sounds played at equal volume in both stereo channels (no panning).
+Not all sounds use 3D positioning. This matches the original MSS behavior where all sounds
+played at equal volume in both stereo channels (no panning).
 
 | Sound Type | Positional? | Rationale |
 |------------|-------------|----------|
@@ -222,22 +233,37 @@ Not all sounds use 3D positioning. This matches the original MSS behavior where 
 
 ### Distance Model
 
-The client uses two different OpenAL distance models depending on whether a sound is a one-shot effect or a looping ambient emitter, and whether the Blakod explicitly specified a cutoff radius:
+The client uses two different OpenAL distance models depending on whether a
+sound is a one-shot effect or a looping ambient emitter, and whether the
+server (kod) explicitly specified a cutoff radius:
 
-| Sound type | Blakod-set radius? | Distance model | Reference distance | Max distance | Behavior |
-|------------|--------------------|----------------|--------------------|--------------|----------|
-| `SF_LOOP` ambient (fountain, firepit, forge) | yes (always) | `AL_LINEAR_DISTANCE_CLAMPED` | 1 tile | radius | Linear falloff to silence at the Blakod-defined radius |
-| One-shot with explicit radius (door, scripted area effect) | yes | `AL_LINEAR_DISTANCE_CLAMPED` | 1 tile | radius | Linear falloff to silence at the Blakod-defined radius |
+| Sound type | Kod-set radius? | Distance model | Reference distance | Max distance | Behavior |
+|------------|-----------------|----------------|--------------------|--------------|----------|
+| `SF_LOOP` ambient (fountain, firepit, forge) | yes (always) | `AL_LINEAR_DISTANCE_CLAMPED` | 1 tile | radius | Linear falloff to silence at the kod-defined radius |
+| One-shot with explicit radius (door, scripted area effect) | yes | `AL_LINEAR_DISTANCE_CLAMPED` | 1 tile | radius | Linear falloff to silence at the kod-defined radius |
 | One-shot with no radius (combat, spells, generic effects) | no | `AL_INVERSE_DISTANCE_CLAMPED` | 2 tiles | 10000 (effectively unbounded) | Smooth `1/d` falloff, never reaches silence |
 
-The Blakod communicates intent via the `cutoff_radius` parameter on `SomethingWaveRoom` / `WaveSendUser`:
+The server (Blakod) communicates intent via the `cutoff_radius` parameter on
+`SomethingWaveRoom` / `WaveSendUser`:
 
-- `cutoff_radius = 0` (default in `user.kod`'s `WaveSendUser`): no opinion. One-shots get the soft inverse falloff so distant combat/spells stay audible across the room, matching pre-OpenAL Miles Sound System behavior where `GamePlaySound()` computed `volume = MAX_VOLUME * 2 / distance` and never let a sound reach zero.
-- `cutoff_radius = N` (Blakod set it explicitly): the Blakod author wants a hard cutoff at N tiles. Used by door open/close (radius=4) so a door slam in one corner of a large hall does not bleed across the whole room.
+- `cutoff_radius = 0` (default in `user.kod`'s `WaveSendUser`):  no opinion.
+  One-shots get the soft inverse falloff so distant combat/spells stay
+  audible across the room, matching pre-OpenAL Miles Sound System behavior
+  where `GamePlaySound()` computed `volume = MAX_VOLUME * 2 / distance` and
+  never let a sound reach zero.
+- `cutoff_radius = N` (kod set it explicitly):  the kod author wants a hard
+  cutoff at N tiles.  Used by door open/close (radius=4) so a door slam in
+  one corner of a large hall does not bleed across the whole room.
 
-Loops always use the linear-clamped model with their Blakod-defined radius. Without the cutoff, every loaded ambient emitter (fountain in every room, firepit in every cave) would mix together forever with no way to bound CPU or audio mix complexity. `fountain.kod` defaults `piSoundRadius = 40` and firepits typically use 5.
+Loops always use the linear-clamped model with their kod-defined radius.
+Without the cutoff, every loaded ambient emitter (fountain in every room,
+firepit in every cave) would mix together forever with no way to bound CPU
+or audio mix complexity.  Fountain.kod defaults `piSoundRadius = 40` and
+firepits typically use 5.
 
-Per-source distance models are enabled via `AL_EXT_source_distance_model` (`alEnable(AL_SOURCE_DISTANCE_MODEL)` at init), which lets each source pick its own model independently of the global default.
+Per-source distance models are enabled via `AL_EXT_source_distance_model`
+(`alEnable(AL_SOURCE_DISTANCE_MODEL)` at init), which lets each source pick
+its own model independently of the global default.
 
 ```mermaid
 flowchart TD
@@ -245,7 +271,7 @@ flowchart TD
     B -->|"No"| C["Centered on local listener<br/>(SOURCE_RELATIVE, no falloff)<br/>Plays equally L/R for this client only"]
     B -->|"Yes"| D{"SF_LOOP flag set?"}
     D -->|"Yes (fountain, firepit)"| E["AL_LINEAR_DISTANCE_CLAMPED<br/>ref=1, max=radius<br/>Hard cutoff at radius"]
-    D -->|"No"| G{"Blakod-set radius?<br/>(radius > 0)"}
+    D -->|"No"| G{"Kod-set radius?<br/>(radius > 0)"}
     G -->|"Yes (door, area effect)"| H["AL_LINEAR_DISTANCE_CLAMPED<br/>ref=1, max=radius<br/>Hard cutoff at radius"]
     G -->|"No (combat, spell)"| F["AL_INVERSE_DISTANCE_CLAMPED<br/>ref=2, max=10000<br/>Soft 1/d falloff, no cutoff"]
 
@@ -262,9 +288,34 @@ All audio positioning uses **tile coordinates** (coarse grid), not fine coordina
 - **Fine coords:** High precision (e.g., 39424, 56832), used for smooth player movement
 - **Tile coords:** Coarse grid (e.g., 56, 18), conversion: `tile = fine >> LOG_FINENESS`
 
-`GamePlaySound()` normalizes object positions (fine) to tile coords before calling audio. `UpdateLoopingSounds()` converts player position (fine) to tile coords for the listener. Server-provided ambient sound positions are already in tile coords.
+`GamePlaySound()` normalizes object positions (fine) to tile coords before calling audio.
+`UpdateLoopingSounds()` converts player position (fine) to tile coords for the listener.
+Server-provided ambient sound positions are already in tile coords.
 
 The listener position is updated each frame via `AudioUpdateListener()`.
+
+### Sources Attached to Moving Objects
+
+When a sound is started for a specific game object (a monster, a player, a
+projectile owner), `GamePlaySound` forwards the object's `source_obj` ID all
+the way down to `SoundPlay`.  If the resulting source is positional, the audio
+layer registers it in a small `g_trackedSources` table.
+
+Each frame `UpdateLoopingSounds()` calls `Audio_UpdateTrackedSources()`, which:
+
+- Drops entries whose source has stopped (one-shots clean themselves up as they
+  finish playing).
+- Looks up the object via `GetRoomObjectById`.  If the object is gone (left the
+  room or was destroyed) the source is stopped to avoid lingering audio at a
+  stale position.
+- Otherwise refreshes `AL_POSITION` from the object's current `motion.x/y` so
+  the sound follows the object as it moves.
+
+Without this, a sound emitted by a moving object stays anchored at the spot
+where the sound first started, regardless of where the object is now.  Sounds
+started with `source_obj == 0` (UI sounds, fixed-position room emitters such as
+fountains and firepits) are never registered and remain at their initial
+position.
 
 ## Audio File Guidelines
 
@@ -288,9 +339,12 @@ When adding new sound files to the game, follow these guidelines for optimal pla
 
 ### Why Mono for 3D Audio?
 
-OpenAL uses the mono audio data and applies HRTF/panning based on the sound's position relative to the listener. With stereo files, OpenAL cannot determine how to spatialize the left vs right channels, so it plays them as-is (no 3D effect).
+OpenAL uses the mono audio data and applies HRTF/panning based on the sound's position
+relative to the listener. With stereo files, OpenAL cannot determine how to spatialize
+the left vs right channels, so it plays them as-is (no 3D effect).
 
-If you notice a sound effect is not panning correctly when you move around it in-game, check if the source file is stereo and convert it to mono.
+If you notice a sound effect is not panning correctly when you move around it in-game,
+check if the source file is stereo and convert it to mono.
 
 ## Configuration
 
@@ -309,7 +363,8 @@ OpenAL Soft supports multiple audio output modes configured via `alsoft.ini` (us
 
 ### HRTF (Headphone 3D Audio)
 
-Head-Related Transfer Function simulates 3D audio for headphone users by applying filters that mimic how sound reaches your ears from different directions.
+Head-Related Transfer Function simulates 3D audio for headphone users by applying filters
+that mimic how sound reaches your ears from different directions.
 
 To enable HRTF, create or edit `alsoft.ini`:
 
@@ -318,11 +373,14 @@ To enable HRTF, create or edit `alsoft.ini`:
 hrtf = true
 ```
 
-OpenAL Soft ships with built-in HRTF data. Additional HRTF profiles (.mhr files) can be placed in the OpenAL Soft data directory.
+OpenAL Soft ships with built-in HRTF data. Additional HRTF profiles (.mhr files) can be
+placed in the OpenAL Soft data directory.
 
 ### Surround Sound (5.1 / 7.1)
 
-OpenAL Soft automatically detects and uses your system's speaker configuration. For multi-channel setups (5.1, 7.1), 3D positional sounds will be correctly spatialized across all speakers.
+OpenAL Soft automatically detects and uses your system's speaker configuration. For
+multi-channel setups (5.1, 7.1), 3D positional sounds will be correctly spatialized
+across all speakers.
 
 To force a specific output mode in `alsoft.ini`:
 
@@ -331,7 +389,8 @@ To force a specific output mode in `alsoft.ini`:
 channels = surround51   ; Options: mono, stereo, quad, surround51, surround61, surround71
 ```
 
-No game configuration is required—OpenAL Soft handles speaker routing automatically based on your Windows audio device settings.
+No game configuration is required—OpenAL Soft handles speaker routing automatically
+based on your Windows audio device settings.
 
 ## Dependencies
 

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -271,7 +271,16 @@ The listener position is updated each frame via `AudioUpdateListener()`.
 
 When a sound is started for a specific game object (a monster, a player, a projectile owner), `GamePlaySound` forwards the object's `source_obj` ID all the way down to `SoundPlay`. If the resulting source is positional, the audio layer registers it in a small `g_trackedSources` table.
 
-Each frame `UpdateLoopingSounds()` calls `AudioUpdateTrackedSources()`, which drops entries whose source has stopped (one-shots clean themselves up as they finish playing), looks up the object via `GetRoomObjectById` and stops the source if the object is gone (left the room or was destroyed) to avoid lingering audio at a stale position, and otherwise refreshes `AL_POSITION` from the object's current `motion.x/y` so the sound follows the object as it moves.
+Each frame `UpdateLoopingSounds()` calls `AudioUpdateTrackedSources()`, which drops entries whose source has stopped (one-shots clean themselves up as they finish playing), looks up the object via `GetRoomObjectById`, and refreshes `AL_POSITION` from the object's current `motion.x/y` so the sound follows the object as it moves.
+
+#### Untrack on missing object
+
+If the object lookup fails, the entry is dropped from the tracker but the source is left playing at its last position. This is intentional. Object IDs can become temporarily unreachable when the server renumbers room contents (for example during a system save), even though the same prop is still present under a new ID. Stopping the source on every miss would briefly silence fountains, fire pits, and other looping world audio every save.
+
+Edge cases worth noting:
+- One-shots play to completion. The source finishes naturally and the next frame removes it via the "source no longer playing" branch.
+- After a renumber, the server resends `BK_PLAY_WAVE` for the same prop with its new ID. For looping sounds, `SoundPlay` notices the WAV is already playing on a source and returns early without starting a duplicate, so there is no overlap. The existing loop keeps playing at its last position and is no longer tracked, which is fine for stationary props (fountains, fire pits). A moving object with a loop would stop following until the next room transition clears state.
+- Genuine "this sound should stop" still flows through the server sending an explicit stop, which `Audio_StopSourcesForFilename` honors. Looping sources are also bounded by `SoundStopAll` on room transitions.
 
 Without this, a sound emitted by a moving object stays anchored at the spot where the sound first started, regardless of where the object is now. Sounds started with `source_obj == 0` (UI sounds, fixed-position room emitters such as fountains and firepits) are never registered and remain at their initial position.
 

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -87,7 +87,7 @@ graph TD
 | `SoundPlay(filename, volume, flags, ...)` | Play sound effect with optional 3D positioning |
 | `SoundStopAll()` | Stop all sound effects |
 | `AudioUpdateListener(x, y, z, ...)` | Update listener position for 3D audio |
-| `Audio_UpdateTrackedSources()` | Refresh positions of sources attached to moving game objects |
+| `AudioUpdateTrackedSources()` | Refresh positions of sources attached to moving game objects |
 
 ### Music API (music.c)
 
@@ -271,7 +271,7 @@ The listener position is updated each frame via `AudioUpdateListener()`.
 
 When a sound is started for a specific game object (a monster, a player, a projectile owner), `GamePlaySound` forwards the object's `source_obj` ID all the way down to `SoundPlay`. If the resulting source is positional, the audio layer registers it in a small `g_trackedSources` table.
 
-Each frame `UpdateLoopingSounds()` calls `Audio_UpdateTrackedSources()`, which drops entries whose source has stopped (one-shots clean themselves up as they finish playing), looks up the object via `GetRoomObjectById` and stops the source if the object is gone (left the room or was destroyed) to avoid lingering audio at a stale position, and otherwise refreshes `AL_POSITION` from the object's current `motion.x/y` so the sound follows the object as it moves.
+Each frame `UpdateLoopingSounds()` calls `AudioUpdateTrackedSources()`, which drops entries whose source has stopped (one-shots clean themselves up as they finish playing), looks up the object via `GetRoomObjectById` and stops the source if the object is gone (left the room or was destroyed) to avoid lingering audio at a stale position, and otherwise refreshes `AL_POSITION` from the object's current `motion.x/y` so the sound follows the object as it moves.
 
 Without this, a sound emitted by a moving object stays anchored at the spot where the sound first started, regardless of where the object is now. Sounds started with `source_obj == 0` (UI sounds, fixed-position room emitters such as fountains and firepits) are never registered and remain at their initial position.
 

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -133,8 +133,7 @@ theme.mp3 -> theme.ogg
 
 This mapping happens in `ConvertLegacyMusicExtension()` in music.c.
 
-Sound effects also prefer .ogg over .wav. When a .wav file is requested, the audio
-system first checks if an .ogg version exists and uses that instead.
+Sound effects also prefer .ogg over .wav. When a .wav file is requested, the audio system first checks if an .ogg version exists and uses that instead.
 
 ### File Naming Convention
 
@@ -159,14 +158,11 @@ Sound effects are cached using an LRU (Least Recently Used) strategy:
 - **Protection:** Buffers currently playing are never evicted
 - **Lookup:** O(1) via case-insensitive hash map
 
-Music is NOT cached because tracks are large and typically don't repeat rapidly.
-Instead, music uses streaming playback (see below).
+Music is NOT cached because tracks are large and typically don't repeat rapidly. Instead, music uses streaming playback (see below).
 
 ## Music Streaming
 
-Music files are played via streaming rather than full-file decoding. This eliminates
-the loading hitch that occurred when decompressing entire OGG files (30-50 MB of
-decoded PCM from 2-7 MB OGG files) in a single blocking call on the main thread.
+Music files are played via streaming rather than full-file decoding. This eliminates the loading hitch that occurred when decompressing entire OGG files (30-50 MB of decoded PCM from 2-7 MB OGG files) in a single blocking call on the main thread.
 
 ### How It Works
 
@@ -181,14 +177,9 @@ chunks and fed to OpenAL through a ring buffer:
 | Memory per buffer | 16,384 bytes (stereo 16-bit) |
 | Total streaming memory | ~64 KB (vs 30-50 MB full decode) |
 
-Music streaming runs on a dedicated background thread (`MusicThreadProc`) started
-in `AudioInit()`. The thread decodes OGG data and rotates OpenAL buffers independently
-of the main thread, so buffer refills cannot be starved by UI activity.
+Music streaming runs on a dedicated background thread (`MusicThreadProc`) started in `AudioInit()`. The thread decodes OGG data and rotates OpenAL buffers independently of the main thread, so buffer refills cannot be starved by UI activity.
 
-`MusicPlay()`, `MusicStop()`, and `MusicSetVolume()` post commands to the thread
-and return immediately. `MusicStreamUpdate()` queries `AL_BUFFERS_PROCESSED` to find
-consumed buffers, decodes the next chunk, and re-queues. If the source underruns,
-it restarts automatically. Looping seeks the decoder back to the start at EOF.
+`MusicPlay()`, `MusicStop()`, and `MusicSetVolume()` post commands to the thread and return immediately. `MusicStreamUpdate()` queries `AL_BUFFERS_PROCESSED` to find consumed buffers, decodes the next chunk, and re-queues. If the source underruns, it restarts automatically. Looping seeks the decoder back to the start at EOF.
 
 ```mermaid
 graph LR
@@ -220,8 +211,7 @@ graph LR
 
 ### Which Sounds Are Positional?
 
-Not all sounds use 3D positioning. This matches the original MSS behavior where all sounds
-played at equal volume in both stereo channels (no panning).
+Not all sounds use 3D positioning. This matches the original MSS behavior where all sounds played at equal volume in both stereo channels (no panning).
 
 | Sound Type | Positional? | Rationale |
 |------------|-------------|----------|
@@ -233,37 +223,22 @@ played at equal volume in both stereo channels (no panning).
 
 ### Distance Model
 
-The client uses two different OpenAL distance models depending on whether a
-sound is a one-shot effect or a looping ambient emitter, and whether the
-server (kod) explicitly specified a cutoff radius:
+The client uses two different OpenAL distance models depending on whether a sound is a one-shot effect or a looping ambient emitter, and whether the Blakod explicitly specified a cutoff radius:
 
-| Sound type | Kod-set radius? | Distance model | Reference distance | Max distance | Behavior |
-|------------|-----------------|----------------|--------------------|--------------|----------|
-| `SF_LOOP` ambient (fountain, firepit, forge) | yes (always) | `AL_LINEAR_DISTANCE_CLAMPED` | 1 tile | radius | Linear falloff to silence at the kod-defined radius |
-| One-shot with explicit radius (door, scripted area effect) | yes | `AL_LINEAR_DISTANCE_CLAMPED` | 1 tile | radius | Linear falloff to silence at the kod-defined radius |
+| Sound type | Blakod-set radius? | Distance model | Reference distance | Max distance | Behavior |
+|------------|--------------------|----------------|--------------------|--------------|----------|
+| `SF_LOOP` ambient (fountain, firepit, forge) | yes (always) | `AL_LINEAR_DISTANCE_CLAMPED` | 1 tile | radius | Linear falloff to silence at the Blakod-defined radius |
+| One-shot with explicit radius (door, scripted area effect) | yes | `AL_LINEAR_DISTANCE_CLAMPED` | 1 tile | radius | Linear falloff to silence at the Blakod-defined radius |
 | One-shot with no radius (combat, spells, generic effects) | no | `AL_INVERSE_DISTANCE_CLAMPED` | 2 tiles | 10000 (effectively unbounded) | Smooth `1/d` falloff, never reaches silence |
 
-The server (Blakod) communicates intent via the `cutoff_radius` parameter on
-`SomethingWaveRoom` / `WaveSendUser`:
+The Blakod communicates intent via the `cutoff_radius` parameter on `SomethingWaveRoom` / `WaveSendUser`:
 
-- `cutoff_radius = 0` (default in `user.kod`'s `WaveSendUser`):  no opinion.
-  One-shots get the soft inverse falloff so distant combat/spells stay
-  audible across the room, matching pre-OpenAL Miles Sound System behavior
-  where `GamePlaySound()` computed `volume = MAX_VOLUME * 2 / distance` and
-  never let a sound reach zero.
-- `cutoff_radius = N` (kod set it explicitly):  the kod author wants a hard
-  cutoff at N tiles.  Used by door open/close (radius=4) so a door slam in
-  one corner of a large hall does not bleed across the whole room.
+- `cutoff_radius = 0` (default in `user.kod`'s `WaveSendUser`): no opinion. One-shots get the soft inverse falloff so distant combat/spells stay audible across the room, matching pre-OpenAL Miles Sound System behavior where `GamePlaySound()` computed `volume = MAX_VOLUME * 2 / distance` and never let a sound reach zero.
+- `cutoff_radius = N` (Blakod set it explicitly): the Blakod author wants a hard cutoff at N tiles. Used by door open/close (radius=4) so a door slam in one corner of a large hall does not bleed across the whole room.
 
-Loops always use the linear-clamped model with their kod-defined radius.
-Without the cutoff, every loaded ambient emitter (fountain in every room,
-firepit in every cave) would mix together forever with no way to bound CPU
-or audio mix complexity.  Fountain.kod defaults `piSoundRadius = 40` and
-firepits typically use 5.
+Loops always use the linear-clamped model with their Blakod-defined radius. Without the cutoff, every loaded ambient emitter (fountain in every room, firepit in every cave) would mix together forever with no way to bound CPU or audio mix complexity. `fountain.kod` defaults `piSoundRadius = 40` and firepits typically use 5.
 
-Per-source distance models are enabled via `AL_EXT_source_distance_model`
-(`alEnable(AL_SOURCE_DISTANCE_MODEL)` at init), which lets each source pick
-its own model independently of the global default.
+Per-source distance models are enabled via `AL_EXT_source_distance_model` (`alEnable(AL_SOURCE_DISTANCE_MODEL)` at init), which lets each source pick its own model independently of the global default.
 
 ```mermaid
 flowchart TD
@@ -271,7 +246,7 @@ flowchart TD
     B -->|"No"| C["Centered on local listener<br/>(SOURCE_RELATIVE, no falloff)<br/>Plays equally L/R for this client only"]
     B -->|"Yes"| D{"SF_LOOP flag set?"}
     D -->|"Yes (fountain, firepit)"| E["AL_LINEAR_DISTANCE_CLAMPED<br/>ref=1, max=radius<br/>Hard cutoff at radius"]
-    D -->|"No"| G{"Kod-set radius?<br/>(radius > 0)"}
+    D -->|"No"| G{"Blakod-set radius?<br/>(radius > 0)"}
     G -->|"Yes (door, area effect)"| H["AL_LINEAR_DISTANCE_CLAMPED<br/>ref=1, max=radius<br/>Hard cutoff at radius"]
     G -->|"No (combat, spell)"| F["AL_INVERSE_DISTANCE_CLAMPED<br/>ref=2, max=10000<br/>Soft 1/d falloff, no cutoff"]
 
@@ -288,34 +263,17 @@ All audio positioning uses **tile coordinates** (coarse grid), not fine coordina
 - **Fine coords:** High precision (e.g., 39424, 56832), used for smooth player movement
 - **Tile coords:** Coarse grid (e.g., 56, 18), conversion: `tile = fine >> LOG_FINENESS`
 
-`GamePlaySound()` normalizes object positions (fine) to tile coords before calling audio.
-`UpdateLoopingSounds()` converts player position (fine) to tile coords for the listener.
-Server-provided ambient sound positions are already in tile coords.
+`GamePlaySound()` normalizes object positions (fine) to tile coords before calling audio. `UpdateLoopingSounds()` converts player position (fine) to tile coords for the listener. Server-provided ambient sound positions are already in tile coords.
 
 The listener position is updated each frame via `AudioUpdateListener()`.
 
 ### Sources Attached to Moving Objects
 
-When a sound is started for a specific game object (a monster, a player, a
-projectile owner), `GamePlaySound` forwards the object's `source_obj` ID all
-the way down to `SoundPlay`.  If the resulting source is positional, the audio
-layer registers it in a small `g_trackedSources` table.
+When a sound is started for a specific game object (a monster, a player, a projectile owner), `GamePlaySound` forwards the object's `source_obj` ID all the way down to `SoundPlay`. If the resulting source is positional, the audio layer registers it in a small `g_trackedSources` table.
 
-Each frame `UpdateLoopingSounds()` calls `Audio_UpdateTrackedSources()`, which:
+Each frame `UpdateLoopingSounds()` calls `Audio_UpdateTrackedSources()`, which drops entries whose source has stopped (one-shots clean themselves up as they finish playing), looks up the object via `GetRoomObjectById` and stops the source if the object is gone (left the room or was destroyed) to avoid lingering audio at a stale position, and otherwise refreshes `AL_POSITION` from the object's current `motion.x/y` so the sound follows the object as it moves.
 
-- Drops entries whose source has stopped (one-shots clean themselves up as they
-  finish playing).
-- Looks up the object via `GetRoomObjectById`.  If the object is gone (left the
-  room or was destroyed) the source is stopped to avoid lingering audio at a
-  stale position.
-- Otherwise refreshes `AL_POSITION` from the object's current `motion.x/y` so
-  the sound follows the object as it moves.
-
-Without this, a sound emitted by a moving object stays anchored at the spot
-where the sound first started, regardless of where the object is now.  Sounds
-started with `source_obj == 0` (UI sounds, fixed-position room emitters such as
-fountains and firepits) are never registered and remain at their initial
-position.
+Without this, a sound emitted by a moving object stays anchored at the spot where the sound first started, regardless of where the object is now. Sounds started with `source_obj == 0` (UI sounds, fixed-position room emitters such as fountains and firepits) are never registered and remain at their initial position.
 
 ## Audio File Guidelines
 
@@ -339,12 +297,9 @@ When adding new sound files to the game, follow these guidelines for optimal pla
 
 ### Why Mono for 3D Audio?
 
-OpenAL uses the mono audio data and applies HRTF/panning based on the sound's position
-relative to the listener. With stereo files, OpenAL cannot determine how to spatialize
-the left vs right channels, so it plays them as-is (no 3D effect).
+OpenAL uses the mono audio data and applies HRTF/panning based on the sound's position relative to the listener. With stereo files, OpenAL cannot determine how to spatialize the left vs right channels, so it plays them as-is (no 3D effect).
 
-If you notice a sound effect is not panning correctly when you move around it in-game,
-check if the source file is stereo and convert it to mono.
+If you notice a sound effect is not panning correctly when you move around it in-game, check if the source file is stereo and convert it to mono.
 
 ## Configuration
 
@@ -363,8 +318,7 @@ OpenAL Soft supports multiple audio output modes configured via `alsoft.ini` (us
 
 ### HRTF (Headphone 3D Audio)
 
-Head-Related Transfer Function simulates 3D audio for headphone users by applying filters
-that mimic how sound reaches your ears from different directions.
+Head-Related Transfer Function simulates 3D audio for headphone users by applying filters that mimic how sound reaches your ears from different directions.
 
 To enable HRTF, create or edit `alsoft.ini`:
 
@@ -373,14 +327,11 @@ To enable HRTF, create or edit `alsoft.ini`:
 hrtf = true
 ```
 
-OpenAL Soft ships with built-in HRTF data. Additional HRTF profiles (.mhr files) can be
-placed in the OpenAL Soft data directory.
+OpenAL Soft ships with built-in HRTF data. Additional HRTF profiles (.mhr files) can be placed in the OpenAL Soft data directory.
 
 ### Surround Sound (5.1 / 7.1)
 
-OpenAL Soft automatically detects and uses your system's speaker configuration. For
-multi-channel setups (5.1, 7.1), 3D positional sounds will be correctly spatialized
-across all speakers.
+OpenAL Soft automatically detects and uses your system's speaker configuration. For multi-channel setups (5.1, 7.1), 3D positional sounds will be correctly spatialized across all speakers.
 
 To force a specific output mode in `alsoft.ini`:
 
@@ -389,8 +340,7 @@ To force a specific output mode in `alsoft.ini`:
 channels = surround51   ; Options: mono, stereo, quad, surround51, surround61, surround71
 ```
 
-No game configuration is required—OpenAL Soft handles speaker routing automatically
-based on your Windows audio device settings.
+No game configuration is required—OpenAL Soft handles speaker routing automatically based on your Windows audio device settings.
 
 ## Dependencies
 


### PR DESCRIPTION
## What
- Sounds tied to a game object now follow that object as it moves, instead of staying at the spot where the sound first played
- Depends on #1411 merging first
  - Without it, this PR turns a static "wrong position" bug into a more obvious "swing follows the victim around the room" bug
- Related to #1413 

## Why
- Reported by a player
> sounds created into the world space doesn't seem to follow the source and just stay where they are created
- The audio layer never knew which object owned a sound
  - `GamePlaySound` looked up the object's position once and forwarded only the snapshot row/col
  - The `source_obj` ID itself never reached the audio layer, so OpenAL had nothing to refresh from
- `UpdateLoopingSounds` already runs every frame but only updated the listener position, not the sources

## How
- Threaded an `ID source_obj` parameter through the audio API: `SoundPlay`, `PlayWaveFile`, `PlayWaveRsc`
  - Default `0` means "no tracking", so call sites without an object (the wading effect, the random pitch sample) are unchanged
- `GamePlaySound` now forwards `source_obj` instead of dropping it after the position snapshot
- Added a small registry inside `audio_openal.c`
  - `std::unordered_map<ALuint, ID>` keyed by OpenAL source ID, value is the owning game object
  - `SoundPlay` registers an entry whenever it starts a positional source with a non-zero `source_obj`
  - Non-positional sounds (UI clicks, ambient loops at placeholder coords) skip registration
- New `AudioUpdateTrackedSources`, called once per frame from `UpdateLoopingSounds`
  - Drops entries whose source has finished playing
  - Drops entries whose object can no longer be found by ID, but leaves the source playing at its last position so a server-side renumber (system save) does not silence in-flight sounds
  - Otherwise refreshes `AL_POSITION` from the object's current `motion.x/y`
- Cleared the registry from `SoundStopAll` and `Audio_StopSourcesForFilename` so room-transition cleanup stays consistent
- Updated `docs/audio.md` with a "Sources Attached to Moving Objects" section

## Notes
- Not an OpenAL regression: the Miles path had the same limitation, and the `BK_PLAY_WAVE` packet only carries position once
- One-shot combat sounds emitted by a moving battler benefit immediately and need no kod changes
- No monster currently emits a looping aura sound; all existing loops come from passive props (`fountain.kod`, `fountjet.kod`, `firepit.kod`). This PR is the prerequisite that would let a future kod change give monsters their own moving ambient sound
- Per-frame cost is trivial: a handful of active sources, sources self-clean once playback ends
- Builds toward Doppler shift for projectiles: per-frame `AL_POSITION` updates are step one, and adding `AL_VELOCITY` alongside in the same loop is the natural next step

## Example

### Before
- Player walks east, monster walks west
- The monster's sound plays from the monster's original tile until the loop ends
- A one-shot combat sound from a moving target stays frozen at wherever the target was when the sound started

### After
- The sound stays attached to the monster as it moves
- If the monster leaves the room or is destroyed mid-play, the in-flight sound finishes at its last position rather than being cut off, so server-side renumbering during a system save does not silence world audio