### PR TITLE
 Add brightness floor to flickering lights so torches don't dip to full darkness

### DIFF
--- a/clientd3d/animate.c
+++ b/clientd3d/animate.c
@@ -33,6 +33,13 @@
 static const float FLICKER_LEVEL = LIGHT_LEVELS / 2.0f;  // Light adjustment range for flickering objects
 static const float FLASH_LEVEL = LIGHT_LEVELS / 2.0f;    // Light adjustment range for flashing objects
 
+// Minimum brightness floor for flickering lights, as a fraction of full intensity.
+// Flicker oscillates between this floor and 1.0 (100%) instead of 0.0 to 1.0, so
+// torches dim and brighten rather than blinking down to full darkness (which looks
+// unrealistic and is visually jarring). Range 0.0-1.0; values >= 0.5 are recommended.
+// Tune this to taste: 0.75 = flicker between 75% and 100% intensity.
+static const float FLICKER_MIN_BRIGHTNESS = 0.70f;
+
 static int animation_timer = 0;   // id of animation timer, or 0 if none
 static DWORD timeLastFrame;
 static const int flickerTimer = FLICKER_PERIOD;  // Global timer for OF_FLICKERING objects (milliseconds)
@@ -217,7 +224,12 @@ bool AnimateObject(object_node *obj, int dt)
         // Normalize to 0.0-1.0 range
         flicker = flicker / amplitudeSum + 0.5f;
         flicker = std::clamp(flicker, 0.0f, 1.0f);
-         
+
+        // Compress the range so flicker oscillates between FLICKER_MIN_BRIGHTNESS and
+        // 1.0 rather than 0.0 and 1.0. This keeps a torch from dipping to full darkness
+        // while preserving the same organic wave shape.
+        flicker = FLICKER_MIN_BRIGHTNESS + (1.0f - FLICKER_MIN_BRIGHTNESS) * flicker;
+
         obj->lightAdjust = (int)(flicker * GetFlickerLevel());
         need_redraw = true;
    }


### PR DESCRIPTION
Flickering lights previously oscillated across the full 0%→100% range, making torches strobe down to complete darkness — jarring and "a little nauseating" per playtest feedback.

This compresses the flicker range to `FLICKER_MIN_BRIGHTNESS → 100%` (currently 70%), keeping the same organic wave shape but raising its floor so flames dim and brighten instead of blinking off.

The fix is a one-line remap at the source in `animate.c`, so it applies consistently to the D3D lights, sprite self-illumination, and software renderer (all derive from `lightAdjust`). `OF_FLASHING` is untouched. Tune via the `FLICKER_MIN_BRIGHTNESS` constant (0.50 = stronger, 0.85 = subtler).