### PR TITLE
justicar: Add adjustable playtime and ballot cost gates

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqclerk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqclerk.kod
@@ -68,10 +68,12 @@ resources:
       "--Caramo"
    barloque_clerk_election_open_subject = "The Election Campaign Hath Begun"
    barloque_clerk_election_open = \
-      "The election for Justicar hath begun.  Thou mayest now buy a ballot from me. "
-      "Write the name of the candidate of thy preference and return it for official"
-      " tally.  Do remember, under current Meridian law, neither new citizens nor "
-      "outlaws can vote or hold office."
+      "The election for Justicar hath begun.  Thou mayest now purchase a ballot from "
+      "me.  Write the name of the candidate of thy preference and return it for "
+      "official tally.  Do remember, under current Meridian law, a citizen must be "
+      "hardy enough and have spent enough time in the lands to vote or hold office, "
+      "by the measure the Crown doth set; neither new citizens nor outlaws can do "
+      "either."
       "\n\n"
       "--Caramo"
    barloque_clerk_tally_day = \
@@ -169,7 +171,9 @@ resources:
 
    barloqueclerk_hands_back = "~bCaramo hands back the ballot."
    barloqueclerk_bad_candidate = "%q is ineligible for the office of Justicar."
-   barloqueclerk_no_newbie_voter = "You are not yet eligible to vote."
+   barloqueclerk_no_newbie_voter = \
+      "You are not yet eligible to vote.  By the Crown's present measure, thou must "
+      "be hardier and have spent more time in the lands ere thou may cast a ballot."
    barloqueclerk_no_outlaw_voter = "Criminals have no voting rights.  Begone."
 
    barloque_clerk_notify_ad = \
@@ -366,6 +370,16 @@ messages:
       plFor_sale = [ [ Create(&BallotItem) ],
                      $,$];
       return;
+   }
+
+   GetPrice(what = $, who = $)
+   {
+      if IsClass(what,&BallotItem)
+      {
+         return Send(Send(SYS,@GetSettings),@GetBallotCost);
+      }
+
+      propagate;
    }
 
    %%% Handling people and disordery conduct.
@@ -946,7 +960,7 @@ messages:
    UserStartAdvertise(who=$)
    "Adds user to the advertising list."
    {
-      if NOT Send(self, @IsPlayerSeniorEnough, #who = who)
+      if NOT Send(self,@IsQualifiedVoter,#who=who)
       {
          Send(self,@Say,#message_rsc=barloque_clerk_no_start_ad_angel);
 
@@ -1019,8 +1033,8 @@ messages:
    "Sends a user to 'who' if not an outlaw/murderer."
    {
       if NOT (Send(who,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
-              OR Send(who,@CheckPlayerFlag,#flag=PFLAG_MURDERER))
-         AND Send(self, @IsPlayerSeniorEnough, #who = who)
+            OR Send(who,@CheckPlayerFlag,#flag=PFLAG_MURDERER))
+         AND Send(self,@IsQualifiedVoter,#who=who)
       {
          Send(who,@MsgSendUser,#message_rsc=barloque_clerk_notify_ad);
       }
@@ -1174,7 +1188,7 @@ messages:
 
    IsLegalVoter(voter=$)
    {
-      if NOT Send(self, @IsPlayerSeniorEnough, #who = voter)
+      if NOT Send(self,@IsQualifiedVoter,#who=voter)
       {
          Send(self,@SayToOne,#message_rsc=barloqueclerk_no_newbie_voter,#target=voter);
          
@@ -1201,6 +1215,11 @@ messages:
       
       if Send(candidate,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
          OR Send(candidate,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
+      {
+         return FALSE;
+      }
+
+      if NOT Send(self,@IsQualifiedCandidate,#who=candidate)
       {
          return FALSE;
       }
@@ -1376,12 +1395,28 @@ messages:
       return poJusticar;
    }
 
-   IsPlayerSeniorEnough(who = $)
-   "Determine whether the given player is senior enough to partipate in Justicar voting. "
-   "This is to prevent mules from swamping the voting."
+   IsQualifiedVoter(who = $)
+   "Whether the player is qualified to vote for Justicar. Prevents mules from swamping the voting."
    {
-      return Send(who, @GetBaseMaxHealth) >= 
-             Send(Send(SYS, @GetSettings), @GetMinHPForJusticar);
+      if Send(who,@GetBaseMaxHealth) < Send(Send(SYS,@GetSettings),@GetMinHPForJusticarVoter)
+      {
+         return FALSE;
+      }
+
+      return Send(who,@GetTimeLoggedIn) >=
+             Send(Send(SYS,@GetSettings),@GetMinHoursOnlineForJusticar) * 3600;
+   }
+
+   IsQualifiedCandidate(who = $)
+   "Whether the player is qualified to hold the office of Justicar."
+   {
+      if Send(who,@GetBaseMaxHealth) < Send(Send(SYS,@GetSettings),@GetMinHPForJusticar)
+      {
+         return FALSE;
+      }
+
+      return Send(who,@GetTimeLoggedIn) >=
+             Send(Send(SYS,@GetSettings),@GetMinHoursOnlineForJusticar) * 3600;
    }
 
    ResetBrain()

--- a/kod/object/active/holder/room/barlqrm/barcourt.kod
+++ b/kod/object/active/holder/room/barlqrm/barcourt.kod
@@ -33,11 +33,13 @@ resources:
       "of being an outlaw or a murderer.  The Justicar is elected by the "
       "people of the land."
       "\n\n"
-      "To vote, buy a ballot from Caramo the royal clerk.  Write the name of "
-      "the person that you wish to vote for on the ballot and hand it back to "
-      "her.  Note that outlaws, murderers, and individuals still under "
-      "Shal'ille's protection are not able to vote for or hold the office of "
-      "Justicar."
+      "To vote, buy a ballot from Caramo the royal clerk, write the name of "
+      "the person that you wish to vote for on the ballot, and hand it back "
+      "to her.  The price of a ballot, along with the hardiness and the time "
+      "spent in the lands required to vote for or hold the office, are set by "
+      "the Crown and may change from time to time.  Outlaws, murderers, and "
+      "individuals still under Shal'ille's protection are not able to vote for "
+      "or hold the office of Justicar."
       "\n\n"
       "If elected Justicar, Caramo will send you a mail with details about "
       "the abilities and responsibilities of the office."
@@ -185,20 +187,6 @@ messages:
    {
       return poBookOfJala;
    }
-   
-   Delete()
-   {
-      if poCaramo <> $
-      {
-         Send(poCaramo,@NewOwner,#what=$);
-         poCaramo = $;
-      }
-      
-      poBookofJala = $;
-
-      propagate;
-   }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -121,9 +121,18 @@ properties:
    % How many summoned objects can be in a room
    piPlayerSummonedObjectLimit = 18
 
-   % Minimum number of HP you have to have to vote for or become
-   % Justicar
+   % Minimum number of HP needed to vote for Justicar
+   piMinHPForJusticarVoter = 100
+   
+   % Minimum number of HP needed to become Justicar
    piMinHPForJusticar = 100
+
+   % Minimum cumulative real playtime (in hours) needed to vote for or
+   % become Justicar
+   piMinHoursOnlineForJusticar = 160
+
+   % Cost per Royal Ballot.
+   piBallotCost = 10000
 
    % If enabled, unsafe penalties send the player to their hometown.
    % This is intended to prevent being players 'kept offline' by enemies.
@@ -329,6 +338,21 @@ messages:
    GetMinHPForJusticar()
    {
       return piMinHPForJusticar;
+   }
+
+   GetMinHPForJusticarVoter()
+   {
+      return piMinHPForJusticarVoter;
+   }
+
+   GetMinHoursOnlineForJusticar()
+   {
+      return piMinHoursOnlineForJusticar;
+   }
+
+   GetBallotCost()
+   {
+      return piBallotCost;
    }
    
    % This returns whether players go to a room's blink spot or their hometown when they pen

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -6670,9 +6670,6 @@ messages:
       % after the ballot cost/eligibility changes.
       Send(&BallotItem, @Delete);
 
-      % Recreate the settings object so the new Justicar eligibility settings take effect
-      Send(SYS,@RecreateSettings);
-
       return;
    }
 

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -6666,6 +6666,13 @@ messages:
       % keeps the old list until recreated. Remove after PostPatchUpdates has been applied.
       Send(Send(self, @FindRoomByNum, #num=RID_KA0), @Recreate);
 
+      % Wipe all outstanding Royal Ballots so no cheaply-purchased ballots remain
+      % after the ballot cost/eligibility changes.
+      Send(&BallotItem, @Delete);
+
+      % Recreate the settings object so the new Justicar eligibility settings take effect
+      Send(SYS,@RecreateSettings);
+
       return;
    }
 


### PR DESCRIPTION
The intent of this PR is to make the Justicar election harder to take advantage of.

Players have pointed out that the Justicar election is too easy to cheat, specifically by players with an army of alt accounts. There were a number of ideas shared in several threads in Discord, but I opted for a few simple changes to the voting itself to get things moving in a positive direction. If deployed and no adjustments are made, the only difference will be the new playtime requirement. From there, an administrator can adjust the ballot cost, HP limit for candidates, for voters, and adjust the amount of playtime required to vote and run.

### What changed

* You now need real time played on the character to vote or run. This is perhaps the biggest change and one I think could even be looked at differently, like recent time played. The required amount is adjustable and defaulted to 160 hours (4 x 40hr "work weeks").
* Ballot cost is defaulted to 1,000, but should be adjusted higher if this change ships (e.g., 10,000). The thought is that anyone with an army of voters should feel pain in their pocketbook. This cost is adjustable by an admin. The current cost of a ballot is 16 shillings.
* Voters and candidates have independent, adjustable HP requirements. Both of these thresholds are set to 100 to match the current state.
* Caramo's announcements and the room signage have been updated to speak to these changes.

### Post Patch Notes
* All existing ballots will be deleted.