### PR TITLE
roomedit: add scroll-wheel zoom (toward cursor)

### DIFF
--- a/roomedit/include/editcli.h
+++ b/roomedit/include/editcli.h
@@ -227,6 +227,7 @@ protected:
 	void CmCheckMenu ();
 	void CmZoomIn ();
 	void CmZoomOut ();
+	void ZoomBy (bool zoomIn, SHORT anchorX, SHORT anchorY);
 	void CmAutoLayout ();
 	void CmLayout ();
 	void CmWindowGridNext ();

--- a/roomedit/source/editcli.cpp
+++ b/roomedit/source/editcli.cpp
@@ -4422,18 +4422,15 @@ void TEditorClient::CmCheckNames ()
 // -------------
 //
 void TEditorClient::EvMouseWheel (uint modKeys, int zDelta, const TPoint& point)
-{
-	if (modKeys & MK_CONTROL)
-	{
-		if (zDelta > 0)
-			CmZoomIn();
-		else if (zDelta < 0)
-			CmZoomOut();
-	}
-	else
-	{
-		TLayoutWindow::EvMouseWheel(modKeys, zDelta, point);
-	}
+{	
+	// WM_MOUSEWHEEL reports screen coords; the zoom transform is client-space
+	TPoint client = point;
+	ScreenToClient(client);
+
+	if (zDelta > 0)
+		ZoomBy(TRUE,  client.x, client.y);
+	else if (zDelta < 0)
+		ZoomBy(FALSE, client.x, client.y);
 }
 
 
@@ -4443,26 +4440,7 @@ void TEditorClient::EvMouseWheel (uint modKeys, int zDelta, const TPoint& point)
 //
 void TEditorClient::CmZoomIn ()
 {
-	float oldScale = Scale;
-
-#ifdef DEU_FOLLOW_POINTER
-	OrigX += (SHORT) ((PointerX - ScrCenterX) * DIV_SCALE);
-	OrigY += (SHORT) ((ScrCenterY - PointerY) * DIV_SCALE);
-#endif
-
-	IncScale();
-
-#ifdef DEU_FOLLOW_POINTER
-	OrigX -= (SHORT) ((PointerX - ScrCenterX) * DIV_SCALE);
-	OrigY -= (SHORT) ((ScrCenterY - PointerY) * DIV_SCALE);
-#endif
-
-	// If scale has really changed
-	if ( Scale != oldScale )
-	{
-		AdjustScroller();       // Adjust scroller units
-		RefreshWindows();     	// Redraw map
-	}
+	ZoomBy(TRUE, ScrCenterX, ScrCenterY);
 }
 
 
@@ -4472,28 +4450,35 @@ void TEditorClient::CmZoomIn ()
 //
 void TEditorClient::CmZoomOut ()
 {
-	float oldScale = Scale;
-
-#ifdef DEU_FOLLOW_POINTER
-	OrigX += (SHORT) ((PointerX - ScrCenterX) * DIV_SCALE);
-	OrigY += (SHORT) ((ScrCenterY - PointerY) * DIV_SCALE);
-#endif
-
-	DecScale();
-
-#ifdef DEU_FOLLOW_POINTER
-	OrigX -= (SHORT) ((PointerX - ScrCenterX) * DIV_SCALE);
-	OrigY -= (SHORT) ((ScrCenterY - PointerY) * DIV_SCALE);
-#endif
-
-	// If scale has really changed
-	if ( Scale != oldScale )
-	{
-		AdjustScroller();       // Adjust scroller units
-		RefreshWindows () ;     // Redraw map
-	}
+	ZoomBy(FALSE, ScrCenterX, ScrCenterY);
 }
 
+
+/////////////////////////////////////////////////////////////////////
+// TEditorClient
+// -------------
+//
+void TEditorClient::ZoomBy (bool zoomIn, SHORT anchorX, SHORT anchorY)
+{
+	float oldScale = Scale;
+
+	OrigX += (SHORT) ((anchorX - ScrCenterX) * DIV_SCALE);
+	OrigY += (SHORT) ((ScrCenterY - anchorY) * DIV_SCALE);
+
+	if (zoomIn)
+		IncScale();
+	else
+		DecScale();
+
+	OrigX -= (SHORT) ((anchorX - ScrCenterX) * DIV_SCALE);
+	OrigY -= (SHORT) ((ScrCenterY - anchorY) * DIV_SCALE);
+
+	if ( Scale != oldScale )
+	{
+		AdjustScroller();  // Adjust scroller units
+		RefreshWindows();  // Redraw map
+	}
+}
 
 /////////////////////////////////////////////////////////////////////
 // TEditorClient


### PR DESCRIPTION
This PR enables zooming the level map with the mouse wheel, without needing to hold a modifier key (`CTRL`). Mouse wheel zooms will be anchored to the cursor position while toolbar zooms will act on window center.

**Question:** Would a feature like this require an update to line? Likewise, should we have updated it for #1394?

```
//
// Main window title
//
#define TITLE "BlakSton Room Editor version 2.2 (December 18, 2023)"
```