### PR TITLE
Attempt to fix crash in who list

### DIFF
--- a/clientd3d/msgfiltr.c
+++ b/clientd3d/msgfiltr.c
@@ -19,6 +19,7 @@ static HWND hWhoDialog = NULL;        /* Non-null if Who dialog is up */
 extern player_info player;
 
 #define WHOM_UPDATE (WM_APP+5)
+#define WHOM_RESET  (WM_APP+6)
 
 bool AddUserToIgnoreList(ID name)
 {
@@ -68,6 +69,12 @@ void UpdateWho(object_node* pUser, BOOL bAdded)
    debug(("UpdateWho\n"));
    if (hWhoDialog)
       SendMessage(hWhoDialog, WHOM_UPDATE, (WPARAM)bAdded, (LPARAM)pUser);
+}
+
+void ResetWhoList(list_type users)
+{
+   if (hWhoDialog)
+      SendMessage(hWhoDialog, WHOM_RESET, 0, (LPARAM)users);
 }
 
 /*****************************************************************************/
@@ -140,6 +147,22 @@ INT_PTR CALLBACK WhoDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lP
      }
      
      num = ListBox_GetCount(hList);
+     SetDlgItemInt(hDlg, IDC_NUMPLAYERS, num, FALSE);
+   }
+   return TRUE;
+
+   case WHOM_RESET:
+   {
+     list_type users = (list_type)lParam;
+     hList = GetDlgItem(hDlg, IDC_USERLIST);
+     ItemListSetContents(hList, users, false);
+     num = ListBox_GetCount(hList);
+     for (i = 0; i < num; i++)
+     {
+       object_node *obj = (object_node *) ListBox_GetItemData(hList, i);
+       if (obj != NULL && !IsUserInIgnoreList(obj->name_res))
+         ListBox_SetSel(hList, TRUE, i);
+     }
      SetDlgItemInt(hDlg, IDC_NUMPLAYERS, num, FALSE);
    }
    return TRUE;

--- a/clientd3d/msgfiltr.h
+++ b/clientd3d/msgfiltr.h
@@ -13,6 +13,7 @@
 #define _MSGFILTR_H
 
 void UpdateWho(object_node* pUser, BOOL bAdded);
+void ResetWhoList(list_type users);
 INT_PTR CALLBACK WhoDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);
 void AbortWhoDialog(void);
 

--- a/clientd3d/say.c
+++ b/clientd3d/say.c
@@ -28,7 +28,8 @@ list_type current_users = NULL;
 */
 void SetCurrentUsers(list_type users)
 {
-	/* Destroy old list, and if dialog is up, reset user list box */
+	/* If the Who dialog is open, repopulate it from the new list before freeing the old one. */
+	ResetWhoList(users);
 	ObjectListDestroy(current_users);
 	current_users = users;
 }


### PR DESCRIPTION
Player objects are deleted while who list is still being drawn.  Update the who list before deleting objects.

Fixes #770