### PR TITLE
feature: add inventory hotkey groups

### DIFF
--- a/blakserv/sprocket.c
+++ b/blakserv/sprocket.c
@@ -36,6 +36,7 @@ client_def_table_type client_def_table[] =
 	{ BP_REQ_GET,              { {4, TAG_OBJECT}, {0, DONE_PARM} } },
 	{ BP_REQ_GET_FROM_CONTAINER,	{ {4, TAG_OBJECT}, {0, DONE_PARM} } },
 	{ BP_REQ_DROP,             { {2, LIST_OBJ_PARM}, {0, DONE_PARM} } },
+	{ BP_REQ_TOGGLE_GROUP,     { {2, LIST_OBJ_PARM}, {0, DONE_PARM} } },
 	{ BP_REQ_INVENTORY_MOVE,   { {2, TAG_INT}, {2, TAG_INT}, {0, DONE_PARM} } },
 	{ BP_REQ_PUT,              { {4, TAG_OBJECT}, {4, TAG_OBJECT}, {0, DONE_PARM} } },
 	{ BP_REQ_LOOK,             { {4, TAG_OBJECT}, {0, DONE_PARM} } },

--- a/clientd3d/protocol.c
+++ b/clientd3d/protocol.c
@@ -39,6 +39,7 @@ static client_message game_msg_table[] = {
 { BP_REQ_INVENTORY,        { PARAM_END }, },
 { BP_REQ_INVENTORY_MOVE,   { PARAM_WORD, PARAM_WORD, PARAM_END }, },
 { BP_REQ_DROP,             { PARAM_OBJECT_LIST, PARAM_END }, },
+{ BP_REQ_TOGGLE_GROUP,     { PARAM_OBJECT_LIST, PARAM_END }, },
 { BP_REQ_PUT,              { PARAM_OBJECT, PARAM_ID, PARAM_END }, },
 { BP_SAY_TO,               { PARAM_SAY_INFO, PARAM_STRING, PARAM_END }, },
 { BP_SAY_GROUP,            { PARAM_ID_LIST, PARAM_STRING, PARAM_END }, },

--- a/clientd3d/protocol.h
+++ b/clientd3d/protocol.h
@@ -86,6 +86,7 @@ ToServer(BP_REQ_MOVE, NULL, FinenessClientToKod(y) + KOD_FINENESS, \
 #define RequestLook(id)              ToServer(BP_REQ_LOOK, NULL, id)
 #define RequestUse(id)               ToServer(BP_REQ_USE, NULL, id)
 #define RequestUnuse(id)             ToServer(BP_REQ_UNUSE, NULL, id)
+#define RequestToggleGroup(objs)     ToServer(BP_REQ_TOGGLE_GROUP, NULL, objs)
 #define RequestAttack(info, id)      ToServer(BP_REQ_ATTACK, NULL, info, id)
 #define RequestOffer(id, objs)       ToServer(BP_REQ_OFFER, NULL, id, objs)
 #define RequestDeposit(id, objs)     ToServer(BP_REQ_DEPOSIT, NULL, id, objs)

--- a/include/proto.h
+++ b/include/proto.h
@@ -133,6 +133,7 @@ enum {
    BP_REQ_BUY_ITEMS         = 125,
    BP_CHANGE_DESCRIPTION    = 126,
    BP_REQ_INVENTORY_MOVE    = 127,
+   BP_REQ_TOGGLE_GROUP      = 128,
 
    BP_PLAYER                = 130,
    BP_STAT                  = 131,

--- a/kod/include/protocol.khd
+++ b/kod/include/protocol.khd
@@ -79,6 +79,7 @@
    BP_REQ_BUY_ITEMS         = 125
    BP_CHANGE_DESCRIPTION    = 126
    BP_REQ_INVENTORY_MOVE    = 127
+   BP_REQ_TOGGLE_GROUP      = 128
 
    BP_PLAYER                = 130
    BP_STAT                  = 131

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -1093,6 +1093,19 @@ messages:
 
          return;
       }
+
+      if liClient_cmd = BP_REQ_TOGGLE_GROUP
+      {
+         if bSpam
+         {
+            return;
+         }
+
+         lItems = Nth(client_msg,2);
+         Send(self,@UserToggleItemGroup,#item_list=lItems);
+
+         return;
+      }
       
       if liClient_cmd = BP_REQ_ATTACK
       {
@@ -4602,6 +4615,107 @@ messages:
 
       Send(self,@TryUseItem,#what=what);
       
+      return;
+   }
+
+   UserToggleItemGroup(item_list = $)
+   "Toggles a list of items as one group.  If every eligible item is in use, "
+   "the group action is unuse.  Otherwise the group action is use.  Duplicate "
+   "entries and wand items are ignored."
+   {
+      local i, iTotal, iUsing, bTargetEquip, lSeen, iPos;
+
+      if NOT IsList(item_list)
+      {
+         return;
+      }
+
+      if item_list = $
+      {
+         return;
+      }
+
+      iTotal = 0;
+      iUsing = 0;
+      lSeen = $;
+      for i in item_list
+      {
+         if NOT IsClass(i,&Item)
+         {
+            continue;
+         }
+
+         iPos = FindListElem(lSeen,i);
+         if iPos <> $ AND iPos <> 0
+         {
+            continue;
+         }
+
+         if Send(i,@IsItemType,#type=ITEMTYPE_WAND)
+         {
+            continue;
+         }
+
+         lSeen = Cons(i,lSeen);
+
+         iTotal = iTotal + 1;
+         iPos = FindListElem(plUsing,i);
+         if iPos <> $ AND iPos <> 0
+         {
+            iUsing = iUsing + 1;
+         }
+      }
+
+      if iTotal = 0
+      {
+         return;
+      }
+
+      bTargetEquip = TRUE;
+      if iUsing = iTotal
+      {
+         bTargetEquip = FALSE;
+      }
+
+      lSeen = $;
+      for i in item_list
+      {
+         if NOT IsClass(i,&Item)
+         {
+            continue;
+         }
+
+         iPos = FindListElem(lSeen,i);
+         if iPos <> $ AND iPos <> 0
+         {
+            continue;
+         }
+
+         if Send(i,@IsItemType,#type=ITEMTYPE_WAND)
+         {
+            continue;
+         }
+
+         lSeen = Cons(i,lSeen);
+
+         iPos = FindListElem(plUsing,i);
+
+         if bTargetEquip
+         {
+            if iPos = $ OR iPos = 0
+            {
+               Send(self,@UserUseItem,#what=i);
+            }
+         }
+         else
+         {
+            if iPos <> $ AND iPos <> 0
+            {
+               Send(self,@UserUnuseItem,#what=i);
+            }
+         }
+      }
+
       return;
    }
 

--- a/module/merintr/inventry.c
+++ b/module/merintr/inventry.c
@@ -1278,8 +1278,10 @@ void InventoryHotkeyTrigger(int digit)
       return;
    last_trigger_time[digit] = now;
 
-   // Build from live inventory entries marked with this digit.  This avoids
-   // dropping members if an id lookup misses during inventory reshuffles.
+   // Add matching items to the front of the wire list so it arrives in
+   // reverse display order.  The server builds its list the same way, which
+   // flips it back, so the server processes top-left first.  Single-use
+   // items (scrolls, potions) consume in the order the player sees them.
    for (l = items; l != NULL; l = l->next)
    {
       InvItem *item = (InvItem *) l->data;
@@ -1292,12 +1294,12 @@ void InventoryHotkeyTrigger(int digit)
          // toggle expects object IDs, and tagged number IDs can fail class checks.
          normalized_objs[normalized_count] = *item->obj;
          normalized_objs[normalized_count].id = GetObjId(item->obj->id);
-         group_list = list_add_item(group_list, &normalized_objs[normalized_count]);
+         group_list = list_add_first(group_list, &normalized_objs[normalized_count]);
          normalized_count++;
       }
       else
       {
-         group_list = list_add_item(group_list, item->obj);
+         group_list = list_add_first(group_list, item->obj);
       }
    }
 

--- a/module/merintr/inventry.c
+++ b/module/merintr/inventry.c
@@ -29,7 +29,18 @@ static int inventory_bg_index;  // Palette index of color to use for window bg b
 typedef struct {
    object_node *obj;            // Pointer to node for object in inventory list
    bool         is_using;       // true iff item is in use
+   int          hotkey;         // -1 if unassigned, else 0..9 for digit binding
 } InvItem;
+
+// Number of hotkey groups (digits 0-9).
+static const int NUM_HOTKEY_GROUPS = 10;
+// Cap members per group.  Server-side use/unuse spam filter (user.kod) accepts
+// roughly 5 actions per tick, so a larger group would just get throttled.
+static const int MAX_HOTKEY_GROUP_SIZE = 5;
+
+// Action data is a void *; encode digit as (digit + 1) so it never collides with NULL.
+#define HOTKEY_DATA(digit) ((void *)(intptr_t)((digit) + 1))
+#define HOTKEY_DIGIT(data) ((int)(intptr_t)(data) - 1)
 
 static list_type items;         // List of InvItem structures for items in inventory
 static int       num_items;     // # of items currently in inventory
@@ -95,7 +106,55 @@ keymap inventory_key_table[] = {
 { VK_F11,         KEY_NONE,             A_TEXTCOMMAND, },
 { VK_F12,         KEY_NONE,             A_TEXTCOMMAND, },
 
+// Inventory hotkey groups: Ctrl+digit assigns the selected slot, plain digit triggers the group.
+{ '0',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(0) },
+{ '1',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(1) },
+{ '2',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(2) },
+{ '3',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(3) },
+{ '4',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(4) },
+{ '5',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(5) },
+{ '6',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(6) },
+{ '7',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(7) },
+{ '8',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(8) },
+{ '9',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(9) },
+{ '0',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(0) },
+{ '1',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(1) },
+{ '2',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(2) },
+{ '3',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(3) },
+{ '4',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(4) },
+{ '5',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(5) },
+{ '6',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(6) },
+{ '7',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(7) },
+{ '8',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(8) },
+{ '9',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(9) },
+
 { 0, 0, 0},   // Must end table this way
+};
+
+// Same bindings registered against GAME_PLAY so the digit hotkeys also fire
+// when the main 3D view has focus, independent of the classic/quickchat config.
+static keymap hotkey_key_table[] = {
+{ '0',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(0) },
+{ '1',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(1) },
+{ '2',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(2) },
+{ '3',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(3) },
+{ '4',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(4) },
+{ '5',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(5) },
+{ '6',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(6) },
+{ '7',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(7) },
+{ '8',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(8) },
+{ '9',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(9) },
+{ '0',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(0) },
+{ '1',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(1) },
+{ '2',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(2) },
+{ '3',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(3) },
+{ '4',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(4) },
+{ '5',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(5) },
+{ '6',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(6) },
+{ '7',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(7) },
+{ '8',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(8) },
+{ '9',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(9) },
+{ 0, 0, 0},
 };
 
 static const COLORREF COLOR_ITEM_UNCOMMON     = RGB(141,242,242);  // cyan
@@ -209,6 +268,10 @@ void InventoryBoxCreate(HWND hParent)
 
    InventoryResetFont();
    InventoryChangeColor();
+
+   // Register hotkey table so digit/Ctrl+digit work whenever main view has focus,
+   // independent of the classic/quickchat key configuration.
+   KeyAddTable(GAME_PLAY, hotkey_key_table);
 }
 /************************************************************************/
 /*
@@ -216,6 +279,8 @@ void InventoryBoxCreate(HWND hParent)
  */
 void InventoryBoxDestroy(void)
 {
+   KeyRemoveTable(GAME_PLAY, hotkey_key_table);
+
    DestroyWindow(hwndInv);
    DestroyWindow(hwndInvDialog);
    DestroyWindow(hwndInvScroll);
@@ -736,6 +801,27 @@ void InventoryDrawSingleItem(InvItem *item, int row, int col)
       }
    }
 
+   // Hotkey group badge: small digit in the top-left corner.
+   if (item->hotkey >= 0 && item->hotkey < NUM_HOTKEY_GROUPS)
+   {
+      const int badgeSize = 11;
+      const int badgeLeft = area.x + 2;
+      const int badgeTop  = area.y + 2;
+      RECT rcBadge = { badgeLeft, badgeTop, badgeLeft + badgeSize, badgeTop + badgeSize };
+      HBRUSH hBg = CreateSolidBrush(RGB(0, 0, 0));
+      FillRect(hdc, &rcBadge, hBg);
+      DeleteObject(hBg);
+
+      char digit[2];
+      digit[0] = (char)('0' + item->hotkey);
+      digit[1] = '\0';
+
+      SetBkMode(hdc, TRANSPARENT);
+      SelectObject(hdc, GetFont(FONT_STATNUM));
+      SetTextColor(hdc, RGB(255, 255, 0));
+      TextOut(hdc, badgeLeft + 2, badgeTop - 1, digit, 1);
+   }
+
    ReleaseDC(hwndInv, hdc);
 }
 /************************************************************************/
@@ -1021,6 +1107,14 @@ bool InventoryKey(HWND hwnd, UINT key, bool fDown, int cRepeat, UINT flags)
 	 SelectedObject(id);
       break;
 
+   case A_HOTKEY_ASSIGN:
+      InventoryHotkeyAssign(HOTKEY_DIGIT(action_data));
+      break;
+
+   case A_HOTKEY_TRIGGER:
+      InventoryHotkeyTrigger(HOTKEY_DIGIT(action_data));
+      break;
+
    default:
       PerformAction(action, action_data);
       break;
@@ -1106,6 +1200,106 @@ void ToggleUse(ID obj_id)
 }
 /************************************************************************/
 /*
+ * InventoryHotkeyAssign:  Toggle assignment of the currently selected inventory
+ *   slot to hotkey group digit (0..9).  If the slot is already in this group,
+ *   clear it.  If it is in a different group, reassign.  No-op if no slot is
+ *   selected or the digit is out of range.
+ */
+void InventoryHotkeyAssign(int digit)
+{
+   InvItem *item;
+
+   if (digit < 0 || digit >= NUM_HOTKEY_GROUPS)
+      return;
+
+   item = InventoryGetCurrentItem();
+   if (item == NULL)
+      return;
+
+   if (item->hotkey == digit)
+   {
+      item->hotkey = -1;
+      InventoryRedrawSingleItem(item);
+      return;
+   }
+
+   // Refuse to assign if the target group is already full.
+   int group_count = 0;
+   for (list_type l = items; l != NULL; l = l->next)
+   {
+      InvItem *other = (InvItem *) l->data;
+      if (other != item && other->hotkey == digit)
+         group_count++;
+   }
+   if (group_count >= MAX_HOTKEY_GROUP_SIZE)
+   {
+      debug(("Hotkey group %d is full (max %d items)\n", digit, MAX_HOTKEY_GROUP_SIZE));
+      return;
+   }
+
+   item->hotkey = digit;
+   InventoryRedrawSingleItem(item);
+}
+/************************************************************************/
+/*
+ * InventoryHotkeyTrigger:  Toggle the entire group as one unit.  If every
+ *   item in group digit (0..9) is currently in use, send unuse for each.
+ *   Otherwise send use for each item not yet in use.  This avoids per-item
+ *   toggling that would alternate state when items conflict over equip slots.
+ */
+void InventoryHotkeyTrigger(int digit)
+{
+   list_type l;
+   int total = 0;
+   int using_count = 0;
+
+   if (digit < 0 || digit >= NUM_HOTKEY_GROUPS)
+      return;
+
+   // Debounce: HandleKeys polls every frame and refires non-repeat actions
+   // every KEY_NOREPEAT_INTERVAL (400 ms) while the key is held.  Without
+   // this gate a single physical press can fire the trigger twice, which
+   // shows up as "You are already using that" or as the group toggling
+   // back to its original state.  600 ms suppresses the held-key case
+   // without preventing intentional retaps.
+   static DWORD last_trigger_time[NUM_HOTKEY_GROUPS] = { 0 };
+   DWORD now = GetTickCount();
+   if (now - last_trigger_time[digit] < 600)
+      return;
+   last_trigger_time[digit] = now;
+
+   for (l = items; l != NULL; l = l->next)
+   {
+      InvItem *item = (InvItem *) l->data;
+      if (item->hotkey != digit)
+         continue;
+      total++;
+      if (item->is_using)
+         using_count++;
+   }
+
+   if (total == 0)
+      return;
+
+   bool unuse_all = (using_count == total);
+
+   for (l = items; l != NULL; l = l->next)
+   {
+      InvItem *item = (InvItem *) l->data;
+      if (item->hotkey != digit)
+         continue;
+
+      if (unuse_all)
+         RequestUnuse(item->obj->id);
+      else if (!item->is_using)
+         RequestUse(item->obj->id);
+   }
+
+   // Return focus to the main view so the player can keep playing.
+   SetFocus(cinfo->hMain);
+}
+/************************************************************************/
+/*
  * InventoryAddItem:  Add the given object to the inventory display.
  * // XXX Maybe should pass in "using" status
  */
@@ -1116,6 +1310,7 @@ void InventoryAddItem(object_node *obj)
    new_item = (InvItem *) SafeMalloc(sizeof(InvItem));
    new_item->obj = obj;
    new_item->is_using = false;
+   new_item->hotkey = -1;
    items = list_add_item(items, new_item);
 
    num_items++;

--- a/module/merintr/inventry.c
+++ b/module/merintr/inventry.c
@@ -38,6 +38,12 @@ static const int NUM_HOTKEY_GROUPS = 10;
 // roughly 5 actions per tick, so a larger group would just get throttled.
 static const int MAX_HOTKEY_GROUP_SIZE = 5;
 
+// Authoritative storage for hotkey assignments.  Keyed by object id so
+// bindings survive InventoryResetData() / DisplayInventory() rebuilds that
+// happen on login, room transitions, and server-pushed inventory refreshes.
+// 0 means an empty slot.
+static ID hotkey_obj_id[10][5];
+
 // Action data is a void *; encode digit as (digit + 1) so it never collides with NULL.
 #define HOTKEY_DATA(digit) ((void *)(intptr_t)((digit) + 1))
 #define HOTKEY_DIGIT(data) ((int)(intptr_t)(data) - 1)
@@ -127,23 +133,14 @@ keymap inventory_key_table[] = {
 { '7',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(7) },
 { '8',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(8) },
 { '9',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(9) },
+{ 'X',            KEY_CTL,              A_HOTKEY_CLEAR,   NULL },
 
 { 0, 0, 0},   // Must end table this way
 };
 
-// Same bindings registered against GAME_PLAY so the digit hotkeys also fire
-// when the main 3D view has focus, independent of the classic/quickchat config.
+// Trigger bindings active in the 3D view.  The full set of hotkey actions
+// (assign and clear) requires the inventory window to have focus.
 static keymap hotkey_key_table[] = {
-{ '0',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(0) },
-{ '1',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(1) },
-{ '2',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(2) },
-{ '3',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(3) },
-{ '4',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(4) },
-{ '5',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(5) },
-{ '6',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(6) },
-{ '7',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(7) },
-{ '8',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(8) },
-{ '9',            KEY_CTL,              A_HOTKEY_ASSIGN,  HOTKEY_DATA(9) },
 { '0',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(0) },
 { '1',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(1) },
 { '2',            KEY_NONE,             A_HOTKEY_TRIGGER, HOTKEY_DATA(2) },
@@ -465,14 +462,14 @@ void InventoryVScroll(HWND hwnd, HWND hwndCtl, UINT code, int pos)
 }
 /************************************************************************/
 /*
- * InventoryResetFont:  Called when a font has changed.
+ * InventoryResetFont:  Resets the font for the inventory display.
  */
 void InventoryResetFont(void)
 {
 }
 /************************************************************************/
 /*
- * InventoryChangeColor:  Called when a color has changed.
+ * InventoryChangeColor:  Updates inventory colors.
  */
 void InventoryChangeColor(void)
 {
@@ -1115,6 +1112,10 @@ bool InventoryKey(HWND hwnd, UINT key, bool fDown, int cRepeat, UINT flags)
       InventoryHotkeyTrigger(HOTKEY_DIGIT(action_data));
       break;
 
+   case A_HOTKEY_CLEAR:
+      InventoryHotkeyClearAll();
+      break;
+
    default:
       PerformAction(action, action_data);
       break;
@@ -1200,10 +1201,9 @@ void ToggleUse(ID obj_id)
 }
 /************************************************************************/
 /*
- * InventoryHotkeyAssign:  Toggle assignment of the currently selected inventory
- *   slot to hotkey group digit (0..9).  If the slot is already in this group,
- *   clear it.  If it is in a different group, reassign.  No-op if no slot is
- *   selected or the digit is out of range.
+ * InventoryHotkeyAssign:  Toggles the selected item in or out of the given
+ *   hotkey group.  Moves the item if it belongs to a different group.
+ *   Does nothing if no item is selected or the group is full.
  */
 void InventoryHotkeyAssign(int digit)
 {
@@ -1216,86 +1216,120 @@ void InventoryHotkeyAssign(int digit)
    if (item == NULL)
       return;
 
+   // Toggle: same digit clears the binding.
    if (item->hotkey == digit)
    {
+      for (int s = 0; s < MAX_HOTKEY_GROUP_SIZE; s++)
+         if (hotkey_obj_id[digit][s] == item->obj->id)
+            hotkey_obj_id[digit][s] = 0;
       item->hotkey = -1;
       InventoryRedrawSingleItem(item);
       return;
    }
 
-   // Refuse to assign if the target group is already full.
-   int group_count = 0;
-   for (list_type l = items; l != NULL; l = l->next)
+   // Item may already be in a different group; remove it from there first.
+   if (item->hotkey >= 0 && item->hotkey < NUM_HOTKEY_GROUPS)
    {
-      InvItem *other = (InvItem *) l->data;
-      if (other != item && other->hotkey == digit)
-         group_count++;
+      for (int s = 0; s < MAX_HOTKEY_GROUP_SIZE; s++)
+         if (hotkey_obj_id[item->hotkey][s] == item->obj->id)
+            hotkey_obj_id[item->hotkey][s] = 0;
    }
-   if (group_count >= MAX_HOTKEY_GROUP_SIZE)
+
+   // Find an empty slot in the target group.
+   int free_slot = -1;
+   for (int s = 0; s < MAX_HOTKEY_GROUP_SIZE; s++)
    {
-      debug(("Hotkey group %d is full (max %d items)\n", digit, MAX_HOTKEY_GROUP_SIZE));
+      if (hotkey_obj_id[digit][s] == 0)
+      {
+         free_slot = s;
+         break;
+      }
+   }
+   if (free_slot < 0)
+   {
       return;
    }
 
+   hotkey_obj_id[digit][free_slot] = item->obj->id;
    item->hotkey = digit;
    InventoryRedrawSingleItem(item);
 }
 /************************************************************************/
 /*
- * InventoryHotkeyTrigger:  Toggle the entire group as one unit.  If every
- *   item in group digit (0..9) is currently in use, send unuse for each.
- *   Otherwise send use for each item not yet in use.  This avoids per-item
- *   toggling that would alternate state when items conflict over equip slots.
+ * InventoryHotkeyTrigger:  Sends a toggle-group packet for all items bound
+ *   to the given hotkey digit.  Number-object ids are normalized before send.
  */
 void InventoryHotkeyTrigger(int digit)
 {
    list_type l;
-   int total = 0;
-   int using_count = 0;
+   list_type group_list = NULL;
+   object_node normalized_objs[MAX_HOTKEY_GROUP_SIZE];
+   int normalized_count = 0;
 
    if (digit < 0 || digit >= NUM_HOTKEY_GROUPS)
       return;
 
    // Debounce: HandleKeys polls every frame and refires non-repeat actions
-   // every KEY_NOREPEAT_INTERVAL (400 ms) while the key is held.  Without
-   // this gate a single physical press can fire the trigger twice, which
-   // shows up as "You are already using that" or as the group toggling
-   // back to its original state.  600 ms suppresses the held-key case
-   // without preventing intentional retaps.
-   static DWORD last_trigger_time[NUM_HOTKEY_GROUPS] = { 0 };
+   // every KEY_NOREPEAT_INTERVAL (400 ms) while the key is held.  600 ms
+   // suppresses the held-key case without blocking intentional retaps.
+   static DWORD last_trigger_time[10] = { 0 };
    DWORD now = GetTickCount();
    if (now - last_trigger_time[digit] < 600)
       return;
    last_trigger_time[digit] = now;
 
+   // Build from live inventory entries marked with this digit.  This avoids
+   // dropping members if an id lookup misses during inventory reshuffles.
    for (l = items; l != NULL; l = l->next)
    {
       InvItem *item = (InvItem *) l->data;
       if (item->hotkey != digit)
          continue;
-      total++;
-      if (item->is_using)
-         using_count++;
+
+      if (IsNumberObj(item->obj->id) && normalized_count < MAX_HOTKEY_GROUP_SIZE)
+      {
+         // Strip NUMBER_OBJECT tag bits before sending.  Server list parsing for
+         // toggle expects object IDs, and tagged number IDs can fail class checks.
+         normalized_objs[normalized_count] = *item->obj;
+         normalized_objs[normalized_count].id = GetObjId(item->obj->id);
+         group_list = list_add_item(group_list, &normalized_objs[normalized_count]);
+         normalized_count++;
+      }
+      else
+      {
+         group_list = list_add_item(group_list, item->obj);
+      }
    }
 
-   if (total == 0)
+   if (group_list == NULL)
       return;
 
-   bool unuse_all = (using_count == total);
-
-   for (l = items; l != NULL; l = l->next)
-   {
-      InvItem *item = (InvItem *) l->data;
-      if (item->hotkey != digit)
-         continue;
-
-      if (unuse_all)
-         RequestUnuse(item->obj->id);
-      else if (!item->is_using)
-         RequestUse(item->obj->id);
-   }
+   RequestToggleGroup(group_list);
+   list_delete(group_list);
 
    // Return focus to the main view so the player can keep playing.
+   SetFocus(cinfo->hMain);
+}
+/************************************************************************/
+/*
+ * InventoryHotkeyClearAll:  Clears all hotkey-group bindings and redraws
+ *   the affected inventory slots.
+ */
+void InventoryHotkeyClearAll(void)
+{
+   for (int g = 0; g < NUM_HOTKEY_GROUPS; g++)
+      for (int s = 0; s < MAX_HOTKEY_GROUP_SIZE; s++)
+         hotkey_obj_id[g][s] = 0;
+
+   for (list_type l = items; l != NULL; l = l->next)
+   {
+      InvItem *item = (InvItem *) l->data;
+      if (item->hotkey < 0)
+         continue;
+      item->hotkey = -1;
+      InventoryRedrawSingleItem(item);
+   }
+
    SetFocus(cinfo->hMain);
 }
 /************************************************************************/
@@ -1311,6 +1345,18 @@ void InventoryAddItem(object_node *obj)
    new_item->obj = obj;
    new_item->is_using = false;
    new_item->hotkey = -1;
+   // Re-attach any persisted hotkey binding for this object id.
+   for (int g = 0; g < NUM_HOTKEY_GROUPS && new_item->hotkey < 0; g++)
+   {
+      for (int s = 0; s < MAX_HOTKEY_GROUP_SIZE; s++)
+      {
+         if (hotkey_obj_id[g][s] == obj->id)
+         {
+            new_item->hotkey = g;
+            break;
+         }
+      }
+   }
    items = list_add_item(items, new_item);
 
    num_items++;
@@ -1340,6 +1386,12 @@ void InventoryRemoveItem(ID id)
    }
 
    items = list_delete_item(items, (void *) id, InventoryCompareIdItem);
+   // Drop any persisted hotkey binding so a future object with the same id
+   // (server reuses ids) does not inherit a stale assignment.
+   for (int g = 0; g < NUM_HOTKEY_GROUPS; g++)
+      for (int s = 0; s < MAX_HOTKEY_GROUP_SIZE; s++)
+         if (hotkey_obj_id[g][s] == id)
+            hotkey_obj_id[g][s] = 0;
    // Object itself freed elsewhere
    SafeFree(item);
 

--- a/module/merintr/inventry.h
+++ b/module/merintr/inventry.h
@@ -39,6 +39,7 @@ void DisplayInventory(list_type inventory);
 
 void InventoryHotkeyAssign(int digit);
 void InventoryHotkeyTrigger(int digit);
+void InventoryHotkeyClearAll(void);
 
 void DisplaySetUsing(ID obj_id, bool is_using);
 void DisplayUsing(list_type using_list);

--- a/module/merintr/inventry.h
+++ b/module/merintr/inventry.h
@@ -37,6 +37,9 @@ void InventoryAddItem(object_node *obj);
 void InventoryRemoveItem(ID id);
 void DisplayInventory(list_type inventory);
 
+void InventoryHotkeyAssign(int digit);
+void InventoryHotkeyTrigger(int digit);
+
 void DisplaySetUsing(ID obj_id, bool is_using);
 void DisplayUsing(list_type using_list);
 

--- a/module/merintr/merintr.h
+++ b/module/merintr/merintr.h
@@ -37,6 +37,8 @@
 #define A_CAST          (A_MODULE + 200)
 #define A_CASTSPELL     (A_MODULE + 201)
 #define A_LOOKINVENTORY (A_MODULE + 202)    // Examine item in inventory
+#define A_HOTKEY_ASSIGN (A_MODULE + 210)    // Ctrl+digit: assign selected inventory slot to a hotkey group
+#define A_HOTKEY_TRIGGER (A_MODULE + 211)   // digit: toggle use on every inventory item in a hotkey group
 
 // Window messages
 #define BK_CREATED      (WM_USER + 100)

--- a/module/merintr/merintr.h
+++ b/module/merintr/merintr.h
@@ -37,9 +37,9 @@
 #define A_CAST          (A_MODULE + 200)
 #define A_CASTSPELL     (A_MODULE + 201)
 #define A_LOOKINVENTORY (A_MODULE + 202)    // Examine item in inventory
-#define A_HOTKEY_ASSIGN (A_MODULE + 210)    // Ctrl+digit: assign selected inventory slot to a hotkey group
-#define A_HOTKEY_TRIGGER (A_MODULE + 211)   // digit: toggle use on every inventory item in a hotkey group
-#define A_HOTKEY_CLEAR (A_MODULE + 212)     // Ctrl+X: clear every hotkey group binding
+#define A_HOTKEY_ASSIGN (A_MODULE + 210)    // Assign selected inventory slot to a hotkey group
+#define A_HOTKEY_TRIGGER (A_MODULE + 211)   // Toggle use on every inventory item in a hotkey group
+#define A_HOTKEY_CLEAR (A_MODULE + 212)     // Clear every inventory hotkey group binding
 
 // Window messages
 #define BK_CREATED      (WM_USER + 100)

--- a/module/merintr/merintr.h
+++ b/module/merintr/merintr.h
@@ -39,6 +39,7 @@
 #define A_LOOKINVENTORY (A_MODULE + 202)    // Examine item in inventory
 #define A_HOTKEY_ASSIGN (A_MODULE + 210)    // Ctrl+digit: assign selected inventory slot to a hotkey group
 #define A_HOTKEY_TRIGGER (A_MODULE + 211)   // digit: toggle use on every inventory item in a hotkey group
+#define A_HOTKEY_CLEAR (A_MODULE + 212)     // Ctrl+X: clear every hotkey group binding
 
 // Window messages
 #define BK_CREATED      (WM_USER + 100)

--- a/module/merintr/mermain.c
+++ b/module/merintr/mermain.c
@@ -391,6 +391,10 @@ bool InterfaceAction(int action, void *action_data)
    case A_HOTKEY_TRIGGER:
       InventoryHotkeyTrigger((int)(intptr_t)action_data - 1);
       return false;
+
+   case A_HOTKEY_CLEAR:
+      InventoryHotkeyClearAll();
+      return false;
    }
 
    return true;

--- a/module/merintr/mermain.c
+++ b/module/merintr/mermain.c
@@ -383,6 +383,14 @@ bool InterfaceAction(int action, void *action_data)
       return InterfaceTab(reinterpret_cast<std::intptr_t>(action_data), true);
    case A_TABBACK:
       return InterfaceTab(reinterpret_cast<std::intptr_t>(action_data), false);
+
+   case A_HOTKEY_ASSIGN:
+      InventoryHotkeyAssign((int)(intptr_t)action_data - 1);
+      return false;
+
+   case A_HOTKEY_TRIGGER:
+      InventoryHotkeyTrigger((int)(intptr_t)action_data - 1);
+      return false;
    }
 
    return true;


### PR DESCRIPTION
## What
- adds inventory hotkey groups for quick item toggles
  - `Control + number` to assign a control group 0-9
  - `Control + x` to clear all control groups
  - Hit `number` when 3D window is selected to activate / deactivate selected item groups
- adds one batched client packet for group toggle so one key press sends one request (like #1361 did)
- keeps group bindings stable through inventory redraws in the same client session
- blocks wand-type items from group toggle
- consumes single-use items in inventory display order (top-left first)
> [!Note]
> Does retain groups through system saves.  Does not if the connection is reset (restarting the client, for example).

## Why
- swapping gear one item at a time is slow during normal play
- sending one packet for a group avoids per-item packet drops from the spam throttle
- wand usage from grouped toggles creates balance risk and is blocked in this change

## How
- client hotkeys
  - `InventoryHotkeyAssign` stores group bindings on inventory items
  - `InventoryHotkeyTrigger` builds one object list and sends `BP_REQ_TOGGLE_GROUP`
  - number-object ids are normalized before send so ammo and other number items resolve correctly on server
  - the client builds the wire list in reverse inventory order so that after the server's parse-time list reversal, top-left items end up at the head of the Blakod list and are processed first
    - this means for example if you have scrolls in a control group and you toggle the group, the first scroll in the group going from top left will be consumed first
- protocol and routing
  - added `BP_REQ_TOGGLE_GROUP` in shared protocol headers
  - added client parameter table entry in `protocol.c`
  - added server parse table entry in `sprocket.c`
- server behavior
  - `UserToggleItemGroup` in `user.kod` validates list input and returns early on empty
  - `UserToggleItemGroup` ignores duplicate entries and wand-type items
  - `UserToggleItemGroup` chooses one target state for the group and applies it item by item

## Example

### Client and Server Flow
```mermaid
flowchart TD
    A[Hotkey Press in Client] --> B[InventoryHotkeyTrigger]
    B --> C[BP_REQ_TOGGLE_GROUP]
    C --> D[Server ParseClientSendBlakod]
    D --> E[user.kod UserToggleItemGroup]
    E --> F{items in use}
    F -->|Yes| G[Unuse eligible items]
    F -->|No| H[Use eligible items]

    classDef step fill:#1f6feb,color:#fff
    classDef decision fill:#b08900,color:#fff
    classDef safe fill:#2f9e44,color:#fff

    class A,B,C,D,E step
    class F decision
    class G,H safe
```

### Gameplay Example
- open inventory, hover over an item, press `Ctrl+1` to assign it to group 1
- assign up to 5 items to the same group number (groups are capped at 5 items)
- press `Ctrl+X` in the inventory window to clear all group assignments
- press `1` from the 3D view or inventory to toggle the whole group at once
- press `1` again to toggle the group back to the previous state

### Recorded Example
<img width="1232" height="766" alt="meridian_lo6Ne4rZP4" src="https://github.com/user-attachments/assets/539366f3-f13e-43a1-95a2-889565a80c43" />

- An example showing how a user can create and switch groups for melee , ranged, and caster items