### PR TITLE
Remove advert tracking from login and char-pick

### DIFF
--- a/blakserv/game.c
+++ b/blakserv/game.c
@@ -406,7 +406,6 @@ void GameProtocolParse(session_node *s,client_msg *msg)
 {
    user_node *u;
    int object_id;
-   char *ptr;
 
    char password[MAX_LOGIN_PASSWORD+1],new_password[MAX_LOGIN_PASSWORD+1];
    int len,index;
@@ -434,28 +433,6 @@ void GameProtocolParse(session_node *s,client_msg *msg)
       GameEchoPing(s);
       break;
 
-   case BP_AD_SELECTED :
-      /* they clicked on an ad; log it */
-      switch (msg->data[1])
-      {
-      case 1:
-	 ptr = LockConfigStr(ADVERTISE_URL1);
-	 lprintf("GameProtocolParse found account %i visited ad 1, %s\n",s->account->account_id,
-		 ptr);
-	 UnlockConfigStr();
-	 break;
-      case 2:
-	 ptr = LockConfigStr(ADVERTISE_URL2);
-	 lprintf("GameProtocolParse found account %i visited ad 2, %s\n",s->account->account_id,
-		 ptr);
-	 UnlockConfigStr();
-	 break;
-      default :
-	 eprintf("GameProtocolParse found account %i visited unknown ad %i\n",
-		 s->account->account_id,msg->data[1]);
-      }
-      break;
-         
    case BP_USE_CHARACTER :
       if (s->game->object_id == INVALID_OBJECT)
       {

--- a/blakserv/synched.c
+++ b/blakserv/synched.c
@@ -527,14 +527,6 @@ void LogUserData(session_node *s)
    if (s->partner)
      buf += ", Partner " + std::to_string(s->partner);
 
-   buf += ", ";
-   buf += LockConfigStr(ADVERTISE_FILE1);
-   UnlockConfigStr();
-
-   buf += ", ";
-   buf += LockConfigStr(ADVERTISE_FILE2);
-   UnlockConfigStr();
-
    buf += "\n";
 
    lprintf("%s",buf.c_str());

--- a/include/proto.h
+++ b/include/proto.h
@@ -61,8 +61,7 @@ enum {
    BP_WAIT                  = 21,
    BP_UNWAIT                = 22,
    BP_CHANGE_PASSWORD       = 23,
-   BP_AD_SELECTED           = 24,
-   
+
    BP_CHANGE_RESOURCE       = 30,
    BP_SYS_MESSAGE           = 31,
    BP_MESSAGE               = 32,

--- a/module/char/char.c
+++ b/module/char/char.c
@@ -40,7 +40,6 @@ client_message msg_table[] = {
 			     PARAM_BYTE, PARAM_BYTE,
 			     PARAM_INT_ARRAY, PARAM_ID_LIST, PARAM_ID_LIST, PARAM_END }, },
 { BP_SEND_CHARINFO,        { PARAM_END }, },
-{ BP_AD_SELECTED,          { PARAM_BYTE, PARAM_END }, },
 { 0,                       { PARAM_END }, },
 };
 

--- a/module/char/char.h
+++ b/module/char/char.h
@@ -153,7 +153,6 @@ extern HINSTANCE hInst;  // module handle
 #define RequestCharInfo()            ToServer(BP_SYSTEM, msg_table, BP_SEND_CHARINFO)
 #define SendNewCharInfo(obj, name, desc, g, len1, parts, t1, t2, len2, stats, spells, skills) \
 ToServer(BP_SYSTEM, msg_table, BP_NEW_CHARINFO, obj, name, desc, g, len1, parts, t1, t2, len2, stats, spells, skills)
-#define SendAdSelected(num)          ToServer(BP_AD_SELECTED, msg_table, num)
 
 
 #endif /* #ifndef _CHAR_H */

--- a/module/char/charpick.c
+++ b/module/char/charpick.c
@@ -279,9 +279,6 @@ void CharPickLButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT keyFla
       if (PtInRect(&rect, p))
       {
 	 WebLaunchBrowser(info->ads[i].url);
-
-	 // Tell server that user selected ad
-	 SendAdSelected(i + 1);
 	 return;
       }
    }


### PR DESCRIPTION
Cleanup: these advert stats aren't believed to be used anywhere - no reporting, no analysis, no consumers - so collecting them is just noise in the logs and dead code on the wire.
                                                                                                                                       
  - `LogUserData` no longer appends `ADVERTISE_FILE1/2` to the login log line
  - Removes `BP_AD_SELECTED` end-to-end: client no longer pings the server when an ad on the char-pick screen is clicked, server no longer logs ad clicks
  - Ads still display on char-pick and clicking still opens the URL - only the tracking is gone
  
This is also ground work / response to feedback from https://github.com/Meridian59/Meridian59/pull/1396


