### PR TITLE
fix: immediately update client sound volume based on sliders

### DIFF
--- a/clientd3d/audio_openal.c
+++ b/clientd3d/audio_openal.c
@@ -39,8 +39,11 @@ static int g_numSources = 0;
 static bool g_initialized = false;
 
 // Per-source state
-static bool  g_sourceIsLoop[MAX_AUDIO_SOURCES];
-static float g_sourceBaseGain[MAX_AUDIO_SOURCES];
+struct SourceState {
+   float baseGain;  // pre-slider gain (max_vol / volume scaled to 0..1)
+   bool  isLoop;    // true if SF_LOOP, picks Ambient slider; else Sound slider
+};
+static SourceState g_sourceState[MAX_AUDIO_SOURCES];
 
 // LRU buffer cache: list ordered by recency (front = newest), map for O(1) lookup.
 struct CacheNode {
@@ -1069,8 +1072,8 @@ bool SoundPlay(const char* filename, int volume, BYTE flags,
       alSourcef(source, AL_ROLLOFF_FACTOR, 1.0f);
 
       float gain = (float)max_vol / (float)MAX_VOLUME;
-      g_sourceBaseGain[sourceIndex] = gain;
-      g_sourceIsLoop[sourceIndex] = (flags & SF_LOOP) != 0;
+      g_sourceState[sourceIndex].baseGain = gain;
+      g_sourceState[sourceIndex].isLoop = (flags & SF_LOOP) != 0;
       if (flags & SF_LOOP)
          gain *= (float)config.ambient_volume / 100.0f;
       else
@@ -1085,8 +1088,8 @@ bool SoundPlay(const char* filename, int volume, BYTE flags,
 
       // Set volume (volume is 0-MAX_VOLUME, convert to 0.0-1.0)
       float gain = (float)volume / (float)MAX_VOLUME;
-      g_sourceBaseGain[sourceIndex] = gain;
-      g_sourceIsLoop[sourceIndex] = (flags & SF_LOOP) != 0;
+      g_sourceState[sourceIndex].baseGain = gain;
+      g_sourceState[sourceIndex].isLoop = (flags & SF_LOOP) != 0;
       if (flags & SF_LOOP)
          gain *= (float)config.ambient_volume / 100.0f;
       else
@@ -1195,10 +1198,10 @@ void ResetSoundVolume(void)
       if (state != AL_PLAYING && state != AL_PAUSED)
          continue;
 
-      float slider = g_sourceIsLoop[i]
+      float slider = g_sourceState[i].isLoop
          ? (float)config.ambient_volume / 100.0f
          : (float)config.sound_volume / 100.0f;
-      alSourcef(g_sources[i], AL_GAIN, g_sourceBaseGain[i] * slider);
+      alSourcef(g_sources[i], AL_GAIN, g_sourceState[i].baseGain * slider);
    }
 }
 

--- a/clientd3d/audio_openal.c
+++ b/clientd3d/audio_openal.c
@@ -40,8 +40,8 @@ static bool g_initialized = false;
 
 // Per-source state
 struct SourceState {
-   float baseGain;  // pre-slider gain (max_vol / volume scaled to 0..1)
-   bool  isLoop;    // true if SF_LOOP, picks Ambient slider; else Sound slider
+   float baseGain;
+   bool  isLoop;
 };
 static SourceState g_sourceState[MAX_AUDIO_SOURCES];
 

--- a/clientd3d/audio_openal.c
+++ b/clientd3d/audio_openal.c
@@ -38,6 +38,10 @@ static ALuint g_sources[MAX_AUDIO_SOURCES];
 static int g_numSources = 0;
 static bool g_initialized = false;
 
+// Per-source state
+static bool  g_sourceIsLoop[MAX_AUDIO_SOURCES];
+static float g_sourceBaseGain[MAX_AUDIO_SOURCES];
+
 // LRU buffer cache: list ordered by recency (front = newest), map for O(1) lookup.
 struct CacheNode {
    std::string filename;
@@ -1065,6 +1069,8 @@ bool SoundPlay(const char* filename, int volume, BYTE flags,
       alSourcef(source, AL_ROLLOFF_FACTOR, 1.0f);
 
       float gain = (float)max_vol / (float)MAX_VOLUME;
+      g_sourceBaseGain[sourceIndex] = gain;
+      g_sourceIsLoop[sourceIndex] = (flags & SF_LOOP) != 0;
       if (flags & SF_LOOP)
          gain *= (float)config.ambient_volume / 100.0f;
       else
@@ -1079,6 +1085,8 @@ bool SoundPlay(const char* filename, int volume, BYTE flags,
 
       // Set volume (volume is 0-MAX_VOLUME, convert to 0.0-1.0)
       float gain = (float)volume / (float)MAX_VOLUME;
+      g_sourceBaseGain[sourceIndex] = gain;
+      g_sourceIsLoop[sourceIndex] = (flags & SF_LOOP) != 0;
       if (flags & SF_LOOP)
          gain *= (float)config.ambient_volume / 100.0f;
       else
@@ -1165,6 +1173,32 @@ void SoundStopLooping(void)
       {
          alSourceStop(g_sources[i]);
       }
+   }
+}
+
+/*
+ * ResetSoundVolume:  Reapply Sound and Ambient slider values to every
+ *   currently-playing source.  Walks the source pool and recomputes each
+ *   source's gain as base * slider, where the base was recorded at SoundPlay
+ *   time and the slider is picked by the source's stored loop flag.  Idle
+ *   sources are skipped.
+ */
+void ResetSoundVolume(void)
+{
+   if (!g_initialized)
+      return;
+
+   for (int i = 0; i < g_numSources; i++)
+   {
+      ALint state;
+      alGetSourcei(g_sources[i], AL_SOURCE_STATE, &state);
+      if (state != AL_PLAYING && state != AL_PAUSED)
+         continue;
+
+      float slider = g_sourceIsLoop[i]
+         ? (float)config.ambient_volume / 100.0f
+         : (float)config.sound_volume / 100.0f;
+      alSourcef(g_sources[i], AL_GAIN, g_sourceBaseGain[i] * slider);
    }
 }
 

--- a/clientd3d/audio_openal.h
+++ b/clientd3d/audio_openal.h
@@ -43,6 +43,9 @@ void Audio_StopSourcesForFilename(const char* filename);
 // per frame.  Stopped sources and missing objects are pruned automatically.
 void AudioUpdateTrackedSources(void);
 
+// Reapply the Sound and Ambient slider values to every playing source
+void ResetSoundVolume(void);
+
 // Sets the listener's position and facing direction for 3D audio
 void AudioUpdateListener(float x, float y, float z, 
                          float forwardX, float forwardY, float forwardZ);

--- a/clientd3d/preferences.c
+++ b/clientd3d/preferences.c
@@ -1179,16 +1179,20 @@ static INT_PTR CALLBACK CommonPreferencesDlgProc(HWND hDlg, UINT message, WPARAM
             config.play_music = IsDlgButtonChecked(hDlg, IDC_MUSIC);
             UserToggleMusic(config.play_music);
             config.play_sound = IsDlgButtonChecked(hDlg, IDC_SOUNDFX);
+            bool old_loop_sounds = config.play_loop_sounds;
             config.play_loop_sounds = IsDlgButtonChecked(hDlg, IDC_LOOPSOUNDS);
             config.play_random_sounds = IsDlgButtonChecked(hDlg, IDC_RANDSOUNDS);
             if (!config.play_sound)
               SoundStopAll();
+            else if (old_loop_sounds && !config.play_loop_sounds)
+              SoundStopLooping();
             config.halocolor = IsDlgButtonChecked(hDlg, IDC_TARGETHALO1) == BST_CHECKED ? 0 :
                                IsDlgButtonChecked(hDlg, IDC_TARGETHALO2) == BST_CHECKED ? 1 : 2;
             config.colorcodes = IsDlgButtonChecked(hDlg, IDC_COLORCODES);
 
             config.sound_volume = Trackbar_GetPos(GetDlgItem(hDlg, IDC_SOUND_VOLUME));
             config.ambient_volume = Trackbar_GetPos(GetDlgItem(hDlg, IDC_AMBIENT_VOLUME));
+            ResetSoundVolume();
             auto new_val = Trackbar_GetPos(GetDlgItem(hDlg, IDC_MUSIC_VOLUME));
             if (new_val != config.music_volume)
             {

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -339,7 +339,7 @@ The `Steady Sounds` checkbox is a master toggle for `SF_LOOP` sounds; the `Atmos
 All three volume sliders (`Music`, `Sound`, `Ambient`) take effect immediately when the player clicks OK in the Options dialog.  No re-login or room change is required.
 
 - `ResetMusicVolume()` re-applies the music slider to the live music source
-- `ResetSoundVolume()` re-applies the sound and ambient sliders to every currently-playing source.  Each source records two pieces of state at `SoundPlay` time: the pre-slider gain (from `max_vol` / `volume`) and a flag indicating whether it is a loop.  On refresh, gain is recomputed as `pre-slider gain * current slider`, where the slider is `Ambient` for loops and `Sound` for one-shots
+- `ResetSoundVolume()` re-applies the sound and ambient sliders to every currently-playing source.  Each source records two pieces of state at `SoundPlay` time in a `SourceState` struct (one entry per source pool slot): the pre-slider gain (from `max_vol` / `volume`) and a flag indicating whether it is a loop.  On refresh, gain is recomputed as `pre-slider gain * current slider`, where the slider is `Ambient` for loops and `Sound` for one-shots
 - Unchecking `Steady Sounds` calls `SoundStopLooping()` to stop loops that are already playing.  Re-checking it does not restart them; the server only sends loop packets on room entry, so loops resume on the next room change
 - Unchecking `Atmospheric Sounds` needs no immediate action; the gated one-shot sounds finish on their own within a few seconds
 

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -86,6 +86,8 @@ graph TD
 | `MusicSetVolume(volume)` | Set music volume (0.0 - 1.0) |
 | `SoundPlay(filename, volume, flags, ...)` | Play sound effect with optional 3D positioning |
 | `SoundStopAll()` | Stop all sound effects |
+| `SoundStopLooping()` | Stop only `SF_LOOP` sources (used when Steady Sounds is unchecked) |
+| `ResetSoundVolume()` | Re-apply Sound and Ambient sliders to every currently-playing source |
 | `AudioUpdateListener(x, y, z, ...)` | Update listener position for 3D audio |
 | `AudioUpdateTrackedSources()` | Refresh positions of sources attached to moving game objects |
 
@@ -331,6 +333,15 @@ The two volume sliders are selected purely by the `SF_LOOP` flag on the sound, r
 | One-shot | Combat hits, spell impacts, doors, death scream, scripted effects | Sound |
 
 The `Steady Sounds` checkbox is a master toggle for `SF_LOOP` sounds; the `Atmospheric Sounds` checkbox toggles `SF_RANDOM_PLACE` sounds (server-picked random ambient one-shots).
+
+### Live slider updates
+
+All three volume sliders (`Music`, `Sound`, `Ambient`) take effect immediately when the player clicks OK in the Options dialog.  No re-login or room change is required.
+
+- `ResetMusicVolume()` re-applies the music slider to the live music source
+- `ResetSoundVolume()` re-applies the sound and ambient sliders to every currently-playing source.  Each source records two pieces of state at `SoundPlay` time: the pre-slider gain (from `max_vol` / `volume`) and a flag indicating whether it is a loop.  On refresh, gain is recomputed as `pre-slider gain * current slider`, where the slider is `Ambient` for loops and `Sound` for one-shots
+- Unchecking `Steady Sounds` calls `SoundStopLooping()` to stop loops that are already playing.  Re-checking it does not restart them; the server only sends loop packets on room entry, so loops resume on the next room change
+- Unchecking `Atmospheric Sounds` needs no immediate action; the gated one-shot sounds finish on their own within a few seconds
 
 ## HRTF and Surround Sound
 


### PR DESCRIPTION
## What
- `Sound` and `Ambient` volume sliders in the Options dialog now take effect on currently-playing sources, instead of waiting for the next login
- Unchecking `Steady Sounds` now stops looping sources that are already playing, instead of leaving them running until you change rooms

## Why

- The `Music` slider already works properly: when you change it, `ResetMusicVolume` re-applies gain to the live music source
- The `Sound` and `Ambient` sliders only updated `config` values.  `SoundPlay` reads them once when starting a sound and never looks at them again, so looping sources (fountain, firepit) kept playing at their original volume forever
  - Reproduction: stand near the East End fountain, drag `Ambient` to 0.  Fountain stays loud until you re-login
- The `Steady Sounds` checkbox only blocked new `SoundPlay` calls.  Existing loops kept playing when you unchecked it
- Players reasonably expect all three sliders and the checkbox to behave the same way
- This appears to predate the December 2025 OpenAL migration.

## How

The Music slider already works this way.  Same approach now applies to the Sound and Ambient sliders.
```mermaid
flowchart LR
    A[Player drags slider<br/>and clicks OK]
    B[Save new value to config]
    C{Which slider?}
    D[ResetMusicVolume:<br/>re-apply to music source]
    E[ResetSoundVolume:<br/>re-apply to every<br/>playing sound]
    F[Volume changes<br/>immediately]

    A --> B --> C
    C -->|Music| D --> F
    C -->|Sound or Ambient| E --> F

    style E fill:#2f9e44,color:#fff
    style F fill:#2f9e44,color:#fff
```

Re-applying a slider to an already-playing sound requires two pieces of information per source:
- its original loudness (the volume the game asked for, before any slider was applied)
- whether it is a loop or a one-shot (loops follow the Ambient slider, one-shots follow the Sound slider)

Both are recorded when the sound starts.  When the sliders change, `ResetSoundVolume` walks the source pool and recomputes each playing sound's volume as `original loudness * current slider`.

For the `Steady Sounds` checkbox: unchecking it now calls `SoundStopLooping` to stop any currently-playing loops.  This mirrors what already happens when the master `Sound` toggle is turned off (it calls `SoundStopAll`).

### Re-enable caveat

- Re-checking `Steady Sounds` after unchecking it does not restart the loops that were silenced.  The server only sends loop packets on room entry, so the loops come back when you next change rooms.  Asking the server to re-push on demand is a much larger change and is out of scope for this PR
- The `Atmospheric Sounds` checkbox needs no immediate action.  It only gates short one-shot periodic sounds, which finish playing on their own within a few seconds

### Naming

- `ResetSoundVolume` matches the existing `ResetMusicVolume` so the pattern is consistent

## Example

### Before
- Player drags `Ambient` slider to 0 to mute the fountain and clicks OK
- Fountain keeps playing at full volume
- Player has to log out and back in for the change to take effect

### After
- Player drags `Ambient` slider to 0 and clicks OK
- Fountain volume drops to 0 immediately
- Same flow as the existing `Music` slider
