### PR TITLE
feature: add client theme infrastructure with starter dark theme (theming part 1)

### DIFF
--- a/clientd3d/client.c
+++ b/clientd3d/client.c
@@ -274,6 +274,21 @@ void ClearMessageQueue(void)
 	}
 }
 /************************************************************************/
+/*
+ * ThemeApply:  Reload the color palette for the active theme and force
+ *   a repaint of the main window.  Called when the user changes themes
+ *   in the Preferences dialog.
+ */
+void ThemeApply(void)
+{
+	ColorsDestroy();
+	ColorsCreate(false);
+	MainChangeColor();
+	ModuleEvent(EVENT_COLORCHANGED, -1, 0);
+	if (hMain != NULL)
+		InvalidateRect(hMain, NULL, TRUE);
+}
+/************************************************************************/
 void SetUpCrashReporting() {
 #ifdef M59_RETAIL
   static MiniDmpSender *pSender;

--- a/clientd3d/client.rc
+++ b/clientd3d/client.rc
@@ -167,7 +167,7 @@ BEGIN
     LISTBOX         IDC_QUANLIST,143,118,22,20,LBS_OWNERDRAWFIXED | LBS_HASSTRINGS | LBS_WANTKEYBOARDINPUT | NOT WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_SETTINGS DIALOGEX 0, 0, 256, 250
+IDD_SETTINGS DIALOGEX 0, 0, 256, 255
 STYLE DS_SETFONT | DS_MODALFRAME | DS_3DLOOK | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Configurações antecipadas Meridian 59"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
@@ -194,7 +194,7 @@ BEGIN
     CONTROL         "",IDC_MUSIC_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,95,129,145,15
     LTEXT           "Volume do som ambiente",IDC_STATIC,13,147,85,10
     CONTROL         "",IDC_AMBIENT_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,95,144,145,15
-    GROUPBOX        "Interface",IDC_STATIC,5,175,246,70,WS_GROUP
+    GROUPBOX        "Interface",IDC_STATIC,5,175,246,85,WS_GROUP
     CONTROL         "Mostrar ícones",IDC_TOOLBAR,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,197,62,9
     CONTROL         "Mostrar barra",IDC_TOOLTIPS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,187,68,9
     CONTROL         "Congelar janela de texto ao retroceder",IDC_SCROLLLOCK,
@@ -204,6 +204,8 @@ BEGIN
     CONTROL         "Mapa dinâmico",IDC_DRAWMAP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,88,197,79,10
     CONTROL         "Texto colorido",IDC_COLORCODES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,172,187,72,10
     PUSHBUTTON      "&Configurações",IDC_PROFANESETTINGS,169,225,70,12
+    LTEXT           "Tema:",IDC_STATIC,14,242,20,9
+    COMBOBOX        IDC_THEME,36,240,60,60,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
 END
 
 IDD_COLOR DIALOG 0, 0, 201, 92
@@ -1028,6 +1030,8 @@ BEGIN
 	IDS_DUPLICATE_BINDINGS			"Foi detectada uma duplicação de atribuições para a mesma tecla.\nIsso pode fazer com que alguns comandos não funcionem em\nMeridian 59. Verifique suas atribuições de teclas."
 	IDS_DEFAULT_ARE_YOU_SURE		"Tem certeza de que deseja restaurar todas as configurações para os valores padrão?"
 	IDS_RESTORE_DEFAULTS			"Restaurar Padrões"
+	IDS_THEME_DEFAULT				"Padrão"
+	IDS_THEME_DARK					"Escuro"
 END
 
 
@@ -1183,7 +1187,7 @@ BEGIN
     LISTBOX         IDC_QUANLIST,143,118,22,20,LBS_OWNERDRAWFIXED | LBS_HASSTRINGS | LBS_WANTKEYBOARDINPUT | NOT WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_SETTINGS DIALOGEX 0, 0, 256, 260
+IDD_SETTINGS DIALOGEX 0, 0, 256, 265
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Meridian 59 Voreinstellungen"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
@@ -1210,7 +1214,7 @@ BEGIN
     CONTROL         "",IDC_MUSIC_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,83,148,159,15
     LTEXT           "Umgebungs Lautstärke",IDC_STATIC,13,149,76,10
     CONTROL         "",IDC_AMBIENT_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,83,131,159,15
-    GROUPBOX        "Oberfläche",IDC_STATIC,5,175,246,70,WS_GROUP
+    GROUPBOX        "Oberfläche",IDC_STATIC,5,175,246,87,WS_GROUP
     CONTROL         "Icons anzeigen",IDC_TOOLBAR,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,197,62,9
     CONTROL         "Iconhilfe an/aus",IDC_TOOLTIPS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,187,68,9
     CONTROL         "Textfenster beim zurückscrollen einfrieren",IDC_SCROLLLOCK,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,207,166,10
@@ -1220,6 +1224,8 @@ BEGIN
     CONTROL         "Dynamische Karte",IDC_DRAWMAP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,88,196,79,10
     CONTROL         "Bunter Text",IDC_COLORCODES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,172,185,72,10
     CONTROL         "Rotierender Würfel",ID_SPINNING_CUBE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,172,197,71,9
+    LTEXT           "Thema:",IDC_STATIC,14,243,24,9
+    COMBOBOX        IDC_THEME,42,241,60,60,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
 END
 
 IDD_COLOR DIALOG 0, 0, 201, 92
@@ -2048,6 +2054,8 @@ BEGIN
 	IDS_DUPLICATE_BINDINGS			"Doppelte Tastenzuweisungen für dieselbe Taste wurden erkannt.\nDies könnte dazu führen, dass einige Befehle in Meridian 59 nicht funktionieren.\nBitte überprüfen Sie Ihre Bindungen."
 	IDS_DEFAULT_ARE_YOU_SURE		"Sind Sie sicher, dass Sie alle Einstellungen auf die Standardwerte zurücksetzen möchten?"
 	IDS_RESTORE_DEFAULTS			"Standardwerte wiederherstellen"
+	IDS_THEME_DEFAULT				"Standard"
+	IDS_THEME_DARK					"Dunkel"
 END
 
 
@@ -2204,7 +2212,7 @@ BEGIN
     LISTBOX         IDC_QUANLIST,143,118,22,20,LBS_OWNERDRAWFIXED | LBS_HASSTRINGS | LBS_WANTKEYBOARDINPUT | NOT WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_SETTINGS DIALOGEX 0, 0, 257, 242
+IDD_SETTINGS DIALOGEX 0, 0, 257, 261
 STYLE DS_SETFONT | DS_MODALFRAME | DS_3DLOOK | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Meridian 59 Preferences"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
@@ -2232,7 +2240,7 @@ BEGIN
     CONTROL         "",IDC_MUSIC_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,69,124,173,15
     LTEXT           "Ambient volume",IDC_STATIC,13,143,53,10
     CONTROL         "",IDC_AMBIENT_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,69,142,173,15
-    GROUPBOX        "Interface Features",IDC_STATIC,6,165,245,59,WS_GROUP
+    GROUPBOX        "Interface Features",IDC_STATIC,6,165,245,78,WS_GROUP
     CONTROL         "Show toolbar",IDC_TOOLBAR,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,176,62,9
     CONTROL         "Show tooltips",IDC_TOOLTIPS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,187,62,9
     CONTROL         "Lock text window in place when scrolling back",IDC_SCROLLLOCK,
@@ -2243,6 +2251,8 @@ BEGIN
     CONTROL         "Show colored text",IDC_COLORCODES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,173,176,72,10
     CONTROL         "Spinning cube",ID_SPINNING_CUBE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,173,187,72,10
     PUSHBUTTON      "&Profanity Options and Policy...",IDC_PROFANESETTINGS,102,208,142,12
+    LTEXT           "Theme:",IDC_STATIC,14,226,24,9
+    COMBOBOX        IDC_THEME,40,224,60,60,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
 END
 
 IDD_COLOR DIALOG 0, 0, 201, 92
@@ -3328,6 +3338,8 @@ BEGIN
 	IDS_DUPLICATE_BINDINGS			"Duplicate bindings for the same key have been detected.\nThis could cause some commands to not work on\nMeridian 59.  Please double check your bindings."
 	IDS_DEFAULT_ARE_YOU_SURE		"Are you sure you want to restore all settings to their default?"
 	IDS_RESTORE_DEFAULTS			"Restore Defaults"
+	IDS_THEME_DEFAULT				"Default"
+	IDS_THEME_DARK					"Dark"
 END
 
 

--- a/clientd3d/color.c
+++ b/clientd3d/color.c
@@ -28,9 +28,10 @@ static COLORREF CustColors[16];  /* User's custom colors for Choose Color dialog
 // Theme color tables.  See docs/themes.md for details.
 // Each theme has a parallel table of MAXCOLORS "R,G,B" strings indexed
 // by the COLOR_* enum from color.h.
+static constexpr size_t COLOR_STR_LEN = 15;
 
 // Default theme.
-static char colorinfo_default[][15] = {
+static char colorinfo_default[][COLOR_STR_LEN] = {
 	{ "0,0,0"},         /* COLOR_BGD */
 	{ "255,255,255"},   /* COLOR_FGD */
 	{ "255,255,255"},   /* COLOR_LISTSELBGD */
@@ -67,7 +68,7 @@ static char colorinfo_default[][15] = {
 };
 
 // Dark theme.
-static char colorinfo_dark[][15] = {
+static char colorinfo_dark[][COLOR_STR_LEN] = {
 	{ "0,0,0"},         /* COLOR_BGD */
 	{ "212,212,212"},   /* COLOR_FGD */
 	{ "255,255,255"},   /* COLOR_LISTSELBGD - matches default for dialog list highlights */
@@ -108,13 +109,13 @@ static char INIColorVersion[]       = "ColorVersion";
 static const int THEME_COLOR_VERSION = 5;
 
 // Returns the INI section name for the active theme.
-static const char *ColorSectionForTheme(Theme theme)
+static char *ColorSectionForTheme(Theme theme)
 {
 	return (theme == Theme::Default) ? color_section_default : color_section_dark;
 }
 
 // Returns the default color table for the active theme.
-static char (*ColorDefaultsForTheme(Theme theme))[15]
+static char (*ColorDefaultsForTheme(Theme theme))[COLOR_STR_LEN]
 {
 	return (theme == Theme::Default) ? colorinfo_default : colorinfo_dark;
 }
@@ -149,7 +150,7 @@ void ColorsCreate(bool use_defaults)
 	bool success;
 
 	const char *section = ColorSectionForTheme(config.theme);
-	char (*defaults)[15] = ColorDefaultsForTheme(config.theme);
+	char (*defaults)[COLOR_STR_LEN] = ColorDefaultsForTheme(config.theme);
 
 	// Discard saved colors when the version doesn't match.
 	if (!use_defaults)
@@ -271,7 +272,7 @@ void ColorsSave(void)
 {
 	int i;
 	char str[100], name[10];
-	const char *section = ColorSectionForTheme(config.theme);
+	char *section = ColorSectionForTheme(config.theme);
 
 	for (i=0; i < MAXCOLORS; i++)
 	{
@@ -283,8 +284,7 @@ void ColorsSave(void)
 	}
 
 	// Stamp the version so future loads can detect stale saved colors.
-	WritePrivateProfileString(section, INIColorVersion,
-		std::to_string(THEME_COLOR_VERSION).c_str(), ini_file);
+	WriteConfigInt(section, INIColorVersion, THEME_COLOR_VERSION, ini_file);
 }
 /************************************************************************/
 void ColorsRestoreDefaults(void)
@@ -438,9 +438,9 @@ HBRUSH MainCtlColor(HWND hwnd, HDC hdc, HWND hwndChild, int type)
 
 	case CTLCOLOR_SCROLLBAR:
 		// Default paints scrollbars black; other themes use the system look.
-		if (config.theme != Theme::Default)
-			return (HBRUSH) FALSE;
-		return (HBRUSH) GetStockObject( BLACK_BRUSH );
+		if (config.theme == Theme::Default)
+			return (HBRUSH) GetStockObject( BLACK_BRUSH );
+		return (HBRUSH) FALSE;
 
 	default:
 		SelectPalette(hdc, hPal, FALSE);

--- a/clientd3d/color.c
+++ b/clientd3d/color.c
@@ -25,9 +25,12 @@ static HBRUSH hDefaultBrush;
 
 static COLORREF CustColors[16];  /* User's custom colors for Choose Color dialog */
 
-/* Default color information structures */
-// default colors changed for grey background in new client - mistery
-static char colorinfo[][15] = {
+// Theme color tables.  See docs/themes.md for details.
+// Each theme has a parallel table of MAXCOLORS "R,G,B" strings indexed
+// by the COLOR_* enum from color.h.
+
+// Default theme.
+static char colorinfo_default[][15] = {
 	{ "0,0,0"},         /* COLOR_BGD */
 	{ "255,255,255"},   /* COLOR_FGD */
 	{ "255,255,255"},   /* COLOR_LISTSELBGD */
@@ -63,7 +66,58 @@ static char colorinfo[][15] = {
 	{ "255,0,0"},	    /* COLOR_ITEM_TEXT_CURSED       - red    */
 };
 
-static char color_section[] = "Colors";  /* Section for colors in INI file */
+// Dark theme.
+static char colorinfo_dark[][15] = {
+	{ "0,0,0"},         /* COLOR_BGD */
+	{ "212,212,212"},   /* COLOR_FGD */
+	{ "255,255,255"},   /* COLOR_LISTSELBGD - matches default for dialog list highlights */
+	{ "0,0,0"},         /* COLOR_LISTSELFGD - matches default for dialog list highlights */
+	{ "50,50,53"},      /* COLOR_MAILBGD */
+	{ "212,212,212"},   /* COLOR_MAILFGD */
+	{ "240,208,25"},    /* COLOR_HIGHLITE */
+	{ "212,212,212"},   /* COLOR_EDITFGD */
+	{ "60,60,64"},      /* COLOR_EDITBGD */
+	{ "200,160,255"},   /* COLOR_SYSMSGFGD */
+	{ "212,212,212"},   /* COLOR_MAINEDITFGD */
+	{ "50,50,53"},      /* COLOR_MAINEDITBGD */
+	{ "255,255,255"},   /* COLOR_LISTFGD - matches default for dialog lists */
+	{ "0,0,0"},         /* COLOR_LISTBGD - matches default for dialog lists */
+	{ "230,100,100"},   /* COLOR_RMMSGFGD */
+	{ "50,50,53"},      /* COLOR_RMMSGBGD */
+	{ "212,212,212"},   /* COLOR_STATSFGD */
+	{ "50,50,53"},      /* COLOR_STATSBGD */
+	{ "0,128,0"},       /* COLOR_BAR1 - bar fill (health/mana/vigor) */
+	{ "128,0,0"},       /* COLOR_BAR2 - limit/damage bar */
+	{ "48,0,0"},        /* COLOR_BAR3 - bar background */
+	{ "255,255,255"},   /* COLOR_BAR4 - bar numbers */
+	{ "180,180,180"},   /* COLOR_INVNUMFGD */
+	{ "50,50,53"},      /* COLOR_INVNUMBGD */
+	{ "141,242,242"},   /* COLOR_ITEM_TEXT_UNCOMMON */
+	{ "0,255,0"},       /* COLOR_ITEM_TEXT_RARE */
+	{ "255,0,255"},     /* COLOR_ITEM_TEXT_LEGENDARY */
+	{ "252,128,0"},     /* COLOR_ITEM_TEXT_UNIDENTIFIED */
+	{ "255,0,0"},       /* COLOR_ITEM_TEXT_CURSED */
+};
+
+// INI section names; one section per theme.
+static char color_section_default[] = "Colors";
+static char color_section_dark[]    = "ColorsDark";
+static char INIColorVersion[]       = "ColorVersion";
+
+// Bump when default values for any color change.
+static const int THEME_COLOR_VERSION = 5;
+
+// Returns the INI section name for the active theme.
+static const char *ColorSectionForTheme(int theme)
+{
+	return (theme == THEME_DEFAULT) ? color_section_default : color_section_dark;
+}
+
+// Returns the default color table for the active theme.
+static char (*ColorDefaultsForTheme(int theme))[15]
+{
+	return (theme == THEME_DEFAULT) ? colorinfo_default : colorinfo_dark;
+}
 
 // Colors for drawing player names
 #define NAME_COLOR_NORMAL_FG   PALETTERGB(255, 255, 255)
@@ -94,6 +148,18 @@ void ColorsCreate(bool use_defaults)
 	const char *separators = ",";
 	bool success;
 
+	const char *section = ColorSectionForTheme(config.theme);
+	char (*defaults)[15] = ColorDefaultsForTheme(config.theme);
+
+	// Discard saved colors when the version doesn't match.
+	if (!use_defaults)
+	{
+		int saved_version = GetPrivateProfileInt(section, INIColorVersion,
+			0, ini_file);
+		if (saved_version != THEME_COLOR_VERSION)
+			use_defaults = true;
+	}
+
 	DefaultColor = PALETTERGB(255, 255, 255);
 	hDefaultBrush = (HBRUSH) GetStockObject(BLACK_BRUSH);
 
@@ -106,11 +172,11 @@ void ColorsCreate(bool use_defaults)
 		for (i=0; i < MAXCOLORS; i++)
 		{
 			if (use_defaults)
-				strcpy(str, colorinfo[i]);
+				strcpy(str, defaults[i]);
 			else
 			{
 				snprintf(name, sizeof(name), "Color%d", i);
-				GetPrivateProfileString(color_section, name, colorinfo[i], str, 100, ini_file);
+				GetPrivateProfileString(section, name, defaults[i], str, 100, ini_file);
 			}
 
 			success = true;
@@ -125,7 +191,7 @@ void ColorsCreate(bool use_defaults)
 			else blue = temp;
 
 			if (success)
-				SetColor(i, PALETTERGB(red, green, blue));
+				SetColor(i, RGB(red, green, blue));
 			else SetColor(i, DefaultColor);
 
 			brushes[i] = NULL;
@@ -148,8 +214,11 @@ COLORREF GetColor(WORD color)
 		debug(("Illegal color #%u in GetColor\n", color));
 		return DefaultColor;
 	}
-	// Return palette-relative color
-	return MAKEPALETTERGB(colors[color]);
+	// Default theme snaps to the indexed game palette; other themes pass
+	// raw 24-bit RGB.
+	if (config.theme == THEME_DEFAULT)
+		return MAKEPALETTERGB(colors[color]);
+	return colors[color] & 0x00FFFFFF;
 }
 /************************************************************************/
 HBRUSH GetBrush(WORD color)
@@ -181,8 +250,11 @@ bool SetColor(WORD color, COLORREF cr)
 		return false;
 	}
 
-	/* Round color to nearest match in our palette; this lets transparency work */
-	colors[color] = GetNearestPaletteColor(cr);
+	// See GetColor.
+	if (config.theme == THEME_DEFAULT)
+		colors[color] = GetNearestPaletteColor(cr);
+	else
+		colors[color] = cr & 0x00FFFFFF;
 
 	if (brushes[color] != NULL)
 	{
@@ -199,6 +271,7 @@ void ColorsSave(void)
 {
 	int i;
 	char str[100], name[10];
+	const char *section = ColorSectionForTheme(config.theme);
 
 	for (i=0; i < MAXCOLORS; i++)
 	{
@@ -206,8 +279,12 @@ void ColorsSave(void)
 			GetRValue(colors[i]), GetGValue(colors[i]), GetBValue(colors[i]));
 		snprintf(name, sizeof(name), "Color%d", i);
 
-		WritePrivateProfileString(color_section, name, str, ini_file);
+		WritePrivateProfileString(section, name, str, ini_file);
 	}
+
+	// Stamp the version so future loads can detect stale saved colors.
+	snprintf(str, sizeof(str), "%d", THEME_COLOR_VERSION);
+	WritePrivateProfileString(section, INIColorVersion, str, ini_file);
 }
 /************************************************************************/
 void ColorsRestoreDefaults(void)
@@ -359,9 +436,11 @@ HBRUSH MainCtlColor(HWND hwnd, HDC hdc, HWND hwndChild, int type)
 		SetBkColor(hdc, GetColor(COLOR_MAINEDITBGD));
 		return GetBrush(COLOR_MAINEDITBGD);
 
-	case CTLCOLOR_SCROLLBAR:  /* Don't color scrollbars */
-		//return (HBRUSH) FALSE;
-		return (HBRUSH) GetStockObject( BLACK_BRUSH );		//	xxx
+	case CTLCOLOR_SCROLLBAR:
+		// Default paints scrollbars black; other themes use the system look.
+		if (config.theme != THEME_DEFAULT)
+			return (HBRUSH) FALSE;
+		return (HBRUSH) GetStockObject( BLACK_BRUSH );
 
 	default:
 		SelectPalette(hdc, hPal, FALSE);
@@ -372,23 +451,40 @@ HBRUSH MainCtlColor(HWND hwnd, HDC hdc, HWND hwndChild, int type)
 }
 /****************************************************************************/
 /*
-* DialogCtlColor:  Handle CTLCOLOR messages for dialog boxes.
+* DialogCtlColor:  Returns a brush and sets DC colors for dialog controls.
+*   Only the default theme reads from GetColor().  Other themes use stock
+*   white/black brushes so theme palettes stay out of dialogs.  See
+*   docs/themes.md.
 */
 HBRUSH DialogCtlColor(HWND hwnd, HDC hdc, HWND hwndChild, int type)
 {
 	switch (type)
 	{
 	case CTLCOLOR_EDIT:
-		SelectPalette(hdc, hPal, FALSE);
-		SetTextColor(hdc, GetColor(COLOR_EDITFGD));
-		SetBkColor(hdc, GetColor(COLOR_EDITBGD));
-		return GetBrush(COLOR_EDITBGD);
-
 	case CTLCOLOR_LISTBOX:
 		SelectPalette(hdc, hPal, FALSE);
-		SetTextColor(hdc, GetColor(COLOR_LISTFGD));
-		SetBkColor(hdc, GetColor(COLOR_LISTBGD));
-		return GetBrush(COLOR_LISTBGD);
+		if (config.theme == THEME_DEFAULT)
+		{
+			if (type == CTLCOLOR_EDIT)
+			{
+				SetTextColor(hdc, GetColor(COLOR_EDITFGD));
+				SetBkColor(hdc, GetColor(COLOR_EDITBGD));
+				return GetBrush(COLOR_EDITBGD);
+			}
+			SetTextColor(hdc, GetColor(COLOR_LISTFGD));
+			SetBkColor(hdc, GetColor(COLOR_LISTBGD));
+			return GetBrush(COLOR_LISTBGD);
+		}
+		// Other themes use stock dialog colors.
+		if (type == CTLCOLOR_EDIT)
+		{
+			SetTextColor(hdc, PALETTERGB(0, 0, 0));
+			SetBkColor(hdc, PALETTERGB(255, 255, 255));
+			return (HBRUSH)GetStockObject(WHITE_BRUSH);
+		}
+		SetTextColor(hdc, PALETTERGB(255, 255, 255));
+		SetBkColor(hdc, PALETTERGB(0, 0, 0));
+		return (HBRUSH)GetStockObject(BLACK_BRUSH);
 
 	case CTLCOLOR_SCROLLBAR:
 		return (HBRUSH) FALSE;

--- a/clientd3d/color.c
+++ b/clientd3d/color.c
@@ -108,15 +108,15 @@ static char INIColorVersion[]       = "ColorVersion";
 static const int THEME_COLOR_VERSION = 5;
 
 // Returns the INI section name for the active theme.
-static const char *ColorSectionForTheme(int theme)
+static const char *ColorSectionForTheme(Theme theme)
 {
-	return (theme == THEME_DEFAULT) ? color_section_default : color_section_dark;
+	return (theme == Theme::Default) ? color_section_default : color_section_dark;
 }
 
 // Returns the default color table for the active theme.
-static char (*ColorDefaultsForTheme(int theme))[15]
+static char (*ColorDefaultsForTheme(Theme theme))[15]
 {
-	return (theme == THEME_DEFAULT) ? colorinfo_default : colorinfo_dark;
+	return (theme == Theme::Default) ? colorinfo_default : colorinfo_dark;
 }
 
 // Colors for drawing player names
@@ -216,7 +216,7 @@ COLORREF GetColor(WORD color)
 	}
 	// Default theme snaps to the indexed game palette; other themes pass
 	// raw 24-bit RGB.
-	if (config.theme == THEME_DEFAULT)
+	if (config.theme == Theme::Default)
 		return MAKEPALETTERGB(colors[color]);
 	return colors[color] & 0x00FFFFFF;
 }
@@ -251,7 +251,7 @@ bool SetColor(WORD color, COLORREF cr)
 	}
 
 	// See GetColor.
-	if (config.theme == THEME_DEFAULT)
+	if (config.theme == Theme::Default)
 		colors[color] = GetNearestPaletteColor(cr);
 	else
 		colors[color] = cr & 0x00FFFFFF;
@@ -283,8 +283,8 @@ void ColorsSave(void)
 	}
 
 	// Stamp the version so future loads can detect stale saved colors.
-	snprintf(str, sizeof(str), "%d", THEME_COLOR_VERSION);
-	WritePrivateProfileString(section, INIColorVersion, str, ini_file);
+	WritePrivateProfileString(section, INIColorVersion,
+		std::to_string(THEME_COLOR_VERSION).c_str(), ini_file);
 }
 /************************************************************************/
 void ColorsRestoreDefaults(void)
@@ -438,7 +438,7 @@ HBRUSH MainCtlColor(HWND hwnd, HDC hdc, HWND hwndChild, int type)
 
 	case CTLCOLOR_SCROLLBAR:
 		// Default paints scrollbars black; other themes use the system look.
-		if (config.theme != THEME_DEFAULT)
+		if (config.theme != Theme::Default)
 			return (HBRUSH) FALSE;
 		return (HBRUSH) GetStockObject( BLACK_BRUSH );
 
@@ -463,7 +463,7 @@ HBRUSH DialogCtlColor(HWND hwnd, HDC hdc, HWND hwndChild, int type)
 	case CTLCOLOR_EDIT:
 	case CTLCOLOR_LISTBOX:
 		SelectPalette(hdc, hPal, FALSE);
-		if (config.theme == THEME_DEFAULT)
+		if (config.theme == Theme::Default)
 		{
 			if (type == CTLCOLOR_EDIT)
 			{

--- a/clientd3d/config.c
+++ b/clientd3d/config.c
@@ -252,7 +252,8 @@ void ConfigLoad(void)
    config.spinning_cube= GetConfigInt(interface_section, INISpinningCube, false, ini_file);
    config.halocolor    = GetConfigInt(interface_section, INIHaloColor, 0, ini_file);
    config.colorcodes   = GetConfigInt(interface_section, INIColorCodes, true, ini_file);
-   config.theme        = GetConfigInt(interface_section, INITheme, THEME_DEFAULT, ini_file);
+   config.theme        = static_cast<Theme>(GetConfigInt(interface_section, INITheme,
+                            static_cast<int>(Theme::Default), ini_file));
    config.map_annotations = GetConfigInt(interface_section, INIMapAnnotations, true, ini_file);
    config.map_text_zoom_limit = GetConfigInt(interface_section, INIMapTextZoomLimit, 50, ini_file);
 
@@ -376,7 +377,7 @@ void ConfigSave(void)
    WriteConfigInt(interface_section, INISpinningCube, config.spinning_cube, ini_file);
    WriteConfigInt(interface_section, INIHaloColor, config.halocolor, ini_file);
    WriteConfigInt(interface_section, INIColorCodes, config.colorcodes, ini_file);
-   WriteConfigInt(interface_section, INITheme, config.theme, ini_file);
+   WriteConfigInt(interface_section, INITheme, static_cast<int>(config.theme), ini_file);
    WriteConfigInt(interface_section, INIMapAnnotations, config.map_annotations, ini_file);
    WriteConfigInt(interface_section, INIMapTextZoomLimit, config.map_text_zoom_limit, ini_file);
    

--- a/clientd3d/config.c
+++ b/clientd3d/config.c
@@ -77,6 +77,7 @@ static char INILagbox[]      = "LatencyMeter";
 static char INISpinningCube[]= "SpinningCube";
 static char INIHaloColor[]   = "HaloColor";
 static char INIColorCodes[]  = "ColorCodes";
+static char INITheme[]       = "Theme";
 static char INIMapAnnotations[] = "MapAnnotations";
 static char INIMapTextZoomLimit[] = "MapTextZoomLimit";
 
@@ -143,9 +144,9 @@ static int   DefaultTimeout       = 20;
 void LoadSettings(void)
 {
    FontsCreate(false);
-   ColorsCreate(false);
    CommLoadSettings();
    ConfigLoad();
+   ColorsCreate(false);
    LoadProfaneTerms();
 
    // Restore defaults if they've changed from previous version
@@ -251,6 +252,7 @@ void ConfigLoad(void)
    config.spinning_cube= GetConfigInt(interface_section, INISpinningCube, false, ini_file);
    config.halocolor    = GetConfigInt(interface_section, INIHaloColor, 0, ini_file);
    config.colorcodes   = GetConfigInt(interface_section, INIColorCodes, true, ini_file);
+   config.theme        = GetConfigInt(interface_section, INITheme, THEME_DEFAULT, ini_file);
    config.map_annotations = GetConfigInt(interface_section, INIMapAnnotations, true, ini_file);
    config.map_text_zoom_limit = GetConfigInt(interface_section, INIMapTextZoomLimit, 50, ini_file);
 
@@ -374,6 +376,7 @@ void ConfigSave(void)
    WriteConfigInt(interface_section, INISpinningCube, config.spinning_cube, ini_file);
    WriteConfigInt(interface_section, INIHaloColor, config.halocolor, ini_file);
    WriteConfigInt(interface_section, INIColorCodes, config.colorcodes, ini_file);
+   WriteConfigInt(interface_section, INITheme, config.theme, ini_file);
    WriteConfigInt(interface_section, INIMapAnnotations, config.map_annotations, ini_file);
    WriteConfigInt(interface_section, INIMapTextZoomLimit, config.map_text_zoom_limit, ini_file);
    

--- a/clientd3d/config.h
+++ b/clientd3d/config.h
@@ -24,6 +24,12 @@
 
 static const int CONFIG_MAX_TEXT_ZOOM_LIMIT = 100;  // Max value of map text zoom limit
 
+// UI themes
+enum {
+   THEME_DEFAULT = 0,
+   THEME_DARK    = 1,
+};
+
 // Communication settings
 typedef struct {
    WORD  timeout;                 /* # of seconds to wait before redialing */
@@ -90,6 +96,7 @@ typedef struct {
    bool clearCache;
 
    bool colorcodes;
+   int  theme;
    int lastPasswordChange;
 
    int soundLibrary;             /* Reserved for struct layout compatibility */
@@ -134,6 +141,8 @@ void SaveSettings(void);
 
 void ConfigLoad(void);
 void ConfigSave(void);
+
+void ThemeApply(void);
 
 void WindowSettingsSave(void);
 void WindowSettingsLoad(WINDOWPLACEMENT *w);

--- a/clientd3d/config.h
+++ b/clientd3d/config.h
@@ -25,9 +25,9 @@
 static const int CONFIG_MAX_TEXT_ZOOM_LIMIT = 100;  // Max value of map text zoom limit
 
 // UI themes
-enum {
-   THEME_DEFAULT = 0,
-   THEME_DARK    = 1,
+enum class Theme : int {
+   Default = 0,
+   Dark    = 1,
 };
 
 // Communication settings
@@ -96,7 +96,7 @@ typedef struct {
    bool clearCache;
 
    bool colorcodes;
-   int  theme;
+   Theme theme;
    int lastPasswordChange;
 
    int soundLibrary;             /* Reserved for struct layout compatibility */

--- a/clientd3d/preferences.c
+++ b/clientd3d/preferences.c
@@ -1136,6 +1136,10 @@ static INT_PTR CALLBACK CommonPreferencesDlgProc(HWND hDlg, UINT message, WPARAM
 
         CheckDlgButton(hDlg, IDC_COLORCODES, config.colorcodes);
 
+        ComboBox_AddString(GetDlgItem(hDlg, IDC_THEME), GetString(hInst, IDS_THEME_DEFAULT));
+        ComboBox_AddString(GetDlgItem(hDlg, IDC_THEME), GetString(hInst, IDS_THEME_DARK));
+        ComboBox_SetCurSel(GetDlgItem(hDlg, IDC_THEME), config.theme);
+
         Trackbar_SetRange(GetDlgItem(hDlg, IDC_SOUND_VOLUME), 0, CONFIG_MAX_VOLUME, FALSE);
         Trackbar_SetRange(GetDlgItem(hDlg, IDC_MUSIC_VOLUME), 0, CONFIG_MAX_VOLUME, FALSE);
         Trackbar_SetRange(GetDlgItem(hDlg, IDC_AMBIENT_VOLUME), 0, CONFIG_MAX_VOLUME, FALSE);
@@ -1186,6 +1190,13 @@ static INT_PTR CALLBACK CommonPreferencesDlgProc(HWND hDlg, UINT message, WPARAM
             config.halocolor = IsDlgButtonChecked(hDlg, IDC_TARGETHALO1) == BST_CHECKED ? 0 :
                                IsDlgButtonChecked(hDlg, IDC_TARGETHALO2) == BST_CHECKED ? 1 : 2;
             config.colorcodes = IsDlgButtonChecked(hDlg, IDC_COLORCODES);
+
+            int new_theme = ComboBox_GetCurSel(GetDlgItem(hDlg, IDC_THEME));
+            if (new_theme != config.theme)
+            {
+                config.theme = new_theme;
+                ThemeApply();
+            }
 
             config.sound_volume = Trackbar_GetPos(GetDlgItem(hDlg, IDC_SOUND_VOLUME));
             config.ambient_volume = Trackbar_GetPos(GetDlgItem(hDlg, IDC_AMBIENT_VOLUME));

--- a/clientd3d/preferences.c
+++ b/clientd3d/preferences.c
@@ -1138,7 +1138,7 @@ static INT_PTR CALLBACK CommonPreferencesDlgProc(HWND hDlg, UINT message, WPARAM
 
         ComboBox_AddString(GetDlgItem(hDlg, IDC_THEME), GetString(hInst, IDS_THEME_DEFAULT));
         ComboBox_AddString(GetDlgItem(hDlg, IDC_THEME), GetString(hInst, IDS_THEME_DARK));
-        ComboBox_SetCurSel(GetDlgItem(hDlg, IDC_THEME), config.theme);
+        ComboBox_SetCurSel(GetDlgItem(hDlg, IDC_THEME), static_cast<int>(config.theme));
 
         Trackbar_SetRange(GetDlgItem(hDlg, IDC_SOUND_VOLUME), 0, CONFIG_MAX_VOLUME, FALSE);
         Trackbar_SetRange(GetDlgItem(hDlg, IDC_MUSIC_VOLUME), 0, CONFIG_MAX_VOLUME, FALSE);
@@ -1191,7 +1191,7 @@ static INT_PTR CALLBACK CommonPreferencesDlgProc(HWND hDlg, UINT message, WPARAM
                                IsDlgButtonChecked(hDlg, IDC_TARGETHALO2) == BST_CHECKED ? 1 : 2;
             config.colorcodes = IsDlgButtonChecked(hDlg, IDC_COLORCODES);
 
-            int new_theme = ComboBox_GetCurSel(GetDlgItem(hDlg, IDC_THEME));
+            Theme new_theme = static_cast<Theme>(ComboBox_GetCurSel(GetDlgItem(hDlg, IDC_THEME)));
             if (new_theme != config.theme)
             {
                 config.theme = new_theme;

--- a/clientd3d/resource.h
+++ b/clientd3d/resource.h
@@ -435,6 +435,7 @@
 #define IDC_EMAIL_ADDRESS               1218
 #define IDC_SIGNUP_TROUBLESHOOT         1219
 #define ID_SPINNING_CUBE                1220
+#define IDC_THEME                       1221
 #define ID_GAME_EXIT                    3002
 #define ID_FONT_MAIL                    3014
 #define ID_FONT_LIST                    3015
@@ -641,6 +642,8 @@
 #define IDS_INTRO                       3651
 #define ID_FONT_ANNOTATIONS             3652
 #define IDC_ANNOTATION_ZOOM_LIMIT       3653
+#define IDS_THEME_DEFAULT               3654
+#define IDS_THEME_DARK                  3655
 
 // Next default values for new objects
 // 
@@ -648,7 +651,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        191
 #define _APS_NEXT_COMMAND_VALUE         3513
-#define _APS_NEXT_CONTROL_VALUE         1221
+#define _APS_NEXT_CONTROL_VALUE         1222
 #define _APS_NEXT_SYMED_VALUE           105
 #endif
 #endif

--- a/clientd3d/srvrstr.c
+++ b/clientd3d/srvrstr.c
@@ -277,7 +277,31 @@ static FormatCode code_table[] = {
 { 'n', CODE_STYLE, STYLE_RESET },
 };
 
+// Dark theme code table; same length and order as code_table.
+static FormatCode code_table_dark[] = {
+{ 'r', CODE_COLOR, PALETTERGB(230, 100, 100) }, // Soft Red
+{ 'g', CODE_COLOR, PALETTERGB( 80, 200, 120) }, // Bright Green
+{ 'l', CODE_COLOR, PALETTERGB(  0, 255,   0) }, // Lime Green
+{ 'b', CODE_COLOR, PALETTERGB(100, 149, 237) }, // Cornflower Blue
+{ 'c', CODE_COLOR, PALETTERGB(100, 220, 220) }, // Soft Cyan
+{ 'k', CODE_COLOR, PALETTERGB(160, 160, 160) }, // Gray
+{ 'w', CODE_COLOR, PALETTERGB(255, 255, 255) }, // White
+{ 'y', CODE_COLOR, PALETTERGB(255, 255,   0) }, // Yellow
+{ 'o', CODE_COLOR, PALETTERGB(255, 172,  28) }, // Bright Orange
+{ 'p', CODE_COLOR, PALETTERGB(255, 192, 203) }, // Pink
+{ 'B', CODE_STYLE, STYLE_BOLD },
+{ 'I', CODE_STYLE, STYLE_ITALIC },
+{ 'U', CODE_STYLE, STYLE_UNDERLINE },
+{ 'n', CODE_STYLE, STYLE_RESET },
+};
+
 static int num_format_codes = sizeof(code_table) / sizeof(FormatCode);
+
+// Returns the color code table for the active theme.
+static FormatCode *ColorCodeTableForTheme(int theme)
+{
+   return (theme == THEME_DEFAULT) ? code_table : code_table_dark;
+}
 
 /************************************************************************/
 /*
@@ -342,20 +366,21 @@ void DisplayMessage(const char *message, COLORREF start_color, BYTE start_style)
 	 break;
 
       new_type = 0;
+      FormatCode *active_table = ColorCodeTableForTheme(config.theme);
       for (i=0; i < num_format_codes; i++)
       {
-	 if (code_table[i].code != ch)
+	 if (active_table[i].code != ch)
 	    continue;
 
-	 switch (code_table[i].type)
+	 switch (active_table[i].type)
 	 {
 	 case CODE_COLOR:
-	    new_color = code_table[i].data;
+	    new_color = active_table[i].data;
 	    new_type |= CODE_COLOR;
 	    break;
 
 	 case CODE_STYLE:
-	    switch (code_table[i].data)
+	    switch (active_table[i].data)
 	    {
 	    case STYLE_NORMAL:
 	       new_style = STYLE_NORMAL;
@@ -368,7 +393,7 @@ void DisplayMessage(const char *message, COLORREF start_color, BYTE start_style)
 	       break;
 	       
 	    default:
-	       new_style = style ^ code_table[i].data;  // Toggle style
+	       new_style = style ^ active_table[i].data;  // Toggle style
 	       break;
 	    }
 	       
@@ -376,7 +401,7 @@ void DisplayMessage(const char *message, COLORREF start_color, BYTE start_style)
 	    break;
 
 	 default:
-	    debug(("DisplayServerMessage got unknown code type %d\n", code_table[i].type));
+	    debug(("DisplayServerMessage got unknown code type %d\n", active_table[i].type));
 	    break;
 	 }
       }

--- a/clientd3d/srvrstr.c
+++ b/clientd3d/srvrstr.c
@@ -298,9 +298,9 @@ static FormatCode code_table_dark[] = {
 static int num_format_codes = sizeof(code_table) / sizeof(FormatCode);
 
 // Returns the color code table for the active theme.
-static FormatCode *ColorCodeTableForTheme(int theme)
+static FormatCode *ColorCodeTableForTheme(Theme theme)
 {
-   return (theme == THEME_DEFAULT) ? code_table : code_table_dark;
+   return (theme == Theme::Default) ? code_table : code_table_dark;
 }
 
 /************************************************************************/

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,131 +1,20 @@
 # Themes
 
-The client supports swappable UI color themes.  This document describes
-the architecture, how to add a theme, and how the saved-color version
-mechanism works.
+The client supports swappable UI color themes selected from the
+Settings dialog under Interface Features.  Theme swaps take effect
+without a restart.
 
-## Status
+Two themes ship today: `Theme::Default` (the original Meridian 59
+palette) and `Theme::Dark` (a starter dark theme).
 
-This is the initial theming infrastructure.  Two themes ship today:
+## Architecture
 
-- `Theme::Default` (0): the original Meridian 59 palette.  Unchanged
-  visual behavior.
-- `Theme::Dark` (1): a starter dark theme that recolors only the main
-  background and the chat edit box.  Dialog list backgrounds, stat
-  bars, bitmaps, and most other UI surfaces still use the default
-  look.  Those land in follow-up work, one surface at a time.
+Theme definitions and the abstraction that hides them live in
+`clientd3d/color.c` and `clientd3d/srvrstr.c`.  The rest of the client
+asks for a color or brush by name (`GetColor(COLOR_X)`,
+`GetBrush(COLOR_X)`) and is theme-blind.
 
-The user picks a theme from the Settings dialog under Interface
-Features.  Swaps take effect immediately without a restart.
-
-## How a theme is selected
-
-The active theme is stored in `Config::theme` (the scoped enum `Theme`
-defined in `clientd3d/config.h`).  It is loaded from the
-`[Interface] Theme=N` key in `meridian.ini` via `ConfigLoad` and saved
-back via `ConfigSave`.
-
-`LoadSettings` calls `ConfigLoad` before `ColorsCreate` so the theme
-is known at the moment the color table is built.
-
-When the user picks a different theme in Settings, `ThemeApply` is
-called.  It tears down the color table, rebuilds it for the new
-theme, refires `EVENT_COLORCHANGED`, and invalidates the main window.
-
-## Color tables
-
-Each theme has its own parallel table of `MAXCOLORS` entries, indexed
-by the `COLOR_*` enum from `clientd3d/color.h`:
-
-- `colorinfo_default[]`
-- `colorinfo_dark[]`
-
-Entries are `"R,G,B"` strings.  They are strings (not `RGB()` macros)
-because they are written verbatim to the INI file when the user
-customizes a color via the color picker.
-
-Two helpers select the active table at runtime:
-
-- `ColorSectionForTheme(int)` -> INI section name
-- `ColorDefaultsForTheme(int)` -> compiled default table
-
-## INI sections
-
-Each theme stores its customized colors in its own INI section so
-switching themes does not clobber the other theme's saved values:
-
-- `[Colors]` for `Theme::Default`
-- `[ColorsDark]` for `Theme::Dark`
-
-Each section contains `Color0`..`ColorN-1` entries plus a
-`ColorVersion=N` stamp.
-
-## Color version stamping
-
-`THEME_COLOR_VERSION` lives in `color.c`.  When `ColorsCreate` runs,
-it reads the `ColorVersion` key from the active theme's section.  If
-the saved version does not match the compiled version, the saved
-colors are discarded and the compiled defaults are used.
-
-Bump `THEME_COLOR_VERSION` whenever a default value in either color
-table changes.  Without the bump, users who already have a saved
-section will keep seeing their stale per-user values instead of the
-new defaults.
-
-## Palette snap (default theme only)
-
-The default theme runs against the original 256-color game palette.
-`GetColor` returns `MAKEPALETTERGB(...)` and `SetColor` calls
-`GetNearestPaletteColor(...)` so colors snap to the closest indexed
-entry.  Other themes pass raw 24-bit RGB through
-(`color & 0x00FFFFFF`) so dark colors are not collapsed against a
-palette they were never tuned for.
-
-## Dialog scoping
-
-Dialog edit boxes and listboxes do not pick up theme colors.
-`DialogCtlColor` returns stock white/black brushes for any non-default
-theme.  Only `MainCtlColor` (the main window and its chat edit box)
-reads from the theme palette.  This keeps the infrastructure PR
-minimal and avoids dragging dialog backgrounds into theme work that
-would need owner-draw changes per surface.
-
-The chat scrollback window uses `MainCtlColor` and so does pick up
-theme colors.  Server message colors (the `^r ^g ^b ...` codes
-parsed by `srvrstr.c::DisplayMessage`) have a parallel
-`code_table_dark[]` chosen at runtime by `ColorCodeTableForTheme`.
-
-## Adding a new theme
-
-1. Add an entry to the `Theme` enum in `clientd3d/config.h`.
-2. Add a `colorinfo_<name>[]` table and an INI section name string
-   in `clientd3d/color.c`.
-3. Extend `ColorDefaultsForTheme` and `ColorSectionForTheme` with a
-   case for the new value.
-4. Optionally add a `code_table_<name>[]` and extend
-   `ColorCodeTableForTheme` in `clientd3d/srvrstr.c`.
-5. Add a localized display string (e.g. `IDS_THEME_<NAME>`) in
-   `clientd3d/client.rc` for each locale and append it to the
-   `IDC_THEME` combo in `preferences.c::CommonPreferencesDlgProc`.
-6. Bump `THEME_COLOR_VERSION` so existing users pick up your defaults.
-
-## Flow at a glance
-
-```
-+----------------+       +----------------+       +-------------------+
-|  meridian.ini  | ----> |  ConfigLoad    | ----> |  config.theme     |
-|  [Interface]   |       |                |       |                   |
-|  Theme=N       |       +----------------+       +---------+---------+
-+----------------+                                          |
-                                                            v
-+----------------+       +----------------+       +-------------------+
-|  [Colors]      | ----> |  ColorsCreate  | ----> |  colors[] table   |
-|  [ColorsDark]  |       |  (per theme)   |       |                   |
-|  ColorVersion  |       +----------------+       +---------+---------+
-+----------------+                                          |
-                                                            v
-+----------------+       +----------------+       +-------------------+
-|  Settings UI   | ----> |  ThemeApply    | ----> |  repaint window   |
-|  IDC_THEME     |       |                |       |                   |
-+----------------+       +----------------+       +-------------------+
-```
+The active theme is stored in `Config::theme` (the `Theme` enum in
+`clientd3d/config.h`).  Each theme keeps its customized colors in its
+own INI section (e.g. `[Colors]`, `[ColorsDark]`) so switching themes
+does not clobber the other theme's saved values.

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -8,9 +8,9 @@ mechanism works.
 
 This is the initial theming infrastructure.  Two themes ship today:
 
-- `THEME_DEFAULT` (0): the original Meridian 59 palette.  Unchanged
+- `Theme::Default` (0): the original Meridian 59 palette.  Unchanged
   visual behavior.
-- `THEME_DARK` (1): a starter dark theme that recolors only the main
+- `Theme::Dark` (1): a starter dark theme that recolors only the main
   background and the chat edit box.  Dialog list backgrounds, stat
   bars, bitmaps, and most other UI surfaces still use the default
   look.  Those land in follow-up work, one surface at a time.
@@ -20,8 +20,8 @@ Features.  Swaps take effect immediately without a restart.
 
 ## How a theme is selected
 
-The active theme is stored in `Config::theme` (an `int` matching the
-`THEME_*` enum in `clientd3d/config.h`).  It is loaded from the
+The active theme is stored in `Config::theme` (the scoped enum `Theme`
+defined in `clientd3d/config.h`).  It is loaded from the
 `[Interface] Theme=N` key in `meridian.ini` via `ConfigLoad` and saved
 back via `ConfigSave`.
 
@@ -54,8 +54,8 @@ Two helpers select the active table at runtime:
 Each theme stores its customized colors in its own INI section so
 switching themes does not clobber the other theme's saved values:
 
-- `[Colors]` for `THEME_DEFAULT`
-- `[ColorsDark]` for `THEME_DARK`
+- `[Colors]` for `Theme::Default`
+- `[ColorsDark]` for `Theme::Dark`
 
 Each section contains `Color0`..`ColorN-1` entries plus a
 `ColorVersion=N` stamp.
@@ -97,7 +97,7 @@ parsed by `srvrstr.c::DisplayMessage`) have a parallel
 
 ## Adding a new theme
 
-1. Add an entry to the `THEME_*` enum in `clientd3d/config.h`.
+1. Add an entry to the `Theme` enum in `clientd3d/config.h`.
 2. Add a `colorinfo_<name>[]` table and an INI section name string
    in `clientd3d/color.c`.
 3. Extend `ColorDefaultsForTheme` and `ColorSectionForTheme` with a

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,0 +1,131 @@
+# Themes
+
+The client supports swappable UI color themes.  This document describes
+the architecture, how to add a theme, and how the saved-color version
+mechanism works.
+
+## Status
+
+This is the initial theming infrastructure.  Two themes ship today:
+
+- `THEME_DEFAULT` (0): the original Meridian 59 palette.  Unchanged
+  visual behavior.
+- `THEME_DARK` (1): a starter dark theme that recolors only the main
+  background and the chat edit box.  Dialog list backgrounds, stat
+  bars, bitmaps, and most other UI surfaces still use the default
+  look.  Those land in follow-up work, one surface at a time.
+
+The user picks a theme from the Settings dialog under Interface
+Features.  Swaps take effect immediately without a restart.
+
+## How a theme is selected
+
+The active theme is stored in `Config::theme` (an `int` matching the
+`THEME_*` enum in `clientd3d/config.h`).  It is loaded from the
+`[Interface] Theme=N` key in `meridian.ini` via `ConfigLoad` and saved
+back via `ConfigSave`.
+
+`LoadSettings` calls `ConfigLoad` before `ColorsCreate` so the theme
+is known at the moment the color table is built.
+
+When the user picks a different theme in Settings, `ThemeApply` is
+called.  It tears down the color table, rebuilds it for the new
+theme, refires `EVENT_COLORCHANGED`, and invalidates the main window.
+
+## Color tables
+
+Each theme has its own parallel table of `MAXCOLORS` entries, indexed
+by the `COLOR_*` enum from `clientd3d/color.h`:
+
+- `colorinfo_default[]`
+- `colorinfo_dark[]`
+
+Entries are `"R,G,B"` strings.  They are strings (not `RGB()` macros)
+because they are written verbatim to the INI file when the user
+customizes a color via the color picker.
+
+Two helpers select the active table at runtime:
+
+- `ColorSectionForTheme(int)` -> INI section name
+- `ColorDefaultsForTheme(int)` -> compiled default table
+
+## INI sections
+
+Each theme stores its customized colors in its own INI section so
+switching themes does not clobber the other theme's saved values:
+
+- `[Colors]` for `THEME_DEFAULT`
+- `[ColorsDark]` for `THEME_DARK`
+
+Each section contains `Color0`..`ColorN-1` entries plus a
+`ColorVersion=N` stamp.
+
+## Color version stamping
+
+`THEME_COLOR_VERSION` lives in `color.c`.  When `ColorsCreate` runs,
+it reads the `ColorVersion` key from the active theme's section.  If
+the saved version does not match the compiled version, the saved
+colors are discarded and the compiled defaults are used.
+
+Bump `THEME_COLOR_VERSION` whenever a default value in either color
+table changes.  Without the bump, users who already have a saved
+section will keep seeing their stale per-user values instead of the
+new defaults.
+
+## Palette snap (default theme only)
+
+The default theme runs against the original 256-color game palette.
+`GetColor` returns `MAKEPALETTERGB(...)` and `SetColor` calls
+`GetNearestPaletteColor(...)` so colors snap to the closest indexed
+entry.  Other themes pass raw 24-bit RGB through
+(`color & 0x00FFFFFF`) so dark colors are not collapsed against a
+palette they were never tuned for.
+
+## Dialog scoping
+
+Dialog edit boxes and listboxes do not pick up theme colors.
+`DialogCtlColor` returns stock white/black brushes for any non-default
+theme.  Only `MainCtlColor` (the main window and its chat edit box)
+reads from the theme palette.  This keeps the infrastructure PR
+minimal and avoids dragging dialog backgrounds into theme work that
+would need owner-draw changes per surface.
+
+The chat scrollback window uses `MainCtlColor` and so does pick up
+theme colors.  Server message colors (the `^r ^g ^b ...` codes
+parsed by `srvrstr.c::DisplayMessage`) have a parallel
+`code_table_dark[]` chosen at runtime by `ColorCodeTableForTheme`.
+
+## Adding a new theme
+
+1. Add an entry to the `THEME_*` enum in `clientd3d/config.h`.
+2. Add a `colorinfo_<name>[]` table and an INI section name string
+   in `clientd3d/color.c`.
+3. Extend `ColorDefaultsForTheme` and `ColorSectionForTheme` with a
+   case for the new value.
+4. Optionally add a `code_table_<name>[]` and extend
+   `ColorCodeTableForTheme` in `clientd3d/srvrstr.c`.
+5. Add a localized display string (e.g. `IDS_THEME_<NAME>`) in
+   `clientd3d/client.rc` for each locale and append it to the
+   `IDC_THEME` combo in `preferences.c::CommonPreferencesDlgProc`.
+6. Bump `THEME_COLOR_VERSION` so existing users pick up your defaults.
+
+## Flow at a glance
+
+```
++----------------+       +----------------+       +-------------------+
+|  meridian.ini  | ----> |  ConfigLoad    | ----> |  config.theme     |
+|  [Interface]   |       |                |       |                   |
+|  Theme=N       |       +----------------+       +---------+---------+
++----------------+                                          |
+                                                            v
++----------------+       +----------------+       +-------------------+
+|  [Colors]      | ----> |  ColorsCreate  | ----> |  colors[] table   |
+|  [ColorsDark]  |       |  (per theme)   |       |                   |
+|  ColorVersion  |       +----------------+       +---------+---------+
++----------------+                                          |
+                                                            v
++----------------+       +----------------+       +-------------------+
+|  Settings UI   | ----> |  ThemeApply    | ----> |  repaint window   |
+|  IDC_THEME     |       |                |       |                   |
++----------------+       +----------------+       +-------------------+
+```

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,20 +1,11 @@
 # Themes
 
-The client supports swappable UI color themes selected from the
-Settings dialog under Interface Features.  Theme swaps take effect
-without a restart.
+The client supports swappable UI color themes selected from the Settings dialog under Interface Features.  Theme swaps take effect without a restart.
 
-Two themes ship today: `Theme::Default` (the original Meridian 59
-palette) and `Theme::Dark` (a starter dark theme).
+Two themes ship today: `Theme::Default` (the original Meridian 59 palette) and `Theme::Dark` (a starter dark theme).
 
 ## Architecture
 
-Theme definitions and the abstraction that hides them live in
-`clientd3d/color.c` and `clientd3d/srvrstr.c`.  The rest of the client
-asks for a color or brush by name (`GetColor(COLOR_X)`,
-`GetBrush(COLOR_X)`) and is theme-blind.
+Theme definitions and the abstraction that hides them live in `clientd3d/color.c` and `clientd3d/srvrstr.c`.  The rest of the client asks for a color or brush by name (`GetColor(COLOR_X)`, `GetBrush(COLOR_X)`) and is theme-blind.
 
-The active theme is stored in `Config::theme` (the `Theme` enum in
-`clientd3d/config.h`).  Each theme keeps its customized colors in its
-own INI section (e.g. `[Colors]`, `[ColorsDark]`) so switching themes
-does not clobber the other theme's saved values.
+The active theme is stored in `Config::theme` (the `Theme` enum in `clientd3d/config.h`).  Each theme keeps its customized colors in its own INI section (e.g. `[Colors]`, `[ColorsDark]`) so switching themes does not clobber the other theme's saved values.


### PR DESCRIPTION
## What

- Adds theme switching capability to the client
- Ships a starter dark theme alongside the existing default theme
- Adds a `Theme` setting to `meridian.ini` and a preferences dropdown to pick one
- Adds `docs/themes.md` describing the architecture
- Related to https://github.com/Meridian59/Meridian59/pull/1397
  - Splitting this enormous closed PR into smaller ones

## Why

- Sets up the framework so future visual work can target a named theme instead of editing the one global palette
- Visuals get iterated on one surface at a time in follow-up PRs that can be reviewed and reverted independently
- The starter dark theme is intentionally narrow.  It recolors the main background and the chat edit box and leaves most surfaces using the default look so this PR stays small

## How

- Config: `theme` field on the `Config` struct typed as the scoped enum `Theme` (`Theme::Default`, `Theme::Dark`).  `INITheme` key in the `[Interface]` section.  `LoadSettings` calls `ConfigLoad` before `ColorsCreate` so the theme is known when colors load
- Color tables: `colorinfo_default[]` and `colorinfo_dark[]` are parallel tables of `MAXCOLORS` entries indexed by the `COLOR_*` enum.  `ColorSectionForTheme` and `ColorDefaultsForTheme` pick the right pair at runtime based on `config.theme`
- Color version: `THEME_COLOR_VERSION` is stamped into each theme's INI section by `ColorsSave`.  On load, if the saved version doesn't match the compiled version, saved colors are discarded and compiled defaults are used.  This keeps stale per-user tweaks from masking later palette improvements
- Palette snap: `GetColor`/`SetColor` apply `MAKEPALETTERGB`/`GetNearestPaletteColor` only for `Theme::Default`.  Other themes round-trip raw 24-bit RGB so dark colors are not collapsed against the indexed game palette
- Dialog scoping: `DialogCtlColor` returns stock white/black brushes for any non-default theme, so dialog controls never inherit theme colors.  Only the main window and its chat edit box pick up theme colors via `MainCtlColor`
- Server message colors: `srvrstr.c` has a parallel `code_table_dark[]` for the `^r ^g ^b ...` color codes, picked at runtime by `ColorCodeTableForTheme`
- `ThemeApply`: tears down and recreates the color table, refires `EVENT_COLORCHANGED`, and invalidates the main window so a theme swap takes effect without a restart
- Settings dialog: `IDC_THEME` combo box added to all three localized `IDD_SETTINGS` dialogs (English, German, Portuguese).  `IDS_THEME_DEFAULT` and `IDS_THEME_DARK` strings are localized

> [!NOTE]
>  I can remove the dropdown theme selector if it is preferred that the dark theme is finalized with all updates before being used.  It does work, albeit without the complete dark theme implementation.

## Diagram

```mermaid
flowchart TD
    INI[meridian.ini<br/>Theme=N]:::file --> CL[ConfigLoad]:::fn
    CL --> CFG[config.theme]:::data
    UI[Settings IDC_THEME]:::ui --> TA[ThemeApply]:::fn
    TA --> CC

    CFG --> CC[ColorsCreate]:::fn
    SEC[Colors / ColorsDark<br/>INI sections]:::file --> CC
    CC --> COLORS[colors array]:::data

    COLORS --> GC[GetColor / GetBrush]:::fn
    GC --> MCC[MainCtlColor]:::fn
    GC --> DCC[DialogCtlColor]:::fn
    GC --> SRV[DisplayMessage<br/>code table]:::fn
    TA --> REP[Repaint main window]:::fn

    classDef file fill:#1f3a5f,color:#fff
    classDef fn fill:#2f9e44,color:#fff
    classDef data fill:#5c5470,color:#fff
    classDef ui fill:#7048e8,color:#fff
```

## Scope

Example follow-up PRs this enables:

- Replacement bitmaps that don't read well on a dark background
- DWM dark title bar via `DwmSetWindowAttribute`
- Larger individually-colored health/mana/vigor stat bars, recolored for dark theme
- Replacement health/mana/vigor icons that read on a dark background
- A button-shading helper so existing buttons can adopt theme colors


None of those are in this PR.  The dark theme today will look mostly like the default theme with a black main background and a dark chat edit window, but it be a starting point to iterate on.

## Example
<img width="1243" height="1150" alt="meridian_voTO8wXe2h" src="https://github.com/user-attachments/assets/c810f1d6-55f9-4286-bddf-7e9abd380933" />