### PR TITLE
Fix password reset for emails containing underscore

### DIFF
--- a/aws/src/m59utils/python/lib/python3.12/site-packages/m59utils.py
+++ b/aws/src/m59utils/python/lib/python3.12/site-packages/m59utils.py
@@ -44,7 +44,7 @@ def util_load_account_db(lookup_email, lookup_username, db_check, db_check_lates
                 try:
 
                     username_key = f"{parts[0].lower()}_{parts[2]}"
-                    lookup_username[username_key] = f"{parts[1]}_{parts[3]}"
+                    lookup_username[username_key] = f"{parts[1]}|{parts[3]}"
 
                     email_key = f"{parts[1].lower()}_{parts[2]}"
                     lookup_email[email_key] = 1

--- a/aws/src/reset_password/app.py
+++ b/aws/src/reset_password/app.py
@@ -114,7 +114,7 @@ def lambda_handler(event, context):
 
     security = util_get_random_string(28)
 
-    details = lookup_username[username_check].rsplit("_", 1)
+    details = lookup_username[username_check].split("|")
 
     email = details[0]
     account = details[1]

--- a/aws/src/reset_password/app.py
+++ b/aws/src/reset_password/app.py
@@ -114,7 +114,7 @@ def lambda_handler(event, context):
 
     security = util_get_random_string(28)
 
-    details = lookup_username[username_check].split("_")
+    details = lookup_username[username_check].rsplit("_", 1)
 
     email = details[0]
     account = details[1]

--- a/aws/src/reset_password/app.py
+++ b/aws/src/reset_password/app.py
@@ -46,9 +46,9 @@ def do_failure():
 
 def do_success():
     return {
-        'statusCode': 302, 
+        'statusCode': 302,
         'headers': {
-            'Location': f"{domain_name}/password-reset"
+            'Location': f"{domain_name}/password-reset-success"
         },
         'body': json.dumps({'message': 'Redirecting...'})
     }


### PR DESCRIPTION
- Use | as the email/account separator in lookup_username values. The previous _ separator was ambiguous because _ is a legal character in email local-parts; | is illegal in emails, so the split is unambiguous. Updates both the encode site (m59utils.py) and the decode site (reset_password/app.py).
 - Fix missing success page on password reset submit. do_success() was redirecting back to /password-reset (the form page itself), so users got no feedback after submitting. Now redirects to /password-reset-success, matching the existing failure-page pattern and the sibling verify_reset Lambda.