### PR TITLE
Better feedback when a kill is too weak to advance

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -144,6 +144,12 @@ resources:
    player_improve_maxhealth = "~I~BYou suddenly feel a little tougher."
    player_improve_health_invigorate = "~I~BYou are invigorated by your success."
    player_spits = "You spit on the corpse of your unworthy foe."
+   % Shown after killing a creature whose level is too low to train the
+   % wielded weapon's proficiency any further.  %s is the proficiency name
+   % (e.g. "fencing").
+   player_weapon_prof_capped = \
+      "~IYou feel you've learned all you can about %s from fighting foes this "
+      "weak.  You should seek tougher opponents."
    player_regain_angel = \
       "Due to your weakness, your protective guardian angel returns."
    player_no_angel = "You suddenly feel more vulnerable."
@@ -7684,17 +7690,70 @@ messages:
          if what = self
          {
             Send(self,@AdvancementCheck,#what=victim,#killing_blow=TRUE);
+            Send(self,@NotifyWeaponProfCapped,#victim=victim);
          }
          else
          {
             Send(self,@AdvancementCheck,#what=victim,#killing_blow=FALSE);
          }
-         
+
          poKill_target=$;
          Send(self,@ResetGainFlags);
       }
       
       propagate;
+   }
+
+   NotifyWeaponProfCapped(victim=$)
+   "Called when this player lands the killing blow.  If the wielded weapon's"
+   "proficiency can no longer improve from a creature this weak, tell the"
+   "player to seek tougher opponents.  Mirrors the spit-on-corpse message:"
+   "informative, fired once at the kill rather than on every swing."
+   {
+      local oWeapon, iProfNum, iAbility, oSkill;
+
+      % Occasional reminder, like the spit-on-corpse message, rather than on
+      % every weak kill.
+      if random(1,100) >= 10
+      {
+         return;
+      }
+
+      % Only meaningful on creatures you can actually advance on (skip
+      % revenants, illusions, etc) and while wielding a weapon.
+      if NOT Send(victim,@CanPlayerAdvanceOnMe)
+      {
+         return;
+      }
+
+      oWeapon = Send(self,@LookupPlayerWeapon);
+      if oWeapon = $
+      {
+         return;
+      }
+
+      iProfNum = Send(oWeapon,@GetProfNumber);
+      iAbility = Send(self,@GetSkillAbility,#skill_num=iProfNum);
+
+      % A weapon proficiency improves only against creatures whose level
+      % exceeds the current ability (see Stroke ImproveStroke).  At 99 it is
+      % effectively maxed, so no creature would help and there's nothing to say.
+      if iAbility >= 99
+         OR iAbility < Send(victim,@GetLevel)
+      {
+         return;
+      }
+
+      oSkill = Send(SYS,@FindSkillByNum,#num=iProfNum);
+      if oSkill = $
+      {
+         return;
+      }
+
+      Send(self,@MsgSendUser,#message_rsc=player_weapon_prof_capped,
+           #parm1=Send(oSkill,@GetName));
+
+      return;
    }
 
    ResetGainFlags()
@@ -7757,21 +7816,20 @@ messages:
          }
          else
          {
-            % Monster was equal or close to player level.  Small bonus,
-            %  no roll chance.
+            % Monster was equal to or below the player's HP.  One within 5 HP
+            % still adds a small amount toward a future gain (no roll chance).
             if (monster_level + 5) > piBase_Max_health
-               AND IsClass(what,&monster) AND killing_blow 
+               AND IsClass(what,&monster) AND killing_blow
                AND Send(self,@CheckPlayerFlag,#flag=PFLAG_TOOK_DAMAGE)
             {
                gain = 1;
             }
-            else
+
+            % A creature at or below your own HP can no longer toughen you, so
+            % occasionally spit on it regardless of any small bonus above.
+            if random(1,100) < 10 AND killing_blow
             {
-               % Monster was too easy for player to kill!
-               if random(1,100) < 10 AND killing_blow
-               {
-                  Send(self,@MsgSendUser,#message_rsc=player_spits);
-               }
+               Send(self,@MsgSendUser,#message_rsc=player_spits);
             }
          }
 

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -7690,7 +7690,7 @@ messages:
          if what = self
          {
             Send(self,@AdvancementCheck,#what=victim,#killing_blow=TRUE);
-            Send(self,@NotifyWeaponProfCapped,#victim=victim);
+            Send(self,@NotifyWeaponProficiencyCapped,#victim=victim);
          }
          else
          {
@@ -7704,11 +7704,10 @@ messages:
       propagate;
    }
 
-   NotifyWeaponProfCapped(victim=$)
-   "Called when this player lands the killing blow.  If the wielded weapon's"
-   "proficiency can no longer improve from a creature this weak, tell the"
-   "player to seek tougher opponents.  Mirrors the spit-on-corpse message:"
-   "informative, fired once at the kill rather than on every swing."
+   NotifyWeaponProficiencyCapped(victim=$)
+   "If the wielded weapon's proficiency can no longer improve from a creature "
+   "this weak, occasionally remind the player to seek tougher opponents.  "
+   "Purely informative, like the spit-on-corpse message."
    {
       local oWeapon, iProfNum, iAbility, oSkill;
 

--- a/kod/object/passive/skill/stroke.kod
+++ b/kod/object/passive/skill/stroke.kod
@@ -23,13 +23,6 @@ resources:
 
    stroke_need_weapon_rsc = "You need a weapon to perform this stroke!"
 
-   % Shown when a creature's level (hit points) is too low for the player to
-   % improve this skill/proficiency any further by fighting it.  %s is the
-   % skill or proficiency name (e.g. "hammer wielding").
-   stroke_creature_cap_hit = \
-      "~IYou feel you've learned all you can about %s from fighting this "
-      "creature. You should seek tougher opponents."
-
    stroke_miss_attacker = "%sYour %s misses %s%s."
    stroke_miss_defender = "%s%s misses you."
    stroke_miss_sound = swordmis.wav
@@ -115,11 +108,6 @@ messages:
              % checking for stroke advancement
              send(self,@ImproveAbility,#who=who,#target=target,#bonus=Send(who,@GetWeaponSwingBonus));
           }
-        else
-          {
-             % Stroke skill is capped by this creature's level (hit points).
-             send(self,@NotifyCreatureCap,#who=who,#target=target,#skill_num=viSkill_num);
-          }
      }
      else
      {
@@ -128,55 +116,13 @@ messages:
              % checking for weapon proficiency advancement
              send(use_weapon,@ImproveProficiency,#who=who,#target=target,#bonus=Send(who,@GetWeaponSwingBonus));
           }
-        else
-          {
-             % Weapon proficiency is capped by this creature's level (hit points).
-             send(self,@NotifyCreatureCap,#who=who,#target=target,#skill_num=prof);
-          }
      }
-
+     
      return;
    }
 
-   NotifyCreatureCap(who=$,target=$,skill_num=$)
-   "Tells the player they can't improve this skill/proficiency any further by"
-   "fighting this creature, because its level (hit points) is too low.  This"
-   "fires on an improve attempt that fails purely because of the creature's"
-   "level cap, and stops once the ability reaches its 99% maximum."
-   {
-      local oSkill, iAbility;
-
-      % Only players learn, and only on creatures they're allowed to advance on
-      % (skip revenants, illusions, etc).
-      if NOT IsClass(who,&Player)
-         OR (target <> $ AND NOT Send(target,@CanPlayerAdvanceOnMe))
-      {
-         return;
-      }
-
-      iAbility = Send(who,@GetSkillAbility,#skill_num=skill_num);
-
-      % At 99 the ability is effectively maxed, so the creature is no longer the
-      % limiting factor and there's nothing to gain from tougher foes.
-      if iAbility >= 99
-      {
-         return;
-      }
-
-      oSkill = Send(SYS,@FindSkillByNum,#num=skill_num);
-      if oSkill = $
-      {
-         return;
-      }
-
-      Send(who,@MsgSendUser,#message_rsc=stroke_creature_cap_hit,
-           #parm1=Send(oSkill,@GetName));
-
-      return;
-   }
-
    SuccessChance()
-   "Always returns TRUE for combat strokes.  COmbat strokes are figured"
+   "Always returns TRUE for combat strokes.  Combat strokes are figured"
    "differently than other skills - are figured in player.kod."
    {
       return TRUE;

--- a/kod/object/passive/skill/stroke.kod
+++ b/kod/object/passive/skill/stroke.kod
@@ -23,6 +23,13 @@ resources:
 
    stroke_need_weapon_rsc = "You need a weapon to perform this stroke!"
 
+   % Shown when a creature's level (hit points) is too low for the player to
+   % improve this skill/proficiency any further by fighting it.  %s is the
+   % skill or proficiency name (e.g. "hammer wielding").
+   stroke_creature_cap_hit = \
+      "~IYou feel you've learned all you can about %s from fighting this "
+      "creature. You should seek tougher opponents."
+
    stroke_miss_attacker = "%sYour %s misses %s%s."
    stroke_miss_defender = "%s%s misses you."
    stroke_miss_sound = swordmis.wav
@@ -108,6 +115,11 @@ messages:
              % checking for stroke advancement
              send(self,@ImproveAbility,#who=who,#target=target,#bonus=Send(who,@GetWeaponSwingBonus));
           }
+        else
+          {
+             % Stroke skill is capped by this creature's level (hit points).
+             send(self,@NotifyCreatureCap,#who=who,#target=target,#skill_num=viSkill_num);
+          }
      }
      else
      {
@@ -116,9 +128,51 @@ messages:
              % checking for weapon proficiency advancement
              send(use_weapon,@ImproveProficiency,#who=who,#target=target,#bonus=Send(who,@GetWeaponSwingBonus));
           }
+        else
+          {
+             % Weapon proficiency is capped by this creature's level (hit points).
+             send(self,@NotifyCreatureCap,#who=who,#target=target,#skill_num=prof);
+          }
      }
-     
+
      return;
+   }
+
+   NotifyCreatureCap(who=$,target=$,skill_num=$)
+   "Tells the player they can't improve this skill/proficiency any further by"
+   "fighting this creature, because its level (hit points) is too low.  This"
+   "fires on an improve attempt that fails purely because of the creature's"
+   "level cap, and stops once the ability reaches its 99% maximum."
+   {
+      local oSkill, iAbility;
+
+      % Only players learn, and only on creatures they're allowed to advance on
+      % (skip revenants, illusions, etc).
+      if NOT IsClass(who,&Player)
+         OR (target <> $ AND NOT Send(target,@CanPlayerAdvanceOnMe))
+      {
+         return;
+      }
+
+      iAbility = Send(who,@GetSkillAbility,#skill_num=skill_num);
+
+      % At 99 the ability is effectively maxed, so the creature is no longer the
+      % limiting factor and there's nothing to gain from tougher foes.
+      if iAbility >= 99
+      {
+         return;
+      }
+
+      oSkill = Send(SYS,@FindSkillByNum,#num=skill_num);
+      if oSkill = $
+      {
+         return;
+      }
+
+      Send(who,@MsgSendUser,#message_rsc=stroke_creature_cap_hit,
+           #parm1=Send(oSkill,@GetName));
+
+      return;
    }
 
    SuccessChance()


### PR DESCRIPTION
Helps players know when a creature is no longer worth fighting:

  - New occasional message on the killing blow when your weapon's proficiency can no longer improve from a creature this weak (fired once at the kill, like the spit-on-corpse message - not every swing).
  - Spit-on-corpse message now fires when the monster is at or below your HP (the point where it can no longer toughen you), instead of the old 5-HP buffer. The small near-level +1 gain bonus is unchanged.
  - Minor comment typo fix in stroke.kod.

  ▎ You feel you've learned all you can about hammer wielding from fighting foes this weak.  You should seek tougher opponents.
  
<img width="1764" height="838" alt="image" src="https://github.com/user-attachments/assets/2667be83-084c-472c-95ae-885e35cff85e" />

Inspired by a suggestion made by Gar at https://discord.com/channels/650824489885630475/1515569949522006106
