### PR TITLE
fix: client sound slider selection logic

### DIFF
--- a/clientd3d/audio_openal.c
+++ b/clientd3d/audio_openal.c
@@ -1065,7 +1065,10 @@ bool SoundPlay(const char* filename, int volume, BYTE flags,
       alSourcef(source, AL_ROLLOFF_FACTOR, 1.0f);
 
       float gain = (float)max_vol / (float)MAX_VOLUME;
-      gain *= (float)config.ambient_volume / 100.0f;
+      if (flags & SF_LOOP)
+         gain *= (float)config.ambient_volume / 100.0f;
+      else
+         gain *= (float)config.sound_volume / 100.0f;
       alSourcef(source, AL_GAIN, gain);
    }
    else

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -316,8 +316,8 @@ Audio settings in `meridian.ini`:
 
 ```ini
 [Meridian]
-MusicVolume=40      ; 0-100
-SoundVolume=99      ; 0-100 (one-shot effects: combat, spells, doors, scream)
+MusicVolume=100      ; 0-100
+SoundVolume=100      ; 0-100 (one-shot effects: combat, spells, doors, scream)
 AmbientVolume=100   ; 0-100 (looping environmental emitters: fountain, firepit)
 ```
 

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -317,9 +317,20 @@ Audio settings in `meridian.ini`:
 ```ini
 [Meridian]
 MusicVolume=40      ; 0-100
-SoundVolume=99      ; 0-100
-AmbientVolume=100   ; 0-100 (looping/3D sounds)
+SoundVolume=99      ; 0-100 (one-shot effects: combat, spells, doors, scream)
+AmbientVolume=100   ; 0-100 (looping environmental emitters: fountain, firepit)
 ```
+
+### Volume routing
+
+The two volume sliders are selected purely by the `SF_LOOP` flag on the sound, regardless of whether the sound is positional (3D) or non-positional (centered):
+
+| Sound type | Examples | Slider |
+|------------|----------|--------|
+| `SF_LOOP` (looping) | Fountain, firepit, forge, future torches/braziers | Ambient |
+| One-shot | Combat hits, spell impacts, doors, death scream, scripted effects | Sound |
+
+The `Steady Sounds` checkbox is a master toggle for `SF_LOOP` sounds; the `Atmospheric Sounds` checkbox toggles `SF_RANDOM_PLACE` sounds (server-picked random ambient one-shots).
 
 ## HRTF and Surround Sound
 


### PR DESCRIPTION
## What
- Changed to use the `SF_LOOP` flag to pick which volume slider applies to a sound, instead of branching on whether the sound is positional
  - Fixes issues with one-shot sounds being routed to the "ambient volume" slider instead of the correct "Sound volume" slider
- Documented the slider detail in `docs/audio.md`

## Why
- The OpenAL Soft port in #1293 (December 2025) regressed the original Miles-era volume rule. The non-positional branch kept the correct `SF_LOOP ? ambient : sound` logic, but the positional branch hard-coded `ambient_volume` for every sound
- Most one-shot combat sounds (death scream, swing impacts, spell hits, scripted effects) arrive with a `source_obj` and therefore positional coords, so they were all routed through the Ambient slider
- Lowering the Ambient slider to quiet a noisy fountain or firepit also silenced all combat audio. This is a confirmed regression: with Ambient at 0, the player death scream cannot be heard
- The original Miles code in `sound.c` (pre-#1293, see `98b710d7~1`) used a single rule: `(flags & SF_LOOP) ? config.ambient_volume : config.sound_volume`. This PR restores that rule in the positional branch so it matches what the non-positional branch already does

## How
- In the positional branch of `SoundPlay`, replace the unconditional `gain *= ambient_volume` with the same `SF_LOOP` check the non-positional branch uses
- Add a Volume routing subsection to `docs/audio.md` Configuration with a table mapping sound types to sliders, plus a note clarifying what the `Steady Sounds` and `Atmospheric Sounds` checkboxes gate
  - Added a small correction to the default volume level documentation in audio.md

## Example

### Before
- Player death scream is positional (originates from the player object), so it was multiplied by `ambient_volume`
- Setting Ambient to 0 to mute the fountain also muted the death scream and all combat sounds

### After
- All one-shot sounds (positional or not) follow the Sound slider
- All looping ambient emitters (positional or not) follow the Ambient slider
- Ambient slider only affects environmental scenery (fountain, firepit, etc.)