### PR TITLE
 fix: translucent walls hiding floor/ceiling caps and invisibility overlay z-fighting

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -792,27 +792,36 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 		D3DRenderParticles(particleSystemStructure);
 	}
 
+	ObjectsRenderParams objectsRenderParams(g_pVertexDecl_PosColorTex1, g_pVertexDecl_PosColorTex2, gD3DDriverProfile,
+		&gObjectPool, &gObjectCacheSystem, view, proj, room, params);
+
+	GameObjectDataParams gameObjectDataParams(nitems, &num_visible_objects, &gNumObjects, drawdata, visible_objects,
+		gpBackBufferTexFull, gpBackBufferTex);
+
+	FontTextureParams fontTextureParams(&gFont, gSmallTextureSize);
+
+	PlayerViewParams playerViewParams(gScreenWidth, gScreenHeight, main_viewport_width, main_viewport_height, gD3DRect);
+
 	if (draw_objects)
 	{
-		ObjectsRenderParams objectsRenderParams(g_pVertexDecl_PosColorTex1, g_pVertexDecl_PosColorTex2, gD3DDriverProfile,
-			&gObjectPool, &gObjectCacheSystem, view, proj, room, params);
-
-		GameObjectDataParams gameObjectDataParams(nitems, &num_visible_objects, &gNumObjects, drawdata, visible_objects, 
-			gpBackBufferTexFull, gpBackBufferTex);
-
-		FontTextureParams fontTextureParams(&gFont, gSmallTextureSize);
-
-		PlayerViewParams playerViewParams(gScreenWidth, gScreenHeight, main_viewport_width, main_viewport_height, gD3DRect);
-
 		timeObjects = D3DRenderObjects(objectsRenderParams, gameObjectDataParams, lightAndTextureParams, fontTextureParams, playerViewParams);
 	}
 
-	// Transparent walls are drawn LAST so that sprites/monsters behind them show
-	// through correctly. Depth write is off during this pass; depth test remains on
-	// so walls behind opaque geometry are still occluded.
+	// Transparent walls draw AFTER opaque/translucent objects so the walls
+	// correctly occlude objects behind them (depth-test on, depth-write off).
 	if (draw_world)
 	{
 		D3DRenderTransparentWallsPass(worldRenderParams);
+	}
+
+	// Invisible-object pass runs LAST so its back-buffer capture contains the
+	// translucent walls. Without this ordering, invisible characters and the
+	// local player's first-person held overlays sample a back buffer that
+	// pre-dates the wall pass; the fishbowl effect then reads colours from
+	// behind the wall and visually erases the wall wherever they overlap.
+	if (draw_objects)
+	{
+		D3DRenderInvisiblePass(objectsRenderParams, gameObjectDataParams, lightAndTextureParams, playerViewParams);
 	}
 
 	D3DRender_SetColorStage(1, D3DTOP_DISABLE, D3DTA_CURRENT, D3DTA_TEXTURE);

--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -252,6 +252,23 @@ long D3DRenderObjects(
 
 	SetZBias(ZBIAS_DEFAULT);
 
+	IDirect3DDevice9_SetVertexShader(gpD3DDevice, NULL);
+	IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, objectsRenderParams.vertexDeclaration);
+
+	return timeGetTime() - timeObjects;
+}
+
+void D3DRenderInvisiblePass(
+	const ObjectsRenderParams& objectsRenderParams,
+	const GameObjectDataParams& gameObjectDataParams,
+	const LightAndTextureParams& lightAndTextureParams,
+	const PlayerViewParams& playerViewParams)
+{
+	// Capture the back buffer AFTER translucent walls have been drawn so the
+	// invisible-object fishbowl effect samples a scene that includes those
+	// walls. If the capture happens before the wall pass, invisible characters
+	// and the local player's held overlays read pre-wall colours and visually
+	// erase translucent walls wherever they overlap.
 	D3DRender_CaptureEffect(gameObjectDataParams.backBufferTexFull, gameObjectDataParams.backBufferTex[0]);
 
 	IDirect3DDevice9_SetTransform(gpD3DDevice, D3DTS_VIEW, &objectsRenderParams.view);
@@ -262,6 +279,7 @@ long D3DRenderObjects(
 	IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, objectsRenderParams.vertexDeclarationInvisible);
 
 	D3DRender_SetAlphaBlendState(TRUE, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA);
+	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, FALSE);
 
 	// Render invisible world objects
 	D3DRenderPoolReset(objectsRenderParams.renderPool, &D3DMaterialObjectInvisiblePool);
@@ -303,7 +321,7 @@ long D3DRenderObjects(
 	IDirect3DDevice9_SetVertexShader(gpD3DDevice, NULL);
 	IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, objectsRenderParams.vertexDeclaration);
 
-	return timeGetTime() - timeObjects;
+	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, TRUE);
 }
 
 /**

--- a/clientd3d/d3drender_objects.h
+++ b/clientd3d/d3drender_objects.h
@@ -146,10 +146,22 @@ struct ObjectsRenderParams {
 };
 
 long D3DRenderObjects(
-    const ObjectsRenderParams& objectsRenderParams, 
-    const GameObjectDataParams& gameObjectDataParams, 
+    const ObjectsRenderParams& objectsRenderParams,
+    const GameObjectDataParams& gameObjectDataParams,
     const LightAndTextureParams& lightAndTextureParams,
     const FontTextureParams& fontTextureParams,
+    const PlayerViewParams& playerViewParams);
+
+// Invisible-object + first-person player-overlay pass. Captures the back buffer
+// (so the invisible fishbowl effect samples it) and renders invisible world
+// objects and the local player's held overlays. Must run AFTER the translucent
+// walls pass so the captured back buffer contains those walls; otherwise the
+// fishbowl reads colours behind the wall and the wall visually disappears
+// wherever an invisible object/overlay is drawn.
+void D3DRenderInvisiblePass(
+    const ObjectsRenderParams& objectsRenderParams,
+    const GameObjectDataParams& gameObjectDataParams,
+    const LightAndTextureParams& lightAndTextureParams,
     const PlayerViewParams& playerViewParams);
 
 #endif	/* #ifndef _D3DRENDEROBJECTS_H */

--- a/clientd3d/d3drender_world.c
+++ b/clientd3d/d3drender_world.c
@@ -226,9 +226,6 @@ void D3DRenderWorldDraw(const WorldRenderParams &worldRenderParams, bool transpa
             if (!ShouldRenderInCurrentPass(transparent_pass, isTransparent))
                continue;
 
-            if (pWall->translucency_level != WALL_TRANSLUCENCY_OPAQUE)
-               continue;
-
             int flags, wallFlags;
 
             flags = 0;
@@ -301,14 +298,14 @@ void D3DRenderWorldDraw(const WorldRenderParams &worldRenderParams, bool transpa
                D3DRenderPacketWallAdd(pWall, pools.worldPool, D3DRENDER_WALL_NORMAL, -1, true);
             }
 
-            if ((pWall->translucency_level == WALL_TRANSLUCENCY_OPAQUE) && (flags & D3DRENDER_WALL_BELOW) &&
+            if ((flags & D3DRENDER_WALL_BELOW) &&
                 (((short) pWall->z1 != (short) pWall->z0) || ((short) pWall->zz1 != (short) pWall->zz0)))
             {
                D3DRenderPacketWallAdd(pWall, pools.worldPool, D3DRENDER_WALL_BELOW, 1, true);
                D3DRenderPacketWallAdd(pWall, pools.worldPool, D3DRENDER_WALL_BELOW, -1, true);
             }
 
-            if ((pWall->translucency_level == WALL_TRANSLUCENCY_OPAQUE) && (flags & D3DRENDER_WALL_ABOVE) &&
+            if ((flags & D3DRENDER_WALL_ABOVE) &&
                 (((short) pWall->z3 != (short) pWall->z2) || ((short) pWall->zz3 != (short) pWall->zz2)))
             {
                D3DRenderPacketWallAdd(pWall, pools.worldPool, D3DRENDER_WALL_ABOVE, 1, true);
@@ -335,6 +332,9 @@ void D3DRenderWorldDraw(const WorldRenderParams &worldRenderParams, bool transpa
 /**
  * Adds all walls that carry a non-zero translucency_level to the dynamic world pool so they
  * can be flushed in a dedicated SRCALPHA-blended pass after the opaque world geometry.
+ * Only WALL_NORMAL (the see-through middle pane) goes through this pass; WALL_BELOW and
+ * WALL_ABOVE are the structural caps that extend to the floor/ceiling and stay opaque
+ * (added by the regular opaque-pool builders).
  */
 void D3DRenderSemiTransparentWalls(const WorldRenderParams &worldRenderParams)
 {
@@ -357,14 +357,10 @@ void D3DRenderSemiTransparentWalls(const WorldRenderParams &worldRenderParams)
          if (pWall->pos_sidedef)
          {
             if (pWall->pos_sidedef->normal_bmap) flags |= D3DRENDER_WALL_NORMAL;
-            if (pWall->pos_sidedef->below_bmap)  flags |= D3DRENDER_WALL_BELOW;
-            if (pWall->pos_sidedef->above_bmap)  flags |= D3DRENDER_WALL_ABOVE;
          }
          if (pWall->neg_sidedef)
          {
             if (pWall->neg_sidedef->normal_bmap) flags |= D3DRENDER_WALL_NORMAL;
-            if (pWall->neg_sidedef->below_bmap)  flags |= D3DRENDER_WALL_BELOW;
-            if (pWall->neg_sidedef->above_bmap)  flags |= D3DRENDER_WALL_ABOVE;
          }
 
          pWall->separator.a = pNode->u.internal.separator.a;
@@ -376,20 +372,6 @@ void D3DRenderSemiTransparentWalls(const WorldRenderParams &worldRenderParams)
          {
             D3DRenderPacketWallAdd(pWall, pools.worldPool, D3DRENDER_WALL_NORMAL, 1, true);
             D3DRenderPacketWallAdd(pWall, pools.worldPool, D3DRENDER_WALL_NORMAL, -1, true);
-         }
-
-         if ((flags & D3DRENDER_WALL_BELOW) &&
-             (((short)pWall->z1 != (short)pWall->z0) || ((short)pWall->zz1 != (short)pWall->zz0)))
-         {
-            D3DRenderPacketWallAdd(pWall, pools.worldPool, D3DRENDER_WALL_BELOW, 1, true);
-            D3DRenderPacketWallAdd(pWall, pools.worldPool, D3DRENDER_WALL_BELOW, -1, true);
-         }
-
-         if ((flags & D3DRENDER_WALL_ABOVE) &&
-             (((short)pWall->z3 != (short)pWall->z2) || ((short)pWall->zz3 != (short)pWall->zz2)))
-         {
-            D3DRenderPacketWallAdd(pWall, pools.worldPool, D3DRENDER_WALL_ABOVE, 1, true);
-            D3DRenderPacketWallAdd(pWall, pools.worldPool, D3DRENDER_WALL_ABOVE, -1, true);
          }
       }
    }
@@ -506,9 +488,6 @@ void D3DRenderLMapsPostDraw(const WorldRenderParams &worldRenderParams,
             if (!ShouldRenderInCurrentPass(transparent_pass, isTransparent))
                continue;
 
-            if (pWall->translucency_level != WALL_TRANSLUCENCY_OPAQUE)
-               continue;
-
             flags = 0;
             wallFlags = 0;
 
@@ -571,7 +550,12 @@ void D3DRenderLMapsPostDraw(const WorldRenderParams &worldRenderParams,
             pWall->separator.b = tree->u.internal.separator.b;
             pWall->separator.c = tree->u.internal.separator.c;
 
-            if ((flags & D3DRENDER_WALL_NORMAL) && ((short) pWall->z2 != (short) pWall->z1) ||
+            // For translucent walls only the structural caps (BELOW/ABOVE) draw in the
+            // opaque pass; the see-through middle pane (NORMAL) is alpha-blended elsewhere
+            // and must not get a lightmap here or the lmap floats with no wall behind it.
+            if ((flags & D3DRENDER_WALL_NORMAL)
+                && (pWall->translucency_level == WALL_TRANSLUCENCY_OPAQUE)
+                && ((short) pWall->z2 != (short) pWall->z1) ||
                 (pWall->zz2 != pWall->zz1))
             {
                D3DRenderLMapPostWallAdd(pWall, pools.lMapPool, D3DRENDER_WALL_NORMAL, side,
@@ -666,9 +650,6 @@ void D3DRenderLMapsDynamicPostDraw(const WorldRenderParams &worldRenderParams,
             if (!ShouldRenderInCurrentPass(transparent_pass, isTransparent))
                continue;
 
-            if (pWall->translucency_level != WALL_TRANSLUCENCY_OPAQUE)
-               continue;
-
             flags = 0;
             wallFlags = 0;
 
@@ -704,7 +685,11 @@ void D3DRenderLMapsDynamicPostDraw(const WorldRenderParams &worldRenderParams,
             pWall->separator.b = tree->u.internal.separator.b;
             pWall->separator.c = tree->u.internal.separator.c;
 
-            if ((flags & D3DRENDER_WALL_NORMAL) && ((short) pWall->z2 != (short) pWall->z1) ||
+            // Skip the lightmap for the see-through middle pane of translucent walls;
+            // BELOW/ABOVE caps are opaque and still need their lmaps.
+            if ((flags & D3DRENDER_WALL_NORMAL)
+                && (pWall->translucency_level == WALL_TRANSLUCENCY_OPAQUE)
+                && ((short) pWall->z2 != (short) pWall->z1) ||
                 ((short) pWall->zz2 != (short) pWall->zz1))
             {
                D3DRenderLMapPostWallAdd(pWall, pools.lMapPool, D3DRENDER_WALL_NORMAL, side,
@@ -2187,9 +2172,6 @@ void D3DGeometryBuildNew(const WorldRenderParams &worldRenderParams, const World
             if (!ShouldRenderInCurrentPass(transparent_pass, isTransparent))
                continue;
 
-            if (pWall->translucency_level != WALL_TRANSLUCENCY_OPAQUE)
-               continue;
-
             int flags, wallFlags;
 
             flags = 0;
@@ -2234,14 +2216,14 @@ void D3DGeometryBuildNew(const WorldRenderParams &worldRenderParams, const World
                D3DRenderPacketWallAdd(pWall, pools.worldPoolStatic, D3DRENDER_WALL_NORMAL, -1, false);
             }
 
-            if ((pWall->translucency_level == WALL_TRANSLUCENCY_OPAQUE) && (flags & D3DRENDER_WALL_BELOW) && ((short) pWall->z1 != (short) pWall->z0) ||
+            if ((flags & D3DRENDER_WALL_BELOW) && ((short) pWall->z1 != (short) pWall->z0) ||
                 ((short) pWall->zz1 != (short) pWall->zz0))
             {
                D3DRenderPacketWallAdd(pWall, pools.worldPoolStatic, D3DRENDER_WALL_BELOW, 1, false);
                D3DRenderPacketWallAdd(pWall, pools.worldPoolStatic, D3DRENDER_WALL_BELOW, -1, false);
             }
 
-            if ((pWall->translucency_level == WALL_TRANSLUCENCY_OPAQUE) && (flags & D3DRENDER_WALL_ABOVE) && ((short) pWall->z3 != (short) pWall->z2) ||
+            if ((flags & D3DRENDER_WALL_ABOVE) && ((short) pWall->z3 != (short) pWall->z2) ||
                 ((short) pWall->zz3 != (short) pWall->zz2))
             {
                D3DRenderPacketWallAdd(pWall, pools.worldPoolStatic, D3DRENDER_WALL_ABOVE, 1, false);


### PR DESCRIPTION
- Stop skipping the BELOW/ABOVE structural caps for translucent walls, only the see-through middle pane (NORMAL) should drop out of the opaque pass, so the floor/ceiling slivers under and above translucent walls render correctly again.
- Skip the lightmap pass for the translucent middle pane only (caps still get their lmaps), so a translucent wall's lightmap doesn't float without geometry behind it.
- Split the invisible-object / first-person held-overlay rendering into its own `D3DRenderInvisiblePass` and run it AFTER the translucent walls pass. The fishbowl effect samples a back-buffer capture; previously that capture happened before walls were drawn, so invisible players and held overlays read pre-wall colours and visually erased translucent walls wherever they overlapped.
- Disable depth-write during the invisible pass to avoid the overlay punching holes in the depth buffer.

  ## Test plan
  - [x] Walk past a translucent wall - floor/ceiling caps draw under/over the wall (no see-through gaps).
  - [x] Translucent wall is properly lit (no floating lightmap).
  - [x] Cast invisibility on self near a translucent wall - wall remains visible through the fishbowl.
  - [x] First-person held items (weapon/spell overlays) no longer erase translucent walls in front of you.
  - [x] Opaque walls and normal objects render unchanged.