### PR TITLE
Fix slow, distance-dependent projectile speed at close/normal range

### DIFF
--- a/clientd3d/moveobj.c
+++ b/clientd3d/moveobj.c
@@ -166,7 +166,7 @@ void MoveObject2(ID object_id, int x, int y, BYTE speed, BOOL turnToFace)
 	else 
 	{
 		float distance = sqrtf((float)(dx * dx + dy * dy)) / (float)FINENESS;
-		r->motion.increment = (((float) r->motion.speed) / OBJECT_SPEED_PERIOD_MSEC) / distance;
+		r->motion.increment = (((float) r->motion.speed) / OBJECT_INTERVAL_MS) / distance;
 	}
 	
 	r->motion.move_animating = true;

--- a/clientd3d/moveobj.c
+++ b/clientd3d/moveobj.c
@@ -166,8 +166,7 @@ void MoveObject2(ID object_id, int x, int y, BYTE speed, BOOL turnToFace)
 	else 
 	{
 		float distance = sqrtf((float)(dx * dx + dy * dy)) / (float)FINENESS;
-		// Object motion is given in # of grid squares per 10 seconds
-		r->motion.increment = (((float) r->motion.speed) / 10000.0f) / distance;
+		r->motion.increment = (((float) r->motion.speed) / OBJECT_SPEED_PERIOD_MSEC) / distance;
 	}
 	
 	r->motion.move_animating = true;

--- a/clientd3d/moveobj.h
+++ b/clientd3d/moveobj.h
@@ -14,6 +14,13 @@
 
 #define GRAVITY_ACCELERATION (- 5 * FINENESS)   // In FINENESS units / second / second
 
+// Smooth-motion increment is the fraction of the journey covered per millisecond:
+// (speed / period) / distance.  A "speed" value is grid squares per time window.
+// Walking objects measure speed over a 10-second window; projectiles over 1 second,
+// so the same speed value moves a projectile ten times as far per millisecond.
+static const float PROJECTILE_SPEED_PERIOD_MSEC = 1000.0f;
+static const float OBJECT_SPEED_PERIOD_MSEC     = 10.0f * PROJECTILE_SPEED_PERIOD_MSEC;
+
 void MoveObject2(ID object_id, int x, int y, BYTE speed, BOOL turnToFace);
 bool ObjectsMove(int dt);
 bool MoveSingle(Motion *m, int dt);

--- a/clientd3d/moveobj.h
+++ b/clientd3d/moveobj.h
@@ -18,8 +18,8 @@
 // (speed / period) / distance.  Object motion is given in # of grid squares per 10
 // seconds; projectiles are given per 1 second, so the same speed value moves a
 // projectile ten times as far per millisecond.
-static const float PROJECTILE_SPEED_PERIOD_MSEC = 1000.0f;
-static const float OBJECT_SPEED_PERIOD_MSEC     = 10.0f * PROJECTILE_SPEED_PERIOD_MSEC;
+static const float PROJECTILE_INTERVAL_MS = 1000.0f;
+static const float OBJECT_INTERVAL_MS     = 10.0f * PROJECTILE_INTERVAL_MS;
 
 void MoveObject2(ID object_id, int x, int y, BYTE speed, BOOL turnToFace);
 bool ObjectsMove(int dt);

--- a/clientd3d/moveobj.h
+++ b/clientd3d/moveobj.h
@@ -15,9 +15,9 @@
 #define GRAVITY_ACCELERATION (- 5 * FINENESS)   // In FINENESS units / second / second
 
 // Smooth-motion increment is the fraction of the journey covered per millisecond:
-// (speed / period) / distance.  A "speed" value is grid squares per time window.
-// Walking objects measure speed over a 10-second window; projectiles over 1 second,
-// so the same speed value moves a projectile ten times as far per millisecond.
+// (speed / period) / distance.  Object motion is given in # of grid squares per 10
+// seconds; projectiles are given per 1 second, so the same speed value moves a
+// projectile ten times as far per millisecond.
 static const float PROJECTILE_SPEED_PERIOD_MSEC = 1000.0f;
 static const float OBJECT_SPEED_PERIOD_MSEC     = 10.0f * PROJECTILE_SPEED_PERIOD_MSEC;
 

--- a/clientd3d/projectile.c
+++ b/clientd3d/projectile.c
@@ -90,10 +90,7 @@ void ProjectileAdd(Projectile *p, ID source_obj, ID dest_obj, BYTE speed, WORD f
 
       distance = sqrtf(dx_f * dx_f + dy_f * dy_f + dz_f * dz_f) / FINENESS;
 
-      // Calculate normal increment based on speed, where increment is "progress per
-      // millisecond". Projectiles fly faster than walking objects, so they use a /1000
-      // divisor rather than the /10000 MoveObject2() uses for object motion.
-      float normal_increment = ((float) speed) / 1000.0f / distance;
+      float normal_increment = ((float) speed) / PROJECTILE_SPEED_PERIOD_MSEC / distance;
 
       // Cap maximum travel time to prevent extremely long-range projectiles from taking
       // 30+ seconds to arrive, which breaks gameplay (attack sounds/animations finish

--- a/clientd3d/projectile.c
+++ b/clientd3d/projectile.c
@@ -90,11 +90,10 @@ void ProjectileAdd(Projectile *p, ID source_obj, ID dest_obj, BYTE speed, WORD f
 
       distance = sqrtf(dx_f * dx_f + dy_f * dy_f + dz_f * dz_f) / FINENESS;
 
-      // Calculate normal increment based on speed
-      // The server sends speed as "grid squares per 10 seconds", and increment is
-      // "progress per millisecond", so we divide by 10000 (10 seconds = 10000 milliseconds).
-      // This matches the calculation in MoveObject2() in moveobj.c.
-      float normal_increment = ((float) speed) / 10000.0f / distance;
+      // Calculate normal increment based on speed, where increment is "progress per
+      // millisecond". Projectiles fly faster than walking objects, so they use a /1000
+      // divisor rather than the /10000 MoveObject2() uses for object motion.
+      float normal_increment = ((float) speed) / 1000.0f / distance;
 
       // Cap maximum travel time to prevent extremely long-range projectiles from taking
       // 30+ seconds to arrive, which breaks gameplay (attack sounds/animations finish

--- a/clientd3d/projectile.c
+++ b/clientd3d/projectile.c
@@ -90,7 +90,7 @@ void ProjectileAdd(Projectile *p, ID source_obj, ID dest_obj, BYTE speed, WORD f
 
       distance = sqrtf(dx_f * dx_f + dy_f * dy_f + dz_f * dz_f) / FINENESS;
 
-      float normal_increment = ((float) speed) / PROJECTILE_SPEED_PERIOD_MSEC / distance;
+      float normal_increment = ((float) speed) / PROJECTILE_INTERVAL_MS / distance;
 
       // Cap maximum travel time to prevent extremely long-range projectiles from taking
       // 30+ seconds to arrive, which breaks gameplay (attack sounds/animations finish


### PR DESCRIPTION
#1356 changed the projectile speed divisor from /1000 to /10000 to "match MoveObject2", but projectiles are meant to fly ~10× faster than walking objects. This made every projectile 10× slower in the normal (uncapped) case, while the new max-travel-time cap only masked it at long range. The result was crawling arrows up close and an obvious speed-vs-distance regime switch ("goofy" flight, very noticeable next to a monster).

Restores the projectile-specific /1000 divisor so close/normal shots fly at their original speed. The `MAX_PROJECTILE_TRAVEL_TIME` long-range cap is preserved, so far shots still arrive within 2 s - and the cap now only kicks in at genuine long range (distance > 2*speed) instead of speed/5.

Client-only change (ProjectileAdd); no server/KOD rebuild needed.