### PR TITLE
Fix handling of server 102 in reset verification

### DIFF
--- a/aws/src/verify_reset/app.py
+++ b/aws/src/verify_reset/app.py
@@ -55,7 +55,7 @@ def lambda_handler(event, context):
         result = "unknown"
         username = ""
         password = ""
-        if server != "101" or server != "102":
+        if server not in ("101", "102"):
             server = "101"
         
         s3_client = boto3.client('s3')


### PR DESCRIPTION
Replace incorrect OR validation with proper membership check so valid server values (101, 102) are preserved instead of always defaulting to 101.