### PR TITLE
feature: add configurable theme borders for chat and stats areas (theming part 5)

### DIFF
--- a/clientd3d/client.def
+++ b/clientd3d/client.def
@@ -60,6 +60,7 @@ EXPORTS
 	GetColor
 	GetBrush
 	ThemeCurrent
+	ThemeBorderColor
 	CenterWindow
 	GetFontHeight	
 	EditBoxScroll

--- a/clientd3d/color.c
+++ b/clientd3d/color.c
@@ -319,6 +319,19 @@ int MainThemeResourceId(int id)
 	}
 }
 /************************************************************************/
+/*
+ * ThemeBorderColor:  Returns the color the active theme draws around a
+ *   panel, or CLR_INVALID to keep the default border.
+ */
+COLORREF ThemeBorderColor(void)
+{
+	switch (ThemeCurrent())
+	{
+	case Theme::Dark: return RGB(80, 80, 80);
+	default:          return CLR_INVALID;
+	}
+}
+/************************************************************************/
 void ColorsRestoreDefaults(void)
 {
 	ColorsDestroy();

--- a/clientd3d/color.c
+++ b/clientd3d/color.c
@@ -320,8 +320,8 @@ int MainThemeResourceId(int id)
 }
 /************************************************************************/
 /*
- * ThemeBorderColor:  Returns the color the active theme draws around a
- *   panel, or CLR_INVALID to keep the default border.
+ * ThemeBorderColor:  Returns the active theme's border color, or
+ *   CLR_INVALID when the theme sets none.
  */
 COLORREF ThemeBorderColor(void)
 {

--- a/clientd3d/color.h
+++ b/clientd3d/color.h
@@ -64,6 +64,7 @@ M59EXPORT COLORREF GetColor(WORD color);
 M59EXPORT HBRUSH GetBrush(WORD color);
 M59EXPORT Theme ThemeCurrent(void);
 int MainThemeResourceId(int id);
+M59EXPORT COLORREF ThemeBorderColor(void);
 COLORREF GetPlayerNameColor(int flags,const char*name);
 
 void UserSelectColor(WORD color);

--- a/clientd3d/textin.c
+++ b/clientd3d/textin.c
@@ -141,10 +141,18 @@ void TextInputDrawBorder(void)
    a.cx += 2 * HIGHLIGHT_THICKNESS;
    a.cy += 2 * HIGHLIGHT_THICKNESS - 1; //There is no bottom treatment on editbox.
 
+   // If the chat box is selected, draw the highlight color.  If not,
+   // draw the theme's border color when it has one, else the default border.
+   int index;
    if (IsChild(hwndInput, GetFocus()))
-      DrawBorder(&a, HIGHLIGHT_INDEX, NULL);
-   else 
-      DrawBorder(&a, border_index, NULL);
+      index = HIGHLIGHT_INDEX;
+   else
+   {
+      COLORREF themeColor = ThemeBorderColor();
+      index = (themeColor != CLR_INVALID) ? GetClosestPaletteIndex(themeColor) : border_index;
+   }
+
+   DrawBorder(&a, index, NULL);
 }
 
 /************************************************************************/

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -24,13 +24,21 @@ Three kinds of themeable bitmap surface exist:
 
 The wrapper ornaments live in `module/merintr/drawint.c`.  Five groups exist today:
 
-| Group | Wraps | Dark variants today |
+| Group | Wraps | Dark theme handling |
 | ----- | ----- | ------------------- |
 | `E*` | Outer client-window edge | Yes |
 | `M*` | Minimap | Yes |
-| `S*` | Stats area outer panel | No (skipped in dark) |
-| `B*` | Chat edit box | No (silver in dark) |
+| `S*` | Stats area outer panel | No (solid-line border) |
+| `B*` | Chat edit box | No (solid-line border) |
 | `I*` | Inventory area | No (skipped for every theme) |
+
+## Optional solid-line border for stats area and chat box
+
+A theme can skip the `S*` and `B*` ornaments and draw a thin solid-line border in their place, for when the ornament artwork does not read well against the theme's sidebar fill.
+
+Three theme switches control this: one to skip the stats area frame, one to skip the chat box frame, and a shared border color used for both.  Returning no color keeps the default border.
+
+The frame and the border are independent.  Setting a border color without skipping the frame draws both, which may not look good.  Whether to combine them is the theme author's choice.
 
 ## Sidebar fill
 

--- a/module/merintr/drawint.c
+++ b/module/merintr/drawint.c
@@ -808,21 +808,18 @@ void InterfaceDrawElements(HDC hdc)
   bool vertical;
 
   // The theme does not change mid-draw, so read these once instead of per element.
-  bool skipStats = ThemeSkipStatsAreaFrame();
-  bool skipChat  = ThemeSkipChatBoxFrame();
+  bool drawStatsOrnamentalFrame = ThemeDrawsStatsAreaOrnamentalFrame();
+  bool drawChatOrnamentalFrame  = ThemeDrawsChatBoxOrnamentalFrame();
 
   for (i=0; i < NUM_AUTO_ELEMENTS; i++)
   {
 	  // Skip inventory corner bitmaps.  The inventory edge repeaters (ELEMENT_ITOP
 	  // through ELEMENT_IRIGHT) are already skipped in the repeater loop below, so
 	  // these corners have no connecting edges and draw as floating fragments.
-	  //
-	  // Stats area corners are skipped when ThemeSkipStatsAreaFrame returns true.
-	  // Chat box corners are skipped independently when ThemeSkipChatBoxFrame
-	  // returns true.
+	  // Stats area and chat box corner bitmaps draw only when the theme draws its ornamental frame.
 	  if ((i >= ELEMENT_IULTOP && i <= ELEMENT_ILRRIGHT) ||
-	      (skipStats && i >= ELEMENT_SULTOP && i <= ELEMENT_SLRRIGHT) ||
-	      (skipChat  && i >= ELEMENT_BULTOP && i <= ELEMENT_BLRRIGHT))
+	      (!drawStatsOrnamentalFrame && i >= ELEMENT_SULTOP && i <= ELEMENT_SLRRIGHT) ||
+	      (!drawChatOrnamentalFrame  && i >= ELEMENT_BULTOP && i <= ELEMENT_BLRRIGHT))
 		  continue;
 
     OffscreenWindowBackground(NULL, elements[i].x, elements[i].y, elements[i].width, elements[i].height);
@@ -841,13 +838,11 @@ void InterfaceDrawElements(HDC hdc)
 	  //	disable xxx
 	if( i >= ELEMENT_TOP && i <= ELEMENT_RIGHT )
 		continue;
-	// Skip the edit box bottom repeater.  Stats area edge repeaters
-	// are skipped independently when ThemeSkipStatsAreaFrame returns
-	// true.  Chat box edge repeaters are skipped independently when
-	// ThemeSkipChatBoxFrame returns true.
+	// Skip the edit box bottom repeater.  Stats area and chat box edge
+	// repeater bitmaps draw only when the theme draws its ornamental frame.
 	if ((i == ELEMENT_BBOTTOM) ||
-	    (skipStats && i >= ELEMENT_STOP && i <= ELEMENT_SRIGHT) ||
-	    (skipChat  && i >= ELEMENT_BTOP && i <= ELEMENT_BRIGHT))
+	    (!drawStatsOrnamentalFrame && i >= ELEMENT_STOP && i <= ELEMENT_SRIGHT) ||
+	    (!drawChatOrnamentalFrame  && i >= ELEMENT_BTOP && i <= ELEMENT_BRIGHT))
 		continue;
 
 	e = &repeaters[i].element;

--- a/module/merintr/drawint.c
+++ b/module/merintr/drawint.c
@@ -812,10 +812,13 @@ void InterfaceDrawElements(HDC hdc)
 	  /* Skip inventory corner bitmaps.  The inventory edge repeaters
 	     (ELEMENT_ITOP through ELEMENT_IRIGHT) are already skipped in
 	     the repeater loop below, so these corners have no connecting
-	     edges and draw as floating fragments.  Stats-area corners are
-	     also skipped, depending on the active theme. */
+	     edges and draw as floating fragments.  Stats area corners are
+	     skipped when ThemeSkipStatsAreaFrame returns true.  Chat box
+	     corners are skipped independently when ThemeSkipChatBoxFrame
+	     returns true. */
 	  if ((i >= ELEMENT_IULTOP && i <= ELEMENT_ILRRIGHT) ||
-	      (ThemeSkipStatsAreaFrame() && i >= ELEMENT_SULTOP && i <= ELEMENT_SLRRIGHT))
+	      (ThemeSkipStatsAreaFrame() && i >= ELEMENT_SULTOP && i <= ELEMENT_SLRRIGHT) ||
+	      (ThemeSkipChatBoxFrame()   && i >= ELEMENT_BULTOP && i <= ELEMENT_BLRRIGHT))
 		  continue;
 
     OffscreenWindowBackground(NULL, elements[i].x, elements[i].y, elements[i].width, elements[i].height);
@@ -834,10 +837,13 @@ void InterfaceDrawElements(HDC hdc)
 	  //	disable xxx
 	if( i >= ELEMENT_TOP && i <= ELEMENT_RIGHT )
 		continue;
-	// Skip the edit-box bottom repeater.  Stats-area edge repeaters
-	// are also skipped, depending on the active theme.
+	// Skip the edit box bottom repeater.  Stats area edge repeaters
+	// are skipped independently when ThemeSkipStatsAreaFrame returns
+	// true.  Chat box edge repeaters are skipped independently when
+	// ThemeSkipChatBoxFrame returns true.
 	if ((i == ELEMENT_BBOTTOM) ||
-	    (ThemeSkipStatsAreaFrame() && i >= ELEMENT_STOP && i <= ELEMENT_SRIGHT))
+	    (ThemeSkipStatsAreaFrame() && i >= ELEMENT_STOP && i <= ELEMENT_SRIGHT) ||
+	    (ThemeSkipChatBoxFrame()   && i >= ELEMENT_BTOP && i <= ELEMENT_BRIGHT))
 		continue;
 
 	e = &repeaters[i].element;
@@ -859,6 +865,15 @@ void InterfaceDrawElements(HDC hdc)
 
       GdiFlush();
     }
+  }
+
+  // Draw a stats area border if the active theme has a border color.
+  COLORREF borderColor = ThemeBorderColor();
+  if (borderColor != CLR_INVALID)
+  {
+    AREA stat;
+    StatsGetArea(&stat);
+    DrawBorder(&stat, GetClosestPaletteIndex(borderColor), NULL);
   }
 }
 /****************************************************************************/

--- a/module/merintr/drawint.c
+++ b/module/merintr/drawint.c
@@ -807,6 +807,10 @@ void InterfaceDrawElements(HDC hdc)
   InterfaceElement *e;
   bool vertical;
 
+  // The theme does not change mid-draw, so read these once instead of per element.
+  bool skipStats = ThemeSkipStatsAreaFrame();
+  bool skipChat  = ThemeSkipChatBoxFrame();
+
   for (i=0; i < NUM_AUTO_ELEMENTS; i++)
   {
 	  // Skip inventory corner bitmaps.  The inventory edge repeaters (ELEMENT_ITOP
@@ -817,8 +821,8 @@ void InterfaceDrawElements(HDC hdc)
 	  // Chat box corners are skipped independently when ThemeSkipChatBoxFrame
 	  // returns true.
 	  if ((i >= ELEMENT_IULTOP && i <= ELEMENT_ILRRIGHT) ||
-	      (ThemeSkipStatsAreaFrame() && i >= ELEMENT_SULTOP && i <= ELEMENT_SLRRIGHT) ||
-	      (ThemeSkipChatBoxFrame()   && i >= ELEMENT_BULTOP && i <= ELEMENT_BLRRIGHT))
+	      (skipStats && i >= ELEMENT_SULTOP && i <= ELEMENT_SLRRIGHT) ||
+	      (skipChat  && i >= ELEMENT_BULTOP && i <= ELEMENT_BLRRIGHT))
 		  continue;
 
     OffscreenWindowBackground(NULL, elements[i].x, elements[i].y, elements[i].width, elements[i].height);
@@ -842,8 +846,8 @@ void InterfaceDrawElements(HDC hdc)
 	// true.  Chat box edge repeaters are skipped independently when
 	// ThemeSkipChatBoxFrame returns true.
 	if ((i == ELEMENT_BBOTTOM) ||
-	    (ThemeSkipStatsAreaFrame() && i >= ELEMENT_STOP && i <= ELEMENT_SRIGHT) ||
-	    (ThemeSkipChatBoxFrame()   && i >= ELEMENT_BTOP && i <= ELEMENT_BRIGHT))
+	    (skipStats && i >= ELEMENT_STOP && i <= ELEMENT_SRIGHT) ||
+	    (skipChat  && i >= ELEMENT_BTOP && i <= ELEMENT_BRIGHT))
 		continue;
 
 	e = &repeaters[i].element;

--- a/module/merintr/drawint.c
+++ b/module/merintr/drawint.c
@@ -809,13 +809,13 @@ void InterfaceDrawElements(HDC hdc)
 
   for (i=0; i < NUM_AUTO_ELEMENTS; i++)
   {
-	  /* Skip inventory corner bitmaps.  The inventory edge repeaters
-	     (ELEMENT_ITOP through ELEMENT_IRIGHT) are already skipped in
-	     the repeater loop below, so these corners have no connecting
-	     edges and draw as floating fragments.  Stats area corners are
-	     skipped when ThemeSkipStatsAreaFrame returns true.  Chat box
-	     corners are skipped independently when ThemeSkipChatBoxFrame
-	     returns true. */
+	  // Skip inventory corner bitmaps.  The inventory edge repeaters (ELEMENT_ITOP
+	  // through ELEMENT_IRIGHT) are already skipped in the repeater loop below, so
+	  // these corners have no connecting edges and draw as floating fragments.
+	  //
+	  // Stats area corners are skipped when ThemeSkipStatsAreaFrame returns true.
+	  // Chat box corners are skipped independently when ThemeSkipChatBoxFrame
+	  // returns true.
 	  if ((i >= ELEMENT_IULTOP && i <= ELEMENT_ILRRIGHT) ||
 	      (ThemeSkipStatsAreaFrame() && i >= ELEMENT_SULTOP && i <= ELEMENT_SLRRIGHT) ||
 	      (ThemeSkipChatBoxFrame()   && i >= ELEMENT_BULTOP && i <= ELEMENT_BLRRIGHT))

--- a/module/merintr/theme.c
+++ b/module/merintr/theme.c
@@ -76,11 +76,23 @@ bool ThemeSidebarUsesInventoryFill(void)
 }
 /****************************************************************************/
 /*
- * ThemeSkipStatsAreaFrame:  Returns true when the active theme does
- *   not draw the ornamental frame (corners and edge repeaters) around
- *   stats_area (the right-side tabbed panel).
+ * ThemeSkipStatsAreaFrame:  Returns true when the active theme does not want
+ *   an ornamental frame around the stats area.
  */
 bool ThemeSkipStatsAreaFrame(void)
+{
+   switch (ThemeCurrent())
+   {
+   case Theme::Dark: return true;
+   default:          return false;
+   }
+}
+/****************************************************************************/
+/*
+ * ThemeSkipChatBoxFrame:  Returns true when the active theme does not want
+ *   an ornamental frame around the chat box.
+ */
+bool ThemeSkipChatBoxFrame(void)
 {
    switch (ThemeCurrent())
    {

--- a/module/merintr/theme.c
+++ b/module/merintr/theme.c
@@ -76,27 +76,27 @@ bool ThemeSidebarUsesInventoryFill(void)
 }
 /****************************************************************************/
 /*
- * ThemeSkipStatsAreaFrame:  Returns true when the active theme skips the
- *   ornamental frame around the stats area.
+ * ThemeDrawsStatsAreaOrnamentalFrame:  Returns true when the active theme draws
+ *   its ornamental frame around the stats area.
  */
-bool ThemeSkipStatsAreaFrame(void)
+bool ThemeDrawsStatsAreaOrnamentalFrame(void)
 {
    switch (ThemeCurrent())
    {
-   case Theme::Dark: return true;
-   default:          return false;
+   case Theme::Dark: return false;
+   default:          return true;
    }
 }
 /****************************************************************************/
 /*
- * ThemeSkipChatBoxFrame:  Returns true when the active theme skips the
- *   ornamental frame around the chat box.
+ * ThemeDrawsChatBoxOrnamentalFrame:  Returns true when the active theme draws
+ *   its ornamental frame around the chat box.
  */
-bool ThemeSkipChatBoxFrame(void)
+bool ThemeDrawsChatBoxOrnamentalFrame(void)
 {
    switch (ThemeCurrent())
    {
-   case Theme::Dark: return true;
-   default:          return false;
+   case Theme::Dark: return false;
+   default:          return true;
    }
 }

--- a/module/merintr/theme.c
+++ b/module/merintr/theme.c
@@ -76,8 +76,8 @@ bool ThemeSidebarUsesInventoryFill(void)
 }
 /****************************************************************************/
 /*
- * ThemeSkipStatsAreaFrame:  Returns true when the active theme does not want
- *   an ornamental frame around the stats area.
+ * ThemeSkipStatsAreaFrame:  Returns true when the active theme skips the
+ *   ornamental frame around the stats area.
  */
 bool ThemeSkipStatsAreaFrame(void)
 {
@@ -89,8 +89,8 @@ bool ThemeSkipStatsAreaFrame(void)
 }
 /****************************************************************************/
 /*
- * ThemeSkipChatBoxFrame:  Returns true when the active theme does not want
- *   an ornamental frame around the chat box.
+ * ThemeSkipChatBoxFrame:  Returns true when the active theme skips the
+ *   ornamental frame around the chat box.
  */
 bool ThemeSkipChatBoxFrame(void)
 {

--- a/module/merintr/theme.h
+++ b/module/merintr/theme.h
@@ -19,5 +19,6 @@
 int InterfaceThemeResourceId(int id);
 bool ThemeSidebarUsesInventoryFill(void);
 bool ThemeSkipStatsAreaFrame(void);
+bool ThemeSkipChatBoxFrame(void);
 
 #endif /* #ifndef _MERINTR_THEME_H */

--- a/module/merintr/theme.h
+++ b/module/merintr/theme.h
@@ -18,7 +18,7 @@
 
 int InterfaceThemeResourceId(int id);
 bool ThemeSidebarUsesInventoryFill(void);
-bool ThemeSkipStatsAreaFrame(void);
-bool ThemeSkipChatBoxFrame(void);
+bool ThemeDrawsStatsAreaOrnamentalFrame(void);
+bool ThemeDrawsChatBoxOrnamentalFrame(void);
 
 #endif /* #ifndef _MERINTR_THEME_H */


### PR DESCRIPTION
## What

- Adds additional theming controls for the chat box and stats area
    - Adds `ThemeSkipChatBoxFrame()` to complement the existing `ThemeSkipStatsAreaFrame` (added in #1430)
    - Adds a customizable border color, `ThemeBorderColor`, that can be used to draw a border around the chat box and/or the stats area in place of the skipped ornament
- Dark theme now uses the above to skip the chat box and stats area ornamental frames and to draw a border specific to the dark theme
- Default theme is unchanged
- related to #1425 

## Why

- #1430 removed the stats area ornamental frame in dark theme, but that left the stats area floating without a border
- The chat box had a border, but it used ornamental frame resources that did not look good in dark theme
- The replacement border should be configurable so future themes can set their own color

## How

### New functions

- `module/merintr/theme.c`
    - `ThemeSkipChatBoxFrame` - returns true when the active theme skips the `B*` chat box ornament.  Same shape as the existing `ThemeSkipStatsAreaFrame`
- `clientd3d/color.c`
    - `ThemeBorderColor` - per-theme border color for the stats area and chat box, or `CLR_INVALID` for the default border.  Exported via `client.def` so both the client and the interface module read it.  One shared color so the two borders match

### Borders

Both borders use the existing `DrawBorder`, converting the color to the nearest palette index with `GetClosestPaletteIndex`.

- Chat box: drawn by `TextInputDrawBorder` in `clientd3d/textin.c`.  No new drawing code.  The chat box already drew its own border, it just uses `ThemeBorderColor` now and keeps its focus highlight (highlight color while focused, theme color while not)
- Stats area: drawn by `InterfaceDrawElements` in `module/merintr/drawint.c`.  New code, since the stats area had no border before

## Notes

- The border color is not a `COLOR_*` table entry.  The table is for user-customizable colors.  This border is a fixed per-theme decision.
- The frame and the border are independent.  Setting a border color without skipping the frame draws both, which may not look good.  Whether to combine them is the theme author's choice.
- The chat box border sits a couple of pixels outside the text area, leaving a thin gap that shows the window background.  This is the existing border geometry, not new to this change.  In the default theme the ornament filled that region, so the gap was hidden.  With the ornament skipped it is faintly visible.  It is minor so I left it out of scope for this change.

### Examples
#### Chat Box (before)
<img width="954" height="516" alt="image" src="https://github.com/user-attachments/assets/99e270f7-9b9e-41b6-9077-3f55d65d4243" />

- default border clashes with dark theme and is not configurable per-theme

#### Chat Box (after)
<img width="953" height="516" alt="image" src="https://github.com/user-attachments/assets/48207cf5-be7b-4a3a-af3a-845f56f1b795" />

#### Stat Area (before)
<img width="363" height="600" alt="image" src="https://github.com/user-attachments/assets/06b31f14-d1ee-47eb-b495-84cef38e7e0d" />

- floats without a border (see lower left)

#### Stat Area (after)
<img width="368" height="600" alt="image" src="https://github.com/user-attachments/assets/a560acbd-afc9-42e3-b28a-677623e3115d" />
