### PR TITLE
Make Spectral Mummies use dynamic light static

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/specmum.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/specmum.kod
@@ -59,7 +59,7 @@ classvars:
 
 properties:
    
-   piDrawfx = DRAWFX_TRANSLUCENT_50 | FLICKERING_YES
+   piDrawfx = DRAWFX_TRANSLUCENT_50
 
 messages:
 


### PR DESCRIPTION
Removes flickering from the Spectral Mummies dynamic light and sprite draw effect, giving it a steady glow instead of the previous pulsing/flickering appearance (as a result of recent dynamic light updates).

Similar to https://github.com/Meridian59/Meridian59/pull/1389