### PR TITLE
Reset the static lightmap cache system

### DIFF
--- a/clientd3d/d3drender_world.c
+++ b/clientd3d/d3drender_world.c
@@ -2245,7 +2245,7 @@ void D3DGeometryBuildNew(const WorldRenderParams &worldRenderParams, const World
 
    if (config.bDynamicLighting)
    {
-      D3DCacheSystemReset(cacheSystem.worldCacheSystemStatic);
+      D3DCacheSystemReset(cacheSystem.lMapCacheSystemStatic);
       D3DRenderPoolReset(pools.lMapPoolStatic, &D3DMaterialLMapDynamicPool);
 
       for (count = 0; count < room.num_nodes; count++)


### PR DESCRIPTION
The static lightmap pass resets its pool but resets a different cache system than the one it fills, so each rebuild added a new cache instead of reusing the existing ones. Memory grew for as long as dynamic lighting was on.

This only kicks in once a room needs more than one cache, so it is limited to rooms with a lot of placed static lights. Turning dynamic lighting off avoids it, since the path is gated on that setting.

Tested on live: allocations climbed past 1.5 GB in an affected room before the change, flat after.

Fixes: https://github.com/Meridian59/Meridian59/issues/1477 and likely https://github.com/Meridian59/Meridian59/issues/1476