### PR TITLE
Refactor particle system

### DIFF
--- a/clientd3d/d3dparticle.c
+++ b/clientd3d/d3dparticle.c
@@ -7,8 +7,9 @@
 // Meridian is a registered trademark.
 #include "client.h"
 
-void D3DParticleDestroy(particle *pParticle);
-
+//////////////////////
+// Public Functions //
+//////////////////////
 void D3DParticleSystemReset(particle_system *pParticleSystem)
 {
 	list_destroy(pParticleSystem->emitterList);
@@ -92,7 +93,7 @@ void D3DParticleSystemUpdate(particle_system *pParticleSystem, d3d_render_pool_n
 
 			if (--pParticle->energy <= 0)
 			{
-				D3DParticleDestroy(pParticle);
+				pParticle->energy = 0;
 				pEmitter->numParticles--;
 			}
 			else
@@ -251,9 +252,4 @@ void D3DParticleSystemUpdate(particle_system *pParticleSystem, d3d_render_pool_n
 
 	D3DCacheFill(pCacheSystem, pPool, 0);
 	D3DCacheFlush(pCacheSystem, pPool, 0, D3DPT_LINESTRIP);
-}
-
-void D3DParticleDestroy(particle *pParticle)
-{
-	pParticle->energy = 0;
 }

--- a/clientd3d/d3dparticle.c
+++ b/clientd3d/d3dparticle.c
@@ -6,247 +6,174 @@
 //
 // Meridian is a registered trademark.
 #include "client.h"
+#include <chrono>
+#include <random>
+
+///////////////
+// Constants //
+///////////////
+static constexpr uint32_t PARTICLE_INDICES = 2;
+static constexpr uint32_t PARTICLE_VERTICES = 2;
+static constexpr uint32_t PARTICLE_PRIMITIVES = 1;
+
+///////////////
+// Variables //
+///////////////
+static std::mt19937 gen(static_cast<uint32_t>(std::chrono::high_resolution_clock::now().time_since_epoch().count()));
+
+////////////////////////
+// Internal Functions //
+////////////////////////
+static float GetRandomFloatRange(float min, float max)
+{
+	if (min >= max)
+	{
+		return min;
+	}
+	std::uniform_real_distribution<float> dist(min, max);
+
+    return dist(gen);
+}
+
+// Returns a new XYZ after adjusting the base XYZ with a specified variance range (if any).
+static custom_xyz GetVariedXYZ(const custom_xyz& base, const custom_xyz& min, const custom_xyz& max)
+{
+	custom_xyz result = base;
+	result.x += GetRandomFloatRange(min.x, max.x);
+	result.y += GetRandomFloatRange(min.y, max.y);
+	result.z += GetRandomFloatRange(min.z, max.z);
+	return result;
+}
+
+static void D3DParticleUpdate(emitter *pEmitter, particle *pParticle, d3d_render_pool_new *pPool)
+{
+	// Skip inactive particles so they don't get added to rendering.
+	if (pParticle->isActive == false)
+		return;
+
+	if (--pParticle->timeLeft <= 0)
+	{
+		pParticle->isActive = false;
+		return;
+	}
+
+	custom_xyzw velocity = {pParticle->velocity.x, pParticle->velocity.y, pParticle->velocity.z, 1.0f};
+
+	D3DMATRIX rotate, matrix;
+	MatrixRotateX(&matrix, pParticle->rotation.x);
+	MatrixRotateY(&rotate, pParticle->rotation.y);
+	MatrixMultiply(&rotate, &matrix, &rotate);
+	MatrixRotateZ(&matrix, pParticle->rotation.z);
+	MatrixMultiply(&rotate, &rotate, &matrix);
+
+	MatrixMultiplyVector(&velocity, &rotate, &velocity);
+	pParticle->velocity.x = velocity.x;
+	pParticle->velocity.y = velocity.y;
+	pParticle->velocity.z = velocity.z;
+	pParticle->oldPosition = pParticle->position;
+	pParticle->position.x += pParticle->velocity.x;
+	pParticle->position.y += pParticle->velocity.y;
+	pParticle->position.z += pParticle->velocity.z;
+
+	auto *pPacket = D3DRenderPacketFindMatch(pPool, nullptr, nullptr, 0, 0, 0);
+	assert(pPacket);
+	pPacket->pMaterialFctn = &D3DMaterialParticlePacket;
+
+	auto *pChunk = D3DRenderChunkNew(pPacket);
+	assert(pChunk);
+	pChunk->numIndices = PARTICLE_INDICES;
+	pChunk->numVertices = PARTICLE_VERTICES;
+	pChunk->numPrimitives = PARTICLE_PRIMITIVES;
+	pChunk->pMaterialFctn = &D3DMaterialParticleChunk;
+
+	MatrixTranslate(&pChunk->xForm, pParticle->position.x, pParticle->position.z, pParticle->position.y);
+
+	CHUNK_XYZ_SET(pChunk, 0, 0, 0, 0);
+	CHUNK_XYZ_SET(pChunk, 1, -pParticle->velocity.x, -pParticle->velocity.y, -pParticle->velocity.z);
+	CHUNK_BGRA_SET(pChunk, 0, pParticle->bgra.b, pParticle->bgra.g, pParticle->bgra.r, pParticle->bgra.a);
+	CHUNK_BGRA_SET(pChunk, 1, pParticle->bgra.b, pParticle->bgra.g, pParticle->bgra.r, 0);
+	CHUNK_INDEX_SET(pChunk, 0, 0);
+	CHUNK_INDEX_SET(pChunk, 1, 1);
+}
+
+// Gets a particle from the object pool
+static void D3DParticleInitialize(emitter *pEmitter, particle *pParticle)
+{
+	// Advance to the next slot in the circular buffer and reset the emitter's timer,
+	// regardless if the recycled particle should show up in its new location or not.
+	pEmitter->nextSlot = (pEmitter->nextSlot + 1) % MAX_PARTICLES;
+	if (pEmitter->numParticles < MAX_PARTICLES)
+	{
+		pEmitter->numParticles++;
+	}
+	pEmitter->timer = pEmitter->timerBase;
+
+	// Apply position/velocity/rotation settings to the particle, and with variance if any.
+	pParticle->position = GetVariedXYZ(pEmitter->position, pEmitter->positionVarianceMin, pEmitter->positionVarianceMax);
+	pParticle->velocity = GetVariedXYZ(pEmitter->velocity, pEmitter->velocityVarianceMin, pEmitter->velocityVarianceMax);
+	pParticle->rotation = GetVariedXYZ(pEmitter->rotation, pEmitter->rotationVarianceMin, pEmitter->rotationVarianceMax);
+
+	pParticle->bgra = pEmitter->bgra;
+	pParticle->timeLeft = pEmitter->particleLifetime;
+
+	// Once the particle is all set, make it active so it can be included in the rendering.
+	pParticle->isActive = true;
+}
 
 //////////////////////
 // Public Functions //
 //////////////////////
 void D3DParticleSystemReset(particle_system *pParticleSystem)
 {
-	list_destroy(pParticleSystem->emitterList);
-	pParticleSystem->emitterList = NULL;
+	// Free memory from each emitter before clearing the pointers.
+	for (auto pEmitter : pParticleSystem->emitterList)
+	{
+		if (pEmitter != nullptr)
+		{
+			SafeFree(pEmitter);
+		}
+	}
+
+	pParticleSystem->emitterList.clear();
 }
 
-void D3DParticleEmitterInit(particle_system *pParticleSystem, float posX, float posY, float posZ,
-							float velX, float velY, float velZ, unsigned char b, unsigned char g,
-							unsigned char r, unsigned char a, int energy, int timerBase,
-							float rotX, float rotY, float rotZ, bool bRandomize, int randomPos,
-							int randomRot)
+emitter* D3DParticleEmitterInit(particle_system *pParticleSystem, int time)
 {
-	emitter	*pEmitter = NULL;
+	emitter	*pEmitter = reinterpret_cast<emitter*>(ZeroSafeMalloc(sizeof(emitter)));
 
-	if (pParticleSystem == NULL)
-		return;
+	pEmitter->timer = time;
+	pEmitter->timerBase = time;
 
-	pEmitter = (emitter *)SafeMalloc(sizeof(emitter));
-
-	if (pEmitter == NULL)
-		return;
-
-	memset(pEmitter, 0, sizeof(emitter));
-
-	pEmitter->numParticles = 0;
-	pEmitter->bRandomize = bRandomize;
-	pEmitter->pos.x = posX;
-	pEmitter->pos.y = posY;
-	pEmitter->pos.z = posZ;
-	pEmitter->rotation.x = rotX;
-	pEmitter->rotation.y = rotY;
-	pEmitter->rotation.z = rotZ;
-	pEmitter->velocity.x = velX;
-	pEmitter->velocity.y = velY;
-	pEmitter->velocity.z = velZ;
-	pEmitter->energy = energy;
-	pEmitter->timer = timerBase;
-	pEmitter->timerBase = timerBase;
-	pEmitter->bgra.b = b;
-	pEmitter->bgra.g = g;
-	pEmitter->bgra.r = r;
-	pEmitter->bgra.a = a;
-	pEmitter->randomPos = randomPos;
-	pEmitter->randomRot = randomRot;
-
-	if (NULL == pParticleSystem->emitterList)
-		pParticleSystem->emitterList =
-			list_create(pEmitter);
-	else
-		list_add_item(pParticleSystem->emitterList, pEmitter);
+	pParticleSystem->emitterList.push_back(pEmitter);
+	return pEmitter;
 }
 
-void D3DParticleEmitterUpdate(emitter *pEmitter, float posX, float posY, float posZ)
+void D3DParticleEmitterUpdate(emitter *pEmitter, custom_xyz deltaPosition)
 {
-	pEmitter->pos.x += posX;
-	pEmitter->pos.y += posY;
-	pEmitter->pos.z += posZ;
+	pEmitter->position.x += deltaPosition.x;
+	pEmitter->position.y += deltaPosition.y;
+	pEmitter->position.z += deltaPosition.z;
 }
 
 void D3DParticleSystemUpdate(particle_system *pParticleSystem, d3d_render_pool_new *pPool,
 							 d3d_render_cache_system *pCacheSystem)
 {
-	int						curParticle;
-	list_type				list;
-	emitter					*pEmitter;
-	particle				*pParticle;
-	d3d_render_packet_new	*pPacket;
-	d3d_render_chunk_new	*pChunk;
-	D3DMATRIX				rotate, matrix;
-
 	D3DCacheSystemReset(pCacheSystem);
 	D3DRenderPoolReset(pPool, &D3DMaterialParticlePool);
 
-	for (list = pParticleSystem->emitterList; list != NULL; list = list->next)
+	for (auto pEmitter : pParticleSystem->emitterList)
 	{
-		pEmitter = (emitter *)list->data;
-
-		for (curParticle = 0; curParticle < pEmitter->numParticles; curParticle++)
+		// Update existing particles.
+		for (int i = 0; i < pEmitter->numParticles; i++)
 		{
-			pParticle = &pEmitter->particles[curParticle];
-
-			if (--pParticle->energy <= 0)
-			{
-				pParticle->energy = 0;
-				pEmitter->numParticles--;
-			}
-			else
-			{
-				custom_xyzw	velocity;
-
-				velocity.x = pParticle->velocity.x;
-				velocity.y = pParticle->velocity.y;
-				velocity.z = pParticle->velocity.z;
-				velocity.w = 1.0f;
-
-				MatrixRotateX(&matrix, pParticle->rotation.x);
-				MatrixRotateY(&rotate, pParticle->rotation.y);
-				MatrixMultiply(&rotate, &matrix, &rotate);
-				MatrixRotateZ(&matrix, pParticle->rotation.z);
-				MatrixMultiply(&rotate, &rotate, &matrix);
-
-				MatrixMultiplyVector(&velocity, &rotate, &velocity);
-
-				pParticle->velocity.x = velocity.x;
-				pParticle->velocity.y = velocity.y;
-				pParticle->velocity.z = velocity.z;
-
-				pParticle->oldPos.x = pParticle->pos.x;
-				pParticle->oldPos.y = pParticle->pos.y;
-				pParticle->oldPos.z = pParticle->pos.z;
-
-				pParticle->pos.x += pParticle->velocity.x;
-				pParticle->pos.y += pParticle->velocity.y;
-				pParticle->pos.z += pParticle->velocity.z;
-
-				pPacket = D3DRenderPacketFindMatch(pPool, NULL, NULL, 0, 0, 0);
-				assert(pPacket);
-				pPacket->pMaterialFctn = &D3DMaterialParticlePacket;
-
-				pChunk = D3DRenderChunkNew(pPacket);
-				assert(pChunk);
-				pChunk->numIndices = 2;
-				pChunk->numVertices = 2;
-				pChunk->numPrimitives = 1;
-				pChunk->pMaterialFctn = &D3DMaterialParticleChunk;
-
-				MatrixTranslate(&pChunk->xForm, pParticle->pos.x, pParticle->pos.z, pParticle->pos.y);
-
-				CHUNK_XYZ_SET(pChunk, 0, 0, 0, 0);
-				CHUNK_XYZ_SET(pChunk, 1, -pParticle->velocity.x, -pParticle->velocity.y,
-					-pParticle->velocity.z);
-				CHUNK_BGRA_SET(pChunk, 0, pParticle->bgra.b, pParticle->bgra.g, pParticle->bgra.r,
-					pParticle->bgra.a);
-				CHUNK_BGRA_SET(pChunk, 1, pParticle->bgra.b, pParticle->bgra.g, pParticle->bgra.r,
-					0);
-				CHUNK_INDEX_SET(pChunk, 0, 0);
-				CHUNK_INDEX_SET(pChunk, 1, 1);
-			}
+			D3DParticleUpdate(pEmitter, &pEmitter->particles[i], pPool);
 		}
 
-		if (pEmitter->numParticles < MAX_PARTICLES)
+		// Initializing new particles
+		if (--pEmitter->timer <= 0)
 		{
-			int	curParticle;
-
-			if (--pEmitter->timer <= 0)
-			{
-				for (curParticle = 0; curParticle < MAX_PARTICLES; curParticle++)
-				{
-					pParticle = &pEmitter->particles[curParticle];
-
-					if (pParticle->energy == 0)
-					{
-						pParticle->pos.x = pEmitter->pos.x;
-						pParticle->pos.y = pEmitter->pos.y;
-						pParticle->pos.z = pEmitter->pos.z;
-
-						if (pEmitter->bRandomize)
-						{
-							int	sign = 1;
-
-							if ((int)rand() & 1)
-								sign = -sign;
-							pParticle->pos.x += sign * ((int)rand() & pEmitter->randomPos);
-
-							if ((int)rand() & 1)
-								sign = -sign;
-							pParticle->pos.y += sign * ((int)rand() & pEmitter->randomPos);
-
-							if ((int)rand() & 1)
-								sign = -sign;
-							pParticle->pos.z += sign * ((int)rand() & pEmitter->randomPos);
-						}
-
-						pParticle->velocity.x = pEmitter->velocity.x;
-						pParticle->velocity.y = pEmitter->velocity.y;
-						pParticle->velocity.z = pEmitter->velocity.z;
-
-						pParticle->rotation.x = pEmitter->rotation.x;
-						pParticle->rotation.y = pEmitter->rotation.y;
-						pParticle->rotation.z = pEmitter->rotation.z;
-
-						if (pEmitter->bRandomize)
-						{
-							float	random, sign;
-
-							sign = 1;
-
-/*							random = (int)rand() % 10;
-							random = DEGREES_TO_RADIANS(random);
-							pParticle->rotation.x += random * sign;
-
-							random = (int)rand() % 10;
-							random = DEGREES_TO_RADIANS(random);
-							pParticle->rotation.y += random * sign;
-
-							random = (int)rand() % 10;
-							random = DEGREES_TO_RADIANS(random);
-							pParticle->rotation.z += random * sign;*/
-							random = (int)rand() % pEmitter->randomRot;
-							if (random <= 1)
-								random = 2;
-							if ((int)rand() & 1)
-								sign = -sign;
-							pParticle->rotation.x += (pEmitter->rotation.x * random * sign);
-							pParticle->pos.x += (int)rand() % FINENESS;
-
-							random = (int)rand() % pEmitter->randomRot;
-							if (random <= 1)
-								random = 2;
-							if ((int)rand() & 1)
-								sign = -sign;
-							pParticle->rotation.y += (pEmitter->rotation.y * random * sign);
-							pParticle->pos.y += (int)rand() % FINENESS;
-
-							random = (int)rand() % pEmitter->randomRot;
-							if (random <= 1)
-								random = 2;
-							if ((int)rand() & 1)
-								sign = -sign;
-							pParticle->rotation.z += (pEmitter->rotation.z * random * sign);
-							pParticle->pos.z += (int)rand() % FINENESS;
-						}
-
-						pParticle->bgra.b = pEmitter->bgra.b;
-						pParticle->bgra.g = pEmitter->bgra.g;
-						pParticle->bgra.r = pEmitter->bgra.r;
-						pParticle->bgra.a = pEmitter->bgra.a;
-
-						pParticle->energy = pEmitter->energy;
-
-						pEmitter->numParticles++;
-						curParticle = MAX_PARTICLES;
-					}
-				}
-
-				pEmitter->timer = pEmitter->timerBase;
-			}
+			// Particles spawn one at a time and use circular buffing to track the next open particle.
+			D3DParticleInitialize(pEmitter, &pEmitter->particles[pEmitter->nextSlot]);
 		}
 	}
 

--- a/clientd3d/d3dparticle.c
+++ b/clientd3d/d3dparticle.c
@@ -19,7 +19,7 @@ static constexpr uint32_t PARTICLE_PRIMITIVES = 1;
 ///////////////
 // Variables //
 ///////////////
-static std::mt19937 gen(static_cast<uint32_t>(std::chrono::high_resolution_clock::now().time_since_epoch().count()));
+static std::mt19937 rng(static_cast<uint32_t>(std::chrono::high_resolution_clock::now().time_since_epoch().count()));
 
 ////////////////////////
 // Internal Functions //
@@ -32,7 +32,7 @@ static float GetRandomFloatRange(float min, float max)
 	}
 	std::uniform_real_distribution<float> dist(min, max);
 
-    return dist(gen);
+    return dist(rng);
 }
 
 // Returns a new XYZ after adjusting the base XYZ with a specified variance range (if any).

--- a/clientd3d/d3dparticle.c
+++ b/clientd3d/d3dparticle.c
@@ -57,8 +57,6 @@ static void D3DParticleUpdate(emitter *pEmitter, particle *pParticle, d3d_render
 		return;
 	}
 
-	custom_xyzw velocity = {pParticle->velocity.x, pParticle->velocity.y, pParticle->velocity.z, 1.0f};
-
 	D3DMATRIX rotate, matrix;
 	MatrixRotateX(&matrix, pParticle->rotation.x);
 	MatrixRotateY(&rotate, pParticle->rotation.y);
@@ -66,10 +64,10 @@ static void D3DParticleUpdate(emitter *pEmitter, particle *pParticle, d3d_render
 	MatrixRotateZ(&matrix, pParticle->rotation.z);
 	MatrixMultiply(&rotate, &rotate, &matrix);
 
-	MatrixMultiplyVector(&velocity, &rotate, &velocity);
-	pParticle->velocity.x = velocity.x;
-	pParticle->velocity.y = velocity.y;
-	pParticle->velocity.z = velocity.z;
+	custom_xyzw rotatedVelocity = {pParticle->velocity.x, pParticle->velocity.y, pParticle->velocity.z, 1.0f};
+	MatrixMultiplyVector(&rotatedVelocity, &rotate, &rotatedVelocity);
+	pParticle->velocity = {rotatedVelocity.x, rotatedVelocity.y, rotatedVelocity.z};
+
 	pParticle->oldPosition = pParticle->position;
 	pParticle->position.x += pParticle->velocity.x;
 	pParticle->position.y += pParticle->velocity.y;
@@ -101,17 +99,20 @@ static void D3DParticleInitialize(emitter *pEmitter, particle *pParticle)
 {
 	// Advance to the next slot in the circular buffer and reset the emitter's timer,
 	// regardless if the recycled particle should show up in its new location or not.
-	pEmitter->nextSlot = (pEmitter->nextSlot + 1) % MAX_PARTICLES;
-	if (pEmitter->numParticles < MAX_PARTICLES)
+	pEmitter->nextSlot = (pEmitter->nextSlot + 1) % MAX_PARTICLES_PER_EMITTER;
+	if (pEmitter->numParticles < MAX_PARTICLES_PER_EMITTER)
 	{
 		pEmitter->numParticles++;
 	}
 	pEmitter->timer = pEmitter->timerBase;
 
 	// Apply position/velocity/rotation settings to the particle, and with variance if any.
-	pParticle->position = GetVariedXYZ(pEmitter->position, pEmitter->positionVarianceMin, pEmitter->positionVarianceMax);
-	pParticle->velocity = GetVariedXYZ(pEmitter->velocity, pEmitter->velocityVarianceMin, pEmitter->velocityVarianceMax);
-	pParticle->rotation = GetVariedXYZ(pEmitter->rotation, pEmitter->rotationVarianceMin, pEmitter->rotationVarianceMax);
+	pParticle->position = GetVariedXYZ(pEmitter->position,
+		pEmitter->positionVarianceMin, pEmitter->positionVarianceMax);
+	pParticle->velocity = GetVariedXYZ(pEmitter->velocity,
+		pEmitter->velocityVarianceMin, pEmitter->velocityVarianceMax);
+	pParticle->rotation = GetVariedXYZ(pEmitter->rotation,
+		pEmitter->rotationVarianceMin, pEmitter->rotationVarianceMax);
 
 	pParticle->bgra = pEmitter->bgra;
 	pParticle->timeLeft = pEmitter->particleLifetime;
@@ -128,10 +129,7 @@ void D3DParticleSystemReset(particle_system *pParticleSystem)
 	// Free memory from each emitter before clearing the pointers.
 	for (auto pEmitter : pParticleSystem->emitterList)
 	{
-		if (pEmitter != nullptr)
-		{
-			SafeFree(pEmitter);
-		}
+		SafeFree(pEmitter);
 	}
 
 	pParticleSystem->emitterList.clear();

--- a/clientd3d/d3dparticle.c
+++ b/clientd3d/d3dparticle.c
@@ -124,8 +124,11 @@ static void D3DParticleInitialize(emitter *pEmitter, particle *pParticle)
 //////////////////////
 // Public Functions //
 //////////////////////
-void D3DParticleSystemReset(particle_system *pParticleSystem)
+void D3DParticleSystemClear(particle_system *pParticleSystem)
 {
+	if (pParticleSystem == nullptr)
+		return;
+
 	// Free memory from each emitter before clearing the pointers.
 	for (auto pEmitter : pParticleSystem->emitterList)
 	{

--- a/clientd3d/d3dparticle.h
+++ b/clientd3d/d3dparticle.h
@@ -64,7 +64,7 @@ struct particle_system
 ////////////////
 // Prototypes //
 ////////////////
-void	D3DParticleSystemReset(particle_system *pParticleSystem);
+void	D3DParticleSystemClear(particle_system *pParticleSystem);
 emitter* D3DParticleEmitterInit(particle_system *pParticleSystem, int time);
 void	D3DParticleEmitterUpdate(emitter *pEmitter, custom_xyz deltaPosition);
 void	D3DParticleSystemUpdate(particle_system *pParticleSystem, d3d_render_pool_new *pPool,

--- a/clientd3d/d3dparticle.h
+++ b/clientd3d/d3dparticle.h
@@ -11,7 +11,7 @@
 ///////////////
 // Constants //
 ///////////////
-static constexpr int MAX_PARTICLES = 128;
+static constexpr int MAX_PARTICLES_PER_EMITTER = 128;
 
 ////////////////
 // Structures //
@@ -36,12 +36,14 @@ struct emitter
 	int			timer;
 	int			timerBase;
 
-	// Base transform settings
+	// The world position of the emitter.
 	custom_xyz	position;
+
+	// Base velocity/rotation for newly initialized particles.
 	custom_xyz	velocity;
 	custom_xyz	rotation;
 
-	// Randomization ranges to apply to the base transform settings.
+	// Randomization ranges to apply to the base transform settings for particles.
 	// Setting both min and max to 0 means no variance.
 	custom_xyz		positionVarianceMin;
 	custom_xyz		positionVarianceMax;
@@ -51,7 +53,7 @@ struct emitter
 	custom_xyz		velocityVarianceMax;
 
 	custom_bgra	bgra;
-	particle	particles[MAX_PARTICLES];
+	particle	particles[MAX_PARTICLES_PER_EMITTER];
 };
 
 struct particle_system

--- a/clientd3d/d3dparticle.h
+++ b/clientd3d/d3dparticle.h
@@ -59,8 +59,6 @@ struct emitter
 struct particle_system
 {
 	std::vector<emitter*>	emitterList;
-	// Points to an external bool that determines if this particle system is active.
-	bool*					pIsActive;	
 };
 
 ////////////////

--- a/clientd3d/d3dparticle.h
+++ b/clientd3d/d3dparticle.h
@@ -8,57 +8,65 @@
 #ifndef __D3DPARTICLE_H__
 #define __D3DPARTICLE_H__
 
+///////////////
+// Constants //
+///////////////
 static constexpr int MAX_PARTICLES = 128;
-#define SANDSTORM_R		226
-#define SANDSTORM_G		153
-#define SANDSTORM_B		6
-#define SANDSTORM_A		255
 
 ////////////////
 // Structures //
 ////////////////
 struct particle
 {
-	int			energy;
-	custom_xyz	pos;
-	custom_xyz	oldPos;
+	custom_xyz	position;
+	custom_xyz	oldPosition;
 	custom_xyz	velocity;
 	custom_xyz	rotation;
 	custom_bgra	bgra;
+	// If false, the particle isn't included in the rendering.
+	bool		isActive;
+	int			timeLeft;
 };
 
 struct emitter
 {
 	int			numParticles;
-	int			energy;
+	int			nextSlot;
+	int			particleLifetime;
 	int			timer;
 	int			timerBase;
-	int			randomPos;
-	int			randomRot;
-	custom_xyz	pos;
-	custom_xyz	delta;
+
+	// Base transform settings
+	custom_xyz	position;
 	custom_xyz	velocity;
 	custom_xyz	rotation;
+
+	// Randomization ranges to apply to the base transform settings.
+	// Setting both min and max to 0 means no variance.
+	custom_xyz		positionVarianceMin;
+	custom_xyz		positionVarianceMax;
+	custom_xyz		rotationVarianceMin;
+	custom_xyz		rotationVarianceMax;
+	custom_xyz		velocityVarianceMin;
+	custom_xyz		velocityVarianceMax;
+
 	custom_bgra	bgra;
 	particle	particles[MAX_PARTICLES];
-	bool		bRandomize;
 };
 
 struct particle_system
 {
-	int			numParticles;
-	list_type	emitterList;
+	std::vector<emitter*>	emitterList;
+	// Points to an external bool that determines if this particle system is active.
+	bool*					pIsActive;	
 };
 
 ////////////////
 // Prototypes //
 ////////////////
 void	D3DParticleSystemReset(particle_system *pParticleSystem);
-void	D3DParticleEmitterInit(particle_system *pParticleSystem, float posX, float posY, float posZ,
-							float velX, float velY, float velZ, unsigned char b, unsigned char g,
-							unsigned char r, unsigned char a, int energy, int timerBase,
-							float rotX, float rotY, float rotZ, bool bRandomize, int randomPos, int randomRot);
-void	D3DParticleEmitterUpdate(emitter *pEmitter, float posX, float posY, float posZ);
+emitter* D3DParticleEmitterInit(particle_system *pParticleSystem, int time);
+void	D3DParticleEmitterUpdate(emitter *pEmitter, custom_xyz deltaPosition);
 void	D3DParticleSystemUpdate(particle_system *pParticleSystem, d3d_render_pool_new *pPool,
 							 d3d_render_cache_system *pCacheSystem);
 

--- a/clientd3d/d3dparticle.h
+++ b/clientd3d/d3dparticle.h
@@ -8,18 +8,16 @@
 #ifndef __D3DPARTICLE_H__
 #define __D3DPARTICLE_H__
 
-#define MAX_PARTICLES	128
+static constexpr int MAX_PARTICLES = 128;
 #define SANDSTORM_R		226
 #define SANDSTORM_G		153
 #define SANDSTORM_B		6
 #define SANDSTORM_A		255
 
-#define RAIN_R			128
-#define RAIN_G			128
-#define RAIN_B			128
-#define RAIN_A			128
-
-typedef struct particle
+////////////////
+// Structures //
+////////////////
+struct particle
 {
 	int			energy;
 	custom_xyz	pos;
@@ -27,11 +25,9 @@ typedef struct particle
 	custom_xyz	velocity;
 	custom_xyz	rotation;
 	custom_bgra	bgra;
-	float		size;
-	float		weight;
-} particle;
+};
 
-typedef struct emitter
+struct emitter
 {
 	int			numParticles;
 	int			energy;
@@ -46,21 +42,23 @@ typedef struct emitter
 	custom_bgra	bgra;
 	particle	particles[MAX_PARTICLES];
 	bool		bRandomize;
-} emitter;
+};
 
-typedef struct particle_system
+struct particle_system
 {
 	int			numParticles;
 	list_type	emitterList;
-} particle_system;
+};
 
+////////////////
+// Prototypes //
+////////////////
 void	D3DParticleSystemReset(particle_system *pParticleSystem);
 void	D3DParticleEmitterInit(particle_system *pParticleSystem, float posX, float posY, float posZ,
 							float velX, float velY, float velZ, unsigned char b, unsigned char g,
 							unsigned char r, unsigned char a, int energy, int timerBase,
 							float rotX, float rotY, float rotZ, bool bRandomize, int randomPos, int randomRot);
 void	D3DParticleEmitterUpdate(emitter *pEmitter, float posX, float posY, float posZ);
-//void	D3DParticleSystemRoomInit(particle_system *pParticleSystem, room_type *room);
 void	D3DParticleSystemUpdate(particle_system *pParticleSystem, d3d_render_pool_new *pPool,
 							 d3d_render_cache_system *pCacheSystem);
 

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -532,6 +532,7 @@ void D3DRenderShutDown(void)
 	D3DRenderPoolShutdown(&gParticlePool);
 
 	D3DRenderLightsShutdown();
+	D3DFxShutdown();
 
 	if (gpNoLookThrough)
 	{

--- a/clientd3d/d3drender_fx.c
+++ b/clientd3d/d3drender_fx.c
@@ -24,7 +24,7 @@ static particle_system sandParticleSystem;
 */
 static void SandstormInit(void)
 {
-	static constexpr int SAND_EMITTER_COUNT = 16;
+	static constexpr int SAND_EMITTER_COUNT = 8;
 	static constexpr int SAND_LIFETIME = 40;
 	static constexpr float SAND_EMITTER_RADIUS = 10000.0f;
 	static constexpr float SAND_Z_VARIANCE = 1000.0f;
@@ -34,10 +34,9 @@ static void SandstormInit(void)
 	static constexpr custom_bgra SANDSTORM_COLOR = {6,153,226,255};
 
 	D3DParticleSystemReset(&sandParticleSystem);
-	emitter* newEmitter = nullptr;
 	for (int i = 0; i < SAND_EMITTER_COUNT; i++)
 	{
-		newEmitter = D3DParticleEmitterInit(&sandParticleSystem, SAND_TIMER);
+		emitter* newEmitter = D3DParticleEmitterInit(&sandParticleSystem, SAND_TIMER);
 		newEmitter->particleLifetime = SAND_LIFETIME;
 		newEmitter->positionVarianceMin = {-SAND_EMITTER_RADIUS, -SAND_EMITTER_RADIUS, -SAND_Z_VARIANCE};
 		newEmitter->positionVarianceMax = {SAND_EMITTER_RADIUS, SAND_EMITTER_RADIUS, SAND_Z_VARIANCE * 2.0f};
@@ -87,10 +86,7 @@ void D3DRenderParticles(const ParticleSystemStructure& pss)
 		// Update world position of each emitter in the particle system.
 		for (emitter* pEmitter : pSystem->emitterList)
 		{
-			if (pEmitter)
-			{
-				D3DParticleEmitterUpdate(pEmitter, {pss.playerDeltaPos.x, pss.playerDeltaPos.y, pss.playerDeltaPos.z});
-			}
+			D3DParticleEmitterUpdate(pEmitter, {pss.playerDeltaPos.x, pss.playerDeltaPos.y, pss.playerDeltaPos.z});
 		}
 
 		// If a particle system is active, update its particles.

--- a/clientd3d/d3drender_fx.c
+++ b/clientd3d/d3drender_fx.c
@@ -7,55 +7,20 @@
 // Meridian is a registered trademark.
 #include "client.h"
 
-// Variables
-
+///////////////
+// Variables //
+///////////////
 static particle_system particleSystem;
 
-// Interfaces
-
-static void SandstormInit(void);
-
-// Implementations
-
-/**
-* Initializes the particle effects, specifically the sandstorm particle emitters.
-*/
-void D3DFxInit()
-{
-	SandstormInit();
-}
-
-/**
-* Updates and renders all active particle emitters, including the sandstorm effect, 
-* in the current frame.
-*/
-void D3DRenderParticles(const ParticleSystemStructure& pss)
-{
-	list_type	list;
-	emitter		*pEmitter;
-
-	for (list = particleSystem.emitterList; list != NULL; list = list->next)
-	{
-		pEmitter = (emitter *)list->data;
-
-		if (pEmitter)
-			D3DParticleEmitterUpdate(pEmitter, pss.playerDeltaPos.x, pss.playerDeltaPos.y, pss.playerDeltaPos.z);
-	}
-
-	if (effects.sand)
-	{
-		IDirect3DDevice9_SetVertexShader(gpD3DDevice, NULL);
-		IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, pss.vertexDeclaration);
-
-		D3DParticleSystemUpdate(&particleSystem, pss.particlePool, pss.particleCacheSystem);
-	}
-}
+/////////////////////////////
+// Internal Implementation //
+/////////////////////////////
 
 /**
 * Initializes the sandstorm particle emitters with predefined positions, energy, and colors for the 
 * particle system.
 */
-void SandstormInit(void)
+static void SandstormInit(void)
 {
 	static const int EMITTER_RADIUS = 12;
 	static const int EMITTER_ENERGY = 40;
@@ -241,6 +206,44 @@ void SandstormInit(void)
 		EMITTER_ENERGY, 1,
 		0, -PI / 500.0f, -PI / 500.0f,
 		1, 1024, 2);
+}
+
+////////////////////////////
+// Public Implementations //
+////////////////////////////
+
+/**
+* Initializes the particle effects, specifically the sandstorm particle emitters.
+*/
+void D3DFxInit()
+{
+	SandstormInit();
+}
+
+/**
+* Updates and renders all active particle emitters, including the sandstorm effect, 
+* in the current frame.
+*/
+void D3DRenderParticles(const ParticleSystemStructure& pss)
+{
+	list_type	list;
+	emitter		*pEmitter;
+
+	for (list = particleSystem.emitterList; list != NULL; list = list->next)
+	{
+		pEmitter = (emitter *)list->data;
+
+		if (pEmitter)
+			D3DParticleEmitterUpdate(pEmitter, pss.playerDeltaPos.x, pss.playerDeltaPos.y, pss.playerDeltaPos.z);
+	}
+
+	if (effects.sand)
+	{
+		IDirect3DDevice9_SetVertexShader(gpD3DDevice, NULL);
+		IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, pss.vertexDeclaration);
+
+		D3DParticleSystemUpdate(&particleSystem, pss.particlePool, pss.particleCacheSystem);
+	}
 }
 
 /**

--- a/clientd3d/d3drender_fx.c
+++ b/clientd3d/d3drender_fx.c
@@ -10,202 +10,51 @@
 ///////////////
 // Variables //
 ///////////////
-static particle_system particleSystem;
+static std::vector<particle_system*> particleSystemList;
+
+static particle_system sandParticleSystem;
 
 /////////////////////////////
 // Internal Implementation //
 /////////////////////////////
 
 /**
-* Initializes the sandstorm particle emitters with predefined positions, energy, and colors for the 
+* Initializes the sandstorm particle emitters with predefined positions, energy, and colors for the
 * particle system.
 */
 static void SandstormInit(void)
 {
-	static const int EMITTER_RADIUS = 12;
-	static const int EMITTER_ENERGY = 40;
-	static const int EMITTER_HEIGHT = 0;
+	static constexpr int SAND_EMITTER_COUNT = 16;
+	static constexpr int SAND_LIFETIME = 40;
+	static constexpr float SAND_EMITTER_RADIUS = 10000.0f;
+	static constexpr float SAND_Z_VARIANCE = 1000.0f;
+	static constexpr float SAND_VELOCITY = 400.0f;
+	static constexpr float SAND_TIMER = 1;
+	static constexpr float SAND_RAND_ROT = PI / 1000.0f;
+	static constexpr custom_bgra SANDSTORM_COLOR = {6,153,226,255};
 
-	D3DParticleSystemReset(&particleSystem);
-	// four corners, blowing around the perimeter
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * -724.0f, EMITTER_RADIUS * -724.0f, EMITTER_HEIGHT,
-		0, 500.0f, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * -724.0f, EMITTER_RADIUS * 724.0f, EMITTER_HEIGHT,
-		500.0f, 0, 0,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * 724.0f, EMITTER_RADIUS * 724.0f, EMITTER_HEIGHT,
-		0, -500.0f, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * 724.0f, EMITTER_RADIUS * -724.0f, EMITTER_HEIGHT,
-		-500.0f, 0, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
+	D3DParticleSystemReset(&sandParticleSystem);
+	emitter* newEmitter = nullptr;
+	for (int i = 0; i < SAND_EMITTER_COUNT; i++)
+	{
+		newEmitter = D3DParticleEmitterInit(&sandParticleSystem, SAND_TIMER);
+		newEmitter->particleLifetime = SAND_LIFETIME;
+		newEmitter->positionVarianceMin = {-SAND_EMITTER_RADIUS, -SAND_EMITTER_RADIUS, -SAND_Z_VARIANCE};
+		newEmitter->positionVarianceMax = {SAND_EMITTER_RADIUS, SAND_EMITTER_RADIUS, SAND_Z_VARIANCE * 2.0f};
+		newEmitter->rotationVarianceMin = {-SAND_RAND_ROT, -SAND_RAND_ROT, -SAND_RAND_ROT};
+		newEmitter->rotationVarianceMax = {SAND_RAND_ROT, SAND_RAND_ROT, SAND_RAND_ROT};
 
-	// four corners, blowing towards player
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * -724.0f, EMITTER_RADIUS * -724.0f, EMITTER_HEIGHT,
-		353.55f, 353.55f, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * -724.0f, EMITTER_RADIUS * 724.0f, EMITTER_HEIGHT,
-		353.55f, -353.55f, 0,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * 724.0f, EMITTER_RADIUS * 724.0f, EMITTER_HEIGHT,
-		-353.55f, -353.55f, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * 724.0f, EMITTER_RADIUS * -724.0f, EMITTER_HEIGHT,
-		-353.55f, 353.55f, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
+		// Each emitters fire sand particles at 22.5 degrees in a full circle.
+		float angle = (static_cast<float>(i) * 2.0f * PI) / static_cast<float>(SAND_EMITTER_COUNT);
+		float directionX = cosf(angle);
+		float directionY = sinf(angle);
+		newEmitter->velocity.x = directionX * SAND_VELOCITY;
+		newEmitter->velocity.y = directionY * SAND_VELOCITY;
+		newEmitter->bgra = SANDSTORM_COLOR;
+	}
 
-	// forward, left, right, and back, blowing towards player
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * -1024.0f, 0, EMITTER_HEIGHT,
-		500.0f, 0.0f, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * 1024.0f, 0, EMITTER_HEIGHT,
-		-500.0f, 0, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		0, EMITTER_RADIUS * 1024.0f, EMITTER_HEIGHT,
-		0, -500.0f, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		0, EMITTER_RADIUS * -1024.0f, EMITTER_HEIGHT,
-		0, 500.0f, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-
-	// four corners, blowing around the perimeter
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * -724.0f, EMITTER_RADIUS * -724.0f, EMITTER_HEIGHT,
-		0, 500.0f, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * -724.0f, EMITTER_RADIUS * 724.0f, EMITTER_HEIGHT,
-		500.0f, 0, 0,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * 724.0f, EMITTER_RADIUS * 724.0f, EMITTER_HEIGHT,
-		0, -500.0f, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * 724.0f, EMITTER_RADIUS * -724.0f, EMITTER_HEIGHT,
-		-500.0f, 0, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-
-	// four corners, blowing towards player
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * -724.0f, EMITTER_RADIUS * -724.0f, EMITTER_HEIGHT,
-		353.55f, 353.55f, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * -724.0f, EMITTER_RADIUS * 724.0f, EMITTER_HEIGHT,
-		353.55f, -353.55f, 0,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * 724.0f, EMITTER_RADIUS * 724.0f, EMITTER_HEIGHT,
-		-353.55f, -353.55f, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * 724.0f, EMITTER_RADIUS * -724.0f, EMITTER_HEIGHT,
-		-353.55f, 353.55f, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-
-	// forward, left, right, and back, blowing towards player
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * -1024.0f, 0, EMITTER_HEIGHT,
-		500.0f, 0.0f, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		EMITTER_RADIUS * 1024.0f, 0, EMITTER_HEIGHT,
-		-500.0f, 0, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		0, EMITTER_RADIUS * 1024.0f, EMITTER_HEIGHT,
-		0, -500.0f, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
-	D3DParticleEmitterInit(&particleSystem,
-		0, EMITTER_RADIUS * -1024.0f, EMITTER_HEIGHT,
-		0, 500.0f, 0.0f,
-		SANDSTORM_B, SANDSTORM_G, SANDSTORM_R, SANDSTORM_A,
-		EMITTER_ENERGY, 1,
-		0, -PI / 500.0f, -PI / 500.0f,
-		1, 1024, 2);
+	sandParticleSystem.pIsActive = &effects.sand;
+	particleSystemList.push_back(&sandParticleSystem);
 }
 
 ////////////////////////////
@@ -217,37 +66,43 @@ static void SandstormInit(void)
 */
 void D3DFxInit()
 {
+	particleSystemList.clear();
 	SandstormInit();
 }
 
 /**
-* Updates and renders all active particle emitters, including the sandstorm effect, 
+* Updates and renders all active particle emitters, including the sandstorm effect,
 * in the current frame.
 */
 void D3DRenderParticles(const ParticleSystemStructure& pss)
 {
-	list_type	list;
-	emitter		*pEmitter;
+	gpD3DDevice->SetVertexShader(nullptr);
+	gpD3DDevice->SetVertexDeclaration(pss.vertexDeclaration);
 
-	for (list = particleSystem.emitterList; list != NULL; list = list->next)
+	for (particle_system* pSystem : particleSystemList)
 	{
-		pEmitter = (emitter *)list->data;
+		// Check if the particle system being iterated is active.
+		bool particleSystemActive = (pSystem->pIsActive != nullptr && *(pSystem->pIsActive));
 
-		if (pEmitter)
-			D3DParticleEmitterUpdate(pEmitter, pss.playerDeltaPos.x, pss.playerDeltaPos.y, pss.playerDeltaPos.z);
-	}
+		// Update world position of each emitter in the particle system.
+		for (emitter* pEmitter : pSystem->emitterList)
+		{
+			if (pEmitter)
+			{
+				D3DParticleEmitterUpdate(pEmitter, {pss.playerDeltaPos.x, pss.playerDeltaPos.y, pss.playerDeltaPos.z});
+			}
+		}
 
-	if (effects.sand)
-	{
-		IDirect3DDevice9_SetVertexShader(gpD3DDevice, NULL);
-		IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, pss.vertexDeclaration);
-
-		D3DParticleSystemUpdate(&particleSystem, pss.particlePool, pss.particleCacheSystem);
+		// If a particle system is active, update its particles.
+		if (particleSystemActive)
+		{
+			D3DParticleSystemUpdate(pSystem, pss.particlePool, pss.particleCacheSystem);
+		}
 	}
 }
 
 /**
-* Applies post-render overlay effects such as alpha blending, screen flashes, and pain effects, 
+* Applies post-render overlay effects such as alpha blending, screen flashes, and pain effects,
 * and resets the rendering cache.
 */
 void D3DPostOverlayEffects(const FxRenderSystemStructure& fxrss)
@@ -663,7 +518,7 @@ void D3DPostOverlayEffects(const FxRenderSystemStructure& fxrss)
 }
 
 /**
-* Creates a blur and wave distortion effects using frame buffers, applying it to the current screen 
+* Creates a blur and wave distortion effects using frame buffers, applying it to the current screen
 * using a series of textures.
 */
 void D3DFxBlurWaver(const FxRenderSystemStructure& fxRss)

--- a/clientd3d/d3drender_fx.c
+++ b/clientd3d/d3drender_fx.c
@@ -10,8 +10,6 @@
 ///////////////
 // Variables //
 ///////////////
-static std::vector<particle_system*> particleSystemList;
-
 static particle_system sandParticleSystem;
 
 /////////////////////////////
@@ -51,9 +49,6 @@ static void SandstormInit(void)
 		newEmitter->velocity.y = directionY * SAND_VELOCITY;
 		newEmitter->bgra = SANDSTORM_COLOR;
 	}
-
-	sandParticleSystem.pIsActive = &effects.sand;
-	particleSystemList.push_back(&sandParticleSystem);
 }
 
 ////////////////////////////
@@ -65,7 +60,6 @@ static void SandstormInit(void)
 */
 void D3DFxInit()
 {
-	particleSystemList.clear();
 	SandstormInit();
 }
 
@@ -78,22 +72,16 @@ void D3DRenderParticles(const ParticleSystemStructure& pss)
 	gpD3DDevice->SetVertexShader(nullptr);
 	gpD3DDevice->SetVertexDeclaration(pss.vertexDeclaration);
 
-	for (particle_system* pSystem : particleSystemList)
+	// Update world position of each emitter in the particle system.
+	for (emitter* pEmitter : sandParticleSystem.emitterList)
 	{
-		// Check if the particle system being iterated is active.
-		bool particleSystemActive = (pSystem->pIsActive != nullptr && *(pSystem->pIsActive));
+		D3DParticleEmitterUpdate(pEmitter, {pss.playerDeltaPos.x, pss.playerDeltaPos.y, pss.playerDeltaPos.z});
+	}
 
-		// Update world position of each emitter in the particle system.
-		for (emitter* pEmitter : pSystem->emitterList)
-		{
-			D3DParticleEmitterUpdate(pEmitter, {pss.playerDeltaPos.x, pss.playerDeltaPos.y, pss.playerDeltaPos.z});
-		}
-
-		// If a particle system is active, update its particles.
-		if (particleSystemActive)
-		{
-			D3DParticleSystemUpdate(pSystem, pss.particlePool, pss.particleCacheSystem);
-		}
+	// If the particle system is active, update its particles.
+	if (effects.sand)
+	{
+		D3DParticleSystemUpdate(&sandParticleSystem, pss.particlePool, pss.particleCacheSystem);
 	}
 }
 

--- a/clientd3d/d3drender_fx.c
+++ b/clientd3d/d3drender_fx.c
@@ -31,7 +31,7 @@ static void SandstormInit(void)
 	static constexpr float SAND_RAND_ROT = PI / 1000.0f;
 	static constexpr custom_bgra SANDSTORM_COLOR = {6,153,226,255};
 
-	D3DParticleSystemReset(&sandParticleSystem);
+	D3DParticleSystemClear(&sandParticleSystem);
 	for (int i = 0; i < SAND_EMITTER_COUNT; i++)
 	{
 		emitter* newEmitter = D3DParticleEmitterInit(&sandParticleSystem, SAND_TIMER);
@@ -61,6 +61,11 @@ static void SandstormInit(void)
 void D3DFxInit()
 {
 	SandstormInit();
+}
+
+void D3DFxShutdown()
+{
+	D3DParticleSystemClear(&sandParticleSystem);
 }
 
 /**

--- a/clientd3d/d3drender_fx.h
+++ b/clientd3d/d3drender_fx.h
@@ -16,13 +16,13 @@
 // Structures //
 ////////////////
 struct ParticleSystemStructure {
-    LPDIRECT3DVERTEXDECLARATION9 vertexDeclaration;
+    IDirect3DVertexDeclaration9* vertexDeclaration;
     const custom_xyz& playerDeltaPos;
     d3d_render_pool_new* particlePool;
     d3d_render_cache_system* particleCacheSystem;
 
     ParticleSystemStructure(
-        LPDIRECT3DVERTEXDECLARATION9 vertexDeclarationParam,
+        IDirect3DVertexDeclaration9* vertexDeclarationParam,
         const custom_xyz& playerDeltaPosParam,
         d3d_render_pool_new* particlePoolParam,
         d3d_render_cache_system* particleCacheSystemParam)
@@ -34,13 +34,13 @@ struct ParticleSystemStructure {
 };
 
 struct FxRenderSystemStructure {
-    LPDIRECT3DVERTEXDECLARATION9 vertexDeclaration;
+    IDirect3DVertexDeclaration9* vertexDeclaration;
     d3d_render_pool_new* objectPool;
     d3d_render_cache_system* objectCacheSystem;
     d3d_render_pool_new* effectPool;
     d3d_render_cache_system* effectCacheSystem;
-    LPDIRECT3DTEXTURE9 (&backBufferTex)[16];
-    LPDIRECT3DTEXTURE9 backBufferTexFull;
+    IDirect3DTexture9* (&backBufferTex)[16];
+    IDirect3DTexture9* backBufferTexFull;
     int fullTextureSize;
     int smallTextureSize;
     const D3DMATRIX& transformMatrix;
@@ -49,13 +49,13 @@ struct FxRenderSystemStructure {
     int	screenHeight;
 
     FxRenderSystemStructure(
-        LPDIRECT3DVERTEXDECLARATION9 vertexDeclarationParam,
+        IDirect3DVertexDeclaration9* vertexDeclarationParam,
         d3d_render_pool_new* objectPoolParam,
         d3d_render_cache_system* objectCacheSystemParam,
         d3d_render_pool_new* effectPoolParam,
         d3d_render_cache_system* effectCacheSystemParam,
-        LPDIRECT3DTEXTURE9 (&backBufferTexParam)[16],
-        LPDIRECT3DTEXTURE9 backBufferTexFullParam,
+        IDirect3DTexture9* (&backBufferTexParam)[16],
+        IDirect3DTexture9* backBufferTexFullParam,
         int fullTextureSizeParam,
         int smallTextureSizeParam,
         const D3DMATRIX& transformMatrixParam,

--- a/clientd3d/d3drender_fx.h
+++ b/clientd3d/d3drender_fx.h
@@ -6,7 +6,7 @@
 //
 // Meridian is a registered trademark.
 //
-// Render area visual effects such as sandstorm, rain, etc as well as visual effects such 
+// Render area visual effects such as sandstorm, rain, etc as well as visual effects such
 // as being dazzled or blinded are provided here.
 //
 #ifndef _D3DRENDERFX_H
@@ -82,6 +82,7 @@ struct FxRenderSystemStructure {
 // Prototypes //
 ////////////////
 void D3DFxInit();
+void D3DFxShutdown();
 void D3DRenderParticles(const ParticleSystemStructure& pss);
 void D3DPostOverlayEffects(const FxRenderSystemStructure& fxrss);
 void D3DFxBlurWaver(const FxRenderSystemStructure& renderSystemStructure);

--- a/clientd3d/d3drender_fx.h
+++ b/clientd3d/d3drender_fx.h
@@ -12,6 +12,9 @@
 #ifndef _D3DRENDERFX_H
 #define _D3DRENDERFX_H
 
+////////////////
+// Structures //
+////////////////
 struct ParticleSystemStructure {
     LPDIRECT3DVERTEXDECLARATION9 vertexDeclaration;
     const custom_xyz& playerDeltaPos;
@@ -75,9 +78,12 @@ struct FxRenderSystemStructure {
     {}
 };
 
+////////////////
+// Prototypes //
+////////////////
 void D3DFxInit();
-void D3DFxBlurWaver(const FxRenderSystemStructure& renderSystemStructure);
-void D3DPostOverlayEffects(const FxRenderSystemStructure& fxrss);
 void D3DRenderParticles(const ParticleSystemStructure& pss);
+void D3DPostOverlayEffects(const FxRenderSystemStructure& fxrss);
+void D3DFxBlurWaver(const FxRenderSystemStructure& renderSystemStructure);
 
 #endif	/* #ifndef _D3DRENDERFX_H */


### PR DESCRIPTION
This PR refactors the particle system to improve readability and performance.  Its randomness is also updated to provide better distribution and also offer more customization on how to vary a particle's position, rotation, and velocity.  These changes only affect the sandstorm effect for now, and helps set up the code to include the future weather particle setup.

Refactoring
- Overhauled randomness to use mt19937 for better distributions.  Added randomizing particle position/rotation/velocity.
- Particle creation now uses circular buffering instead of a for-loop to optimize fetching of new particles.
- Refactored sandstorm emitter setup to use a for-loop to set up emitters, making it easier to read and adjust.
- Extracted parts of `D3DParticleSystemUpdate()` and made them into their own functions.
- Updated C-style code to use C++ equivalents.
- Fixed possible leak from emitters that were never freed upon game shutdown.

Cleanup
- Reorganized `d3dparticle.c` and `d3drender_fx.c` 
- Removed unused variables and redundant if-statements.