### PR TITLE
fix: account script crash loop when network is not ready at boot

### DIFF
--- a/aws/src/server_process/server_process.py
+++ b/aws/src/server_process/server_process.py
@@ -134,12 +134,19 @@ def process_message(account):
 print("Processing script has started")
 
 while True:
-    # Poll the incoming queue for messages
-    messages = sqs.receive_message(
-        QueueUrl=incoming_queue_url,
-        MaxNumberOfMessages=1,
-        WaitTimeSeconds=5,
-    )
+    # Poll the incoming queue for messages.  Wrap in try/except so that
+    # transient network failures (e.g. DNS not yet available at boot) do
+    # not exit the process and trigger a systemd restart loop.
+    try:
+        messages = sqs.receive_message(
+            QueueUrl=incoming_queue_url,
+            MaxNumberOfMessages=1,
+            WaitTimeSeconds=5,
+        )
+    except Exception as e:
+        print(f"Exception polling incoming queue: {e}")
+        time.sleep(30)
+        continue
 
     if 'Messages' in messages:
         for message in messages['Messages']:


### PR DESCRIPTION
## What
- wraps the SQS poll in `server_process.py` in a `try/except` so that transient network failures no longer exit the process
- fixes https://github.com/Meridian59/Meridian59/issues/1419

## Why
-  `m59accounts.service` started before the network was up at boot
- the very first `sqs.receive_message(...)` call raised `socket.gaierror: [Errno -3] Temporary failure in name resolution`, the script exited with status 1, and systemd restarted it immediately
- this repeated ~2000 times in a few minutes, filling the system event log
- the existing `try/except` only covered the message-processing block, not the SQS poll itself, so any boto/network error at the poll step was fatal

## How
- wrapped the `sqs.receive_message(...)` call at the top of the main loop in `aws/src/server_process/server_process.py` in `try/except`
- on exception, log the error, sleep 30 seconds, and `continue` the loop instead of exiting
- this matches the existing 30 second sleep used when the queue is empty

## Example

### Before
- DNS not ready at boot -> `gaierror` -> process exit 1 -> systemd restart -> repeat
- restart counter climbed past 2000 in the journal before DNS came up

### After
- DNS not ready at boot -> exception caught -> 30 second sleep -> retry
- service stays alive, journal stays clean, no systemd restart loop