### PR TITLE
fix: increase max client simultaneous sounds

### DIFF
--- a/clientd3d/audio_openal.c
+++ b/clientd3d/audio_openal.c
@@ -28,7 +28,7 @@
 #include <stb_vorbis.c>
 
 // Configuration
-static const int MAX_AUDIO_SOURCES = 32;
+static const int MAX_AUDIO_SOURCES = 64;
 static const int MAX_CACHED_BUFFERS = 256;
 
 // Global state

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -159,6 +159,17 @@ Sound effects are cached using an LRU (Least Recently Used) strategy:
 
 Music is NOT cached because tracks are large and typically don't repeat rapidly. Instead, music uses streaming playback (see below).
 
+## Source Pool
+
+OpenAL plays sound effects through a fixed pool of pre-allocated sources. The pool size is set by `MAX_AUDIO_SOURCES` in `clientd3d/audio_openal.c`.
+
+- Current size: 64 sources
+- Allocated once at `AudioInit` via `alGenSources(MAX_AUDIO_SOURCES, g_sources)`
+- Each `SoundPlay` call consumes one source while the sound is active, regardless of whether the listener is in audible range
+- When the pool is full, `SoundPlay` returns false silently and the new sound is dropped
+
+The pool was originally 32 when OpenAL Soft replaced wavemix in PR #1293 (December 2025). It was raised to 64 to leave headroom for combat sounds when many ambient looping emitters (firepits, torches, braziers) are active in a room.
+
 ## Music Streaming
 
 Music files are played via streaming rather than full-file decoding. This eliminates the loading hitch that occurred when decompressing entire OGG files (30-50 MB of decoded PCM from 2-7 MB OGG files) in a single blocking call on the main thread.


### PR DESCRIPTION
## What
- Raise `MAX_AUDIO_SOURCES` in `clientd3d/audio_openal.c` from `32` to `64`
- Update `docs/audio.md` with a Source Pool section describing the constant and its history

## Why
- Every active sound holds a source slot regardless of audible range, so a room with several looping ambient emitters plus active combat can approach the 32-source ceiling
- When the pool is full, `SoundPlay` returns false silently and the new sound is dropped, which players notice during busy fights
- The original 32 was a conservative starting point chosen during the OpenAL Soft conversion in #1293 (December 2025), replacing the legacy `wavemix.dll` engine that was hardcoded to 8 channels
    - This was too conservative on my part
- OpenAL Soft itself ships with `sources = 256` as the default in [alsoftrc.sample](https://github.com/kcat/openal-soft/blob/master/alsoftrc.sample), so 64 is well within comfortable limits on modern hardware

## Example

### Before
- Room with a firepit, a fountain, ambient music, several other sound emitting objects, and active combat could approach the 32-source ceiling
- New combat sounds drop silently with `SoundPlay: No available sources` in the debug log

### After
- The same room has comfortable headroom for combat audio
- Future ambient emitters (torches, braziers) can be added without immediately competing with combat