### PR TITLE
fix: use regular helm instead of MSH for cavern shrine puzzle

### DIFF
--- a/kod/object/active/holder/room/monsroom/kcforest/ka0.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/ka0.kod
@@ -89,7 +89,7 @@ messages:
                        &ForgetPotion,
                        &JewelofFroz,
                        &Gauntlet,
-                       &Helm,
+                       &SimpleHelm,
                        &IvyCirclet,
                        &OrcShield,
                        &ChickenSoup,

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -6661,6 +6661,11 @@ messages:
       % Remove this line after PostPatchUpdates has been successfully applied. -- Aesica
       Send(&BarloqueApothecary, @SetForSale);
 
+      % Rebuild OutdoorsKA0 so the corrected plVentItems1 list (SimpleHelm in place of Helm)
+      % takes effect. Constructed only runs when the room is created, so an existing room
+      % keeps the old list until recreated. Remove after PostPatchUpdates has been applied.
+      Send(Send(self, @FindRoomByNum, #num=RID_KA0), @Recreate);
+
       return;
    }
 


### PR DESCRIPTION
## What
- small change to swap `&Helm` for `&SimpleHelm` in the KA0 "A dark, humid cavern" shrine puzzle item-vent list

## Why
- the KA0 shrine puzzle asks players to drop a randomly chosen item from a list of items
- `&Helm` is the "magic spirit helmet"
  - it is extremely rare and expensive
- the rest of the list contains common items (mace, rose, mushroom, jewel, etc.)
  - `&Helm` is out of place and was almost certainly meant to be `&SimpleHelm` (the ordinary "helm")
- this issue was mentioned by players on the official Discord server