### PR TITLE
`bbgun` updates

### DIFF
--- a/bbgun/bbgun.h
+++ b/bbgun/bbgun.h
@@ -36,7 +36,7 @@
 
 #define MAX_BITMAPS 150
 #define MAX_BBGS 3
-#define MAX_GROUPS 25
+#define MAX_GROUPS 64
 #define MAX_INDICES 12
 #define MAX_HOTSPOTS 15
 #define MAX_COMMENT 4096

--- a/bbgun/bbgun.h
+++ b/bbgun/bbgun.h
@@ -31,6 +31,8 @@
 #define NUM_COLORS 256       // # of colors in bitmaps
 #define LIGHT_LEVELS 256      // # of lighting levels (not used yet)
 
+#define TRANSPARENT_INDEX 254   // Index of transparent color
+#define BACKGROUND_INDEX 255    // Index of background color
 
 #define MAX_BITMAPS 150
 #define MAX_BBGS 3

--- a/bbgun/bmparea.c
+++ b/bbgun/bmparea.c
@@ -23,7 +23,7 @@ static int capture_type;
 // When a hotspot drag begins, remember the gap between the cursor and the
 // hotspot so the hotspot moves relative to its current position rather than
 // snapping to wherever the user first clicks.
-static BOOL hotspot_grab_init;
+static bool hotspot_grab_init;
 static int  grab_dx, grab_dy;
 
 static WNDPROC lpfnDefButtonProc;
@@ -209,7 +209,7 @@ LRESULT CALLBACK MainButtonProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM l
 
       SetCapture(hwnd);
       capture_type = CAPTURE_HOTSPOT;
-      hotspot_grab_init = TRUE;
+      hotspot_grab_init = true;
       HideCursor();
       SendMessage(hwnd, WM_MOUSEMOVE, wParam, lParam);
       break;
@@ -300,7 +300,7 @@ void HotspotDrag(HWND hwnd)
    {
       grab_dx = spot->X - mbx;
       grab_dy = spot->Y - mby;
-      hotspot_grab_init = FALSE;
+      hotspot_grab_init = false;
    }
 
    spot->X = mbx + grab_dx;

--- a/bbgun/bmparea.c
+++ b/bbgun/bmparea.c
@@ -20,6 +20,12 @@ enum {
 
 static int capture_type;
 
+// When a hotspot drag begins, remember the gap between the cursor and the
+// hotspot so the hotspot moves relative to its current position rather than
+// snapping to wherever the user first clicks.
+static BOOL hotspot_grab_init;
+static int  grab_dx, grab_dy;
+
 static WNDPROC lpfnDefButtonProc;
 static int bwidth, bheight;   // Size of bitmap area
 
@@ -66,7 +72,12 @@ void DoDraw(HDC hDC1, HWND hWnd)
    Bitmap *b, *anchor, *wanderer;
 
    ClearBitmap();
-      
+
+   // Confine all drawing (bitmaps and hotspot markers) to the bitmap view area.
+   // Otherwise a hotspot dragged near/past the edges draws its marker outside
+   // the view and over the surrounding window UI.
+   IntersectClipRect(hDC1, 0, 0, bwidth, bheight);
+
    if (!config.dual_mode && NumBBGs > 0 && BBGs[CurrentBBG].NumBitmaps > 0)
    {
       // Draw single bitmap
@@ -198,6 +209,7 @@ LRESULT CALLBACK MainButtonProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM l
 
       SetCapture(hwnd);
       capture_type = CAPTURE_HOTSPOT;
+      hotspot_grab_init = TRUE;
       HideCursor();
       SendMessage(hwnd, WM_MOUSEMOVE, wParam, lParam);
       break;
@@ -247,41 +259,52 @@ LRESULT CALLBACK MainButtonProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM l
  */
 void HotspotDrag(HWND hwnd)
 {
-   Bitmap *anchor, *wanderer, *b;
+   Bitmap *anchor, *b;
+   Spot   *spot;
 
    int mouse_x, mouse_y;
+   int mbx, mby;   // Cursor position in bitmap coordinates
 
    if ((NumBBGs == 0) || (BBGs[CurrentBBG].NumBitmaps == 0)) 
       return;
       
    if (GetCursorWindowPos(hwnd, &mouse_x, &mouse_y) == FALSE)
       return;
-   
+
+   StaticX = (bwidth - DibWidth(pdib1) * Zoom) / 2;
+   StaticY = (bheight - DibHeight(pdib1) * Zoom) / 2;
+
+   mbx = (mouse_x - StaticX) / Zoom;
+   mby = (mouse_y - StaticY) / Zoom;
+
    if (config.dual_mode)
    {
       if (Anchor.BBG == -1)
 	 return;
       
-      anchor   = &BBGs[Anchor.BBG].Bitmaps[BBGs[Anchor.BBG].CurrentBitmap];
-      wanderer = &BBGs[WanderOne.BBG].Bitmaps[BBGs[WanderOne.BBG].CurrentBitmap];
-
-      StaticX = (bwidth - DibWidth(pdib1) * Zoom) / 2;
-      StaticY = (bheight - DibHeight(pdib1) * Zoom) / 2;
-      anchor->Hotspots[BBGs[Anchor.BBG].CurrentHotspot].X = (mouse_x - StaticX) / Zoom;
-      anchor->Hotspots[BBGs[Anchor.BBG].CurrentHotspot].Y = (mouse_y - StaticY) / Zoom;
+      anchor = &BBGs[Anchor.BBG].Bitmaps[BBGs[Anchor.BBG].CurrentBitmap];
+      spot   = &anchor->Hotspots[BBGs[Anchor.BBG].CurrentHotspot];
       BBGs[Anchor.BBG].changed = TRUE;
    }
    else
    {
-      b = &BBGs[CurrentBBG].Bitmaps[CurrentBitmap];
-      
-      StaticX = (bwidth - DibWidth(pdib1) * Zoom) / 2;
-      StaticY = (bheight - DibHeight(pdib1) * Zoom) / 2;
-      
-      b->Hotspots[CurrentHotspot].X = (mouse_x - StaticX) / Zoom;
-      b->Hotspots[CurrentHotspot].Y = (mouse_y - StaticY) / Zoom;
+      b    = &BBGs[CurrentBBG].Bitmaps[CurrentBitmap];
+      spot = &b->Hotspots[CurrentHotspot];
       BBGs[CurrentBBG].changed = TRUE;
    }
+
+   // On the first move after the click, capture the gap between the hotspot
+   // and the cursor.  Subsequent moves keep that gap, so the hotspot tracks
+   // the mouse from where it started instead of jumping under the cursor.
+   if (hotspot_grab_init)
+   {
+      grab_dx = spot->X - mbx;
+      grab_dy = spot->Y - mby;
+      hotspot_grab_init = FALSE;
+   }
+
+   spot->X = mbx + grab_dx;
+   spot->Y = mby + grab_dy;
 
    UpdateHotspot();
    DrawIt();

--- a/bbgun/dibutil.c
+++ b/bbgun/dibutil.c
@@ -45,6 +45,19 @@ PDIB DibOpenFile(LPSTR szFile)
     if (!pdib)
         return NULL;
 
+    /* Some BMPs store a biSizeImage smaller than the actual DWORD-aligned
+     * pixel data (e.g. saved as width*height with no row padding).  Trusting
+     * it under-allocates the buffer, and the row-flip below - which steps by
+     * the DWORD-aligned row size - then reads and writes past the end of the
+     * allocation, corrupting the heap and crashing later.  Recompute the
+     * aligned size for uncompressed bitmaps and use the larger value. */
+    if (pdib->biCompression == BI_RGB)
+    {
+       DWORD aligned = (DWORD) WIDTHBYTES(DibWidth(pdib)) * (DWORD) abs(DibHeight(pdib));
+       if (pdib->biSizeImage < aligned)
+          pdib->biSizeImage = aligned;
+    }
+
     /* How much memory do we need to hold the DIB */
 
     dwBits = pdib->biSizeImage;
@@ -83,6 +96,10 @@ PDIB DibOpenFile(LPSTR szFile)
 	  memcpy(row2, temp, (size_t) width);
        }
        free(temp);
+
+       /* Normalize pixels to the standard palette so colors display correctly
+	* regardless of the source bitmap's palette ordering. */
+       DibRemapToBasePalette(pdib);
     }
 
     close(fh);

--- a/bbgun/draw.c
+++ b/bbgun/draw.c
@@ -13,9 +13,6 @@
 
 #include "bbgun.h"
 
-#define TRANSPARENT_INDEX 254   // Index of transparent color
-#define BACKGROUND_INDEX 255    // Index of background color
-
 #define OFFSCREEN_BITMAP_SIZE 512
 
 #define FIX_DECIMAL 16

--- a/bbgun/palette.c
+++ b/bbgun/palette.c
@@ -206,3 +206,50 @@ int GetClosestPaletteIndex(COLORREF c)
    }
    return min_index;
 }
+/************************************************************************/
+/*
+ * DibRemapToBasePalette:  Remap an 8-bit DIB's pixels from its own color
+ *   table to the indices of our standard (base) palette, so that the raw
+ *   indices line up with the offscreen buffer's color table when drawn.
+ *   The transparent (254) and background (255) indices are preserved, since
+ *   the drawing code relies on those specific index values.
+ *   Requires that InitializePalette has been called.
+ */
+void DibRemapToBasePalette(PDIB pdib)
+{
+   RGBQUAD FAR *src;
+   int numColors, i, x, y, width, height, rowbytes;
+   BYTE map[NUM_COLORS];
+   BYTE *bits, *row;
+
+   if (pdib == NULL || DibBitCount(pdib) != 8)
+      return;
+
+   src = DibColors(pdib);
+   numColors = DibNumColors(pdib);
+   if (numColors > NUM_COLORS)
+      numColors = NUM_COLORS;
+
+   for (i = 0; i < numColors; i++)
+      map[i] = (BYTE) GetClosestPaletteIndex(
+		  RGB(src[i].rgbRed, src[i].rgbGreen, src[i].rgbBlue));
+
+   // Preserve special indices used by the drawing code
+   if (numColors > TRANSPARENT_INDEX)
+      map[TRANSPARENT_INDEX] = TRANSPARENT_INDEX;
+   if (numColors > BACKGROUND_INDEX)
+      map[BACKGROUND_INDEX] = BACKGROUND_INDEX;
+
+   bits = (BYTE *) DibPtr(pdib);
+   width = DibWidth(pdib);
+   height = DibHeight(pdib);
+   rowbytes = WIDTHBYTES(width);
+
+   for (y = 0; y < height; y++)
+   {
+      row = bits + y * rowbytes;
+      for (x = 0; x < width; x++)
+	 if (row[x] < numColors)
+	    row[x] = map[row[x]];
+   }
+}

--- a/bbgun/palette.c
+++ b/bbgun/palette.c
@@ -218,7 +218,6 @@ int GetClosestPaletteIndex(COLORREF c)
 void DibRemapToBasePalette(PDIB pdib)
 {
    RGBQUAD FAR *src;
-   int numColors, i, x, y, width, height, rowbytes;
    BYTE map[NUM_COLORS];
    BYTE *bits, *row;
 
@@ -226,11 +225,11 @@ void DibRemapToBasePalette(PDIB pdib)
       return;
 
    src = DibColors(pdib);
-   numColors = DibNumColors(pdib);
+   int numColors = DibNumColors(pdib);
    if (numColors > NUM_COLORS)
       numColors = NUM_COLORS;
 
-   for (i = 0; i < numColors; i++)
+   for (int i = 0; i < numColors; i++)
       map[i] = (BYTE) GetClosestPaletteIndex(
 		  RGB(src[i].rgbRed, src[i].rgbGreen, src[i].rgbBlue));
 
@@ -241,15 +240,15 @@ void DibRemapToBasePalette(PDIB pdib)
       map[BACKGROUND_INDEX] = BACKGROUND_INDEX;
 
    bits = (BYTE *) DibPtr(pdib);
-   width = DibWidth(pdib);
-   height = DibHeight(pdib);
-   rowbytes = WIDTHBYTES(width);
+   int width = DibWidth(pdib);
+   int height = DibHeight(pdib);
+   int rowbytes = WIDTHBYTES(width);
 
-   for (y = 0; y < height; y++)
+   for (int y = 0; y < height; y++)
    {
       row = bits + y * rowbytes;
-      for (x = 0; x < width; x++)
-	 if (row[x] < numColors)
-	    row[x] = map[row[x]];
+      for (int x = 0; x < width; x++)
+	   if (row[x] < numColors)
+	      row[x] = map[row[x]];
    }
 }

--- a/bbgun/palette.c
+++ b/bbgun/palette.c
@@ -217,7 +217,7 @@ int GetClosestPaletteIndex(COLORREF c)
  */
 void DibRemapToBasePalette(PDIB pdib)
 {
-   RGBQUAD FAR *src;
+   RGBQUAD *src;
    BYTE map[NUM_COLORS];
    BYTE *bits, *row;
 

--- a/bbgun/palette.h
+++ b/bbgun/palette.h
@@ -17,6 +17,7 @@ typedef struct {
 HPALETTE InitializePalette(void);
 void     SetDIBPalette(HDC gdc);
 COLORREF GetNearestPaletteColor(COLORREF c);
+void     DibRemapToBasePalette(PDIB pdib);
 
 extern HPALETTE hPal;                       /* our standard drawing palette */
 


### PR DESCRIPTION
This PR includes some improvements to bbgun:

1. Remap loaded bitmaps to the standard palette. Loaded art would sometimes display with the wrong colors because the bitmap color table didn't align with the editor's palette. It now remaps each source color to the nearest editor palette index.
2. Improves hotspot dragging by moving them relative to their position instead of snapping under the cursor.
3. Fixes an issue with hotspots drawing outside of the bitmap view if dragged too close.
4. Raises `MAX_GROUPS` from 25 to 64 because many of the current art files define more than 25 groups. This would overflow the fixed `Groups[]` array and crash the editor.