### PR TITLE
Harden table API against NULL resource table to fix post-download crash

### DIFF
--- a/clientd3d/table.c
+++ b/clientd3d/table.c
@@ -88,6 +88,9 @@ void table_destroy(Table *t, TableDestroyProc destructor)
    DWORD i;
    list_type l;
 
+   if (t == NULL)
+      return;
+
    for (i=0; i < t->size; i++)
    {
       for (l = t->entries[i]; l != NULL; l = l->next)

--- a/clientd3d/table.c
+++ b/clientd3d/table.c
@@ -49,8 +49,6 @@ Table *table_create(DWORD size)
  */
 int table_insert(Table *t, void *data, HashProc hasher, CompareProc compare)
 {
-   if (t == NULL)
-      return 1;
 
    int hashval = (*hasher)(data, t->size);
    Entry p = t->entries[hashval];
@@ -74,8 +72,6 @@ int table_insert(Table *t, void *data, HashProc hasher, CompareProc compare)
  */
 void *table_lookup(Table *t, void *data, HashProc hasher, CompareProc compare)
 {
-   if (t == NULL)
-      return NULL;
 
    DWORD hashval = (*hasher)(data, t->size);
    Entry p = t->entries[hashval];
@@ -94,7 +90,7 @@ void table_destroy(Table *t, TableDestroyProc destructor)
    DWORD i;
    list_type l;
 
-   if (t == NULL)
+   if (t == nullptr)
       return;
 
    for (i=0; i < t->size; i++)
@@ -117,7 +113,7 @@ void table_delete(Table *t)
 {
    DWORD i;
 
-   if (t == NULL)
+   if (t == nullptr)
       return;
 
    for (i=0; i < t->size; i++)
@@ -130,9 +126,6 @@ void table_delete(Table *t)
  */
 void table_delete_item(Table *t, void *data, HashProc hasher, CompareProc compare)
 {
-   if (t == NULL)
-      return;
-
    DWORD hashval = (*hasher)(data, t->size);
    t->entries[hashval] = list_delete_item(t->entries[hashval], data, compare);
 }

--- a/clientd3d/table.c
+++ b/clientd3d/table.c
@@ -49,12 +49,10 @@ Table *table_create(DWORD size)
  */
 int table_insert(Table *t, void *data, HashProc hasher, CompareProc compare)
 {
-   int hashval;
-
    if (t == NULL)
       return 1;
 
-   hashval = (*hasher)(data, t->size);
+   int hashval = (*hasher)(data, t->size);
    Entry p = t->entries[hashval];
    
    /* Look for duplicate entry */
@@ -76,14 +74,11 @@ int table_insert(Table *t, void *data, HashProc hasher, CompareProc compare)
  */
 void *table_lookup(Table *t, void *data, HashProc hasher, CompareProc compare)
 {
-   DWORD hashval;
-   Entry p;
-
    if (t == NULL)
       return NULL;
 
-   hashval = (*hasher)(data, t->size);
-   p = t->entries[hashval];
+   DWORD hashval = (*hasher)(data, t->size);
+   Entry p = t->entries[hashval];
 
    return list_find_item(p, data, compare);
 }
@@ -135,12 +130,10 @@ void table_delete(Table *t)
  */
 void table_delete_item(Table *t, void *data, HashProc hasher, CompareProc compare)
 {
-   DWORD hashval;
-
    if (t == NULL)
       return;
 
-   hashval = (*hasher)(data, t->size);
+   DWORD hashval = (*hasher)(data, t->size);
    t->entries[hashval] = list_delete_item(t->entries[hashval], data, compare);
 }
 /***********************************************************************/ 

--- a/clientd3d/table.c
+++ b/clientd3d/table.c
@@ -49,7 +49,6 @@ Table *table_create(DWORD size)
  */
 int table_insert(Table *t, void *data, HashProc hasher, CompareProc compare)
 {
-
    int hashval = (*hasher)(data, t->size);
    Entry p = t->entries[hashval];
    
@@ -72,7 +71,6 @@ int table_insert(Table *t, void *data, HashProc hasher, CompareProc compare)
  */
 void *table_lookup(Table *t, void *data, HashProc hasher, CompareProc compare)
 {
-
    DWORD hashval = (*hasher)(data, t->size);
    Entry p = t->entries[hashval];
 
@@ -127,6 +125,7 @@ void table_delete(Table *t)
 void table_delete_item(Table *t, void *data, HashProc hasher, CompareProc compare)
 {
    DWORD hashval = (*hasher)(data, t->size);
+
    t->entries[hashval] = list_delete_item(t->entries[hashval], data, compare);
 }
 /***********************************************************************/ 

--- a/clientd3d/table.c
+++ b/clientd3d/table.c
@@ -49,7 +49,12 @@ Table *table_create(DWORD size)
  */
 int table_insert(Table *t, void *data, HashProc hasher, CompareProc compare)
 {
-   int hashval = (*hasher)(data, t->size);
+   int hashval;
+
+   if (t == NULL)
+      return 1;
+
+   hashval = (*hasher)(data, t->size);
    Entry p = t->entries[hashval];
    
    /* Look for duplicate entry */
@@ -71,8 +76,14 @@ int table_insert(Table *t, void *data, HashProc hasher, CompareProc compare)
  */
 void *table_lookup(Table *t, void *data, HashProc hasher, CompareProc compare)
 {
-   DWORD hashval = (*hasher)(data, t->size);
-   Entry p = t->entries[hashval];
+   DWORD hashval;
+   Entry p;
+
+   if (t == NULL)
+      return NULL;
+
+   hashval = (*hasher)(data, t->size);
+   p = t->entries[hashval];
 
    return list_find_item(p, data, compare);
 }
@@ -111,6 +122,9 @@ void table_delete(Table *t)
 {
    DWORD i;
 
+   if (t == NULL)
+      return;
+
    for (i=0; i < t->size; i++)
       t->entries[i] = list_delete(t->entries[i]);
 }
@@ -121,8 +135,12 @@ void table_delete(Table *t)
  */
 void table_delete_item(Table *t, void *data, HashProc hasher, CompareProc compare)
 {
-   DWORD hashval = (*hasher)(data, t->size);
+   DWORD hashval;
 
+   if (t == NULL)
+      return;
+
+   hashval = (*hasher)(data, t->size);
    t->entries[hashval] = list_delete_item(t->entries[hashval], data, compare);
 }
 /***********************************************************************/ 


### PR DESCRIPTION
 After an update download, some clients crashed at `table.c:91` via `DownloadFiles → FreeResources → table_destroy`.

PR #1314 added a `FreeResources()` call to the download path, but there source table `t` is NULL until `LoadResources()` runs at game start, and the `table_*` functions dereferenced `t->size` with no NULL check.

**Fix:** NULL-guard `table_destroy` and `table_delete`. Each returns its existing empty/not-found result, so callers are unaffected on a valid table and a NULL table becomes a safe no-op instead of a crash.