### PR TITLE
roomedit: Remove support for Things

### DIFF
--- a/roomedit/include/editcli.h
+++ b/roomedit/include/editcli.h
@@ -184,7 +184,6 @@ protected:
 	void CmSearchJump ();
 	void CmObjectsRectangle ();
 	void CmObjectsPolygon ();
-	void CmModeThings ();
 	void CmModeVertexes ();
 	void CmModeLinedefs ();
 	void CmModeSectors ();

--- a/roomedit/res/WINDEAPP.RC
+++ b/roomedit/res/WINDEAPP.RC
@@ -136,7 +136,6 @@ MENU_EDITOR MENU
 
  POPUP "&Modes"
  {
-  MENUITEM "&Things\tT", CM_MODE_THINGS
   MENUITEM "&Vertices\tV", CM_MODE_VERTEXES
   MENUITEM "&LineDefs / SideDefs\tL", CM_MODE_LINEDEFS
   MENUITEM "&Sectors\tS", CM_MODE_SECTORS
@@ -273,7 +272,6 @@ MENU_THINGS MENU
 
   POPUP "Modes"
   {
-   MENUITEM "Things", CM_MODE_THINGS
    MENUITEM "Vertices", CM_MODE_VERTEXES
    MENUITEM "LineDefs / SideDefs", CM_MODE_LINEDEFS
    MENUITEM "Sectors", CM_MODE_SECTORS
@@ -321,7 +319,6 @@ MENU_LINEDEFS MENU
 
   POPUP "Modes"
   {
-   MENUITEM "Things", CM_MODE_THINGS
    MENUITEM "Vertices", CM_MODE_VERTEXES
    MENUITEM "LineDefs / SideDefs", CM_MODE_LINEDEFS
    MENUITEM "Sectors", CM_MODE_SECTORS
@@ -358,7 +355,6 @@ MENU_VERTEXES MENU
 
   POPUP "Modes"
   {
-   MENUITEM "Things", CM_MODE_THINGS
    MENUITEM "Vertices", CM_MODE_VERTEXES
    MENUITEM "LineDefs / SideDefs", CM_MODE_LINEDEFS
    MENUITEM "Sectors", CM_MODE_SECTORS
@@ -396,7 +392,6 @@ MENU_SECTORS MENU
 
   POPUP "Modes"
   {
-   MENUITEM "Things", CM_MODE_THINGS
    MENUITEM "Vertices", CM_MODE_VERTEXES
    MENUITEM "LineDefs / SideDefs", CM_MODE_LINEDEFS
    MENUITEM "Sectors", CM_MODE_SECTORS
@@ -426,7 +421,6 @@ MENU_OBJECTS MENU
 
   POPUP "Edit mode"
   {
-   MENUITEM "Things", CM_MODE_THINGS
    MENUITEM "Vertices", CM_MODE_VERTEXES
    MENUITEM "LineDefs / SideDefs", CM_MODE_LINEDEFS
    MENUITEM "Sectors", CM_MODE_SECTORS
@@ -461,7 +455,6 @@ MENU_EDITOR ACCELERATORS
  "O", CM_EDIT_COPYOBJ, VIRTKEY, NOINVERT
  VK_TAB, CM_MODE_NEXT, VIRTKEY, NOINVERT
  VK_TAB, CM_MODE_PREV, VIRTKEY, NOINVERT, SHIFT
- "T", CM_MODE_THINGS, VIRTKEY, NOINVERT
  "L", CM_MODE_LINEDEFS, VIRTKEY, NOINVERT
  "V", CM_MODE_VERTEXES, VIRTKEY, NOINVERT
  "S", CM_MODE_SECTORS, VIRTKEY, NOINVERT
@@ -547,7 +540,6 @@ STRINGTABLE
  CM_SEARCH_JUMPOBJ, "Go to a object given its number"
  CM_OBJECTS_RECTANGLE, "Insert a rectangle\nInsert rectangle"
  CM_OBJECTS_POLYGON, "Insert a polygon given its number of sides\nInsert polygon"
- CM_MODE_THINGS, "Switch to the 'things' editing mode\nThings mode"
  CM_MODE_LINEDEFS, "Switch to the 'LineDefs and SideDefs' editing mode\nLineDefs mode"
  CM_MODE_VERTEXES, "Switch to the 'Vertices' editing mode\nVertices mode"
  CM_MODE_SECTORS, "Switch to the 'Sectors' editing mode\nSectors mode"

--- a/roomedit/source/editcli.cpp
+++ b/roomedit/source/editcli.cpp
@@ -3101,7 +3101,7 @@ void TEditorClient::CmModePrev ()
 			NewMode = OBJ_SECTORS;
 			break;
 		case OBJ_VERTEXES:
-			NewMode = OBJ_THINGS;
+			NewMode = OBJ_SECTORS;
 			break;
 		case OBJ_LINEDEFS:
 			NewMode = OBJ_VERTEXES;

--- a/roomedit/source/editcli.cpp
+++ b/roomedit/source/editcli.cpp
@@ -189,7 +189,6 @@ DEFINE_RESPONSE_TABLE1(TEditorClient, TWindow)
 	EV_COMMAND(CM_EDIT_ADDOBJ, CmEditAdd),
 	EV_COMMAND(CM_EDIT_OBJECT, CmEditObject),
 	EV_COMMAND(CM_EDIT_PREFERENCES, CmEditPreferences),
-	EV_COMMAND(CM_MODE_THINGS, CmModeThings),
 	EV_COMMAND(CM_MODE_LINEDEFS, CmModeLinedefs),
 	EV_COMMAND(CM_MODE_VERTEXES, CmModeVertexes),
 	EV_COMMAND(CM_MODE_SECTORS, CmModeSectors),
@@ -356,7 +355,7 @@ TEditorClient::TEditorClient (TWindow* parent, char *_levelName,
 	//
 	// Init. Editor data member
 	//
-	EditMode = OBJ_THINGS;
+	EditMode = OBJ_VERTEXES;
 
 	CurObject = -1;
 
@@ -684,9 +683,6 @@ void TEditorClient::SetupMenu()
 	const char *newMiscMenuName;
 
 	// Uncheck and check appropriate mode menu item
-	menu.CheckMenuItem (CM_MODE_THINGS, MF_BYCOMMAND |
-		(EditMode == OBJ_THINGS ? MF_CHECKED : MF_UNCHECKED) );
-
 	menu.CheckMenuItem (CM_MODE_LINEDEFS, MF_BYCOMMAND |
 		(EditMode == OBJ_LINEDEFS ? MF_CHECKED : MF_UNCHECKED) );
 
@@ -3014,20 +3010,6 @@ void TEditorClient::CmObjectsPolygon ()
 // TEditorClient
 // -------------
 //
-void TEditorClient::CmModeThings ()
-{
-	// Ignore if "insert object" mode
-	if ( InsertingObject )
-		return;
-
-	ForgetSelection(&Selected);
-	ChangeMode (OBJ_THINGS);
-}
-
-/////////////////////////////////////////////////////////////////////
-// TEditorClient
-// -------------
-//
 void TEditorClient::CmModeVertexes ()
 {
 	// Ignore if "insert object" mode
@@ -3079,7 +3061,7 @@ void TEditorClient::CmModeNext ()
 	if ( InsertingObject )
 		return;
 
-	int NewMode;
+	int NewMode = EditMode;
 
 	switch (EditMode)
 	{
@@ -3093,7 +3075,7 @@ void TEditorClient::CmModeNext ()
 			NewMode = OBJ_SECTORS;
 			break;
 		case OBJ_SECTORS:
-			NewMode = OBJ_THINGS;
+			NewMode = OBJ_VERTEXES;
 			break;
 	}
 
@@ -3111,7 +3093,7 @@ void TEditorClient::CmModePrev ()
 	if ( InsertingObject )
 		return;
 
-	int NewMode;
+	int NewMode = EditMode;
 
 	switch (EditMode)
 	{

--- a/roomedit/source/mainfram.cpp
+++ b/roomedit/source/mainfram.cpp
@@ -339,7 +339,6 @@ void TMainFrame::SetupEditorControlBar()
 	// Inserts editor window gadgets
 	controlBar->Insert(*new TButtonGadget(CM_FILE_SAVE, CM_FILE_SAVE));
 	controlBar->Insert(*new TSeparatorGadget(6));
-	controlBar->Insert(*new TButtonGadget(CM_MODE_THINGS, CM_MODE_THINGS));
 	controlBar->Insert(*new TButtonGadget(CM_MODE_VERTEXES, CM_MODE_VERTEXES));
 	controlBar->Insert(*new TButtonGadget(CM_MODE_LINEDEFS, CM_MODE_LINEDEFS));
 	controlBar->Insert(*new TButtonGadget(CM_MODE_SECTORS, CM_MODE_SECTORS));


### PR DESCRIPTION
This PR is a surface level removal of Things support from the room editor. It removes Things from the menu, toolbar, hotkeys, and mode cycling in an effort to streamline the editor experience.