### PR TITLE
Fix for Hunt errors on invalid names

### DIFF
--- a/kod/object/passive/spell/multicst/hunt.kod
+++ b/kod/object/passive/spell/multicst/hunt.kod
@@ -164,17 +164,17 @@ messages:
 
       oPrey = Send(SYS,@FindUserByString,#string=string);
 
-      if IsClass(oPrey,&DM) AND NOT Send(oPrey,@IsHuntable)
+      if (oPrey <> $)
       {
-         Send(who,@MsgSendUser,#message_rsc=hunt_target_is_dm);
+         if IsClass(oPrey,&DM) AND NOT Send(oPrey,@IsHuntable)
+         {
+            Send(who,@MsgSendUser,#message_rsc=hunt_target_is_dm);
 
-         return;
-      }
+            return;
+         }
 
-      lTargets = $;
+         lTargets = $;
 
-      if oPrey <> $
-      {
          % Use EVENT_STEER so we don't print message
          Send(who,@breaktrance,#event=EVENT_STEER);  
          lTargets = cons(oPrey,lTargets);


### PR DESCRIPTION
This fixes a bug where casting hunt and then specifying a player name that doesn't exist sends error messages to the server.  The fix adds a null check after attempting to find the player by name.  This shouldn't change how the spell functions for players in any way.

Addresses https://github.com/Meridian59/Meridian59/issues/1464