### PR TITLE
Fix bouncing objects being lit as flickering light sources

### DIFF
--- a/clientd3d/animate.c
+++ b/clientd3d/animate.c
@@ -185,7 +185,7 @@ bool AnimateObject(object_node *obj, int dt)
    bool need_redraw = false;
    list_type over_list;
 
-   if (OF_FLICKERING == (OF_FLICKERING & obj->flags))
+   if (ObjectIsFlickering(obj->flags))
    {
         // Initialize flicker time with random offset on first use to desynchronize lights
         if (obj->flickerTime == 0)
@@ -234,7 +234,7 @@ bool AnimateObject(object_node *obj, int dt)
         need_redraw = true;
    }
 
-   if (OF_FLASHING == (OF_FLASHING & obj->flags))
+   if (ObjectIsFlashing(obj->flags))
    {
       DWORD angleFlash;
       obj->bounceTime += std::min(dt,50);

--- a/clientd3d/animate.c
+++ b/clientd3d/animate.c
@@ -185,7 +185,7 @@ bool AnimateObject(object_node *obj, int dt)
    bool need_redraw = false;
    list_type over_list;
 
-   if (ObjectIsFlickering(obj->flags))
+   if (ObjectHasFlickeringLight(obj->flags))
    {
         // Initialize flicker time with random offset on first use to desynchronize lights
         if (obj->flickerTime == 0)
@@ -234,7 +234,7 @@ bool AnimateObject(object_node *obj, int dt)
         need_redraw = true;
    }
 
-   if (ObjectIsFlashing(obj->flags))
+   if (ObjectHasFlashingLight(obj->flags))
    {
       DWORD angleFlash;
       obj->bounceTime += std::min(dt,50);

--- a/clientd3d/d3drender_lights.c
+++ b/clientd3d/d3drender_lights.c
@@ -125,7 +125,7 @@ static int CalculateFlickeredIntensity(const LightSourceData& lightData, float* 
    float flickerBrightness = 1.0f;
    int flickeredIntensity;
 
-   if (lightData.objFlags & (OF_FLICKERING | OF_FLASHING))
+   if (ObjectHasLightEffect(lightData.objFlags))
    {
       flickerBrightness = (float)lightData.lightAdjust / GetFlickerLevel();
       flickeredIntensity = (int)(D3DLightScale(lightData.baseIntensity) * flickerBrightness);
@@ -356,7 +356,7 @@ void D3DLMapsStaticGet(room_type* room, const LightCacheUpdateParams& params)
          if (flickerPerfProfile)
          {
             totalLightCount++;
-            if (pRNode->obj.flags & (OF_FLICKERING | OF_FLASHING))
+            if (ObjectHasLightEffect(pRNode->obj.flags))
                flickerCount++;
          }
       }
@@ -385,7 +385,7 @@ void D3DLMapsStaticGet(room_type* room, const LightCacheUpdateParams& params)
                              pRNode->obj.dLighting.intensity))
             continue;
 
-         bool isFlickering = (pRNode->obj.flags & (OF_FLICKERING | OF_FLASHING)) != 0;
+         bool isFlickering = ObjectHasLightEffect(pRNode->obj.flags);
 
          // Select target cache: flickering lights go to dynamic cache, static lights to main cache
          d_light_cache* targetCache = isFlickering ? lightCacheDynamic : lightCache;

--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -2507,12 +2507,12 @@ bool D3DObjectLightingCalc(
 	// OF_FLASHING (used e.g. for detect-invisible reveal) must pulse regardless
 	// of daylight, so only OF_FLICKERING is daylight-gated.
 	int effectiveLightAdjust = pRNode->obj.lightAdjust;
-	if (light > 127 && (pRNode->obj.flags & OF_FLICKERING))
+	if (light > 127 && ObjectIsFlickering(pRNode->obj.flags))
 	{
 		effectiveLightAdjust = 0;  // Disable visual flicker during daytime
 	}
 
-	if (pRNode->obj.flags & (OF_FLICKERING | OF_FLASHING))
+	if (ObjectHasLightEffect(pRNode->obj.flags))
 		light = GetLightPaletteIndex(intDistance, light, FINENESS, effectiveLightAdjust);
 	else
 		light = GetLightPaletteIndex(intDistance, light, FINENESS, 0);
@@ -2531,7 +2531,7 @@ bool D3DObjectLightingCalc(
 		bgra->r = std::min((float)COLOR_AMBIENT, bgra->r + (lastDistance * pDLight->color.r / COLOR_AMBIENT));
 		
 		// Apply flickering/flashing adjustment to the combined lighting (base + dynamic)
-		if (pRNode->obj.flags & (OF_FLICKERING | OF_FLASHING))
+		if (ObjectHasLightEffect(pRNode->obj.flags))
 		{
 			float adjustment = (float)pRNode->obj.lightAdjust / GetFlickerLevel();
 			bgra->b = std::min((float)COLOR_AMBIENT, bgra->b + (bgra->b * adjustment));

--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -478,14 +478,7 @@ void D3DRenderNamesDraw3D(
 		else
 		{
 			// Draw name with color that fades with distance, just like object
-			if (pRNode->obj.flags & (OF_FLICKERING | OF_FLASHING))
-			{
-				palette = GetLightPalette(D3DRENDER_LIGHT_DISTANCE, 63, FINENESS, 0);
-			}
-			else
-			{
-				palette = GetLightPalette(D3DRENDER_LIGHT_DISTANCE, 63, FINENESS, 0);
-			}
+			palette = GetLightPalette(D3DRENDER_LIGHT_DISTANCE, 63, FINENESS, 0);
 			color = base_palette[palette[GetClosestPaletteIndex(fg_color)]];
 			D3DObjectLightingCalc(objectsRenderParams.room, pRNode, &bgra, 0, objectsRenderParams.driverProfile.bFogEnable, lightAndTextureParams);
 
@@ -2507,7 +2500,7 @@ bool D3DObjectLightingCalc(
 	// OF_FLASHING (used e.g. for detect-invisible reveal) must pulse regardless
 	// of daylight, so only OF_FLICKERING is daylight-gated.
 	int effectiveLightAdjust = pRNode->obj.lightAdjust;
-	if (light > 127 && ObjectIsFlickering(pRNode->obj.flags))
+	if (light > 127 && ObjectHasFlickeringLight(pRNode->obj.flags))
 	{
 		effectiveLightAdjust = 0;  // Disable visual flicker during daytime
 	}

--- a/clientd3d/moveobj.c
+++ b/clientd3d/moveobj.c
@@ -229,7 +229,7 @@ bool ObjectsMove(int dt)
 			if (r->motion.v_z == 0)
 				RoomObjectSetHeight(r);
 		}
-		if (OF_BOUNCING == (OF_BOUNCING & r->obj.flags))
+		if (ObjectIsBouncing(r->obj.flags))
 		{
 			if (!(OF_PLAYER & r->obj.flags))
 			{

--- a/clientd3d/object.c
+++ b/clientd3d/object.c
@@ -73,6 +73,34 @@ int CompareObjectNameAndNumber(void *obj1, void *obj2)
 }
 /*****************************************************************************/
 /*
+ * Object light effect predicates.
+ *
+ * OF_BOUNCING is not a bit of its own: it is OF_FLICKERING | OF_FLASHING.  A
+ * bouncing object therefore satisfies a bare test for either light effect, and
+ * would be lit as though it were carrying a torch.  Test light effects through
+ * these predicates rather than against the flag bits directly.
+ */
+bool ObjectIsBouncing(int flags)
+{
+   return OF_BOUNCING == (OF_BOUNCING & flags);
+}
+/*****************************************************************************/
+bool ObjectIsFlickering(int flags)
+{
+   return 0 != (flags & OF_FLICKERING) && !ObjectIsBouncing(flags);
+}
+/*****************************************************************************/
+bool ObjectIsFlashing(int flags)
+{
+   return 0 != (flags & OF_FLASHING) && !ObjectIsBouncing(flags);
+}
+/*****************************************************************************/
+bool ObjectHasLightEffect(int flags)
+{
+   return ObjectIsFlickering(flags) || ObjectIsFlashing(flags);
+}
+/*****************************************************************************/
+/*
  * OverlayListDestroy:  Free memory associated with a list of overlays, and return NULL.
  */
 list_type OverlayListDestroy(list_type overlays)

--- a/clientd3d/object.c
+++ b/clientd3d/object.c
@@ -85,19 +85,19 @@ bool ObjectIsBouncing(int flags)
    return OF_BOUNCING == (OF_BOUNCING & flags);
 }
 /*****************************************************************************/
-bool ObjectIsFlickering(int flags)
+bool ObjectHasFlickeringLight(int flags)
 {
    return 0 != (flags & OF_FLICKERING) && !ObjectIsBouncing(flags);
 }
 /*****************************************************************************/
-bool ObjectIsFlashing(int flags)
+bool ObjectHasFlashingLight(int flags)
 {
    return 0 != (flags & OF_FLASHING) && !ObjectIsBouncing(flags);
 }
 /*****************************************************************************/
 bool ObjectHasLightEffect(int flags)
 {
-   return ObjectIsFlickering(flags) || ObjectIsFlashing(flags);
+   return ObjectHasFlickeringLight(flags) || ObjectHasFlashingLight(flags);
 }
 /*****************************************************************************/
 /*

--- a/clientd3d/object.h
+++ b/clientd3d/object.h
@@ -109,8 +109,8 @@ typedef struct {
 } room_contents_node;
 
 bool ObjectIsBouncing(int flags);
-bool ObjectIsFlickering(int flags);
-bool ObjectIsFlashing(int flags);
+bool ObjectHasFlickeringLight(int flags);
+bool ObjectHasFlashingLight(int flags);
 bool ObjectHasLightEffect(int flags);
 
 M59EXPORT bool CompareIdObject(void *idnum, void *obj);

--- a/clientd3d/object.h
+++ b/clientd3d/object.h
@@ -108,6 +108,11 @@ typedef struct {
    int			boundingHeightAdjust;	// adjustment in height from overlays
 } room_contents_node;
 
+bool ObjectIsBouncing(int flags);
+bool ObjectIsFlickering(int flags);
+bool ObjectIsFlashing(int flags);
+bool ObjectHasLightEffect(int flags);
+
 M59EXPORT bool CompareIdObject(void *idnum, void *obj);
 bool CompareId(void *id1, void *id2);
 bool CompareIdRoomObject(void *idnum, void *obj);

--- a/clientd3d/object3d.c
+++ b/clientd3d/object3d.c
@@ -315,7 +315,7 @@ bool DrawObjectBitmap( DrawObjectInfo *dos, AREA *obj_area, bool bTargetSelectEf
    y = (starty - obj_area->y) * yinc;
 
    /* Find palette to use, depending on distance */
-   if (dos->flags & (OF_FLICKERING | OF_FLASHING))
+   if (ObjectHasLightEffect(dos->flags))
    {
       palette = GetLightPalette(dos->distance, dos->light, FINENESS,GetFlicker(dos->obj));
    }
@@ -770,7 +770,7 @@ void DrawObjectDecorations(DrawnObject *object)
    else
    {
       // Draw name with color that fades with distance, just like object
-      if (r->obj.flags & (OF_FLICKERING | OF_FLASHING))
+      if (ObjectHasLightEffect(r->obj.flags))
       {
          palette = GetLightPalette(object->distance, object->light, FINENESS,GetFlicker(r));
       }

--- a/clientd3d/server.c
+++ b/clientd3d/server.c
@@ -341,7 +341,7 @@ void ExtractObject(char **ptr, object_node *item, bool includeLight)
    item->normal_overlays = ExtractOverlays(ptr);
    item->overlays = &item->normal_overlays;
 
-   if (OF_BOUNCING == (OF_BOUNCING & item->flags))
+   if (ObjectIsBouncing(item->flags))
    {
       item->bounceTime = (WORD)(rand() % 1000);
    }


### PR DESCRIPTION
`OF_BOUNCING` is not a distinct flag bit - it is defined as `OF_FLICKERING | OF_FLASHING` (proto.h:376), set from KOD as the drawing effect `BOUNCE_YES`. Any code testing the light-effect bits directly therefore matched bouncing objects too, so anything that bounces was animated and lit as though it were carrying a flickering torch, in both the D3D and software renderers.

Eight monster classes set `BOUNCE_YES` and were affected. Good Fairy, Dark Fairy and Dark Angel were worst hit: they are genuine dynamic light sources, so the spurious flicker modulated the light they cast on the surrounding room, not just their own sprite. Dragonfly, Dragonfly Pet, Dragonfly Queen, Riija Monk and Decorator carry no light of their own, so the bug showed only as their sprites pulsing while bouncing. The dragonflies toggle `BOUNCE_YES` at runtime, so they visibly changed lighting behavior as they started and stopped hovering.

Adds four predicates in object.c (`ObjectIsBouncing`, `ObjectHasFlickeringLight`, `ObjectHasFlashingLight`, `ObjectHasLightEffect`) that exclude the bouncing case, and routes the existing flag tests in animate.c, moveobj.c, server.c,
object3d.c, d3drender_lights.c and d3drender_objects.c through them.

Also removes a dead `if/else` in the player-name draw path whose two arms were identical.

No behavior change for objects that are only flickering or only flashing.