### PR TITLE
Cancel timers that reference unreachable objects.

### DIFF
--- a/blakserv/garbage.c
+++ b/blakserv/garbage.c
@@ -56,6 +56,7 @@ bool ResetObjectReference(val_type *vobject_ptr);
 void CompactObject(object_node *o);
 
 /* timer garbage collection (well, renumbering) */
+void CancelOrphanedTimer(timer_node *t);
 void RenumberTimer(timer_node *t);
 void RenumberObjectTimerReferences(object_node *o);
 void RenumberListNodeTimerReferences(list_node *l,int list_id);
@@ -139,11 +140,21 @@ void GarbageCollect()
     *        and change its object id to that object's new object id.
     *  then, go through each object in increasing numerical order and
     *        move it to its new object id spot.
+    *
+    * We also cancel any timers that point to unreachable objects.  An
+    * alternative would be to instead consider timers' target objects
+    * as reachable GC roots.  The problem with that is that Blakod
+    * bugs that fail to correctly cancel timers could lead to objects
+    * that are kept live forever (timer fires, new timer is set up in
+    * handler function -> object never dies).  The symptom would be
+    * ever-increasing memory usage that would be very difficult to
+    * track down.
     */
 
    ForEachObject(ClearObjectGarbageRef);
    ForEachUser(MarkUserObjectNodes);
    MarkObject(GetSystemObjectID());
+   ForEachTimer(CancelOrphanedTimer);
    ForEachObject(DeleteUnreferencedObject);
 
    next_renumber = SERVER_MERGE_BASE;
@@ -494,6 +505,15 @@ bool ResetObjectReference(val_type *vobject_ptr)
 void CompactObject(object_node *o)
 {
    MoveObject(o->garbage_ref,o->object_id);
+}
+
+// If the timer targets an otherwise-unreachable object, delete the
+// timer.
+void CancelOrphanedTimer(timer_node *t)
+{
+   object_node *o = GetObjectByID(t->object_id);
+   if (o == NULL || o->garbage_ref == UNREFERENCED)
+      DeleteTimer(t->timer_id);
 }
 
 void RenumberTimer(timer_node *t)

--- a/blakserv/timer.c
+++ b/blakserv/timer.c
@@ -346,13 +346,14 @@ timer_node * GetTimerByID(int timer_id)
 
 void ForEachTimer(void (*callback_func)(timer_node *t))
 {
-   timer_node *t;
+   timer_node *t, *next;
 
    t = timers;
    while (t != NULL)
    {
+      next = t->next;  // In case callback_func deletes timer
       callback_func(t);
-      t = t->next;
+      t = next;
    }
 }
 


### PR DESCRIPTION
This should fix some errors in the server log, in particular GC errors related to RainbowFern timers.  Their ChangeColor timers stay around even after their target object becomes otherwise unreachable, which causes an error at the next garbage collection.

It's not clear why the RainbowFern timer isn't getting cleared in the Delete function, but this change is defensive against similar Blakod errors.