### PR TITLE
Refactor: Centralize game unit to radian rendering constants for hardware renderer.

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -665,8 +665,8 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	int anglePitch = PlayerGetHeightOffset();
 
-	MatrixRotateY(&rot, static_cast<float>(angleHeading) * 360.0f / 4096.0f * PI / 180.0f);
-	MatrixRotateX(&mat, static_cast<float>(anglePitch) * 45.0f / 414.0f * PI / 180.0f);
+	MatrixRotateY(&rot, static_cast<float>(angleHeading) * GAME_ANGLE_TO_RAD);
+	MatrixRotateX(&mat, static_cast<float>(anglePitch) * Y_UNIT_TO_VIEW_RAD);
 	MatrixMultiply(&rot, &rot, &mat);
 	MatrixTranslate(&trans, -static_cast<float>(params->viewer_x), 
 							-static_cast<float>(params->viewer_height), 

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -657,11 +657,9 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	MatrixIdentity(&mat);
 	gpD3DDevice->SetTransform(D3DTS_WORLD, &mat);
 
-	// A full 360-degree circle is 4096 game units. Player camera rotation is offset
-	// by 270 degrees (3072 game units) to align it with the legacy engine orientation.
-	int angleHeading = params->viewer_angle + 3072;
-	if (angleHeading >= 4096)
-		angleHeading -= 4096;
+	int angleHeading = params->viewer_angle + LEGACY_HEADING_OFFSET;
+	if (angleHeading >= NUMDEGREES)
+		angleHeading -= NUMDEGREES;
 
 	int anglePitch = PlayerGetHeightOffset();
 

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -666,7 +666,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	int anglePitch = PlayerGetHeightOffset();
 
 	MatrixRotateY(&rot, static_cast<float>(angleHeading) * GAME_ANGLE_TO_RAD);
-	MatrixRotateX(&mat, static_cast<float>(anglePitch) * Y_UNIT_TO_VIEW_RAD);
+	MatrixRotateX(&mat, static_cast<float>(anglePitch) * Y_UNIT_TO_VIEW_PITCH_RAD);
 	MatrixMultiply(&rot, &rot, &mat);
 	MatrixTranslate(&trans, -static_cast<float>(params->viewer_x), 
 							-static_cast<float>(params->viewer_height), 

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -36,6 +36,17 @@ static constexpr float Z_RANGE = 200000.0f;
 // Standard ASCII table, minus the first 32 non-printable control characters.
 static constexpr int NUM_CHARS = 128 - 32;
 
+// The software renderer's angles are in game units. A full 360-degree circle is 4096 game units.
+// Note that matrix rotations expect radians.
+static constexpr float GAME_ANGLE_TO_RAD = (2.0f * PI) / static_cast<float>(NUMDEGREES);
+
+// Maps legacy software y-offset units (max 414 units from the center view) to world-space pitch (50 degrees).
+// Derived from software renderer's max vertical offset calculation: (3 * CLASSIC_HEIGHT / 2), where CLASSIC_HEIGHT = 276.
+static constexpr float Y_UNIT_TO_WORLD_RAD = deg_to_rad(50.0f) / 414.0f;
+
+// For the backgrounds and player camera, the angle is instead 45 degrees.  Helps prevent sliding artifacts. 
+static constexpr float Y_UNIT_TO_VIEW_RAD = deg_to_rad(45.0f) / 414.0f;
+
 /////////////
 // Globals //
 /////////////
@@ -87,16 +98,6 @@ struct font_3d
 //////////////////////
 // Helper Functions //
 //////////////////////
-constexpr float deg_to_rad(float degrees)
-{
-	constexpr float DEG_TO_RAD_FACTOR = PITWICE / 360.0f;
-	return degrees * DEG_TO_RAD_FACTOR;
-}
-constexpr float rad_to_deg(float radians)
-{	
-	constexpr float RAD_TO_DEG_FACTOR = 360.0f / PITWICE;
-	return radians * RAD_TO_DEG_FACTOR;
-}
 
 // Calculates light range in world units.
 constexpr float dlight_scale(float intensity)

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -40,12 +40,13 @@ static constexpr int NUM_CHARS = 128 - 32;
 // Note that matrix rotations expect radians.
 static constexpr float GAME_ANGLE_TO_RAD = (2.0f * PI) / static_cast<float>(NUMDEGREES);
 
-// Maps legacy software y-offset units (max 414 units from the center view) to world-space pitch (50 degrees).
-// Derived from software renderer's max vertical offset calculation: (3 * CLASSIC_HEIGHT / 2), where CLASSIC_HEIGHT = 276.
-static constexpr float Y_UNIT_TO_WORLD_RAD = deg_to_rad(50.0f) / 414.0f;
+// Maps legacy software y-offset units to world-space pitch for rendering objects.
+// Derived from software renderer's max vertical offset calculation in 'move.c'.
+static constexpr float Y_UNIT_TO_OBJECT_PITCH_RAD = deg_to_rad(50.0f) / static_cast<float>((3 * CLASSIC_HEIGHT) / 2);
 
-// For the backgrounds and player camera, the angle is instead 45 degrees.  Helps prevent sliding artifacts. 
-static constexpr float Y_UNIT_TO_VIEW_RAD = deg_to_rad(45.0f) / 414.0f;
+// Maps legacy software y-offset units to view-space pitch for rendering backgrounds and player view.
+// The angle here is instead 45 degrees to help prevent sliding artifacts.
+static constexpr float Y_UNIT_TO_VIEW_PITCH_RAD = deg_to_rad(45.0f) / static_cast<float>((3 * CLASSIC_HEIGHT) / 2);
 
 /////////////
 // Globals //

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -40,6 +40,9 @@ static constexpr int NUM_CHARS = 128 - 32;
 // Note that matrix rotations expect radians.
 static constexpr float GAME_ANGLE_TO_RAD = (2.0f * PI) / static_cast<float>(NUMDEGREES);
 
+// Player camera rotation is offset by 270 degrees to align it with the legacy engine orientation.
+static constexpr int LEGACY_HEADING_OFFSET = (3 * NUMDEGREES) / 4;
+
 // Maps legacy software y-offset units to world-space pitch for rendering objects.
 // Derived from software renderer's max vertical offset calculation in 'move.c'.
 static constexpr float Y_UNIT_TO_OBJECT_PITCH_RAD = deg_to_rad(50.0f) / static_cast<float>((3 * CLASSIC_HEIGHT) / 2);

--- a/clientd3d/d3drender_bgoverlays.c
+++ b/clientd3d/d3drender_bgoverlays.c
@@ -98,15 +98,11 @@ void D3DRenderBackgroundOverlays(const BackgroundOverlaysRenderStateParams& bgoR
 		MatrixIdentity(&mat);
 		MatrixIdentity(&rot);
 
-		const float FULL_CIRCLE_TO_DEGREES = 360.0f / 4096.0f;
-		const float DEGREES_TO_RADIANS = PI / 180.0f;
-		const float ANGLE_RANGE_TO_DEGREES = 45.0f / 414.0f;
-
 		const auto& angleHeading = bgoSceneParams.angleHeading;
 		const auto& anglePitch = bgoSceneParams.anglePitch;
 
-		MatrixRotateY(&rot, (float)angleHeading * FULL_CIRCLE_TO_DEGREES * DEGREES_TO_RADIANS);
-		MatrixRotateX(&mat, (float)anglePitch * ANGLE_RANGE_TO_DEGREES * DEGREES_TO_RADIANS);
+		MatrixRotateY(&rot, static_cast<float>(angleHeading) * GAME_ANGLE_TO_RAD);
+		MatrixRotateX(&mat, static_cast<float>(anglePitch) * Y_UNIT_TO_VIEW_RAD);
 		MatrixTranspose(&rot, &rot);
 		MatrixTranslate(&mat, bg_overlay_pos.x, bg_overlay_pos.z, bg_overlay_pos.y);
 		MatrixMultiply(&pChunk->xForm, &rot, &mat);

--- a/clientd3d/d3drender_bgoverlays.c
+++ b/clientd3d/d3drender_bgoverlays.c
@@ -102,7 +102,7 @@ void D3DRenderBackgroundOverlays(const BackgroundOverlaysRenderStateParams& bgoR
 		const auto& anglePitch = bgoSceneParams.anglePitch;
 
 		MatrixRotateY(&rot, static_cast<float>(angleHeading) * GAME_ANGLE_TO_RAD);
-		MatrixRotateX(&mat, static_cast<float>(anglePitch) * Y_UNIT_TO_VIEW_RAD);
+		MatrixRotateX(&mat, static_cast<float>(anglePitch) * Y_UNIT_TO_VIEW_PITCH_RAD);
 		MatrixTranspose(&rot, &rot);
 		MatrixTranslate(&mat, bg_overlay_pos.x, bg_overlay_pos.z, bg_overlay_pos.y);
 		MatrixMultiply(&pChunk->xForm, &rot, &mat);

--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -1125,7 +1125,7 @@ void D3DRenderOverlaysDraw(
 						bottomRight.w = 1.0f;
 
 						MatrixRotateY(&rot, static_cast<float>(angleHeading) * GAME_ANGLE_TO_RAD);
-						MatrixRotateX(&mat, static_cast<float>(anglePitch) * Y_UNIT_TO_WORLD_RAD);
+						MatrixRotateX(&mat, static_cast<float>(anglePitch) * Y_UNIT_TO_OBJECT_PITCH_RAD);
 						MatrixMultiply(&rot, &rot, &mat);
 						MatrixTranslate(&trans, -(float)objectsRenderParams.params->viewer_x, 
 							-(float)objectsRenderParams.params->viewer_height, -(float)objectsRenderParams.params->viewer_y);
@@ -1672,7 +1672,7 @@ void D3DRenderObjectsDraw(
 			bottomRight.w = 1.0f;
 
 			MatrixRotateY(&rot, static_cast<float>(angleHeading) * GAME_ANGLE_TO_RAD);
-			MatrixRotateX(&mat, static_cast<float>(anglePitch) * Y_UNIT_TO_WORLD_RAD);
+			MatrixRotateX(&mat, static_cast<float>(anglePitch) * Y_UNIT_TO_OBJECT_PITCH_RAD);
 			MatrixMultiply(&rot, &rot, &mat);
 			MatrixTranslate(&trans, -(float)objectsRenderParams.params->viewer_x, 
 				-(float)objectsRenderParams.params->viewer_height, -(float)objectsRenderParams.params->viewer_y);

--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -170,7 +170,7 @@ long D3DRenderObjects(
 	int angleHeading = objectsRenderParams.params->viewer_angle + 3 * NUMDEGREES / 4;
 	if (angleHeading >= NUMDEGREES)
 		angleHeading -= NUMDEGREES;
-	float theta = (float)angleHeading * (2.0f * PI / (float)NUMDEGREES);
+	float theta = static_cast<float>(angleHeading) * GAME_ANGLE_TO_RAD;
 	float fwdX = sinf(theta);
 	float fwdY = cosf(theta);
 
@@ -430,7 +430,7 @@ void D3DRenderNamesDraw3D(
 			}
 		}
 
-		MatrixRotateY(&rot, (float)angleHeading * 360.0f / (float)NUMDEGREES * PI / 180.0f);
+		MatrixRotateY(&rot, static_cast<float>(angleHeading) * GAME_ANGLE_TO_RAD);
 		MatrixTranspose(&rot, &rot);
 		MatrixTranslate(&mat, (float)pRNode->motion.x, (float)std::max(bottom,
 			(long)pRNode->motion.z) - depth +
@@ -1028,7 +1028,7 @@ void D3DRenderOverlaysDraw(
 						}
 					}
 
-					MatrixRotateY(&rot, (float)angleHeading * 360.0f / (float)NUMDEGREES * PI / 180.0f);
+					MatrixRotateY(&rot, static_cast<float>(angleHeading) * GAME_ANGLE_TO_RAD);
 					MatrixTranspose(&rot, &rot);
 					MatrixTranslate(&mat, (float)pRNode->motion.x, (float)std::max(bottom,
 						(long)pRNode->motion.z) - depthf, (float)pRNode->motion.y);
@@ -1124,8 +1124,8 @@ void D3DRenderOverlaysDraw(
 						bottomRight.z = 0;
 						bottomRight.w = 1.0f;
 
-						MatrixRotateY(&rot, (float)angleHeading * 360.0f / (float)NUMDEGREES * PI / 180.0f);
-						MatrixRotateX(&mat, (float)anglePitch * 50.0f / 414.0f * PI / 180.0f);
+						MatrixRotateY(&rot, static_cast<float>(angleHeading) * GAME_ANGLE_TO_RAD);
+						MatrixRotateX(&mat, static_cast<float>(anglePitch) * Y_UNIT_TO_WORLD_RAD);
 						MatrixMultiply(&rot, &rot, &mat);
 						MatrixTranslate(&trans, -(float)objectsRenderParams.params->viewer_x, 
 							-(float)objectsRenderParams.params->viewer_height, -(float)objectsRenderParams.params->viewer_y);
@@ -1534,7 +1534,7 @@ void D3DRenderObjectsDraw(
 			}
 		}
 
-		MatrixRotateY(&rot, (float)angleHeading * 360.0f / (float)NUMDEGREES * PI / 180.0f);
+		MatrixRotateY(&rot, static_cast<float>(angleHeading) * GAME_ANGLE_TO_RAD);
 		MatrixTranspose(&rot, &rot);
 		MatrixTranslate(&mat, (float)pRNode->motion.x, std::max(bottom, (long)pRNode->motion.z) - depth,
 			(float)pRNode->motion.y);
@@ -1671,8 +1671,8 @@ void D3DRenderObjectsDraw(
 			bottomRight.z = 0;
 			bottomRight.w = 1.0f;
 
-			MatrixRotateY(&rot, (float)angleHeading * 360.0f / (float)NUMDEGREES * PI / 180.0f);
-			MatrixRotateX(&mat, (float)anglePitch * 50.0f / 414.0f * PI / 180.0f);
+			MatrixRotateY(&rot, static_cast<float>(angleHeading) * GAME_ANGLE_TO_RAD);
+			MatrixRotateX(&mat, static_cast<float>(anglePitch) * Y_UNIT_TO_WORLD_RAD);
 			MatrixMultiply(&rot, &rot, &mat);
 			MatrixTranslate(&trans, -(float)objectsRenderParams.params->viewer_x, 
 				-(float)objectsRenderParams.params->viewer_height, -(float)objectsRenderParams.params->viewer_y);
@@ -1924,7 +1924,7 @@ int D3DRenderProjectilesDraw(const ObjectsRenderParams& objectsRenderParams)
 		if (angle < -NUMDEGREES)
 			angle += NUMDEGREES;
 
-		MatrixRotateY(&rot, (float)angleHeading * 360.0f / (float)NUMDEGREES * PI / 180.0f);
+		MatrixRotateY(&rot, static_cast<float>(angleHeading) * GAME_ANGLE_TO_RAD);
 		MatrixTranspose(&rot, &rot);
 		MatrixTranslate(&mat, (float)pProjectile->motion.x, (float)pProjectile->motion.z,
 			(float)pProjectile->motion.y);

--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -657,7 +657,7 @@ void D3DRenderOverlaysDraw(
 
 	const auto* player = GetPlayerInfo();;
 
-	angleHeading = objectsRenderParams.params->viewer_angle + 3 * NUMDEGREES / 4;
+	angleHeading = objectsRenderParams.params->viewer_angle + LEGACY_HEADING_OFFSET;
 	if (angleHeading >= NUMDEGREES)
 		angleHeading -= NUMDEGREES;
 

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -154,8 +154,8 @@ static void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, in
 	MatrixIdentity(&mat);
 	gpD3DDevice->SetTransform(D3DTS_WORLD, &mat);
 
-	MatrixRotateY(&rot, static_cast<float>(angleHeading) * 360.0f / 4096.0f * PI / 180.0f);
-	MatrixRotateX(&mat, static_cast<float>(anglePitch) * 45.0f / 414.0f * PI / 180.0f);
+	MatrixRotateY(&rot, static_cast<float>(angleHeading) * GAME_ANGLE_TO_RAD);
+	MatrixRotateX(&mat, static_cast<float>(anglePitch) * Y_UNIT_TO_VIEW_RAD);
 	MatrixMultiply(&mat, &rot, &mat);
 
 	gpD3DDevice->SetTransform(D3DTS_VIEW, &mat);

--- a/clientd3d/d3drender_skybox.c
+++ b/clientd3d/d3drender_skybox.c
@@ -155,7 +155,7 @@ static void D3DRenderSkyboxDraw(d3d_render_pool_new* pPool, int angleHeading, in
 	gpD3DDevice->SetTransform(D3DTS_WORLD, &mat);
 
 	MatrixRotateY(&rot, static_cast<float>(angleHeading) * GAME_ANGLE_TO_RAD);
-	MatrixRotateX(&mat, static_cast<float>(anglePitch) * Y_UNIT_TO_VIEW_RAD);
+	MatrixRotateX(&mat, static_cast<float>(anglePitch) * Y_UNIT_TO_VIEW_PITCH_RAD);
 	MatrixMultiply(&mat, &rot, &mat);
 
 	gpD3DDevice->SetTransform(D3DTS_VIEW, &mat);

--- a/clientd3d/drawdefs.h
+++ b/clientd3d/drawdefs.h
@@ -1,4 +1,4 @@
-// Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+// Meridian 59, Copyright 1994-2026 Andrew Kirmse and Chris Kirmse.
 // All rights reserved.
 //
 // This software is distributed under a license that is described in
@@ -63,10 +63,6 @@
 #define VIEWER_DISTANCE  (FINENESS >> 1)         /* Distance from viewer to screen in pixels */
 #define LOG_VIEWER_DISTANCE  (LOG_FINENESS - 1)
 
-/* Convert from pseudo degrees to radians */
-#define DegToRad(x) ((float) (x) * PITWICE / NUMDEGREES)
-#define RadToDeg(x) ((long)  ((x) * NUMDEGREES / PITWICE))
-
 constexpr float deg_to_rad(float degrees)
 {
 	constexpr float DEG_TO_RAD_FACTOR = PITWICE / 360.0f;
@@ -76,6 +72,18 @@ constexpr float rad_to_deg(float radians)
 {	
 	constexpr float RAD_TO_DEG_FACTOR = 360.0f / PITWICE;
 	return radians * RAD_TO_DEG_FACTOR;
+}
+
+/* Convert between pseudo degrees and radians */
+constexpr float game_angle_to_rad(float angle)
+{
+	constexpr float GAME_ANGLE_TO_RAD_FACTOR = PITWICE / static_cast<float>(NUMDEGREES);
+	return angle * GAME_ANGLE_TO_RAD_FACTOR;
+}
+constexpr long rad_to_game_angle(float radians)
+{
+	constexpr float RAD_TO_GAME_ANGLE_FACTOR = static_cast<float>(NUMDEGREES) / PITWICE;
+	return radians * RAD_TO_GAME_ANGLE_FACTOR;
 }
 
 #define NUM_COLORS 256

--- a/clientd3d/drawdefs.h
+++ b/clientd3d/drawdefs.h
@@ -18,8 +18,7 @@ constexpr int NUMDEGREES = 4096;
 #define NUMDEGREES_MASK 0xfff
 
 constexpr float PI = 3.1415926f;
-constexpr float PITWICE = 6.2831853f;
-#define PIHALF  1.5707963f
+constexpr float PITWICE = 2.0f * PI;
 
 /* Turning MACROs */
 #define TURN_LEFT(angle) ((angle + 3 * NUMDEGREES / 4) % NUMDEGREES)
@@ -65,25 +64,21 @@ constexpr int CLASSIC_HEIGHT = 276;
 
 constexpr float deg_to_rad(float degrees)
 {
-	constexpr float DEG_TO_RAD_FACTOR = PITWICE / 360.0f;
-	return degrees * DEG_TO_RAD_FACTOR;
+	return degrees * (PITWICE / 360.0f);
 }
 constexpr float rad_to_deg(float radians)
 {	
-	constexpr float RAD_TO_DEG_FACTOR = 360.0f / PITWICE;
-	return radians * RAD_TO_DEG_FACTOR;
+	return radians * (360.0f / PITWICE);
 }
 
 /* Convert between game units and radians */
 constexpr float game_angle_to_rad(float angle)
 {
-	constexpr float GAME_ANGLE_TO_RAD_FACTOR = PITWICE / static_cast<float>(NUMDEGREES);
-	return angle * GAME_ANGLE_TO_RAD_FACTOR;
+	return angle * (PITWICE / static_cast<float>(NUMDEGREES));
 }
 constexpr long rad_to_game_angle(float radians)
 {
-	constexpr float RAD_TO_GAME_ANGLE_FACTOR = static_cast<float>(NUMDEGREES) / PITWICE;
-	return static_cast<long>(radians * RAD_TO_GAME_ANGLE_FACTOR);
+	return static_cast<long>(radians * (static_cast<float>(NUMDEGREES) / PITWICE));
 }
 
 #define NUM_COLORS 256

--- a/clientd3d/drawdefs.h
+++ b/clientd3d/drawdefs.h
@@ -67,6 +67,17 @@
 #define DegToRad(x) ((float) (x) * PITWICE / NUMDEGREES)
 #define RadToDeg(x) ((long)  ((x) * NUMDEGREES / PITWICE))
 
+constexpr float deg_to_rad(float degrees)
+{
+	constexpr float DEG_TO_RAD_FACTOR = PITWICE / 360.0f;
+	return degrees * DEG_TO_RAD_FACTOR;
+}
+constexpr float rad_to_deg(float radians)
+{	
+	constexpr float RAD_TO_DEG_FACTOR = 360.0f / PITWICE;
+	return radians * RAD_TO_DEG_FACTOR;
+}
+
 #define NUM_COLORS 256
 #define MAX_LIGHT 256  
 #define LIGHT_LEVELS 64

--- a/clientd3d/drawdefs.h
+++ b/clientd3d/drawdefs.h
@@ -13,12 +13,12 @@
 #ifndef _DRAWDEFS_H
 #define _DRAWDEFS_H
 
-#define NUMDEGREES 4096
+constexpr int NUMDEGREES = 4096;
 #define LOG_NUMDEGREES 12
 #define NUMDEGREES_MASK 0xfff
 
-#define PI      3.1415926f
-#define PITWICE 6.2831853f
+constexpr float PI = 3.1415926f;
+constexpr float PITWICE = 6.2831853f;
 #define PIHALF  1.5707963f
 
 /* Turning MACROs */
@@ -27,8 +27,8 @@
 #define TURN_BACK(angle) ((angle + NUMDEGREES / 2) % NUMDEGREES)
 
 /* Original game clients view port size -- must be DWORD aligned for WinG */
-#define CLASSIC_WIDTH 452
-#define CLASSIC_HEIGHT 276
+constexpr int CLASSIC_WIDTH = 452;
+constexpr int CLASSIC_HEIGHT = 276;
 
 /* Scaler used to increase the classic view port x,y values */
 #define VIEW_SCALER 5

--- a/clientd3d/drawdefs.h
+++ b/clientd3d/drawdefs.h
@@ -74,7 +74,7 @@ constexpr float rad_to_deg(float radians)
 	return radians * RAD_TO_DEG_FACTOR;
 }
 
-/* Convert between pseudo degrees and radians */
+/* Convert between game units and radians */
 constexpr float game_angle_to_rad(float angle)
 {
 	constexpr float GAME_ANGLE_TO_RAD_FACTOR = PITWICE / static_cast<float>(NUMDEGREES);
@@ -83,7 +83,7 @@ constexpr float game_angle_to_rad(float angle)
 constexpr long rad_to_game_angle(float radians)
 {
 	constexpr float RAD_TO_GAME_ANGLE_FACTOR = static_cast<float>(NUMDEGREES) / PITWICE;
-	return radians * RAD_TO_GAME_ANGLE_FACTOR;
+	return static_cast<long>(radians * RAD_TO_GAME_ANGLE_FACTOR);
 }
 
 #define NUM_COLORS 256

--- a/clientd3d/fixed.c
+++ b/clientd3d/fixed.c
@@ -1,4 +1,4 @@
-// Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+// Meridian 59, Copyright 1994-2026 Andrew Kirmse and Chris Kirmse.
 // All rights reserved.
 //
 // This software is distributed under a license that is described in
@@ -37,7 +37,7 @@ FixedPoint fpMul(FixedPoint m1, FixedPoint m2)
 
 int intATan2(int dy, int dx)
 {
-   return RadToDeg(atan2((float) dy,dx));
+   return rad_to_game_angle(atan2(static_cast<float>(dy), static_cast<float>(dx)));
 }
 
 int Distance(int dx, int dy)

--- a/clientd3d/sound.c
+++ b/clientd3d/sound.c
@@ -1,4 +1,4 @@
-// Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+// Meridian 59, Copyright 1994-2026 Andrew Kirmse and Chris Kirmse.
 // All rights reserved.
 //
 // This software is distributed under a license that is described in
@@ -164,7 +164,7 @@ void NewSound(WPARAM type, ID rsc)
  */
 void UpdateLoopingSounds(int px, int py, int angle)
 {
-	float radians = DegToRad(angle);
+	float radians = game_angle_to_rad(angle);
 	float forwardX = (float)cos(radians);
 	float forwardZ = (float)-sin(radians);  // Negate so north faces -Z
 


### PR DESCRIPTION
This PR defines the magic numbers used for angle calculations and conversions in the D3D source files and centralizes them in `d3drender.h`.  It also moves the degree/radian conversion functions into `drawdefs.h`, and updates the macros used for angle calculations to be static constexpr instead.

- Added new constants used for angle calculations in D3D.
- Move degree/radian conversion functions from `d3drender.c` into `drawdefs.h`.
- Refactored part of `drawdefs.h`:
  - Converted specific macros in `drawdefs.h` used for angle calculation into static constexpr.
  - Refactored existing `DegToRad` and `RadToDeg` macros to be helper functions.
  - Renamed the new helper functions to clarify that they convert game units to radians (and vice versa).