### PR TITLE
Match dialog image backdrop to the window background color

### DIFF
--- a/clientd3d/dialog.c
+++ b/clientd3d/dialog.c
@@ -356,7 +356,7 @@ INT_PTR CALLBACK DescDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
 	   GetClientRect(hwndBitmap, &dlg_rect);
 	   
 	   RectToArea(&dlg_rect, &area);
-	   DrawStretchedObjectGroup(hdc, info->obj, info->obj->animate->group, &area, 
+	   DrawStretchedObjectGroupTransparent(hdc, info->obj, info->obj->animate->group, &area,
 		   GetSysColorBrush(COLOR_3DFACE));
 	   
 	   ReleaseDC(hwndBitmap, hdc);

--- a/clientd3d/drawbmp.c
+++ b/clientd3d/drawbmp.c
@@ -125,8 +125,8 @@ void DrawStretchedObjectGroup(HDC hdc, object_node *obj, int group, AREA *area, 
 *   is drawn in true color (rather than filled into the 8-bit palettised
 *   offscreen buffer and then copied), it matches the surrounding window/dialog
 *   color exactly instead of snapping to the nearest game-palette entry.  Used
-*   for the avatar in the description dialogs so the bitmap's backdrop blends
-*   seamlessly into the dialog face.
+*   for the object/avatar bitmap in the description dialogs so the backdrop
+*   blends seamlessly into the dialog face.
 */
 void DrawStretchedObjectGroupTransparent(HDC hdc, object_node *obj, int group, AREA *area, HBRUSH brush)
 {

--- a/clientd3d/drawbmp.c
+++ b/clientd3d/drawbmp.c
@@ -117,6 +117,79 @@ void DrawStretchedObjectGroup(HDC hdc, object_node *obj, int group, AREA *area, 
 	else
 		DrawObject(hdc, obj, group, true, area, brush, 0, 0, 0, true);
 }
+/************************************************************************/
+/*
+* DrawStretchedObjectGroupTransparent:  Like DrawStretchedObjectGroup, but
+*   the background is painted directly on hdc with the given brush and only
+*   the object's opaque pixels are composited on top.  Because the background
+*   is drawn in true color (rather than filled into the 8-bit palettised
+*   offscreen buffer and then copied), it matches the surrounding window/dialog
+*   color exactly instead of snapping to the nearest game-palette entry.  Used
+*   for the avatar in the description dialogs so the bitmap's backdrop blends
+*   seamlessly into the dialog face.
+*/
+void DrawStretchedObjectGroupTransparent(HDC hdc, object_node *obj, int group, AREA *area, HBRUSH brush)
+{
+	int angle = (obj->flags & OF_PLAYER) ? 7 * MAX_ANGLE / 8 : 0;
+	int draw_size = std::min(OFFSCREEN_BITMAP_SIZE, std::max(area->cx, area->cy));
+	RECT bgRect;
+	HDC memDC, maskDC;
+	HBITMAP memBmp, maskBmp, oldMemBmp, oldMaskBmp;
+	PALETTEENTRY pe;
+	COLORREF keyColor, oldDestBk, oldDestText;
+
+	// Paint the background straight onto the destination DC in true color, so
+	// it matches the dialog window exactly.
+	bgRect.left = area->x;
+	bgRect.top = area->y;
+	bgRect.right = area->x + area->cx;
+	bgRect.bottom = area->y + area->cy;
+	FillRect(hdc, &bgRect, brush);
+
+	// Render the object into the offscreen buffer over a transparent background.
+	// Filling with TRANSPARENT_INDEX makes every pixel the sprite doesn't cover
+	// the chroma key; the NULL brush stops DrawObject from overwriting it, and
+	// copy == false leaves the result in the offscreen buffer for us to mask.
+	memset(gOffscreenBits, TRANSPARENT_INDEX, OFFSCREEN_BITMAP_SIZE * OFFSCREEN_BITMAP_SIZE);
+	DrawObject(hdc, obj, group, true, area, NULL, 0, 0, angle, false);
+
+	// The chroma key is the RGB the offscreen's transparent index resolves to.
+	GetPaletteEntries(hPal, TRANSPARENT_INDEX, 1, &pe);
+	keyColor = RGB(pe.peRed, pe.peGreen, pe.peBlue);
+
+	// Make a true-color copy of the rendered square.
+	memDC = CreateCompatibleDC(hdc);
+	memBmp = CreateCompatibleBitmap(hdc, draw_size, draw_size);
+	oldMemBmp = (HBITMAP) SelectObject(memDC, memBmp);
+	BitBlt(memDC, 0, 0, draw_size, draw_size, gOffscreenDC, 0, 0, SRCCOPY);
+
+	// Build a 1-bpp mask: white where the chroma key shows, black on the object.
+	maskDC = CreateCompatibleDC(hdc);
+	maskBmp = CreateBitmap(draw_size, draw_size, 1, 1, NULL);
+	oldMaskBmp = (HBITMAP) SelectObject(maskDC, maskBmp);
+	SetBkColor(memDC, keyColor);
+	BitBlt(maskDC, 0, 0, draw_size, draw_size, memDC, 0, 0, SRCCOPY);
+
+	// Knock the background out of the color copy, leaving the object on black.
+	SetBkColor(memDC, RGB(0, 0, 0));
+	SetTextColor(memDC, RGB(255, 255, 255));
+	BitBlt(memDC, 0, 0, draw_size, draw_size, maskDC, 0, 0, SRCAND);
+
+	// Punch the object's silhouette out of the destination, then OR it in.
+	oldDestBk = SetBkColor(hdc, RGB(255, 255, 255));
+	oldDestText = SetTextColor(hdc, RGB(0, 0, 0));
+	BitBlt(hdc, area->x, area->y, draw_size, draw_size, maskDC, 0, 0, SRCAND);
+	BitBlt(hdc, area->x, area->y, draw_size, draw_size, memDC, 0, 0, SRCPAINT);
+	SetBkColor(hdc, oldDestBk);
+	SetTextColor(hdc, oldDestText);
+
+	SelectObject(memDC, oldMemBmp);
+	SelectObject(maskDC, oldMaskBmp);
+	DeleteObject(memBmp);
+	DeleteObject(maskBmp);
+	DeleteDC(memDC);
+	DeleteDC(maskDC);
+}
 /*
 */
 void DrawObjectIcon(HDC hdc, ID icon, int group, bool draw_obj, AREA *area, HBRUSH brush,

--- a/clientd3d/drawbmp.h
+++ b/clientd3d/drawbmp.h
@@ -18,6 +18,7 @@ void DrawBitmapClose(void);
 M59EXPORT void DrawStretchedObjectDefault(HDC hdc, object_node *obj, AREA *area, HBRUSH brush);
 M59EXPORT void DrawStretchedOverlays(HDC hdc, object_node *obj, AREA *area, HBRUSH brush);
 M59EXPORT void DrawStretchedObjectGroup(HDC hdc, object_node *obj, int group, AREA *area, HBRUSH brush);
+M59EXPORT void DrawStretchedObjectGroupTransparent(HDC hdc, object_node *obj, int group, AREA *area, HBRUSH brush);
 M59EXPORT void DrawStretchedOverlayRange(HDC hdc, object_node *obj, AREA *area, HBRUSH brush, 
 					int low, int high);
 


### PR DESCRIPTION
In Description dialogs, the backdrop behind the image (player avatars and objects alike) was filled with `COLOR_3DFACE` through the game's 8-bit palette, so it snapped to the nearest palette grey and rendered as a visibly different shade than the surrounding dialog face - a grey box around the image.

<img width="631" height="303" alt="image" src="https://github.com/user-attachments/assets/c697343e-b307-4a89-a5d4-9cda5ce5232f" />
<img width="622" height="353" alt="image" src="https://github.com/user-attachments/assets/62489d6c-57e5-485c-8f24-4b6b24c73628" />
<img width="625" height="629" alt="image" src="https://github.com/user-attachments/assets/19840a53-ebcd-4624-8ac2-cc6013a48efe" />

This adds DrawStretchedObjectGroupTransparent(), which paints the backdrop directly on the dialog DC in true colour and composites only the image's opaque pixels on top (monochrome-mask blit keyed on `TRANSPARENT_INDEX`). No palette snapping, so the backdrop blends seamlessly into the window.

Applies to any image in the Description dialog - both item descriptions (`IDD_DESC`) and player descriptions (`IDD_DESCPLAYER`) share the same draw path.

  - clientd3d/drawbmp.c / .h - new transparent-composite draw helper
  - clientd3d/dialog.c - Description dialog uses it for the object/avatar image

Inventory and other owner-drawn icons are unchanged.