### PR TITLE
fix: send sound loop owner values to client

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3307,7 +3307,7 @@ messages:
       return;
    }
 
-   WaveSendUser(wave_rsc = $, source_obj = 0, flags = 0, row = 0, col = 0,
+   WaveSendUser(wave_rsc = $, source_obj = $, flags = 0, row = 0, col = 0,
                 cutoff_radius = 0, max_volume = 0)
    %  If source_obj defined, use its location for source of sound
    %  if not, check row & col, and use that location if either or both are
@@ -3320,6 +3320,11 @@ messages:
    {
       if (wave_rsc <> $) and (pbLogged_on)
       {
+         % Convert since AddPacket expects a number.
+         if source_obj = $
+         {
+            source_obj = 0;
+         }
          AddPacket(1,BP_PLAY_WAVE, 4,wave_rsc, 4,source_obj, 1,flags,
                    4,row, 4,col, 4,cutoff_radius, 4,max_volume);
          SendPacket(poSession);

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -655,7 +655,7 @@ messages:
          {
             iRadius = 0;
             iMaxVol = 0;
-            oSource = 0;
+            oSource = $;
             if length(lLoopSound) > 3
             {
                iRadius = Nth(lLoopSound,4);
@@ -693,7 +693,7 @@ messages:
          % Send sound to all players
          iRadius = 0;
          iMaxVol = 0;
-         oSource = 0;
+         oSource = $;
          if length(lSoundData) > 3
          {
             iRadius = Nth(lSoundData,4);

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -644,7 +644,7 @@ messages:
    % Tell client to begin playing room-owned sounds that loop
    SendLoopingSounds(who = $)
    {
-      local lLoopSound, iRadius, iMaxVol;
+      local lLoopSound, iRadius, iMaxVol, oSource;
 
       % Each sound is:
       %  [wave_file, row, col, cutoff radius, maximum volume, object]
@@ -655,6 +655,7 @@ messages:
          {
             iRadius = 0;
             iMaxVol = 0;
+            oSource = 0;
             if length(lLoopSound) > 3
             {
                iRadius = Nth(lLoopSound,4);
@@ -665,7 +666,13 @@ messages:
                iMaxVol = Nth(lLoopSound,5);
             }
 
+            if length(lLoopSound) > 5
+            {
+               oSource = Nth(lLoopSound,6);
+            }
+
             Send(who,@WaveSendUser,#wave_rsc=First(lLoopSound),
+                 #source_obj=oSource,
                  #flags=SOUND_LOOP,
                  #row=Nth(lLoopSound,2),#col=Nth(lLoopSound,3),
                  #cutoff_radius=iRadius,#max_volume=iMaxVol);
@@ -677,7 +684,7 @@ messages:
 
    AddLoopingSound(lSoundData = $)
    {
-      local iRadius, iMaxVol, oObject;
+      local iRadius, iMaxVol, oObject, oSource;
 
       if lSoundData <> $
       {
@@ -686,6 +693,7 @@ messages:
          % Send sound to all players
          iRadius = 0;
          iMaxVol = 0;
+         oSource = 0;
          if length(lSoundData) > 3
          {
             iRadius = Nth(lSoundData,4);
@@ -696,11 +704,17 @@ messages:
             iMaxVol = Nth(lSoundData,5);
          }
 
+         if length(lSoundData) > 5
+         {
+            oSource = Nth(lSoundData,6);
+         }
+
          for oObject in plActive
          {
             if IsClass(first(oObject),&User)
             {
                Send(first(oObject),@WaveSendUser,#wave_rsc=First(lSoundData),
+                    #source_obj=oSource,
                     #flags=SOUND_LOOP,
                     #row=Nth(lSoundData,2),#col=Nth(lSoundData,3),
                     #cutoff_radius=iRadius,#max_volume=iMaxVol);


### PR DESCRIPTION
## What
- `room.kod` now forwards the optional 6th element of a looping-sound list (the owning object) to `WaveSendUser` as `#source_obj`
- Pairs with #1412
  - Either PR can be merged first

## Why
- The looping-sound list format documented in `room.kod` is `[wave_file, row, col, cutoff_radius, max_volume, object]`
- Passive props like `fountain.kod`, `fountjet.kod`, and `firepit.kod` have always passed `self` as the 6th element
- `room.kod` was extracting only elements 1-5 in `SendLoopingSounds` and `AddLoopingSound`, silently dropping the 6th before sending to the client
- Result: the client never learned which object owns the sound, so the audio could not follow the object if the object moved

## How
- Added a local `oSource` to both `SendLoopingSounds` and `AddLoopingSound`
- Defaulted it to `$` to match the Blakod `o`-prefix convention for object handles
- Set it to `Nth(lSoundData, 6)` when the list has at least 6 elements
- Passed it through to `WaveSendUser` as `#source_obj`
- `WaveSendUser` now defaults `source_obj` to `$` and converts to `0` at the wire-protocol boundary, since the packet packs `source_obj` as a 4-byte object ID

## Notes
- Backwards compatible
  - Old clients already accept a `source_obj` field in `BK_PLAY_WAVE`; they just ignore it for looping sounds today. Sending a non-zero value does not break them
  - Kod call sites that register a 5-element sound list still work, `oSource` falls back to `$` and `WaveSendUser` converts to `0` before sending
  - Existing callers of `WaveSendUser` that omit `#source_obj` are unaffected since the new default of `$` is converted to the same `0` they got before
- Sounds anchored to a fixed point (a wall torch with no movable owner) can keep using the 5-element form to stay anchored
- Conversely, any future placed prop that wants its sound to follow it just needs to include `self` as the 6th element. No new convention to learn, the format has been documented this way for years
- This PR has no visible runtime effect on its own. It becomes visible only if #1412 is merged

## Example

### Before
- Fountain in Tos registers `[fountain.wav, 44, 18, 40, 100, fountain_obj]`
- `room.kod` sends `WaveSendUser(... #row=44, #col=18 ...)` and drops `fountain_obj`
- Client plays the loop at tile (44,18) forever

### After
- Same registration
- `room.kod` sends `WaveSendUser(... #source_obj=fountain_obj, #row=44, #col=18 ...)`
- Client knows the loop is tied to `fountain_obj`. With #1412, moving the fountain to a new tile makes the sound follow the fountain
