### PR TITLE
Fix for rented rooms not deleting properly

### DIFF
--- a/kod/object/active/holder/room/rentroom.kod
+++ b/kod/object/active/holder/room/rentroom.kod
@@ -1475,6 +1475,7 @@ messages:
       Send(oMasterKey, @DeleteCopies);
       Send(oMaintenance, @RoomDeleted,#what=self);
       Send(oMasterKey, @RoomExpired);
+      Send(SYS, @DeleteRoom, #what=self);
 
       if ptDecoratorArrives <> $
       {


### PR DESCRIPTION
Fixes a bug where rented rooms weren't being properly deleted upon expiration, which resulted in these half-deleted rooms being incorrectly rented out again.

- Renting an incorrectly deleted room locked the renter to that room's class regardless of where they rented from.  Someone renting a room in Marion might end up with a room from Barloque, for example.
- Renting an incorrectly deleted room would result in a room that couldn't be modified, as the bell used to summon the decorator would be missing.

This fix solves both of these issues.