### PR TITLE
Fix depth sort order for overlapping translucent objects

### DIFF
--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -190,12 +190,13 @@ long D3DRenderObjects(
 	long vx = objectsRenderParams.params->viewer_x;
 	long vy = objectsRenderParams.params->viewer_y;
 
-	// Compute camera forward direction in world space.
-	int angleHeading = objectsRenderParams.params->viewer_angle + 3 * NUMDEGREES / 4;
+	// Camera forward direction on the ground plane. The X term must be negative to
+	// match the view rotation.
+	int angleHeading = objectsRenderParams.params->viewer_angle + LEGACY_HEADING_OFFSET;
 	if (angleHeading >= NUMDEGREES)
 		angleHeading -= NUMDEGREES;
 	float theta = static_cast<float>(angleHeading) * GAME_ANGLE_TO_RAD;
-	float fwdX = sinf(theta);
+	float fwdX = -sinf(theta);
 	float fwdY = cosf(theta);
 
 	std::sort(drawdata, drawdata + gameObjectDataParams.numItems,


### PR DESCRIPTION
The translucent draw pass sorts objects back-to-front using the camera's forward vector, but the vector's X term had the wrong sign relative to the view rotation. This only mis-orders objects that are more side-by-side than front-to-back, so a farther translucent monster could blend on top of a nearer one.

Why it wasn't spotted before: the effect was originally validated on creatures that were staggered at different distances, where every pair sorts one-behind-the-other and the sign error never flips an order. The bug only shows when translucent objects cluster side-by-side at similar range (slimes, ghosts, stone-effect monsters), and only at off-axis viewing angles.

Also switched the sort's heading calculation to the existing `LEGACY_HEADING_OFFSET` constant (the same value it used before), so it stays in step with the view transform, which already uses it. No behavior change from that part.

Tested across a range of translucent creatures, including slimes, ghosts, stone/petrified creatures - stone trolls/statues, and ice creatures, both with and without fog. Also tested at specific rooms mention that had an issue: The Forest Shrine, The Throne Room, Marion Crypt 2.