### PR TITLE
QOL: Reduce shroud concentration time

### DIFF
--- a/kod/object/passive/spell/shroud.kod
+++ b/kod/object/passive/spell/shroud.kod
@@ -40,7 +40,7 @@ classvars:
    viSpell_level = 3
    viMana = 10
    viSpellExertion = 10
-   viCast_time = 30000
+   viCast_time = 7000
 
    viChance_To_Increase = 25
 


### PR DESCRIPTION
**What**
This change updates the concentration time to seven seconds, down from thirty.  

**Why**
A recent uptick in use of Shatter and Swap has caused a good deal of conversation about the painful nature of Shrouding items; the counterplay.

**Rationale**
I settled on seven seconds in terms of relative 'battle preparation' tasks.  Shrouding your shillings, weapon, armor and most expensive reagent now takes the same amount of time as enchanting your weapon.