### PR TITLE
Ignore source bitmaps in `resource/graphics` in favor of external management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ bin/rscprint.exe
 install/meridian59-installer.exe
 roomedit/windeu32.log
 resource/rooms/*~
+resource/graphics/*.bmp
 
 # Include runtime scripts
 !run/scripts


### PR DESCRIPTION
This PR ignores bitmaps in `resource/graphics`. In practice, these files are shared and managed outside of the codebase.