### PR TITLE
Fix NPCs greeting morphed players

### DIFF
--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -1804,6 +1804,7 @@ messages:
 
          if NOT Send(what,@CheckPlayerFlag,#flag=PFLAG_ANONYMOUS)
                AND NOT Send(what,@CheckPlayerFlag,#flag=PFLAG_INVISIBLE)
+			   AND NOT Send(what,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
          {
             for i in plActive
             {


### PR DESCRIPTION
This PR fixes a minor bug where NPCs will attempt to greet morphed players.  Currently, NPCs will not greet anonymous or invisible players.  However, they will still greet morphed players even if they are technically anonymous.  Some NPCs will also attempt to refer to them by name, which can lead to some bugged dialogue.

<img width="461" height="155" alt="beforenpcdialogfix" src="https://github.com/user-attachments/assets/a13e0a8e-0bd4-4f2c-85d3-661510287fb9" />


This PR adds a `PFLAG_MORPHED` check with the player entering the room.  A quick test confirms that NPCs don't greet morphed players.