### PR TITLE
Refactor d3drender_skybox

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -709,8 +709,8 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	if (draw_sky) // Render the skybox first
 	{
-		D3DRenderSkyBox(params, angleHeading, anglePitch, view,
-			SkyboxRenderParams{g_pVertexDecl_PosColorTex1, gD3DDriverProfile, gWorldPool, gWorldCacheSystem});
+		SkyboxRenderParams skyboxRenderParams(g_pVertexDecl_PosColorTex1, gD3DDriverProfile, gWorldPool, gWorldCacheSystem);
+		D3DRenderSkyBox(params, angleHeading, anglePitch, view, skyboxRenderParams);
 	}
 
 	// Prepare our rendering parameters

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -709,8 +709,8 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	if (draw_sky) // Render the skybox first
 	{
-		SkyboxRenderParams skyboxRenderParams(g_pVertexDecl_PosColorTex1, gD3DDriverProfile, gWorldPool, gWorldCacheSystem);
-		D3DRenderSkyBox(params, angleHeading, anglePitch, view, skyboxRenderParams);
+		D3DRenderSkyBox(params, angleHeading, anglePitch, view,
+			SkyboxRenderParams{g_pVertexDecl_PosColorTex1, gD3DDriverProfile, gWorldPool, gWorldCacheSystem});
 	}
 
 	// Prepare our rendering parameters

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -6,122 +6,87 @@
 //
 // Meridian is a registered trademark.
 #include "client.h"
-#include <unordered_map>
+#include <filesystem>
+#include <iterator>
 
 // Variables
 
-static const float SKYBOX_DIMENSIONS = 75000.0f;
-static const float SKYBOX_Y = 37000.0f;
+static constexpr float SKYBOX_DIMENSIONS = 75000.0f;
+static constexpr float SKYBOX_Y = 37000.0f;
+static constexpr int SKYBOX_SIDES = 6;
 
-static LPDIRECT3DTEXTURE9 gpSkyboxTextures[5][6];
+static constexpr int SKYBOX_QUAD_VERTICES = 4;
+static constexpr int SKYBOX_QUAD_INDICES = 4;
+static constexpr int SKYBOX_QUAD_PRIMITIVES = SKYBOX_QUAD_VERTICES - 2;
+
 static int gCurBackground;
 static ID tempBkgnd = 0;
 
-static float gSkyboxXYZ[] =
+// Defines vertices of the skybox.
+static constexpr custom_xyz gSkyboxXYZ[] =
 {
-	// back
-	SKYBOX_DIMENSIONS, SKYBOX_Y, -SKYBOX_DIMENSIONS,
-	SKYBOX_DIMENSIONS, -SKYBOX_Y, -SKYBOX_DIMENSIONS,
-	-SKYBOX_DIMENSIONS, -SKYBOX_Y, -SKYBOX_DIMENSIONS,
-	-SKYBOX_DIMENSIONS, SKYBOX_Y, -SKYBOX_DIMENSIONS,
+	// Back
+	{SKYBOX_DIMENSIONS, SKYBOX_Y, -SKYBOX_DIMENSIONS}, {SKYBOX_DIMENSIONS, -SKYBOX_Y, -SKYBOX_DIMENSIONS},
+	{-SKYBOX_DIMENSIONS, -SKYBOX_Y, -SKYBOX_DIMENSIONS}, {-SKYBOX_DIMENSIONS, SKYBOX_Y, -SKYBOX_DIMENSIONS},
 
-	// bottom
-	-SKYBOX_DIMENSIONS, -SKYBOX_Y, SKYBOX_DIMENSIONS,
-	-SKYBOX_DIMENSIONS, -SKYBOX_Y, -SKYBOX_DIMENSIONS,
-	SKYBOX_DIMENSIONS, -SKYBOX_Y, -SKYBOX_DIMENSIONS,
-	SKYBOX_DIMENSIONS, -SKYBOX_Y, SKYBOX_DIMENSIONS,
+	// Bottom
+	{-SKYBOX_DIMENSIONS, -SKYBOX_Y, SKYBOX_DIMENSIONS}, {-SKYBOX_DIMENSIONS, -SKYBOX_Y, -SKYBOX_DIMENSIONS},
+	{SKYBOX_DIMENSIONS, -SKYBOX_Y, -SKYBOX_DIMENSIONS}, {SKYBOX_DIMENSIONS, -SKYBOX_Y, SKYBOX_DIMENSIONS},
 
-	// front
-	-SKYBOX_DIMENSIONS, SKYBOX_Y, SKYBOX_DIMENSIONS,
-	-SKYBOX_DIMENSIONS, -SKYBOX_Y, SKYBOX_DIMENSIONS,
-	SKYBOX_DIMENSIONS, -SKYBOX_Y, SKYBOX_DIMENSIONS,
-	SKYBOX_DIMENSIONS, SKYBOX_Y, SKYBOX_DIMENSIONS,
+	// Front
+	{-SKYBOX_DIMENSIONS, SKYBOX_Y, SKYBOX_DIMENSIONS}, {-SKYBOX_DIMENSIONS, -SKYBOX_Y, SKYBOX_DIMENSIONS},
+	{SKYBOX_DIMENSIONS, -SKYBOX_Y, SKYBOX_DIMENSIONS}, {SKYBOX_DIMENSIONS, SKYBOX_Y, SKYBOX_DIMENSIONS},
 
-	// left
-	-SKYBOX_DIMENSIONS, SKYBOX_Y, -SKYBOX_DIMENSIONS,
-	-SKYBOX_DIMENSIONS, -SKYBOX_Y, -SKYBOX_DIMENSIONS,
-	-SKYBOX_DIMENSIONS, -SKYBOX_Y, SKYBOX_DIMENSIONS,
-	-SKYBOX_DIMENSIONS, SKYBOX_Y, SKYBOX_DIMENSIONS,
+	// Left
+	{-SKYBOX_DIMENSIONS, SKYBOX_Y, -SKYBOX_DIMENSIONS}, {-SKYBOX_DIMENSIONS, -SKYBOX_Y, -SKYBOX_DIMENSIONS},
+	{-SKYBOX_DIMENSIONS, -SKYBOX_Y, SKYBOX_DIMENSIONS}, {-SKYBOX_DIMENSIONS, SKYBOX_Y, SKYBOX_DIMENSIONS},
 
-	// right
-	SKYBOX_DIMENSIONS, SKYBOX_Y, SKYBOX_DIMENSIONS,
-	SKYBOX_DIMENSIONS, -SKYBOX_Y, SKYBOX_DIMENSIONS,
-	SKYBOX_DIMENSIONS, -SKYBOX_Y, -SKYBOX_DIMENSIONS,
-	SKYBOX_DIMENSIONS, SKYBOX_Y, -SKYBOX_DIMENSIONS,
+	// Right
+	{SKYBOX_DIMENSIONS, SKYBOX_Y, SKYBOX_DIMENSIONS}, {SKYBOX_DIMENSIONS, -SKYBOX_Y, SKYBOX_DIMENSIONS},
+	{SKYBOX_DIMENSIONS, -SKYBOX_Y, -SKYBOX_DIMENSIONS}, {SKYBOX_DIMENSIONS, SKYBOX_Y, -SKYBOX_DIMENSIONS},
 
-	// top
-	-SKYBOX_DIMENSIONS, SKYBOX_Y, -SKYBOX_DIMENSIONS,
-	-SKYBOX_DIMENSIONS, SKYBOX_Y, SKYBOX_DIMENSIONS,
-	SKYBOX_DIMENSIONS, SKYBOX_Y, SKYBOX_DIMENSIONS,
-	SKYBOX_DIMENSIONS, SKYBOX_Y, -SKYBOX_DIMENSIONS,
+	// Top
+	{-SKYBOX_DIMENSIONS, SKYBOX_Y, -SKYBOX_DIMENSIONS}, {-SKYBOX_DIMENSIONS, SKYBOX_Y, SKYBOX_DIMENSIONS},
+	{SKYBOX_DIMENSIONS, SKYBOX_Y, SKYBOX_DIMENSIONS}, {SKYBOX_DIMENSIONS, SKYBOX_Y, -SKYBOX_DIMENSIONS}
 };
 
-static float gSkyboxST[] =
+// Defines the four corners of a skybox texture.
+static constexpr custom_st gSkyboxST[] =
 {
-	0.001f, 0.001f,
-	0.001f, 0.999f,
-	0.999f, 0.999f,
-	0.999f, 0.001f,
-
-	0.001f, 0.001f,
-	0.001f, 0.999f,
-	0.999f, 0.999f,
-	0.999f, 0.001f,
-
-	0.001f, 0.001f,
-	0.001f, 0.999f,
-	0.999f, 0.999f,
-	0.999f, 0.001f,
-
-	0.001f, 0.001f,
-	0.001f, 0.999f,
-	0.999f, 0.999f,
-	0.999f, 0.001f,
-
-	0.001f, 0.001f,
-	0.001f, 0.999f,
-	0.999f, 0.999f,
-	0.999f, 0.001f,
-
-	0.001f, 0.001f,
-	0.001f, 0.999f,
-	0.999f, 0.999f,
-	0.999f, 0.001f,
+	{ 0.001f, 0.001f },		// Top-Left
+	{ 0.001f, 0.999f },		// Bottom-Left
+	{ 0.999f, 0.999f },		// Bottom-Right
+	{ 0.999f, 0.001f }		// Top-Right
 };
 
-static unsigned char gSkyboxBGRA[] =
+static constexpr custom_bgra gSkyboxBGRA = {192, 192, 192, 255};
+
+// Defines which .bgf resource gets paired with its respective hardware rendered skybox.
+struct SkyboxDefinition
 {
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-	192, 192, 192, 255,
-	192, 192, 192, 255,
+	const char* resourceName;	// The .bgf file used by the software renderer.
+	const char* fileName;		// The .bsf/.png file used in the hardware renderer.
 };
 
+// Lookup table that pairs software-rendered skyboxes to hardware-rendered skyboxes.
+// Note: In hardware rendering, Ko'catan uses the same skybox textures as the mainland.
+static constexpr SkyboxDefinition gSkyboxTable[] = 
+{
+	// Clear skies
+    {"1skya.bgf", "skya.bsf"}, 		// Index 0
+    {"2skya.bgf", "skya.bsf"}, 		
+    {"1skyb.bgf", "skyb.bsf"}, 		// Index 1
+    {"2skyb.bgf", "skyb.bsf"}, 		
+    {"1skyc.bgf", "skyc.bsf"}, 		// Index 2
+	{"2skyc.bgf", "skyc.bsf"}, 
+    {"1skyd.bgf", "skyd.bsf"}, 		// Index 3
+	{"2skyd.bgf", "skyd.bsf"}, 
+	// Frenzy
+    {"redsky.bgf", "redsky.bsf"}, 	// Index 4
+};
+
+static constexpr int NUM_SKYBOXES = static_cast<int>(std::size(gSkyboxTable));
+static LPDIRECT3DTEXTURE9 gpSkyboxTextures[NUM_SKYBOXES][SKYBOX_SIDES];
 
 // Interfaces
 
@@ -139,13 +104,17 @@ bool D3DRenderUpdateSkyBox(DWORD background)
 {
 	if (background == 0) return false;
 
-	if (gpSkyboxTextures[0][0] == NULL)
-	{
-		D3DRenderBackgroundsLoad("./resource/skya.bsf", 0);
-		D3DRenderBackgroundsLoad("./resource/skyb.bsf", 1);
-		D3DRenderBackgroundsLoad("./resource/skyc.bsf", 2);
-		D3DRenderBackgroundsLoad("./resource/skyd.bsf", 3);
-		D3DRenderBackgroundsLoad("./resource/redsky.bsf", 4);
+	if (gpSkyboxTextures[0][0] == nullptr)
+	{	
+		for(int i = 0; i < NUM_SKYBOXES; i++)
+		{
+			std::filesystem::path fullPath = std::filesystem::path("./resource") / gSkyboxTable[i].fileName;
+			
+			// Skip any skybox that is missing.
+			if (!std::filesystem::exists(fullPath)) continue;
+			
+			D3DRenderBackgroundsLoad(fullPath.string().c_str(), i);
+		}
 	}
 	if (tempBkgnd != background)
 	{
@@ -205,70 +174,58 @@ void D3DRenderSkyBox(Draw3DParams* params, int angleHeading, int anglePitch, con
 */
 void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, int anglePitch)
 {
-	int			i, j;
-	D3DMATRIX	rot, mat;
-
-	d3d_render_packet_new* pPacket;
-	d3d_render_chunk_new* pChunk;
-
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHABLENDENABLE, FALSE);
 
+	D3DMATRIX rot, mat;
 	MatrixIdentity(&mat);
 	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_WORLD, &mat);
 
-	MatrixRotateY(&rot, (float)angleHeading * 360.0f / 4096.0f * PI / 180.0f);
-	MatrixRotateX(&mat, (float)anglePitch * 45.0f / 414.0f * PI / 180.0f);
+	MatrixRotateY(&rot, static_cast<float>(angleHeading) * 360.0f / 4096.0f * PI / 180.0f);
+	MatrixRotateX(&mat, static_cast<float>(anglePitch) * 45.0f / 414.0f * PI / 180.0f);
 	MatrixMultiply(&mat, &rot, &mat);
 
 	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_VIEW, &mat);
 
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0,
-		D3DSAMP_ADDRESSU, D3DTADDRESS_CLAMP);
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0,
-		D3DSAMP_ADDRESSV, D3DTADDRESS_CLAMP);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_ADDRESSU, D3DTADDRESS_CLAMP);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_ADDRESSV, D3DTADDRESS_CLAMP);
 
-	for (i = 0; i < 6; i++)
+	for (int i = 0; i < SKYBOX_SIDES; i++)
 	{
-		pPacket = D3DRenderPacketFindMatch(pPool, gpSkyboxTextures[gCurBackground][i], NULL, 0, 0, 0);
-		if (NULL == pPacket)
+		d3d_render_packet_new* pPacket = D3DRenderPacketFindMatch(pPool, gpSkyboxTextures[gCurBackground][i], NULL, 0, 0, 0);
+		if (pPacket == nullptr)
 			return;
 
-		pChunk = D3DRenderChunkNew(pPacket);
+		d3d_render_chunk_new* pChunk = D3DRenderChunkNew(pPacket);
 		assert(pChunk);
 
-		pChunk->numIndices = 4;
-		pChunk->numVertices = 4;
-		pChunk->numPrimitives = pChunk->numVertices - 2;
+		pChunk->numIndices = SKYBOX_QUAD_INDICES;
+		pChunk->numVertices = SKYBOX_QUAD_VERTICES;
+		pChunk->numPrimitives = SKYBOX_QUAD_PRIMITIVES;
 		pPacket->pMaterialFctn = &D3DMaterialWorldPacket;
 		pChunk->pMaterialFctn = &D3DMaterialWorldDynamicChunk;
 		pChunk->flags |= D3DRENDER_NOAMBIENT;
 
 		// add xyz, st, and bgra data
-		for (j = 0; j < 4; j++)
+		for (int j = 0; j < SKYBOX_QUAD_VERTICES; j++)
 		{
-			pChunk->xyz[j].x = gSkyboxXYZ[(i * 4 * 3) + (j * 3)];
-			pChunk->xyz[j].z = gSkyboxXYZ[(i * 4 * 3) + (j * 3) + 1];
-			pChunk->xyz[j].y = gSkyboxXYZ[(i * 4 * 3) + (j * 3) + 2];
+			// Note that the coordinate system is z-up, so y-z are flipped here.
+			pChunk->xyz[j].x = gSkyboxXYZ[(i * 4) + j].x;
+			pChunk->xyz[j].y = gSkyboxXYZ[(i * 4) + j].z;
+			pChunk->xyz[j].z = gSkyboxXYZ[(i * 4) + j].y;
 
-			pChunk->st0[j].s = gSkyboxST[(i * 4 * 2) + (j * 2)];
-			pChunk->st0[j].t = gSkyboxST[(i * 4 * 2) + (j * 2) + 1];
+			pChunk->st0[j] = gSkyboxST[j];
 
-			pChunk->bgra[j].b = gSkyboxBGRA[(i * 4 * 4) + (j * 4)];
-			pChunk->bgra[j].g = gSkyboxBGRA[(i * 4 * 4) + (j * 4) + 1];
-			pChunk->bgra[j].r = gSkyboxBGRA[(i * 4 * 4) + (j * 4) + 2];
-			pChunk->bgra[j].a = gSkyboxBGRA[(i * 4 * 4) + (j * 4) + 3];
-
+			pChunk->bgra[j] = gSkyboxBGRA;
 		}
+		
 		pChunk->indices[0] = 1;
 		pChunk->indices[1] = 2;
 		pChunk->indices[2] = 0;
 		pChunk->indices[3] = 3;
 	}
 
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0,
-		D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP);
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0,
-		D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP);
+	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP);
 }
 
 /**
@@ -281,22 +238,14 @@ bool D3DRenderBackgroundSet(ID background)
 
 	if (!filename) return false;
 
-	static const std::unordered_map<std::string, int> backgroundMap = {
-		{"1skya.bgf", 0},
-		{"2skya.bgf", 0},
-		{"1skyb.bgf", 1},
-		{"2skyb.bgf", 1},
-		{"1skyc.bgf", 2},
-		{"2skyc.bgf", 2},
-		{"1skyd.bgf", 3},
-		{"2skyd.bgf", 3},
-		{"redsky.bgf", 4}
-	};
-
-	auto it = backgroundMap.find(filename);
-	if (it != backgroundMap.end())
+	for (int i = 0; i < NUM_SKYBOXES; i++)
 	{
-		gCurBackground = it->second;
+        // If the string names match, then set the index.
+		if (_stricmp(filename, gSkyboxTable[i].resourceName) == 0)
+        {
+            gCurBackground = i;
+            return true;
+        }
 	}
 
 	return true;
@@ -307,14 +256,14 @@ bool D3DRenderBackgroundSet(ID background)
 */
 void D3DRenderSkyBoxShutdown()
 {
-	for (int j = 0; j < 5; j++)
+	for (int j = 0; j < NUM_SKYBOXES; j++)
 	{
-		for (int i = 0; i < 6; i++)
+		for (int i = 0; i < SKYBOX_SIDES; i++)
 		{
 			if (gpSkyboxTextures[j][i])
 			{
 				IDirect3DTexture9_Release(gpSkyboxTextures[j][i]);
-				gpSkyboxTextures[j][i] = NULL;
+				gpSkyboxTextures[j][i] = nullptr;
 			}
 		}
 	}
@@ -326,109 +275,91 @@ void D3DRenderSkyBoxShutdown()
 */
 void D3DRenderBackgroundsLoad(const char* pFilename, int index)
 {
-	FILE* pFile;
-	png_structp	pPng = NULL;
-	png_infop	pInfo = NULL;
-	png_infop	pInfoEnd = NULL;
-	png_bytepp   rows;
-
-	D3DLOCKED_RECT		lockedRect;
-	unsigned char* pBits = NULL;
-	unsigned int		w, h, b;
-	int					pitchHalf, bytePP;
-	fpos_t				pos;
-
-	pFile = fopen(pFilename, "rb");
-	if (pFile == NULL)
+	// The .bsf/.png files for skyboxes are actually six .png files stored in a single 
+	// file by appending each picture's binary data into one file.
+	//
+	// The pictures for each cubemap face are stored in this order, similarly in gSkyboxXYZ[]:
+	// Back -> Bottom -> Front -> Left -> Right -> Top
+	//
+	// Color depth is also 24-bit since the alpha channel (transparency) isn't used.
+	
+	FILE* pFile = fopen(pFilename, "rb");
+	if (pFile == nullptr)
 		return;
+	fpos_t pos = 0;
 
-	pPng = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
-	if (NULL == pPng)
+	for (int i = 0; i < SKYBOX_SIDES; i++)
 	{
-		fclose(pFile);
-		return;
-	}
-
-	pInfo = png_create_info_struct(pPng);
-	if (NULL == pInfo)
-	{
-		png_destroy_read_struct(&pPng, NULL, NULL);
-		fclose(pFile);
-		return;
-	}
-
-	pInfoEnd = png_create_info_struct(pPng);
-	if (NULL == pInfoEnd)
-	{
-		png_destroy_read_struct(&pPng, &pInfo, NULL);
-		fclose(pFile);
-		return;
-	}
-
-	if (setjmp(png_jmpbuf(pPng)))
-	{
-		png_destroy_read_struct(&pPng, &pInfo, &pInfoEnd);
-		fclose(pFile);
-		return;
-	}
-
-	png_destroy_read_struct(&pPng, &pInfo, &pInfoEnd);
-
-	pos = 0;
-
-	{
-		int	i;
-		png_bytep curRow;
-
-		for (i = 0; i < 6; i++)
+		png_structp pPng = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+		if (pPng == nullptr )
 		{
-			pPng = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
-			pInfo = png_create_info_struct(pPng);
-			pInfoEnd = png_create_info_struct(pPng);
-			setjmp(png_jmpbuf(pPng));
+			fclose(pFile);
+			return;
+		}
 
-			fseek(pFile, pos, SEEK_SET);
+		png_infop pInfo = png_create_info_struct(pPng);
+		if (pInfo == nullptr)
+		{
+			png_destroy_read_struct(&pPng, nullptr, nullptr);
+			fclose(pFile);
+			return;
+		}
 
-			png_init_io(pPng, pFile);
-			png_read_png(pPng, pInfo, PNG_TRANSFORM_IDENTITY, NULL);
-			rows = png_get_rows(pPng, pInfo);
+		png_infop pInfoEnd = png_create_info_struct(pPng);
+		if (pInfoEnd == nullptr)
+		{
+			png_destroy_read_struct(&pPng, &pInfo, nullptr);
+			fclose(pFile);
+			return;
+		}
 
-			unsigned int image_width = png_get_image_width(pPng, pInfo);
-			unsigned int image_height = png_get_image_height(pPng, pInfo);
-			bytePP = png_get_bit_depth(pPng, pInfo) / 8;
+		if (setjmp(png_jmpbuf(pPng)))
+		{
+			png_destroy_read_struct(&pPng, &pInfo, &pInfoEnd);
+			fclose(pFile);
+			return;
+		}
+		
+		fseek(pFile, pos, SEEK_SET);
 
-			IDirect3DDevice9_CreateTexture(gpD3DDevice, image_width, image_height, 1, 0,
-				D3DFMT_A8R8G8B8, D3DPOOL_MANAGED, &gpSkyboxTextures[index][i], NULL);
+		png_init_io(pPng, pFile);
+		png_read_png(pPng, pInfo, PNG_TRANSFORM_IDENTITY, nullptr);
+		png_bytepp rows = png_get_rows(pPng, pInfo);
 
-			IDirect3DTexture9_LockRect(gpSkyboxTextures[index][i], 0, &lockedRect, NULL, 0);
+		unsigned int image_width = png_get_image_width(pPng, pInfo);
+		unsigned int image_height = png_get_image_height(pPng, pInfo);
+		int bytePP = png_get_bit_depth(pPng, pInfo) / 8;
 
-			pitchHalf = lockedRect.Pitch / 2;
+		IDirect3DDevice9_CreateTexture(gpD3DDevice, image_width, image_height, 1, 0,
+			D3DFMT_A8R8G8B8, D3DPOOL_MANAGED, &gpSkyboxTextures[index][i], nullptr);
 
-			pBits = (unsigned char*)lockedRect.pBits;
+		D3DLOCKED_RECT lockedRect;
+		IDirect3DTexture9_LockRect(gpSkyboxTextures[index][i], 0, &lockedRect, nullptr, 0);
 
-			for (h = 0; h < image_height; h++)
+		unsigned char *pBits = (unsigned char*)lockedRect.pBits;
+
+		for (unsigned int h = 0; h < image_height; h++)
+		{
+			png_bytep curRow = rows[h];
+
+			for (unsigned int w = 0; w < image_width; w++)
 			{
-				curRow = rows[h];
-
-				for (w = 0; w < image_width; w++)
+				for (unsigned int b = 0; b < 4; b++)
 				{
-					for (b = 0; b < 4; b++)
-					{
-						if (b == 3)
-							pBits[h * lockedRect.Pitch + w * 4 + b] = 255;
-						else
-							// Apparently PNGs are BGR, while DirectX wants RGB
-							pBits[h * lockedRect.Pitch + w * 4 + (2 - b)] =
-							curRow[(w * 3) + b];
-					}
+					if (b == 3)
+						pBits[h * lockedRect.Pitch + w * 4 + b] = 255;
+					else
+						// PNGs are in RGB, while DirectX wants BGRA.
+						pBits[h * lockedRect.Pitch + w * 4 + (2 - b)] =
+						curRow[(w * 3) + b];
 				}
 			}
-
-			IDirect3DTexture9_UnlockRect(gpSkyboxTextures[index][i], 0);
-
-			fgetpos(pFile, &pos);
-			png_destroy_read_struct(&pPng, &pInfo, &pInfoEnd);
 		}
+
+		IDirect3DTexture9_UnlockRect(gpSkyboxTextures[index][i], 0);
+
+		fgetpos(pFile, &pos);
+		png_destroy_read_struct(&pPng, &pInfo, &pInfoEnd);
 	}
 
 	fclose(pFile);

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -7,6 +7,7 @@
 // Meridian is a registered trademark.
 #include "client.h"
 #include "skybox_load.h"
+#include <unordered_map>
 #include <filesystem>
 #include <iterator>
 
@@ -62,37 +63,30 @@ static constexpr custom_st SKYBOX_ST[] =
 	{ 0.999f, 0.001f }		// Top-Right
 };
 
-// Defines which .bgf resource gets paired with its respective hardware rendered skybox.
-struct SkyboxDefinition
-{
-	const char* resourceName;	// The .bgf file used by the software renderer.
-	const char* fileName;		// The .bsf/.png file used in the hardware renderer.
-};
-
 // Lookup table that pairs software-rendered skyboxes to hardware-rendered skyboxes.
-static constexpr SkyboxDefinition SKYBOX_TABLE[] =
+static const std::unordered_map<std::string, std::string> SKYBOX_ASSET_MAPPING =
 {
 	// Clear skies
-    {"1skya.bgf", "skya.bsf"}, 		// Index 0
-    {"2skya.bgf", "skya.bsf"},
-    {"1skyb.bgf", "skyb.bsf"}, 		// Index 1
-    {"2skyb.bgf", "skyb.bsf"},
-    {"1skyc.bgf", "skyc.bsf"}, 		// Index 2
+	{"1skya.bgf", "skya.bsf"},
+	{"2skya.bgf", "skya.bsf"},
+	{"1skyb.bgf", "skyb.bsf"},
+	{"2skyb.bgf", "skyb.bsf"},
+	{"1skyc.bgf", "skyc.bsf"},
 	{"2skyc.bgf", "skyc.bsf"},
-    {"1skyd.bgf", "skyd.bsf"}, 		// Index 3
+	{"1skyd.bgf", "skyd.bsf"},
 	{"2skyd.bgf", "skyd.bsf"},
 	// Frenzy
-    {"redsky.bgf", "redsky.bsf"}, 	// Index 4
+	{"redsky.bgf", "redsky.bsf"},
 };
-
-static constexpr int NUM_SKYBOXES = static_cast<int>(std::size(SKYBOX_TABLE));
 
 /////////////////////
 // Local Variables //
 /////////////////////
-static int gCurBackground;
-static ID tempBkgnd = 0;
-static IDirect3DTexture9* gpSkyboxTextures[NUM_SKYBOXES][SKYBOX_SIDES];
+static ID gCachedBackgroundID = 0;
+// Dynamic texture cache that maps filenames of hardware-rendered skyboxes to their loaded texture pointers.
+static std::unordered_map<std::string, std::vector<IDirect3DTexture9*>> gSkyboxCache;
+// Holds the six texture pointers for the skybox actively being rendered on screen this frame.
+static std::vector<IDirect3DTexture9*> gpActiveSkyboxTextures;
 
 ////////////////////////
 // Internal Functions //
@@ -105,22 +99,46 @@ static IDirect3DTexture9* gpSkyboxTextures[NUM_SKYBOXES][SKYBOX_SIDES];
 static bool D3DRenderBackgroundSet(ID background)
 {
 	char* filename = LookupRsc(background);
-
 	if (!filename)
 		return false;
 
-	for (int i = 0; i < NUM_SKYBOXES; i++)
+	// Check if the .bgf file is in the lookup table.
+	auto assetIt = SKYBOX_ASSET_MAPPING.find(filename);
+	if (assetIt == SKYBOX_ASSET_MAPPING.end())
 	{
-        // If the string names match, then set the index.
-		if (_stricmp(filename, SKYBOX_TABLE[i].resourceName) == 0)
-        {
-            gCurBackground = i;
-            return true;
-        }
+		debug(("Skybox Error: '%s' is not mapped in SKYBOX_ASSET_MAPPING.\n", filename));
+		return false;
+	}
+	// If found, get the filename of the hardware-rendered counterpart.
+	const std::string& hwFilename = assetIt->second;
+
+	// Now check if we can reuse skybox textures that are already cached.
+	auto cacheIt = gSkyboxCache.find(hwFilename);
+	if (cacheIt != gSkyboxCache.end())
+	{
+		gpActiveSkyboxTextures = cacheIt->second;
+		return true;
 	}
 
-	debug(("Skybox Error: '%s' is not mapped in SKYBOX_TABLE.\n", filename));
-	return false;
+	// Otherwise, check if the file exists before attempting to load the PNG.
+	auto fullPath = std::filesystem::path("./resource") / hwFilename;
+	if (!std::filesystem::exists(fullPath))
+	{
+		debug(("Skybox Error: File missing at %s\n", fullPath.string().c_str()));
+		return false;
+	}
+
+	// Allocate space for the six dynamic texture pointers.
+	std::vector<IDirect3DTexture9*> newTextures(SKYBOX_SIDES, nullptr);
+
+	// Load the PNG file data directly into the pre-allocated data.
+	LoadSkyboxFaces(fullPath.string().c_str(), newTextures.data());
+
+	// Save into the dynamic cache map and mark as active for rendering.
+	gSkyboxCache[hwFilename] = newTextures;
+	gpActiveSkyboxTextures = newTextures;
+
+	return true;
 }
 
 /**
@@ -128,6 +146,9 @@ static bool D3DRenderBackgroundSet(ID background)
 */
 static void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, int anglePitch)
 {
+	if (gpActiveSkyboxTextures.empty())
+		return;
+	
 	gpD3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
 
 	D3DMATRIX rot, mat;
@@ -145,7 +166,11 @@ static void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, in
 
 	for (int i = 0; i < SKYBOX_SIDES; i++)
 	{
-		auto *pPacket = D3DRenderPacketFindMatch(pPool, gpSkyboxTextures[gCurBackground][i], nullptr, 0, 0, 0);
+		// Ensure the pointer slot is valid before fetching.
+		if (i >= gpActiveSkyboxTextures.size() || gpActiveSkyboxTextures[i] == nullptr)
+			continue;
+		
+		auto *pPacket = D3DRenderPacketFindMatch(pPool, gpActiveSkyboxTextures[i], nullptr, 0, 0, 0);
 		if (pPacket == nullptr)
 			return;
 
@@ -182,35 +207,6 @@ static void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, in
 	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP);
 }
 
-// Checks if a skybox is already loaded. If a match is found, the existing texture pointers are copied
-// over to the new index. Used for hardware-rendered skyboxes that are shared with multiple BGF files.
-static bool TryMapToExistingSkybox(int targetIndex)
-{
-    // 'targetIndex' is passed in so this function only checks against indices that have already been loaded.
-	for (int existingIndex = 0; existingIndex < targetIndex; existingIndex++)
-    {
-        // Compare filenames in the lookup table to find duplicates.
-		if (_stricmp(SKYBOX_TABLE[targetIndex].fileName, SKYBOX_TABLE[existingIndex].fileName) != 0)
-            continue;
-
-		// Once a match is found, copy the pointers over.
-		for (int side = 0; side < SKYBOX_SIDES; side++)
-		{
-			IDirect3DTexture9* pSharedTex = gpSkyboxTextures[existingIndex][side];
-			gpSkyboxTextures[targetIndex][side] = pSharedTex;
-
-			// Increment the reference count so the texture isn't
-			// freed while another skybox index is still using it.
-			if (pSharedTex != nullptr)
-			{
-				pSharedTex->AddRef();
-			}
-		}
-		return true;
-    }
-    return false;
-}
-
 //////////////////////
 // Public Functions //
 //////////////////////
@@ -223,33 +219,11 @@ static bool TryMapToExistingSkybox(int targetIndex)
 bool D3DRenderUpdateSkyBox(DWORD background)
 {
 	// Skip if there's no background yet or if it's already set.
-	if (background == 0 || tempBkgnd == background)
+	if (background == 0 || gCachedBackgroundID == background)
 		return false;
 
-	static bool bSkyboxesInitialized = false;
-	if (!bSkyboxesInitialized)
-	{
-		for (int i = 0; i < NUM_SKYBOXES; i++)
-		{
-			// Check if the skybox was already set up in a previous index.
-			// If so, map the new index to the existing pointers and skip PNG loading.
-			if (TryMapToExistingSkybox(i))
-				continue;
-
-			// Otherwise, check if the file exists before attempting to load the PNG.
-			auto fullPath = std::filesystem::path("./resource") / SKYBOX_TABLE[i].fileName;
-			if (!std::filesystem::exists(fullPath))
-			{
-				debug(("Skybox Error: File not found at %s\n", fullPath.string().c_str()));
-				continue;
-			}
-			LoadSkyboxFaces(fullPath.string().c_str(), gpSkyboxTextures[i]);
-		}
-		bSkyboxesInitialized = true;
-	}
-
-	tempBkgnd = background;
-	return D3DRenderBackgroundSet(tempBkgnd);
+	gCachedBackgroundID = background;
+	return D3DRenderBackgroundSet(gCachedBackgroundID);
 }
 
 /**
@@ -301,15 +275,18 @@ void D3DRenderSkyBox(Draw3DParams* params, int angleHeading, int anglePitch, con
 */
 void D3DRenderSkyBoxShutdown()
 {
-	for (int j = 0; j < NUM_SKYBOXES; j++)
+	// Release each skybox texture that was stored in the skybox cache.
+	for (auto& [hwFilename, textures] : gSkyboxCache)
 	{
-		for (int i = 0; i < SKYBOX_SIDES; i++)
+		for (auto* pTexture : textures)
 		{
-			if (gpSkyboxTextures[j][i])
+			if (pTexture != nullptr)
 			{
-				gpSkyboxTextures[j][i]->Release();
-				gpSkyboxTextures[j][i] = nullptr;
+				pTexture->Release();
 			}
 		}
 	}
+	gSkyboxCache.clear();
+	gpActiveSkyboxTextures.clear();
+	gCachedBackgroundID = 0;
 }

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -70,7 +70,6 @@ struct SkyboxDefinition
 };
 
 // Lookup table that pairs software-rendered skyboxes to hardware-rendered skyboxes.
-// Note: In hardware rendering, Ko'catan uses the same skybox textures as the mainland.
 static constexpr SkyboxDefinition SKYBOX_TABLE[] =
 {
 	// Clear skies
@@ -183,18 +182,31 @@ static void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, in
 	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP);
 }
 
-// Checks if a skybox is already set up, and copies the pointers over if a match is found..
-// Used for hardware rendered skyboxes that is shared with both the mainland and Ko'catan island.
-static bool CheckExistingSkyboxTextures(int currentIndex)
+// Checks if a skybox is already loaded. If a match is found, the existing texture pointers are copied
+// over to the new index. Used for hardware-rendered skyboxes that are shared with multiple BGF files.
+static bool TryMapToExistingSkybox(int targetIndex)
 {
-    for (int i = 0; i < currentIndex; i++)
+    // 'targetIndex' is passed in so this function only checks against indices that have already been loaded.
+	for (int existingIndex = 0; existingIndex < targetIndex; existingIndex++)
     {
-        if (_stricmp(SKYBOX_TABLE[currentIndex].fileName, SKYBOX_TABLE[i].fileName) == 0)
-        {
-            // Copy the pointers from the existing skybox over to this one.
-            memcpy(gpSkyboxTextures[currentIndex], gpSkyboxTextures[i], sizeof(gpSkyboxTextures[currentIndex]));
-            return true;
-        }
+        // Compare filenames in the lookup table to find duplicates.
+		if (_stricmp(SKYBOX_TABLE[targetIndex].fileName, SKYBOX_TABLE[existingIndex].fileName) != 0)
+            continue;
+
+		// Once a match is found, copy the pointers over.
+		for (int side = 0; side < SKYBOX_SIDES; side++)
+		{
+			IDirect3DTexture9* pSharedTex = gpSkyboxTextures[existingIndex][side];
+			gpSkyboxTextures[targetIndex][side] = pSharedTex;
+
+			// Increment the reference count so the texture isn't
+			// freed while another skybox index is still using it.
+			if (pSharedTex != nullptr)
+			{
+				pSharedTex->AddRef();
+			}
+		}
+		return true;
     }
     return false;
 }
@@ -219,8 +231,9 @@ bool D3DRenderUpdateSkyBox(DWORD background)
 	{
 		for (int i = 0; i < NUM_SKYBOXES; i++)
 		{
-			// If the skybox was already set up, just copy the pointers over and skip.
-			if (CheckExistingSkyboxTextures(i))
+			// Check if the skybox was already set up in a previous index.
+			// If so, map the new index to the existing pointers and skip PNG loading.
+			if (TryMapToExistingSkybox(i))
 				continue;
 
 			// Otherwise, check if the file exists before attempting to load the PNG.

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -10,10 +10,12 @@
 #include <unordered_map>
 #include <filesystem>
 #include <iterator>
+#include <string_view>
 
 ///////////////
 // Constants //
 ///////////////
+static constexpr std::string_view RESOURCE_DIRECTORY = "resource";
 
 // Geometry constants for rendering a quad as a triangular strip.
 static constexpr int SKYBOX_QUAD_VERTICES = 4;
@@ -121,7 +123,7 @@ static bool D3DRenderBackgroundSet(ID background)
 	}
 
 	// Otherwise, check if the file exists before attempting to load the PNG.
-	auto fullPath = std::filesystem::path("./resource") / hwFilename;
+	auto fullPath = std::filesystem::path(RESOURCE_DIRECTORY) / hwFilename;
 	if (!std::filesystem::exists(fullPath))
 	{
 		debug(("Skybox Error: File missing at %s\n", fullPath.string().c_str()));
@@ -146,9 +148,6 @@ static bool D3DRenderBackgroundSet(ID background)
 */
 static void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, int anglePitch)
 {
-	if (gpActiveSkyboxTextures.empty())
-		return;
-	
 	gpD3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
 
 	D3DMATRIX rot, mat;

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -16,9 +16,11 @@ static constexpr float SKYBOX_DIMENSIONS = 75000.0f;
 static constexpr float SKYBOX_Y = 37000.0f;
 static constexpr int SKYBOX_SIDES = 6;
 
+// Geometry constants for rendering a quad as a triangular strip.
 static constexpr int SKYBOX_QUAD_VERTICES = 4;
 static constexpr int SKYBOX_QUAD_INDICES = 4;
 static constexpr int SKYBOX_QUAD_PRIMITIVES = SKYBOX_QUAD_VERTICES - 2;
+static constexpr int SKYBOX_QUAD_INDICES_PATTERN[] = {1, 2, 0, 3};
 
 static constexpr custom_bgra SKYBOX_BGRA = {192, 192, 192, 255};
 
@@ -101,22 +103,26 @@ static IDirect3DTexture9* gpSkyboxTextures[NUM_SKYBOXES][SKYBOX_SIDES];
 */
 static void D3DRenderBackgroundsLoad(const char* pFilename, int index)
 {
-	// The .bsf/.png files for skyboxes are actually six .png files stored in a single
+	// The .bsf/.png files for skyboxes are actually six PNGs stored in a single
 	// file by appending each picture's binary data into one file.
 	//
 	// The pictures for each cubemap face are stored in this order, similarly in SKYBOX_XYZ[]:
 	// Back -> Bottom -> Front -> Left -> Right -> Top
 	//
-	// Color depth is also 24-bit since the alpha channel (transparency) isn't used.
+	// The pixel-packing loop expects a 24-bit PNG file since the alpha channel isn't used.
+	// However, a 32-bit PNG can still be used even if it's larger in file size.
 
 	auto *pFile = fopen(pFilename, "rb");
 	if (pFile == nullptr)
 		return;
 
-	fpos_t pos = 0;
+	long filePosition = 0;
 
 	for (int i = 0; i < SKYBOX_SIDES; i++)
 	{
+		// Jumps to the number of bytes.
+		fseek(pFile, filePosition, SEEK_SET);
+		
 		png_structp pPng = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
 		if (pPng == nullptr)
 		{
@@ -147,15 +153,18 @@ static void D3DRenderBackgroundsLoad(const char* pFilename, int index)
 			return;
 		}
 
-		fseek(pFile, pos, SEEK_SET);
-
 		png_init_io(pPng, pFile);
+		
+		// Discard alpha channel in case a 32-bit PNG is used, ensuring 3 bytes per pixel.
+		png_set_strip_alpha(pPng); 
+		
 		png_read_png(pPng, pInfo, PNG_TRANSFORM_IDENTITY, nullptr);
 		png_bytepp rows = png_get_rows(pPng, pInfo);
 
 		uint32_t image_width = png_get_image_width(pPng, pInfo);
 		uint32_t image_height = png_get_image_height(pPng, pInfo);
 
+		// Creates the D3D texture in a 32-bit BGRA format, even if the source PNG is 24-bit.
 		gpD3DDevice->CreateTexture(image_width, image_height, 1, 0,
 			D3DFMT_A8R8G8B8, D3DPOOL_MANAGED, &gpSkyboxTextures[index][i], nullptr);
 
@@ -164,26 +173,32 @@ static void D3DRenderBackgroundsLoad(const char* pFilename, int index)
 
 		auto *pBits = reinterpret_cast<uint8_t*>(lockedRect.pBits);
 
+		// Iterate through each row of the skybox image.
 		for (uint32_t h = 0; h < image_height; h++)
 		{
-			png_bytep curRow = rows[h];
+			// Use pitch to find the start of the row, then treat it as 32-bit pixels.
+			auto *pRowDest = reinterpret_cast<uint32_t*>(pBits + (h * lockedRect.Pitch));
+			
+			// Get the source row from the PNG data.
+			png_bytep pSourceRow = rows[h];
 
 			for (uint32_t w = 0; w < image_width; w++)
 			{
-				for (uint32_t b = 0; b < 4; b++)
-				{
-					if (b == 3)
-						pBits[h * lockedRect.Pitch + w * 4 + b] = 255;
-					else
-						// PNGs are in RGB, while DirectX wants BGRA.
-						pBits[h * lockedRect.Pitch + w * 4 + (2 - b)] = curRow[(w * 3) + b];
-				}
+				// Reads 24-bit RGB data from the PNG row.
+				uint8_t r = pSourceRow[w * 3 + 0];
+				uint8_t g = pSourceRow[w * 3 + 1];
+				uint8_t b = pSourceRow[w * 3 + 2];
+
+				// Converts RGB to 32-bit BGRA (D3D native) using bit-shifting.
+				// Alpha is set to '0xFF' to keep the skybox fully opaque.
+				pRowDest[w] = (0xFF << 24) | (r << 16) | (g << 8) | b;
 			}
 		}
 
 		gpSkyboxTextures[index][i]->UnlockRect(0);
 
-		fgetpos(pFile, &pos);
+		// Save current byte count so the next iteration finds the next PNG header.
+		filePosition = ftell(pFile);
 		png_destroy_read_struct(&pPng, &pInfo, &pInfoEnd);
 	}
 
@@ -239,10 +254,10 @@ static void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, in
 			pChunk->bgra[j] = SKYBOX_BGRA;
 		}
 
-		pChunk->indices[0] = 1;
-		pChunk->indices[1] = 2;
-		pChunk->indices[2] = 0;
-		pChunk->indices[3] = 3;
+		for (int i = 0; i < SKYBOX_QUAD_INDICES; i++)
+		{
+			pChunk->indices[i] = SKYBOX_QUAD_INDICES_PATTERN[i];
+		}
 	}
 
 	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP);

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -196,7 +196,7 @@ static bool CheckExistingSkyboxTextures(int currentIndex)
             return true;
         }
     }
-    return false;	
+    return false;
 }
 
 //////////////////////
@@ -222,17 +222,15 @@ bool D3DRenderUpdateSkyBox(DWORD background)
 			// If the skybox was already set up, just copy the pointers over and skip.
 			if (CheckExistingSkyboxTextures(i))
 				continue;
-			
-			// Otherwise, load the PNG as normal.
+
+			// Otherwise, check if the file exists before attempting to load the PNG.
 			auto fullPath = std::filesystem::path("./resource") / SKYBOX_TABLE[i].fileName;
-			if (std::filesystem::exists(fullPath))
-			{
-				LoadSkyboxFaces(fullPath.string().c_str(), gpSkyboxTextures[i]);
-			}
-			else
+			if (!std::filesystem::exists(fullPath))
 			{
 				debug(("Skybox Error: File not found at %s\n", fullPath.string().c_str()));
+				continue;
 			}
+			LoadSkyboxFaces(fullPath.string().c_str(), gpSkyboxTextures[i]);
 		}
 		bSkyboxesInitialized = true;
 	}

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -114,7 +114,10 @@ static void D3DRenderBackgroundsLoad(const char* pFilename, int index)
 
 	auto *pFile = fopen(pFilename, "rb");
 	if (pFile == nullptr)
+	{
+		debug(("Skybox Error: Found file but unable to open: %s\n", pFilename));
 		return;
+	}
 
 	long filePosition = 0;
 
@@ -122,7 +125,7 @@ static void D3DRenderBackgroundsLoad(const char* pFilename, int index)
 	{
 		// Jumps to the number of bytes.
 		fseek(pFile, filePosition, SEEK_SET);
-		
+
 		png_structp pPng = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
 		if (pPng == nullptr)
 		{
@@ -148,16 +151,17 @@ static void D3DRenderBackgroundsLoad(const char* pFilename, int index)
 
 		if (setjmp(png_jmpbuf(pPng)))
 		{
+			debug(("Skybox Error: %s has corrupt or invalid PNG data.\n", pFilename));
 			png_destroy_read_struct(&pPng, &pInfo, &pInfoEnd);
 			fclose(pFile);
 			return;
 		}
 
 		png_init_io(pPng, pFile);
-		
+
 		// Discard alpha channel in case a 32-bit PNG is used, ensuring 3 bytes per pixel.
-		png_set_strip_alpha(pPng); 
-		
+		png_set_strip_alpha(pPng);
+
 		png_read_png(pPng, pInfo, PNG_TRANSFORM_IDENTITY, nullptr);
 		png_bytepp rows = png_get_rows(pPng, pInfo);
 
@@ -178,7 +182,7 @@ static void D3DRenderBackgroundsLoad(const char* pFilename, int index)
 		{
 			// Use pitch to find the start of the row, then treat it as 32-bit pixels.
 			auto *pRowDest = reinterpret_cast<uint32_t*>(pBits + (h * lockedRect.Pitch));
-			
+
 			// Get the source row from the PNG data.
 			png_bytep pSourceRow = rows[h];
 
@@ -285,14 +289,15 @@ static bool D3DRenderBackgroundSet(ID background)
         }
 	}
 
-	return true;
+	debug(("Skybox Error: '%s' is not mapped in SKYBOX_TABLE.\n", filename));
+	return false;
 }
 
 //////////////////////
 // Public Functions //
 //////////////////////
 
-/**
+/*
 * Update the skybox with the current background.
 * Return true the background has changed and false otherwise.
 * If the background has changed, the caller should trigger a redraw all.
@@ -310,7 +315,10 @@ bool D3DRenderUpdateSkyBox(DWORD background)
 
 			// Skip any skybox that is missing.
 			if (!std::filesystem::exists(fullPath))
+			{
+				debug(("Skybox Error: File not found at %s\n", fullPath.string().c_str()));
 				continue;
+			}
 
 			D3DRenderBackgroundsLoad(fullPath.string().c_str(), i);
 		}

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -10,7 +10,6 @@
 #include <iterator>
 
 // Variables
-
 static constexpr float SKYBOX_DIMENSIONS = 75000.0f;
 static constexpr float SKYBOX_Y = 37000.0f;
 static constexpr int SKYBOX_SIDES = 6;
@@ -23,7 +22,7 @@ static int gCurBackground;
 static ID tempBkgnd = 0;
 
 // Defines vertices of the skybox.
-static constexpr custom_xyz gSkyboxXYZ[] =
+static constexpr custom_xyz SKYBOX_XYZ[] =
 {
 	// Back
 	{SKYBOX_DIMENSIONS, SKYBOX_Y, -SKYBOX_DIMENSIONS}, {SKYBOX_DIMENSIONS, -SKYBOX_Y, -SKYBOX_DIMENSIONS},
@@ -51,7 +50,7 @@ static constexpr custom_xyz gSkyboxXYZ[] =
 };
 
 // Defines the four corners of a skybox texture.
-static constexpr custom_st gSkyboxST[] =
+static constexpr custom_st SKYBOX_ST[] =
 {
 	{ 0.001f, 0.001f },		// Top-Left
 	{ 0.001f, 0.999f },		// Bottom-Left
@@ -59,7 +58,7 @@ static constexpr custom_st gSkyboxST[] =
 	{ 0.999f, 0.001f }		// Top-Right
 };
 
-static constexpr custom_bgra gSkyboxBGRA = {192, 192, 192, 255};
+static constexpr custom_bgra SKYBOX_BGRA = {192, 192, 192, 255};
 
 // Defines which .bgf resource gets paired with its respective hardware rendered skybox.
 struct SkyboxDefinition
@@ -70,7 +69,7 @@ struct SkyboxDefinition
 
 // Lookup table that pairs software-rendered skyboxes to hardware-rendered skyboxes.
 // Note: In hardware rendering, Ko'catan uses the same skybox textures as the mainland.
-static constexpr SkyboxDefinition gSkyboxTable[] = 
+static constexpr SkyboxDefinition SKYBOX_TABLE[] = 
 {
 	// Clear skies
     {"1skya.bgf", "skya.bsf"}, 		// Index 0
@@ -85,13 +84,14 @@ static constexpr SkyboxDefinition gSkyboxTable[] =
     {"redsky.bgf", "redsky.bsf"}, 	// Index 4
 };
 
-static constexpr int NUM_SKYBOXES = static_cast<int>(std::size(gSkyboxTable));
-static LPDIRECT3DTEXTURE9 gpSkyboxTextures[NUM_SKYBOXES][SKYBOX_SIDES];
+static constexpr int NUM_SKYBOXES = static_cast<int>(std::size(SKYBOX_TABLE));
+static IDirect3DTexture9* gpSkyboxTextures[NUM_SKYBOXES][SKYBOX_SIDES];
 
 // Interfaces
-
+static void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, int anglePitch);
 static void D3DRenderBackgroundsLoad(const char* pFilename, int index);
 static bool D3DRenderBackgroundSet(ID background);
+
 
 // Implementations
 
@@ -102,16 +102,18 @@ static bool D3DRenderBackgroundSet(ID background);
 */
 bool D3DRenderUpdateSkyBox(DWORD background)
 {
-	if (background == 0) return false;
+	if (background == 0)
+		return false;
 
 	if (gpSkyboxTextures[0][0] == nullptr)
 	{	
-		for(int i = 0; i < NUM_SKYBOXES; i++)
+		for (int i = 0; i < NUM_SKYBOXES; i++)
 		{
-			std::filesystem::path fullPath = std::filesystem::path("./resource") / gSkyboxTable[i].fileName;
+			auto fullPath = std::filesystem::path("./resource") / SKYBOX_TABLE[i].fileName;
 			
 			// Skip any skybox that is missing.
-			if (!std::filesystem::exists(fullPath)) continue;
+			if (!std::filesystem::exists(fullPath))
+				continue;
 			
 			D3DRenderBackgroundsLoad(fullPath.string().c_str(), i);
 		}
@@ -131,17 +133,17 @@ void D3DRenderSkyBox(Draw3DParams* params, int angleHeading, int anglePitch, con
 	const SkyboxRenderParams& skyboxRenderParams)
 {
 	// Set render states for skybox
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_CULLMODE, D3DCULL_NONE);
+	gpD3DDevice->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
 	SetZBias(0);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, FALSE);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZENABLE, FALSE);
+	gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+	gpD3DDevice->SetRenderState(D3DRS_ZENABLE, FALSE);
 
 	// Disable alpha blending and alpha testing for the skybox
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHABLENDENABLE, FALSE);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, FALSE);
+	gpD3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
+	gpD3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
 
 	// Disable fog for the skybox
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGENABLE, FALSE);
+	gpD3DDevice->SetRenderState(D3DRS_FOGENABLE, FALSE);
 
 	// Set texture stages for the skybox
 	D3DRender_SetColorStage(0, D3DTOP_SELECTARG1, D3DTA_TEXTURE, D3DTA_DIFFUSE);
@@ -150,23 +152,22 @@ void D3DRenderSkyBox(Draw3DParams* params, int angleHeading, int anglePitch, con
 	D3DRender_SetAlphaStage(1, D3DTOP_DISABLE, 0, 0);
 
 	// Set vertex shader and declaration for the skybox
-	IDirect3DDevice9_SetVertexShader(gpD3DDevice, NULL);
-	IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, skyboxRenderParams.vertexDeclaration);
+	gpD3DDevice->SetVertexShader(nullptr);
+	gpD3DDevice->SetVertexDeclaration(skyboxRenderParams.vertexDeclaration);
 
 	// Render the skybox
 	D3DRenderPoolReset(&skyboxRenderParams.renderPool, &D3DMaterialWorldPool);
 	D3DRenderSkyboxDraw(&skyboxRenderParams.renderPool, angleHeading, anglePitch);
 	D3DCacheFill(&skyboxRenderParams.cacheSystem, &skyboxRenderParams.renderPool, 1);
-	D3DCacheFlush(&skyboxRenderParams.cacheSystem, &skyboxRenderParams.renderPool, 1, 
-		D3DPT_TRIANGLESTRIP);
+	D3DCacheFlush(&skyboxRenderParams.cacheSystem, &skyboxRenderParams.renderPool, 1, D3DPT_TRIANGLESTRIP);
 
 	// Restore render states after skybox rendering
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, TRUE);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZENABLE, TRUE);
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGENABLE, TRUE);
+	gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+	gpD3DDevice->SetRenderState(D3DRS_ZENABLE, TRUE);
+	gpD3DDevice->SetRenderState(D3DRS_FOGENABLE, TRUE);
 
 	// restore the correct view matrix
-	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_VIEW, &view);
+	gpD3DDevice->SetTransform(D3DTS_VIEW, &view);
 }
 
 /**
@@ -174,28 +175,28 @@ void D3DRenderSkyBox(Draw3DParams* params, int angleHeading, int anglePitch, con
 */
 void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, int anglePitch)
 {
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHABLENDENABLE, FALSE);
+	gpD3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
 
 	D3DMATRIX rot, mat;
 	MatrixIdentity(&mat);
-	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_WORLD, &mat);
+	gpD3DDevice->SetTransform(D3DTS_WORLD, &mat);
 
 	MatrixRotateY(&rot, static_cast<float>(angleHeading) * 360.0f / 4096.0f * PI / 180.0f);
 	MatrixRotateX(&mat, static_cast<float>(anglePitch) * 45.0f / 414.0f * PI / 180.0f);
 	MatrixMultiply(&mat, &rot, &mat);
 
-	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_VIEW, &mat);
+	gpD3DDevice->SetTransform(D3DTS_VIEW, &mat);
 
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_ADDRESSU, D3DTADDRESS_CLAMP);
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_ADDRESSV, D3DTADDRESS_CLAMP);
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSU, D3DTADDRESS_CLAMP);
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_CLAMP);
 
 	for (int i = 0; i < SKYBOX_SIDES; i++)
 	{
-		d3d_render_packet_new* pPacket = D3DRenderPacketFindMatch(pPool, gpSkyboxTextures[gCurBackground][i], NULL, 0, 0, 0);
+		auto *pPacket = D3DRenderPacketFindMatch(pPool, gpSkyboxTextures[gCurBackground][i], nullptr, 0, 0, 0);
 		if (pPacket == nullptr)
 			return;
 
-		d3d_render_chunk_new* pChunk = D3DRenderChunkNew(pPacket);
+		auto *pChunk = D3DRenderChunkNew(pPacket);
 		assert(pChunk);
 
 		pChunk->numIndices = SKYBOX_QUAD_INDICES;
@@ -209,13 +210,13 @@ void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, int angle
 		for (int j = 0; j < SKYBOX_QUAD_VERTICES; j++)
 		{
 			// Note that the coordinate system is z-up, so y-z are flipped here.
-			pChunk->xyz[j].x = gSkyboxXYZ[(i * 4) + j].x;
-			pChunk->xyz[j].y = gSkyboxXYZ[(i * 4) + j].z;
-			pChunk->xyz[j].z = gSkyboxXYZ[(i * 4) + j].y;
+			pChunk->xyz[j].x = SKYBOX_XYZ[(i * 4) + j].x;
+			pChunk->xyz[j].y = SKYBOX_XYZ[(i * 4) + j].z;
+			pChunk->xyz[j].z = SKYBOX_XYZ[(i * 4) + j].y;
 
-			pChunk->st0[j] = gSkyboxST[j];
+			pChunk->st0[j] = SKYBOX_ST[j];
 
-			pChunk->bgra[j] = gSkyboxBGRA;
+			pChunk->bgra[j] = SKYBOX_BGRA;
 		}
 		
 		pChunk->indices[0] = 1;
@@ -224,8 +225,8 @@ void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, int angle
 		pChunk->indices[3] = 3;
 	}
 
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP);
-	IDirect3DDevice9_SetSamplerState(gpD3DDevice, 0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP);
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP);
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP);
 }
 
 /**
@@ -236,12 +237,13 @@ bool D3DRenderBackgroundSet(ID background)
 {
 	char* filename = LookupRsc(background);
 
-	if (!filename) return false;
+	if (!filename)
+		return false;
 
 	for (int i = 0; i < NUM_SKYBOXES; i++)
 	{
         // If the string names match, then set the index.
-		if (_stricmp(filename, gSkyboxTable[i].resourceName) == 0)
+		if (_stricmp(filename, SKYBOX_TABLE[i].resourceName) == 0)
         {
             gCurBackground = i;
             return true;
@@ -262,13 +264,12 @@ void D3DRenderSkyBoxShutdown()
 		{
 			if (gpSkyboxTextures[j][i])
 			{
-				IDirect3DTexture9_Release(gpSkyboxTextures[j][i]);
+				gpSkyboxTextures[j][i]->Release();
 				gpSkyboxTextures[j][i] = nullptr;
 			}
 		}
 	}
 }
-
 
 /**
 * Loads a series of PNG images from a specified file and creates textures for the skybox.
@@ -278,20 +279,21 @@ void D3DRenderBackgroundsLoad(const char* pFilename, int index)
 	// The .bsf/.png files for skyboxes are actually six .png files stored in a single 
 	// file by appending each picture's binary data into one file.
 	//
-	// The pictures for each cubemap face are stored in this order, similarly in gSkyboxXYZ[]:
+	// The pictures for each cubemap face are stored in this order, similarly in SKYBOX_XYZ[]:
 	// Back -> Bottom -> Front -> Left -> Right -> Top
 	//
 	// Color depth is also 24-bit since the alpha channel (transparency) isn't used.
 	
-	FILE* pFile = fopen(pFilename, "rb");
+	auto *pFile = fopen(pFilename, "rb");
 	if (pFile == nullptr)
 		return;
-	fpos_t pos = 0;
+
+	fpos_t pos = 0;	
 
 	for (int i = 0; i < SKYBOX_SIDES; i++)
 	{
 		png_structp pPng = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
-		if (pPng == nullptr )
+		if (pPng == nullptr)
 		{
 			fclose(pFile);
 			return;
@@ -319,44 +321,42 @@ void D3DRenderBackgroundsLoad(const char* pFilename, int index)
 			fclose(pFile);
 			return;
 		}
-		
+
 		fseek(pFile, pos, SEEK_SET);
 
 		png_init_io(pPng, pFile);
 		png_read_png(pPng, pInfo, PNG_TRANSFORM_IDENTITY, nullptr);
 		png_bytepp rows = png_get_rows(pPng, pInfo);
 
-		unsigned int image_width = png_get_image_width(pPng, pInfo);
-		unsigned int image_height = png_get_image_height(pPng, pInfo);
-		int bytePP = png_get_bit_depth(pPng, pInfo) / 8;
+		uint32_t image_width = png_get_image_width(pPng, pInfo);
+		uint32_t image_height = png_get_image_height(pPng, pInfo);
 
-		IDirect3DDevice9_CreateTexture(gpD3DDevice, image_width, image_height, 1, 0,
+		gpD3DDevice->CreateTexture(image_width, image_height, 1, 0,
 			D3DFMT_A8R8G8B8, D3DPOOL_MANAGED, &gpSkyboxTextures[index][i], nullptr);
 
-		D3DLOCKED_RECT lockedRect;
-		IDirect3DTexture9_LockRect(gpSkyboxTextures[index][i], 0, &lockedRect, nullptr, 0);
+		D3DLOCKED_RECT lockedRect = {};
+		gpSkyboxTextures[index][i]->LockRect(0, &lockedRect, nullptr, 0);
 
-		unsigned char *pBits = (unsigned char*)lockedRect.pBits;
+		auto *pBits = reinterpret_cast<uint8_t*>(lockedRect.pBits);
 
-		for (unsigned int h = 0; h < image_height; h++)
+		for (uint32_t h = 0; h < image_height; h++)
 		{
 			png_bytep curRow = rows[h];
 
-			for (unsigned int w = 0; w < image_width; w++)
+			for (uint32_t w = 0; w < image_width; w++)
 			{
-				for (unsigned int b = 0; b < 4; b++)
+				for (uint32_t b = 0; b < 4; b++)
 				{
 					if (b == 3)
 						pBits[h * lockedRect.Pitch + w * 4 + b] = 255;
 					else
 						// PNGs are in RGB, while DirectX wants BGRA.
-						pBits[h * lockedRect.Pitch + w * 4 + (2 - b)] =
-						curRow[(w * 3) + b];
+						pBits[h * lockedRect.Pitch + w * 4 + (2 - b)] = curRow[(w * 3) + b];
 				}
 			}
 		}
 
-		IDirect3DTexture9_UnlockRect(gpSkyboxTextures[index][i], 0);
+		gpSkyboxTextures[index][i]->UnlockRect(0);
 
 		fgetpos(pFile, &pos);
 		png_destroy_read_struct(&pPng, &pInfo, &pInfoEnd);

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -13,8 +13,6 @@
 ///////////////
 // Constants //
 ///////////////
-static constexpr float SKYBOX_DIMENSIONS = 75000.0f;
-static constexpr float SKYBOX_Y = 37000.0f;
 
 // Geometry constants for rendering a quad as a triangular strip.
 static constexpr int SKYBOX_QUAD_VERTICES = 4;
@@ -23,6 +21,9 @@ static constexpr int SKYBOX_QUAD_PRIMITIVES = SKYBOX_QUAD_VERTICES - 2;
 static constexpr int SKYBOX_QUAD_INDICES_PATTERN[] = {1, 2, 0, 3};
 
 static constexpr custom_bgra SKYBOX_BGRA = {192, 192, 192, 255};
+
+static constexpr float SKYBOX_DIMENSIONS = 75000.0f;
+static constexpr float SKYBOX_Y = 37000.0f;
 
 // Defines vertices of the skybox.
 static constexpr custom_xyz SKYBOX_XYZ[] =
@@ -182,6 +183,22 @@ static void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, in
 	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP);
 }
 
+// Checks if a skybox is already set up, and copies the pointers over if a match is found..
+// Used for hardware rendered skyboxes that is shared with both the mainland and Ko'catan island.
+static bool CheckExistingSkyboxTextures(int currentIndex)
+{
+    for (int i = 0; i < currentIndex; i++)
+    {
+        if (_stricmp(SKYBOX_TABLE[currentIndex].fileName, SKYBOX_TABLE[i].fileName) == 0)
+        {
+            // Copy the pointers from the existing skybox over to this one.
+            memcpy(gpSkyboxTextures[currentIndex], gpSkyboxTextures[i], sizeof(gpSkyboxTextures[currentIndex]));
+            return true;
+        }
+    }
+    return false;	
+}
+
 //////////////////////
 // Public Functions //
 //////////////////////
@@ -193,32 +210,35 @@ static void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, in
 */
 bool D3DRenderUpdateSkyBox(DWORD background)
 {
-	if (background == 0)
+	// Skip if there's no background yet or if it's already set.
+	if (background == 0 || tempBkgnd == background)
 		return false;
 
-	if (gpSkyboxTextures[0][0] == nullptr)
+	static bool bSkyboxesInitialized = false;
+	if (!bSkyboxesInitialized)
 	{
 		for (int i = 0; i < NUM_SKYBOXES; i++)
 		{
+			// If the skybox was already set up, just copy the pointers over and skip.
+			if (CheckExistingSkyboxTextures(i))
+				continue;
+			
+			// Otherwise, load the PNG as normal.
 			auto fullPath = std::filesystem::path("./resource") / SKYBOX_TABLE[i].fileName;
-
-			// Skip any skybox that is missing.
-			if (!std::filesystem::exists(fullPath))
+			if (std::filesystem::exists(fullPath))
+			{
+				LoadSkyboxFaces(fullPath.string().c_str(), gpSkyboxTextures[i]);
+			}
+			else
 			{
 				debug(("Skybox Error: File not found at %s\n", fullPath.string().c_str()));
-				continue;
 			}
-
-			LoadSkyboxFaces(fullPath.string().c_str(), gpSkyboxTextures[i]);
 		}
-	}
-	if (tempBkgnd != background)
-	{
-		tempBkgnd = background;
-		return D3DRenderBackgroundSet(tempBkgnd);
+		bSkyboxesInitialized = true;
 	}
 
-	return false;
+	tempBkgnd = background;
+	return D3DRenderBackgroundSet(tempBkgnd);
 }
 
 /**

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -197,9 +197,9 @@ static void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, in
 			pChunk->bgra[j] = SKYBOX_BGRA;
 		}
 
-		for (int i = 0; i < SKYBOX_QUAD_INDICES; i++)
+		for (int k = 0; k < SKYBOX_QUAD_INDICES; k++)
 		{
-			pChunk->indices[i] = SKYBOX_QUAD_INDICES_PATTERN[i];
+			pChunk->indices[k] = SKYBOX_QUAD_INDICES_PATTERN[k];
 		}
 	}
 

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -9,7 +9,9 @@
 #include <filesystem>
 #include <iterator>
 
-// Variables
+///////////////
+// Constants //
+///////////////
 static constexpr float SKYBOX_DIMENSIONS = 75000.0f;
 static constexpr float SKYBOX_Y = 37000.0f;
 static constexpr int SKYBOX_SIDES = 6;
@@ -18,8 +20,7 @@ static constexpr int SKYBOX_QUAD_VERTICES = 4;
 static constexpr int SKYBOX_QUAD_INDICES = 4;
 static constexpr int SKYBOX_QUAD_PRIMITIVES = SKYBOX_QUAD_VERTICES - 2;
 
-static int gCurBackground;
-static ID tempBkgnd = 0;
+static constexpr custom_bgra SKYBOX_BGRA = {192, 192, 192, 255};
 
 // Defines vertices of the skybox.
 static constexpr custom_xyz SKYBOX_XYZ[] =
@@ -58,8 +59,6 @@ static constexpr custom_st SKYBOX_ST[] =
 	{ 0.999f, 0.001f }		// Top-Right
 };
 
-static constexpr custom_bgra SKYBOX_BGRA = {192, 192, 192, 255};
-
 // Defines which .bgf resource gets paired with its respective hardware rendered skybox.
 struct SkyboxDefinition
 {
@@ -69,226 +68,52 @@ struct SkyboxDefinition
 
 // Lookup table that pairs software-rendered skyboxes to hardware-rendered skyboxes.
 // Note: In hardware rendering, Ko'catan uses the same skybox textures as the mainland.
-static constexpr SkyboxDefinition SKYBOX_TABLE[] = 
+static constexpr SkyboxDefinition SKYBOX_TABLE[] =
 {
 	// Clear skies
     {"1skya.bgf", "skya.bsf"}, 		// Index 0
-    {"2skya.bgf", "skya.bsf"}, 		
+    {"2skya.bgf", "skya.bsf"},
     {"1skyb.bgf", "skyb.bsf"}, 		// Index 1
-    {"2skyb.bgf", "skyb.bsf"}, 		
+    {"2skyb.bgf", "skyb.bsf"},
     {"1skyc.bgf", "skyc.bsf"}, 		// Index 2
-	{"2skyc.bgf", "skyc.bsf"}, 
+	{"2skyc.bgf", "skyc.bsf"},
     {"1skyd.bgf", "skyd.bsf"}, 		// Index 3
-	{"2skyd.bgf", "skyd.bsf"}, 
+	{"2skyd.bgf", "skyd.bsf"},
 	// Frenzy
     {"redsky.bgf", "redsky.bsf"}, 	// Index 4
 };
 
 static constexpr int NUM_SKYBOXES = static_cast<int>(std::size(SKYBOX_TABLE));
+
+/////////////////////
+// Local Variables //
+/////////////////////
+static int gCurBackground;
+static ID tempBkgnd = 0;
 static IDirect3DTexture9* gpSkyboxTextures[NUM_SKYBOXES][SKYBOX_SIDES];
 
-// Interfaces
-static void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, int anglePitch);
-static void D3DRenderBackgroundsLoad(const char* pFilename, int index);
-static bool D3DRenderBackgroundSet(ID background);
-
-
-// Implementations
-
-/**
-* Update the skybox with the current background.
-* Return true the background has changed and false otherwise.
-* If the background has changed, the caller should trigger a redraw all.
-*/
-bool D3DRenderUpdateSkyBox(DWORD background)
-{
-	if (background == 0)
-		return false;
-
-	if (gpSkyboxTextures[0][0] == nullptr)
-	{	
-		for (int i = 0; i < NUM_SKYBOXES; i++)
-		{
-			auto fullPath = std::filesystem::path("./resource") / SKYBOX_TABLE[i].fileName;
-			
-			// Skip any skybox that is missing.
-			if (!std::filesystem::exists(fullPath))
-				continue;
-			
-			D3DRenderBackgroundsLoad(fullPath.string().c_str(), i);
-		}
-	}
-	if (tempBkgnd != background)
-	{
-		tempBkgnd = background;
-		return D3DRenderBackgroundSet(tempBkgnd);
-	}
-	return false;
-}
-
-/**
-* Function to render the skybox with the current background.
-*/
-void D3DRenderSkyBox(Draw3DParams* params, int angleHeading, int anglePitch, const D3DMATRIX& view, 
-	const SkyboxRenderParams& skyboxRenderParams)
-{
-	// Set render states for skybox
-	gpD3DDevice->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
-	SetZBias(0);
-	gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
-	gpD3DDevice->SetRenderState(D3DRS_ZENABLE, FALSE);
-
-	// Disable alpha blending and alpha testing for the skybox
-	gpD3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
-	gpD3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
-
-	// Disable fog for the skybox
-	gpD3DDevice->SetRenderState(D3DRS_FOGENABLE, FALSE);
-
-	// Set texture stages for the skybox
-	D3DRender_SetColorStage(0, D3DTOP_SELECTARG1, D3DTA_TEXTURE, D3DTA_DIFFUSE);
-	D3DRender_SetAlphaStage(0, D3DTOP_SELECTARG1, D3DTA_TEXTURE, D3DTA_DIFFUSE);
-	D3DRender_SetColorStage(1, D3DTOP_DISABLE, 0, 0);
-	D3DRender_SetAlphaStage(1, D3DTOP_DISABLE, 0, 0);
-
-	// Set vertex shader and declaration for the skybox
-	gpD3DDevice->SetVertexShader(nullptr);
-	gpD3DDevice->SetVertexDeclaration(skyboxRenderParams.vertexDeclaration);
-
-	// Render the skybox
-	D3DRenderPoolReset(&skyboxRenderParams.renderPool, &D3DMaterialWorldPool);
-	D3DRenderSkyboxDraw(&skyboxRenderParams.renderPool, angleHeading, anglePitch);
-	D3DCacheFill(&skyboxRenderParams.cacheSystem, &skyboxRenderParams.renderPool, 1);
-	D3DCacheFlush(&skyboxRenderParams.cacheSystem, &skyboxRenderParams.renderPool, 1, D3DPT_TRIANGLESTRIP);
-
-	// Restore render states after skybox rendering
-	gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
-	gpD3DDevice->SetRenderState(D3DRS_ZENABLE, TRUE);
-	gpD3DDevice->SetRenderState(D3DRS_FOGENABLE, TRUE);
-
-	// restore the correct view matrix
-	gpD3DDevice->SetTransform(D3DTS_VIEW, &view);
-}
-
-/**
-* Function to draw the individual faces of the skybox.
-*/
-void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, int anglePitch)
-{
-	gpD3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
-
-	D3DMATRIX rot, mat;
-	MatrixIdentity(&mat);
-	gpD3DDevice->SetTransform(D3DTS_WORLD, &mat);
-
-	MatrixRotateY(&rot, static_cast<float>(angleHeading) * 360.0f / 4096.0f * PI / 180.0f);
-	MatrixRotateX(&mat, static_cast<float>(anglePitch) * 45.0f / 414.0f * PI / 180.0f);
-	MatrixMultiply(&mat, &rot, &mat);
-
-	gpD3DDevice->SetTransform(D3DTS_VIEW, &mat);
-
-	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSU, D3DTADDRESS_CLAMP);
-	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_CLAMP);
-
-	for (int i = 0; i < SKYBOX_SIDES; i++)
-	{
-		auto *pPacket = D3DRenderPacketFindMatch(pPool, gpSkyboxTextures[gCurBackground][i], nullptr, 0, 0, 0);
-		if (pPacket == nullptr)
-			return;
-
-		auto *pChunk = D3DRenderChunkNew(pPacket);
-		assert(pChunk);
-
-		pChunk->numIndices = SKYBOX_QUAD_INDICES;
-		pChunk->numVertices = SKYBOX_QUAD_VERTICES;
-		pChunk->numPrimitives = SKYBOX_QUAD_PRIMITIVES;
-		pPacket->pMaterialFctn = &D3DMaterialWorldPacket;
-		pChunk->pMaterialFctn = &D3DMaterialWorldDynamicChunk;
-		pChunk->flags |= D3DRENDER_NOAMBIENT;
-
-		// add xyz, st, and bgra data
-		for (int j = 0; j < SKYBOX_QUAD_VERTICES; j++)
-		{
-			// Note that the coordinate system is z-up, so y-z are flipped here.
-			pChunk->xyz[j].x = SKYBOX_XYZ[(i * 4) + j].x;
-			pChunk->xyz[j].y = SKYBOX_XYZ[(i * 4) + j].z;
-			pChunk->xyz[j].z = SKYBOX_XYZ[(i * 4) + j].y;
-
-			pChunk->st0[j] = SKYBOX_ST[j];
-
-			pChunk->bgra[j] = SKYBOX_BGRA;
-		}
-		
-		pChunk->indices[0] = 1;
-		pChunk->indices[1] = 2;
-		pChunk->indices[2] = 0;
-		pChunk->indices[3] = 3;
-	}
-
-	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP);
-	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP);
-}
-
-/**
-* Set the current background texture for the skybox by background ID.
-* Returns true if the background was set successfully and false otherwise.
-*/
-bool D3DRenderBackgroundSet(ID background)
-{
-	char* filename = LookupRsc(background);
-
-	if (!filename)
-		return false;
-
-	for (int i = 0; i < NUM_SKYBOXES; i++)
-	{
-        // If the string names match, then set the index.
-		if (_stricmp(filename, SKYBOX_TABLE[i].resourceName) == 0)
-        {
-            gCurBackground = i;
-            return true;
-        }
-	}
-
-	return true;
-}
-
-/**
-* Shutdown the skybox by releasing all textures.
-*/
-void D3DRenderSkyBoxShutdown()
-{
-	for (int j = 0; j < NUM_SKYBOXES; j++)
-	{
-		for (int i = 0; i < SKYBOX_SIDES; i++)
-		{
-			if (gpSkyboxTextures[j][i])
-			{
-				gpSkyboxTextures[j][i]->Release();
-				gpSkyboxTextures[j][i] = nullptr;
-			}
-		}
-	}
-}
+////////////////////////
+// Internal Functions //
+////////////////////////
 
 /**
 * Loads a series of PNG images from a specified file and creates textures for the skybox.
 */
-void D3DRenderBackgroundsLoad(const char* pFilename, int index)
+static void D3DRenderBackgroundsLoad(const char* pFilename, int index)
 {
-	// The .bsf/.png files for skyboxes are actually six .png files stored in a single 
+	// The .bsf/.png files for skyboxes are actually six .png files stored in a single
 	// file by appending each picture's binary data into one file.
 	//
 	// The pictures for each cubemap face are stored in this order, similarly in SKYBOX_XYZ[]:
 	// Back -> Bottom -> Front -> Left -> Right -> Top
 	//
 	// Color depth is also 24-bit since the alpha channel (transparency) isn't used.
-	
+
 	auto *pFile = fopen(pFilename, "rb");
 	if (pFile == nullptr)
 		return;
 
-	fpos_t pos = 0;	
+	fpos_t pos = 0;
 
 	for (int i = 0; i < SKYBOX_SIDES; i++)
 	{
@@ -363,4 +188,185 @@ void D3DRenderBackgroundsLoad(const char* pFilename, int index)
 	}
 
 	fclose(pFile);
+}
+
+/**
+* Function to draw the individual faces of the skybox.
+*/
+static void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, int anglePitch)
+{
+	gpD3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
+
+	D3DMATRIX rot, mat;
+	MatrixIdentity(&mat);
+	gpD3DDevice->SetTransform(D3DTS_WORLD, &mat);
+
+	MatrixRotateY(&rot, static_cast<float>(angleHeading) * 360.0f / 4096.0f * PI / 180.0f);
+	MatrixRotateX(&mat, static_cast<float>(anglePitch) * 45.0f / 414.0f * PI / 180.0f);
+	MatrixMultiply(&mat, &rot, &mat);
+
+	gpD3DDevice->SetTransform(D3DTS_VIEW, &mat);
+
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSU, D3DTADDRESS_CLAMP);
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_CLAMP);
+
+	for (int i = 0; i < SKYBOX_SIDES; i++)
+	{
+		auto *pPacket = D3DRenderPacketFindMatch(pPool, gpSkyboxTextures[gCurBackground][i], nullptr, 0, 0, 0);
+		if (pPacket == nullptr)
+			return;
+
+		auto *pChunk = D3DRenderChunkNew(pPacket);
+		assert(pChunk);
+
+		pChunk->numIndices = SKYBOX_QUAD_INDICES;
+		pChunk->numVertices = SKYBOX_QUAD_VERTICES;
+		pChunk->numPrimitives = SKYBOX_QUAD_PRIMITIVES;
+		pPacket->pMaterialFctn = &D3DMaterialWorldPacket;
+		pChunk->pMaterialFctn = &D3DMaterialWorldDynamicChunk;
+		pChunk->flags |= D3DRENDER_NOAMBIENT;
+
+		// add xyz, st, and bgra data
+		for (int j = 0; j < SKYBOX_QUAD_VERTICES; j++)
+		{
+			// Note that the coordinate system is z-up, so y-z are flipped here.
+			pChunk->xyz[j].x = SKYBOX_XYZ[(i * 4) + j].x;
+			pChunk->xyz[j].y = SKYBOX_XYZ[(i * 4) + j].z;
+			pChunk->xyz[j].z = SKYBOX_XYZ[(i * 4) + j].y;
+
+			pChunk->st0[j] = SKYBOX_ST[j];
+
+			pChunk->bgra[j] = SKYBOX_BGRA;
+		}
+
+		pChunk->indices[0] = 1;
+		pChunk->indices[1] = 2;
+		pChunk->indices[2] = 0;
+		pChunk->indices[3] = 3;
+	}
+
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP);
+	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP);
+}
+
+/**
+* Set the current background texture for the skybox by background ID.
+* Returns true if the background was set successfully and false otherwise.
+*/
+static bool D3DRenderBackgroundSet(ID background)
+{
+	char* filename = LookupRsc(background);
+
+	if (!filename)
+		return false;
+
+	for (int i = 0; i < NUM_SKYBOXES; i++)
+	{
+        // If the string names match, then set the index.
+		if (_stricmp(filename, SKYBOX_TABLE[i].resourceName) == 0)
+        {
+            gCurBackground = i;
+            return true;
+        }
+	}
+
+	return true;
+}
+
+//////////////////////
+// Public Functions //
+//////////////////////
+
+/**
+* Update the skybox with the current background.
+* Return true the background has changed and false otherwise.
+* If the background has changed, the caller should trigger a redraw all.
+*/
+bool D3DRenderUpdateSkyBox(DWORD background)
+{
+	if (background == 0)
+		return false;
+
+	if (gpSkyboxTextures[0][0] == nullptr)
+	{
+		for (int i = 0; i < NUM_SKYBOXES; i++)
+		{
+			auto fullPath = std::filesystem::path("./resource") / SKYBOX_TABLE[i].fileName;
+
+			// Skip any skybox that is missing.
+			if (!std::filesystem::exists(fullPath))
+				continue;
+
+			D3DRenderBackgroundsLoad(fullPath.string().c_str(), i);
+		}
+	}
+	if (tempBkgnd != background)
+	{
+		tempBkgnd = background;
+		return D3DRenderBackgroundSet(tempBkgnd);
+	}
+
+	return false;
+}
+
+/**
+* Function to render the skybox with the current background.
+*/
+void D3DRenderSkyBox(Draw3DParams* params, int angleHeading, int anglePitch, const D3DMATRIX& view,
+	const SkyboxRenderParams& skyboxRenderParams)
+{
+	// Set render states for skybox
+	gpD3DDevice->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
+	SetZBias(0);
+	gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+	gpD3DDevice->SetRenderState(D3DRS_ZENABLE, FALSE);
+
+	// Disable alpha blending and alpha testing for the skybox
+	gpD3DDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
+	gpD3DDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
+
+	// Disable fog for the skybox
+	gpD3DDevice->SetRenderState(D3DRS_FOGENABLE, FALSE);
+
+	// Set texture stages for the skybox
+	D3DRender_SetColorStage(0, D3DTOP_SELECTARG1, D3DTA_TEXTURE, D3DTA_DIFFUSE);
+	D3DRender_SetAlphaStage(0, D3DTOP_SELECTARG1, D3DTA_TEXTURE, D3DTA_DIFFUSE);
+	D3DRender_SetColorStage(1, D3DTOP_DISABLE, 0, 0);
+	D3DRender_SetAlphaStage(1, D3DTOP_DISABLE, 0, 0);
+
+	// Set vertex shader and declaration for the skybox
+	gpD3DDevice->SetVertexShader(nullptr);
+	gpD3DDevice->SetVertexDeclaration(skyboxRenderParams.vertexDeclaration);
+
+	// Render the skybox
+	D3DRenderPoolReset(&skyboxRenderParams.renderPool, &D3DMaterialWorldPool);
+	D3DRenderSkyboxDraw(&skyboxRenderParams.renderPool, angleHeading, anglePitch);
+	D3DCacheFill(&skyboxRenderParams.cacheSystem, &skyboxRenderParams.renderPool, 1);
+	D3DCacheFlush(&skyboxRenderParams.cacheSystem, &skyboxRenderParams.renderPool, 1, D3DPT_TRIANGLESTRIP);
+
+	// Restore render states after skybox rendering
+	gpD3DDevice->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+	gpD3DDevice->SetRenderState(D3DRS_ZENABLE, TRUE);
+	gpD3DDevice->SetRenderState(D3DRS_FOGENABLE, TRUE);
+
+	// restore the correct view matrix
+	gpD3DDevice->SetTransform(D3DTS_VIEW, &view);
+}
+
+/**
+* Shutdown the skybox by releasing all textures.
+*/
+void D3DRenderSkyBoxShutdown()
+{
+	for (int j = 0; j < NUM_SKYBOXES; j++)
+	{
+		for (int i = 0; i < SKYBOX_SIDES; i++)
+		{
+			if (gpSkyboxTextures[j][i])
+			{
+				gpSkyboxTextures[j][i]->Release();
+				gpSkyboxTextures[j][i] = nullptr;
+			}
+		}
+	}
 }

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -164,7 +164,7 @@ static void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, in
 	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSU, D3DTADDRESS_CLAMP);
 	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_CLAMP);
 
-	for (int i = 0; i < SKYBOX_SIDES; i++)
+	for (size_t i = 0; i < SKYBOX_SIDES; i++)
 	{
 		// Ensure the pointer slot is valid before fetching.
 		if (i >= gpActiveSkyboxTextures.size() || gpActiveSkyboxTextures[i] == nullptr)

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -1,4 +1,4 @@
-// Meridian 59, Copyright 1994-2024 Andrew Kirmse and Chris Kirmse.
+// Meridian 59, Copyright 1994-2026 Andrew Kirmse and Chris Kirmse.
 // All rights reserved.
 //
 // This software is distributed under a license that is described in
@@ -6,6 +6,7 @@
 //
 // Meridian is a registered trademark.
 #include "client.h"
+#include "skybox_load.h"
 #include <filesystem>
 #include <iterator>
 
@@ -14,7 +15,6 @@
 ///////////////
 static constexpr float SKYBOX_DIMENSIONS = 75000.0f;
 static constexpr float SKYBOX_Y = 37000.0f;
-static constexpr int SKYBOX_SIDES = 6;
 
 // Geometry constants for rendering a quad as a triangular strip.
 static constexpr int SKYBOX_QUAD_VERTICES = 4;
@@ -99,114 +99,28 @@ static IDirect3DTexture9* gpSkyboxTextures[NUM_SKYBOXES][SKYBOX_SIDES];
 ////////////////////////
 
 /**
-* Loads a series of PNG images from a specified file and creates textures for the skybox.
+* Set the current background texture for the skybox by background ID.
+* Returns true if the background was set successfully and false otherwise.
 */
-static void D3DRenderBackgroundsLoad(const char* pFilename, int index)
+static bool D3DRenderBackgroundSet(ID background)
 {
-	// The .bsf/.png files for skyboxes are actually six PNGs stored in a single
-	// file by appending each picture's binary data into one file.
-	//
-	// The pictures for each cubemap face are stored in this order, similarly in SKYBOX_XYZ[]:
-	// Back -> Bottom -> Front -> Left -> Right -> Top
-	//
-	// The pixel-packing loop expects a 24-bit PNG file since the alpha channel isn't used.
-	// However, a 32-bit PNG can still be used even if it's larger in file size.
+	char* filename = LookupRsc(background);
 
-	auto *pFile = fopen(pFilename, "rb");
-	if (pFile == nullptr)
+	if (!filename)
+		return false;
+
+	for (int i = 0; i < NUM_SKYBOXES; i++)
 	{
-		debug(("Skybox Error: Found file but unable to open: %s\n", pFilename));
-		return;
+        // If the string names match, then set the index.
+		if (_stricmp(filename, SKYBOX_TABLE[i].resourceName) == 0)
+        {
+            gCurBackground = i;
+            return true;
+        }
 	}
 
-	long filePosition = 0;
-
-	for (int i = 0; i < SKYBOX_SIDES; i++)
-	{
-		// Jumps to the number of bytes.
-		fseek(pFile, filePosition, SEEK_SET);
-
-		png_structp pPng = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
-		if (pPng == nullptr)
-		{
-			fclose(pFile);
-			return;
-		}
-
-		png_infop pInfo = png_create_info_struct(pPng);
-		if (pInfo == nullptr)
-		{
-			png_destroy_read_struct(&pPng, nullptr, nullptr);
-			fclose(pFile);
-			return;
-		}
-
-		png_infop pInfoEnd = png_create_info_struct(pPng);
-		if (pInfoEnd == nullptr)
-		{
-			png_destroy_read_struct(&pPng, &pInfo, nullptr);
-			fclose(pFile);
-			return;
-		}
-
-		if (setjmp(png_jmpbuf(pPng)))
-		{
-			debug(("Skybox Error: %s has corrupt or invalid PNG data.\n", pFilename));
-			png_destroy_read_struct(&pPng, &pInfo, &pInfoEnd);
-			fclose(pFile);
-			return;
-		}
-
-		png_init_io(pPng, pFile);
-
-		// Discard alpha channel in case a 32-bit PNG is used, ensuring 3 bytes per pixel.
-		png_set_strip_alpha(pPng);
-
-		png_read_png(pPng, pInfo, PNG_TRANSFORM_IDENTITY, nullptr);
-		png_bytepp rows = png_get_rows(pPng, pInfo);
-
-		uint32_t image_width = png_get_image_width(pPng, pInfo);
-		uint32_t image_height = png_get_image_height(pPng, pInfo);
-
-		// Creates the D3D texture in a 32-bit BGRA format, even if the source PNG is 24-bit.
-		gpD3DDevice->CreateTexture(image_width, image_height, 1, 0,
-			D3DFMT_A8R8G8B8, D3DPOOL_MANAGED, &gpSkyboxTextures[index][i], nullptr);
-
-		D3DLOCKED_RECT lockedRect = {};
-		gpSkyboxTextures[index][i]->LockRect(0, &lockedRect, nullptr, 0);
-
-		auto *pBits = reinterpret_cast<uint8_t*>(lockedRect.pBits);
-
-		// Iterate through each row of the skybox image.
-		for (uint32_t h = 0; h < image_height; h++)
-		{
-			// Use pitch to find the start of the row, then treat it as 32-bit pixels.
-			auto *pRowDest = reinterpret_cast<uint32_t*>(pBits + (h * lockedRect.Pitch));
-
-			// Get the source row from the PNG data.
-			png_bytep pSourceRow = rows[h];
-
-			for (uint32_t w = 0; w < image_width; w++)
-			{
-				// Reads 24-bit RGB data from the PNG row.
-				uint8_t r = pSourceRow[w * 3 + 0];
-				uint8_t g = pSourceRow[w * 3 + 1];
-				uint8_t b = pSourceRow[w * 3 + 2];
-
-				// Converts RGB to 32-bit BGRA (D3D native) using bit-shifting.
-				// Alpha is set to '0xFF' to keep the skybox fully opaque.
-				pRowDest[w] = (0xFF << 24) | (r << 16) | (g << 8) | b;
-			}
-		}
-
-		gpSkyboxTextures[index][i]->UnlockRect(0);
-
-		// Save current byte count so the next iteration finds the next PNG header.
-		filePosition = ftell(pFile);
-		png_destroy_read_struct(&pPng, &pInfo, &pInfoEnd);
-	}
-
-	fclose(pFile);
+	debug(("Skybox Error: '%s' is not mapped in SKYBOX_TABLE.\n", filename));
+	return false;
 }
 
 /**
@@ -268,31 +182,6 @@ static void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, in
 	gpD3DDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP);
 }
 
-/**
-* Set the current background texture for the skybox by background ID.
-* Returns true if the background was set successfully and false otherwise.
-*/
-static bool D3DRenderBackgroundSet(ID background)
-{
-	char* filename = LookupRsc(background);
-
-	if (!filename)
-		return false;
-
-	for (int i = 0; i < NUM_SKYBOXES; i++)
-	{
-        // If the string names match, then set the index.
-		if (_stricmp(filename, SKYBOX_TABLE[i].resourceName) == 0)
-        {
-            gCurBackground = i;
-            return true;
-        }
-	}
-
-	debug(("Skybox Error: '%s' is not mapped in SKYBOX_TABLE.\n", filename));
-	return false;
-}
-
 //////////////////////
 // Public Functions //
 //////////////////////
@@ -320,7 +209,7 @@ bool D3DRenderUpdateSkyBox(DWORD background)
 				continue;
 			}
 
-			D3DRenderBackgroundsLoad(fullPath.string().c_str(), i);
+			LoadSkyboxFaces(fullPath.string().c_str(), gpSkyboxTextures[i]);
 		}
 	}
 	if (tempBkgnd != background)

--- a/clientd3d/d3drender_skybox.h
+++ b/clientd3d/d3drender_skybox.h
@@ -15,13 +15,13 @@
 #define _D3DRENDERSKYBOX_H
 
 struct SkyboxRenderParams {
-    LPDIRECT3DVERTEXDECLARATION9 vertexDeclaration;
+    IDirect3DVertexDeclaration9* vertexDeclaration;
     d3d_driver_profile driverProfile;
     mutable d3d_render_pool_new renderPool;
     mutable d3d_render_cache_system cacheSystem;
 
     SkyboxRenderParams(
-        LPDIRECT3DVERTEXDECLARATION9 vertexDeclarationParam,
+        IDirect3DVertexDeclaration9* vertexDeclarationParam,
         d3d_driver_profile driverProfileParam,
         d3d_render_pool_new renderPoolParam,
         d3d_render_cache_system cacheSystemParam)
@@ -35,7 +35,6 @@ struct SkyboxRenderParams {
 bool D3DRenderUpdateSkyBox(DWORD background);
 void D3DRenderSkyBox(Draw3DParams* params, int angleHeading, int anglePitch, const D3DMATRIX& view, 
     const SkyboxRenderParams& skyboxRenderParams);
-void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, int anglePitch);
 void D3DRenderSkyBoxShutdown();
 
 #endif	/* #ifndef _D3DRENDERSKYBOX_H */

--- a/clientd3d/d3drender_skybox.h
+++ b/clientd3d/d3drender_skybox.h
@@ -14,6 +14,8 @@
 #ifndef _D3DRENDERSKYBOX_H
 #define _D3DRENDERSKYBOX_H
 
+static constexpr int SKYBOX_SIDES = 6;
+
 struct SkyboxRenderParams {
     IDirect3DVertexDeclaration9* vertexDeclaration;
     d3d_driver_profile driverProfile;

--- a/clientd3d/makefile
+++ b/clientd3d/makefile
@@ -144,6 +144,7 @@ OBJS = \
         $(OUTDIR)\d3drender_skybox.obj \
         $(OUTDIR)\d3drender_textures.obj \
         $(OUTDIR)\d3drender_world.obj \
+        $(OUTDIR)\skybox_load.obj \
         $(OUTDIR)\matrix.obj \
         $(OUTDIR)\xform.obj \
         $(OUTDIR)\signup.obj\

--- a/clientd3d/skybox_load.c
+++ b/clientd3d/skybox_load.c
@@ -26,20 +26,20 @@ static bool LoadPngChunkToTexture(FILE* pFile, IDirect3DTexture9*& pTexture)
 	// Remove alpha in case a 32-bit PNG is used. Then fill in the 4th byte with 0xFF (opaque).
 	png_set_strip_alpha(pPng);
 	png_set_filler(pPng, 0xFF, PNG_FILLER_AFTER);
-	
+
 	png_set_bgr(pPng); // Swap red and blue to match D3D's BGRA format.
 	png_read_update_info(pPng, pInfo);
-	
+
 	uint32_t image_width = png_get_image_width(pPng, pInfo);
-	uint32_t image_height = png_get_image_height(pPng, pInfo);	
-	
+	uint32_t image_height = png_get_image_height(pPng, pInfo);
+
 	// Creates the D3D texture in a 32-bit BGRA format, even if the source PNG is 24-bit.
 	HRESULT hrTex = gpD3DDevice->CreateTexture(image_width, image_height, 1, 0,
 						D3DFMT_A8R8G8B8, D3DPOOL_MANAGED, &pTexture, nullptr);
 
     if (FAILED(hrTex))
 	{
-		debug(("Skybox Error: Failed to create %dx%d texture (HRESULT: 0x%08X). Possible VRAM limit.\n", 
+		debug(("Skybox Error: Failed to create %dx%d texture (HRESULT: 0x%08X). Possible VRAM limit.\n",
 				image_width, image_height, hrTex));
 		png_destroy_read_struct(&pPng, &pInfo, nullptr);
         return false;
@@ -53,7 +53,7 @@ static bool LoadPngChunkToTexture(FILE* pFile, IDirect3DTexture9*& pTexture)
 		png_destroy_read_struct(&pPng, &pInfo, nullptr);
 		return false;
 	}
-	
+
 	// Read directly into the texture buffer, row-by-row.
 	for (uint32_t h = 0; h < image_height; h++)
 	{
@@ -61,8 +61,8 @@ static bool LoadPngChunkToTexture(FILE* pFile, IDirect3DTexture9*& pTexture)
 		png_read_row(pPng, pRowDest, nullptr);
 	}
 	pTexture->UnlockRect(0);
-	
-	png_read_end(pPng, pInfo); 
+
+	png_read_end(pPng, pInfo);
 	png_destroy_read_struct(&pPng, &pInfo, nullptr);
 	return true;
 }
@@ -70,7 +70,7 @@ static bool LoadPngChunkToTexture(FILE* pFile, IDirect3DTexture9*& pTexture)
 /**
 * Loads a series of PNG images from a specified file and creates textures for the skybox.
 */
-void LoadSkyboxFaces(const char* pFilename, IDirect3DTexture9** ppSkyboxFace)
+void LoadSkyboxFaces(const char* pFilePath, IDirect3DTexture9** ppSkyboxFace)
 {
 	// The .bsf/.png files for skyboxes are actually six PNGs stored in a single
 	// file by appending each picture's binary data into one file.
@@ -81,11 +81,14 @@ void LoadSkyboxFaces(const char* pFilename, IDirect3DTexture9** ppSkyboxFace)
 	// The pixel-packing loop expects a 24-bit PNG file since the alpha channel isn't used.
 	// However, a 32-bit PNG can still be used even if it's larger in file size.
 
-	auto *pFile = fopen(pFilename, "rb");
+	// The calling function should verify that the file exists.
+	auto *pFile = fopen(pFilePath, "rb");
 
 	if (pFile == nullptr)
 	{
-		debug(("Skybox Error: Found file but unable to open: %s\n", pFilename));
+		// If 'fopen' fails here, the file exists and is verified by the caller, but cannot be opened.
+		// It's possible that it's locked by another process, or has restricted permissions.
+		debug(("Skybox Error: File is inaccessible at: %s\n", pFilePath));
 		return;
 	}
 
@@ -93,7 +96,7 @@ void LoadSkyboxFaces(const char* pFilename, IDirect3DTexture9** ppSkyboxFace)
 	{
 		if(!LoadPngChunkToTexture(pFile, ppSkyboxFace[i]))
 		{
-            debug(("Skybox Error: Failed to load face %d in %s\n", i, pFilename));
+            debug(("Skybox Error: Failed to load face %d in %s\n", i, pFilePath));
             break;
 		}
 	}

--- a/clientd3d/skybox_load.c
+++ b/clientd3d/skybox_load.c
@@ -34,28 +34,34 @@ static bool LoadPngChunkToTexture(FILE* pFile, IDirect3DTexture9*& pTexture)
 	uint32_t image_height = png_get_image_height(pPng, pInfo);	
 	
 	// Creates the D3D texture in a 32-bit BGRA format, even if the source PNG is 24-bit.
-	HRESULT hr = gpD3DDevice->CreateTexture(image_width, image_height, 1, 0,
+	HRESULT hrTex = gpD3DDevice->CreateTexture(image_width, image_height, 1, 0,
 						D3DFMT_A8R8G8B8, D3DPOOL_MANAGED, &pTexture, nullptr);
 
-    if (FAILED(hr))
+    if (FAILED(hrTex))
 	{
 		debug(("Skybox Error: Failed to create %dx%d texture (HRESULT: 0x%08X). Possible VRAM limit.\n", 
-				image_width, image_height, hr));
+				image_width, image_height, hrTex));
 		png_destroy_read_struct(&pPng, &pInfo, nullptr);
         return false;
     }
 
 	D3DLOCKED_RECT lockedRect = {};
-	if (SUCCEEDED(pTexture->LockRect(0, &lockedRect, nullptr, 0)))
+	HRESULT hrLock = pTexture->LockRect(0, &lockedRect, nullptr, 0);
+	if (FAILED(hrLock))
 	{
-        // Read directly into the texture buffer, row-by-row.
-        for (uint32_t h = 0; h < image_height; h++)
-		{
-            uint8_t* pRowDest = static_cast<uint8_t*>(lockedRect.pBits) + (h * lockedRect.Pitch);
-            png_read_row(pPng, pRowDest, nullptr);
-        }
-		pTexture->UnlockRect(0);
+		debug(("Skybox Error: LockRect failed (HRESULT: 0x%08X). Skybox face will be empty.\n", hrLock));
+		png_destroy_read_struct(&pPng, &pInfo, nullptr);
+		return false;
 	}
+	
+	// Read directly into the texture buffer, row-by-row.
+	for (uint32_t h = 0; h < image_height; h++)
+	{
+		uint8_t* pRowDest = static_cast<uint8_t*>(lockedRect.pBits) + (h * lockedRect.Pitch);
+		png_read_row(pPng, pRowDest, nullptr);
+	}
+	pTexture->UnlockRect(0);
+	
 	png_read_end(pPng, pInfo); 
 	png_destroy_read_struct(&pPng, &pInfo, nullptr);
 	return true;

--- a/clientd3d/skybox_load.c
+++ b/clientd3d/skybox_load.c
@@ -9,9 +9,6 @@
 #include <filesystem>
 #include <iterator>
 
-////////////////////////
-// Internal Functions //
-////////////////////////
 static bool LoadPngChunkToTexture(FILE* pFile, IDirect3DTexture9*& pTexture)
 {
 	png_structp pPng = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
@@ -63,10 +60,6 @@ static bool LoadPngChunkToTexture(FILE* pFile, IDirect3DTexture9*& pTexture)
 	png_destroy_read_struct(&pPng, &pInfo, nullptr);
 	return true;
 }
-
-//////////////////////
-// Public Functions //
-//////////////////////
 
 /**
 * Loads a series of PNG images from a specified file and creates textures for the skybox.

--- a/clientd3d/skybox_load.c
+++ b/clientd3d/skybox_load.c
@@ -1,0 +1,103 @@
+// Meridian 59, Copyright 1994-2026 Andrew Kirmse and Chris Kirmse.
+// All rights reserved.
+//
+// This software is distributed under a license that is described in
+// the LICENSE file that accompanies it.
+//
+// Meridian is a registered trademark.
+#include "client.h"
+#include <filesystem>
+#include <iterator>
+
+////////////////////////
+// Internal Functions //
+////////////////////////
+static bool LoadPngChunkToTexture(FILE* pFile, IDirect3DTexture9*& pTexture)
+{
+	png_structp pPng = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+	png_infop pInfo = png_create_info_struct(pPng);
+
+	if (setjmp(png_jmpbuf(pPng)))
+	{
+		png_destroy_read_struct(&pPng, &pInfo, nullptr);
+		return false;
+	}
+
+	png_init_io(pPng, pFile);
+	png_read_info(pPng, pInfo);
+
+	// Remove alpha in case a 32-bit PNG is used. Then fill in the 4th byte with 0xFF (opaque).
+	png_set_strip_alpha(pPng);
+	png_set_filler(pPng, 0xFF, PNG_FILLER_AFTER);
+	
+	png_set_bgr(pPng); // Swap red and blue to match D3D's BGRA format.
+	png_read_update_info(pPng, pInfo);
+	
+	uint32_t image_width = png_get_image_width(pPng, pInfo);
+	uint32_t image_height = png_get_image_height(pPng, pInfo);	
+	
+	// Creates the D3D texture in a 32-bit BGRA format, even if the source PNG is 24-bit.
+	HRESULT hr = gpD3DDevice->CreateTexture(image_width, image_height, 1, 0,
+						D3DFMT_A8R8G8B8, D3DPOOL_MANAGED, &pTexture, nullptr);
+
+    if (FAILED(hr))
+	{
+		debug(("Skybox Error: Failed to create %dx%d texture (HRESULT: 0x%08X). Possible VRAM limit.\n", 
+				image_width, image_height, hr));
+		png_destroy_read_struct(&pPng, &pInfo, nullptr);
+        return false;
+    }
+
+	D3DLOCKED_RECT lockedRect = {};
+	if (SUCCEEDED(pTexture->LockRect(0, &lockedRect, nullptr, 0)))
+	{
+        // Read directly into the texture buffer, row-by-row.
+        for (uint32_t h = 0; h < image_height; h++)
+		{
+            uint8_t* pRowDest = static_cast<uint8_t*>(lockedRect.pBits) + (h * lockedRect.Pitch);
+            png_read_row(pPng, pRowDest, nullptr);
+        }
+		pTexture->UnlockRect(0);
+	}
+	png_read_end(pPng, pInfo); 
+	png_destroy_read_struct(&pPng, &pInfo, nullptr);
+	return true;
+}
+
+//////////////////////
+// Public Functions //
+//////////////////////
+
+/**
+* Loads a series of PNG images from a specified file and creates textures for the skybox.
+*/
+void LoadSkyboxFaces(const char* pFilename, IDirect3DTexture9** ppSkyboxFace)
+{
+	// The .bsf/.png files for skyboxes are actually six PNGs stored in a single
+	// file by appending each picture's binary data into one file.
+	//
+	// The pictures for each cubemap face are stored in this order, similarly in SKYBOX_XYZ[]:
+	// Back -> Bottom -> Front -> Left -> Right -> Top
+	//
+	// The pixel-packing loop expects a 24-bit PNG file since the alpha channel isn't used.
+	// However, a 32-bit PNG can still be used even if it's larger in file size.
+
+	auto *pFile = fopen(pFilename, "rb");
+
+	if (pFile == nullptr)
+	{
+		debug(("Skybox Error: Found file but unable to open: %s\n", pFilename));
+		return;
+	}
+
+	for (int i = 0; i < SKYBOX_SIDES; i++)
+	{
+		if(!LoadPngChunkToTexture(pFile, ppSkyboxFace[i]))
+		{
+            debug(("Skybox Error: Failed to load face %d in %s\n", i, pFilename));
+            break;
+		}
+	}
+
+	fclose(pFile);
+}

--- a/clientd3d/skybox_load.h
+++ b/clientd3d/skybox_load.h
@@ -6,12 +6,9 @@
 //
 // Meridian is a registered trademark.
 
-#ifndef _D3DCUBEMAP_H
-#define _D3DCUBEMAP_H
+#ifndef _SKYBOXLOAD_H
+#define _SKYBOXLOAD_H
 
-////////////////
-// Prototypes //
-////////////////
 void LoadSkyboxFaces(const char* pFilename, IDirect3DTexture9** ppSkyboxFace);
 
-#endif	/* #ifndef _D3DCUBEMAP_H */
+#endif	/* #ifndef _SKYBOXLOAD_H */

--- a/clientd3d/skybox_load.h
+++ b/clientd3d/skybox_load.h
@@ -6,9 +6,9 @@
 //
 // Meridian is a registered trademark.
 
-#ifndef _SKYBOXLOAD_H
-#define _SKYBOXLOAD_H
+#ifndef _SKYBOX_LOAD_H
+#define _SKYBOX_LOAD_H
 
 void LoadSkyboxFaces(const char* pFilename, IDirect3DTexture9** ppSkyboxFace);
 
-#endif	/* #ifndef _SKYBOXLOAD_H */
+#endif	/* #ifndef _SKYBOX_LOAD_H */

--- a/clientd3d/skybox_load.h
+++ b/clientd3d/skybox_load.h
@@ -1,0 +1,17 @@
+// Meridian 59, Copyright 1994-2026 Andrew Kirmse and Chris Kirmse.
+// All rights reserved.
+//
+// This software is distributed under a license that is described in
+// the LICENSE file that accompanies it.
+//
+// Meridian is a registered trademark.
+
+#ifndef _D3DCUBEMAP_H
+#define _D3DCUBEMAP_H
+
+////////////////
+// Prototypes //
+////////////////
+void LoadSkyboxFaces(const char* pFilename, IDirect3DTexture9** ppSkyboxFace);
+
+#endif	/* #ifndef _D3DCUBEMAP_H */


### PR DESCRIPTION
This PR ports the `d3drender_skybox.c` refactoring from #1304 to clean up and refactor the skybox setup.  These changes should help make it easier to read and adjust how both legacy and hardware rendering skyboxes are paired together.  It also reorganizes and condenses parts of the source file for improved readability.  This PR also refactors the pixel packing loop to use 32-bit pixel packing via bit-shifting to streamline its performance and be easier to understand.

Refactoring
- Added `SKYBOX_ASSET_MAPPING` that pairs .bgf files with .bsf/.png skybox files in an `std::unordered_map` table.
- Added `gSkyboxCache` table that pairs .bsf/.png filenames to loaded texture pointers.  Skyboxes files are loaded in on demand.
- Replaced defined arrays of floats to arrays of structs to help condense them.
- Replaced D3D wrapper functions with direct calls.
- Modernized source file using `auto` and `static constexpr`.
- Refactored pixel-copying logic by replacing nested byte loop with libpng transform functions.
- Split PNG loading code into newly added `skybox_load.c`
- Skyboxes can support 32-bit PNG files.

Code Cleanup
- Reorganized source file.
- Removed unused `pitchHalf` and `bytePP` variables.
- Replaced type casting with C++ equivalent