### PR TITLE
Bound the combined brightness of moving monster lights

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -36,6 +36,7 @@ D3DVIEWPORT9			gViewport;
 d3d_render_cache_system	gObjectCacheSystem;
 d3d_render_cache_system	gWorldCacheSystem;
 d3d_render_cache_system	gLMapCacheSystem;
+d3d_render_cache_system	gLMapCacheSystemMoving;
 d3d_render_cache_system	gWorldCacheSystemStatic;
 d3d_render_cache_system	gLMapCacheSystemStatic;
 d3d_render_cache_system	gWallMaskCacheSystem;
@@ -44,6 +45,7 @@ d3d_render_cache_system	gParticleCacheSystem;
 
 d_light_cache			gDLightCache;
 d_light_cache			gDLightCacheDynamic;
+d_light_cache			gDLightCacheFlicker;
 
 d3d_render_pool_new		gObjectPool;
 d3d_render_pool_new		gWorldPool;
@@ -398,6 +400,7 @@ HRESULT D3DRenderInit(HWND hWnd)
 		D3DCOLORWRITEENABLE_BLUE);
 
     D3DCacheSystemInit(&gLMapCacheSystem, gD3DDriverProfile.texMemLMapDynamic);
+    D3DCacheSystemInit(&gLMapCacheSystemMoving, gD3DDriverProfile.texMemLMapDynamic);
     D3DCacheSystemInit(&gLMapCacheSystemStatic, gD3DDriverProfile.texMemLMapStatic);
     D3DRenderPoolInit(&gLMapPool, POOL_SIZE, PACKET_SIZE);
     D3DRenderPoolInit(&gLMapPoolStatic, POOL_SIZE, PACKET_SIZE);
@@ -512,6 +515,7 @@ void D3DRenderShutDown(void)
 	if (config.bDynamicLighting)
 	{
 		D3DCacheSystemShutdown(&gLMapCacheSystem);
+		D3DCacheSystemShutdown(&gLMapCacheSystemMoving);
 		D3DCacheSystemShutdown(&gLMapCacheSystemStatic);
 		D3DRenderPoolShutdown(&gLMapPool);
 		D3DRenderPoolShutdown(&gLMapPoolStatic);
@@ -647,7 +651,8 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	gDLightCache.numLights = 0;
 	gDLightCacheDynamic.numLights = 0;
-	LightCacheUpdateParams lightCacheParams{&gDLightCache, &gDLightCacheDynamic, gD3DRedrawAll};
+	gDLightCacheFlicker.numLights = 0;
+	LightCacheUpdateParams lightCacheParams{&gDLightCache, &gDLightCacheDynamic, &gDLightCacheFlicker, gD3DRedrawAll};
 	D3DLMapsStaticGet(room, lightCacheParams);
 
 	gpD3DDevice->Clear(0, nullptr, (D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER | D3DCLEAR_STENCIL), D3DCOLOR_ARGB(0, 0, 0, 0), 1.0, 0);
@@ -685,6 +690,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	D3DCacheSystemReset(&gObjectCacheSystem);
 	D3DCacheSystemReset(&gLMapCacheSystem);
+	D3DCacheSystemReset(&gLMapCacheSystemMoving);
 	D3DCacheSystemReset(&gWorldCacheSystem);
 
 	SetZBias(ZBIAS_DEFAULT);
@@ -713,14 +719,15 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	// Prepare our rendering parameters
 	WorldCacheSystemParams worldCacheSystemParams(&gWorldCacheSystem, &gWorldCacheSystemStatic,
-		&gLMapCacheSystem, &gLMapCacheSystemStatic, &gWallMaskCacheSystem);
+		&gLMapCacheSystem, &gLMapCacheSystemMoving, &gLMapCacheSystemStatic, &gWallMaskCacheSystem);
 
 	WorldPoolParams worldPoolParams(&gWorldPool, &gWorldPoolStatic, &gLMapPool, &gLMapPoolStatic, &gWallMaskPool);
 
 	WorldRenderParams worldRenderParams(g_pVertexDecl_PosColorTex1, g_pVertexDecl_PosColorTex2,
 											gD3DDriverProfile, worldCacheSystemParams, worldPoolParams, view, proj);
 
-	LightAndTextureParams lightAndTextureParams(&gDLightCache, &gDLightCacheDynamic, gSmallTextureSize, sector_depths);
+	LightAndTextureParams lightAndTextureParams(&gDLightCache, &gDLightCacheDynamic, &gDLightCacheFlicker,
+		gSmallTextureSize, sector_depths);
 
 	WorldPropertyParams worldPropertyParams(gpNoLookThrough, D3DRenderLightsGetOrange());
 

--- a/clientd3d/d3drender_lights.c
+++ b/clientd3d/d3drender_lights.c
@@ -264,6 +264,7 @@ void D3DLMapsStaticGet(room_type* room, const LightCacheUpdateParams& params)
 
    d_light_cache* lightCache = params.lightCache;
    d_light_cache* lightCacheDynamic = params.lightCacheDynamic;
+   d_light_cache* lightCacheFlicker = params.lightCacheFlicker;
 
    if (projectileLightsEnable)
    {
@@ -381,15 +382,16 @@ void D3DLMapsStaticGet(room_type* room, const LightCacheUpdateParams& params)
          if (isDynamic)
             continue;
 
-         if (ShouldSkipLight(lightCacheDynamic->numLights, pRNode->obj.dLighting.flags, pRNode->obj.dLighting.color,
-                             pRNode->obj.dLighting.intensity))
-            continue;
-
          bool isFlickering = ObjectHasLightEffect(pRNode->obj.flags);
 
-         // Select target cache: flickering lights go to dynamic cache, static lights to main cache
-         d_light_cache* targetCache = isFlickering ? lightCacheDynamic : lightCache;
+         // Select target cache: flickering lights go to flicker cache, static lights to main cache
+         d_light_cache* targetCache = isFlickering ? lightCacheFlicker : lightCache;
          const char* debugLabel = isFlickering ? "Flickering" : "Static";
+
+         // Each cache holds its own share of the light budget
+         if (ShouldSkipLight(targetCache->numLights, pRNode->obj.dLighting.flags, pRNode->obj.dLighting.color,
+                             pRNode->obj.dLighting.intensity))
+            continue;
 
          // Non-flickering lights need structural change detection
          if (!isFlickering)

--- a/clientd3d/d3drender_lights.h
+++ b/clientd3d/d3drender_lights.h
@@ -17,7 +17,8 @@
 struct LightCacheUpdateParams
 {
    d_light_cache* lightCache;          // Static lights cache
-   d_light_cache* lightCacheDynamic;   // Dynamic/flickering lights cache
+   d_light_cache* lightCacheDynamic;   // Moving lights cache (light-emitting monsters, projectiles)
+   d_light_cache* lightCacheFlicker;   // Stationary flickering lights cache
    int& redrawFlags;                    // Reference to allow light cache updates to trigger scene redraws
 };
 
@@ -30,7 +31,8 @@ struct LightDebugRenderParams
 };
 
 // Populate the light caches with lights from the room's objects and projectiles.
-// Separates lights into static (lightCache) and dynamic/flickering (lightCacheDynamic).
+// Moving lights are kept apart from the flickering ones because the world draws them with a
+// different blend.
 void D3DLMapsStaticGet(room_type* room, const LightCacheUpdateParams& params);
 
 // Check if a light's cached properties match the current object state.

--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -2416,6 +2416,36 @@ void D3DRenderPlayerOverlayOverlaysDraw(
 }
 
 /**
+* Narrows closestLight to the nearest light in the cache, if any of them beats what is already
+* there. Distance is measured in units of each light's own half radius, so a large light wins over
+* a small one that is nearer.
+*/
+static void UpdateClosestLight(d_light_cache* pDLightCache, const room_contents_node* pRNode,
+	float& closestDistance, d_light*& closestLight)
+{
+	for (int numLights = 0; numLights < pDLightCache->numLights; numLights++)
+	{
+		d_light* pLight = &pDLightCache->dLights[numLights];
+		custom_xyz vector;
+
+		vector.x = pRNode->motion.x - pLight->xyz.x;
+		vector.y = pRNode->motion.y - pLight->xyz.y;
+		vector.z = pRNode->motion.z - pLight->xyz.z;
+
+		float distance = (vector.x * vector.x) + (vector.y * vector.y) + (vector.z * vector.z);
+		distance = (float)sqrt((double)distance);
+
+		distance /= (pLight->xyzScale.x / 2.0f);
+
+		if (distance < closestDistance)
+		{
+			closestDistance = distance;
+			closestLight = pLight;
+		}
+	}
+}
+
+/**
 * Lighting calculations for world objects.
 */
 bool D3DObjectLightingCalc(
@@ -2426,55 +2456,17 @@ bool D3DObjectLightingCalc(
 	bool fogEnabled,
 	const LightAndTextureParams& lightAndTextureParams)
 {
-	int			light, intDistance, numLights;
+	int			light, intDistance;
 	d_light* pDLight = NULL;
 	float		distX, distY;
-	float		lastDistance, distance;
+	float		lastDistance;
 	bool		bFogDisable = false;
 
 	lastDistance = dlight_scale(255);
 
-	for (numLights = 0; numLights < lightAndTextureParams.lightCache->numLights; numLights++)
-	{
-		custom_xyz	vector;
-
-		vector.x = pRNode->motion.x - lightAndTextureParams.lightCache->dLights[numLights].xyz.x;
-		vector.y = pRNode->motion.y - lightAndTextureParams.lightCache->dLights[numLights].xyz.y;
-		vector.z = pRNode->motion.z - lightAndTextureParams.lightCache->dLights[numLights].xyz.z;
-
-		distance = (vector.x * vector.x) + (vector.y * vector.y) +
-			(vector.z * vector.z);
-		distance = (float)sqrt((double)distance);
-
-		distance /= (lightAndTextureParams.lightCache->dLights[numLights].xyzScale.x / 2.0f);
-
-		if (distance < lastDistance)
-		{
-			lastDistance = distance;
-			pDLight = &lightAndTextureParams.lightCache->dLights[numLights];
-		}
-	}
-
-	for (numLights = 0; numLights < lightAndTextureParams.lightCacheDynamic->numLights; numLights++)
-	{
-		custom_xyz	vector;
-
-		vector.x = pRNode->motion.x - lightAndTextureParams.lightCacheDynamic->dLights[numLights].xyz.x;
-		vector.y = pRNode->motion.y - lightAndTextureParams.lightCacheDynamic->dLights[numLights].xyz.y;
-		vector.z = pRNode->motion.z - lightAndTextureParams.lightCacheDynamic->dLights[numLights].xyz.z;
-
-		distance = (vector.x * vector.x) + (vector.y * vector.y) +
-			(vector.z * vector.z);
-		distance = (float)sqrt((double)distance);
-
-		distance /= (lightAndTextureParams.lightCacheDynamic->dLights[numLights].xyzScale.x / 2.0f);
-
-		if (distance < lastDistance)
-		{
-			lastDistance = distance;
-			pDLight = &lightAndTextureParams.lightCacheDynamic->dLights[numLights];
-		}
-	}
+	UpdateClosestLight(lightAndTextureParams.lightCache, pRNode, lastDistance, pDLight);
+	UpdateClosestLight(lightAndTextureParams.lightCacheDynamic, pRNode, lastDistance, pDLight);
+	UpdateClosestLight(lightAndTextureParams.lightCacheFlicker, pRNode, lastDistance, pDLight);
 
 	lastDistance = 1.0f - lastDistance;
 	lastDistance = std::max(0.0f, lastDistance);

--- a/clientd3d/d3drender_objects.h
+++ b/clientd3d/d3drender_objects.h
@@ -59,6 +59,7 @@ struct LightAndTextureParams
     // Light cache details
     d_light_cache* lightCache;
     d_light_cache* lightCacheDynamic;
+    d_light_cache* lightCacheFlicker;
 
     // Texture and sector settings
     int smallTextureSize;
@@ -67,10 +68,12 @@ struct LightAndTextureParams
     LightAndTextureParams(
         d_light_cache* lightCacheParam,
         d_light_cache* lightCacheDynamicParam,
+        d_light_cache* lightCacheFlickerParam,
         int smallTextureSizeParam,
         int* sectorDepthsParam)
         : lightCache(lightCacheParam),
           lightCacheDynamic(lightCacheDynamicParam),
+          lightCacheFlicker(lightCacheFlickerParam),
           smallTextureSize(smallTextureSizeParam),
           sectorDepths(sectorDepthsParam)
     {}

--- a/clientd3d/d3drender_world.c
+++ b/clientd3d/d3drender_world.c
@@ -172,19 +172,39 @@ void D3DRenderWorldLighting(const WorldRenderParams &worldRenderParams,
       IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FILLMODE, D3DFILL_SOLID);
       D3DCacheFlush(cacheSystem.lMapCacheSystemStatic, pools.lMapPoolStatic, 2, D3DPT_TRIANGLESTRIP);
 
+      // Flickering lights belong with the room's own lighting, which adds onto the world.
+      LightAndTextureParams flickerParams = lightAndTextureParams;
+      flickerParams.lightCacheDynamic = lightAndTextureParams.lightCacheFlicker;
+
       D3DRenderPoolReset(pools.lMapPool, &D3DMaterialLMapDynamicPool);
 
       D3DRenderLMapsPostDraw(worldRenderParams, lightAndTextureParams, room.tree, false);
-      D3DRenderLMapsDynamicPostDraw(worldRenderParams, lightAndTextureParams, room.tree, false);
+      D3DRenderLMapsDynamicPostDraw(worldRenderParams, flickerParams, room.tree, false);
 
       IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, FALSE);  // Disable depth writing
       D3DRender_SetAlphaTestState(TRUE, alpha_test_threshold, D3DCMP_GREATEREQUAL);
 
       D3DRenderLMapsPostDraw(worldRenderParams, lightAndTextureParams, room.tree, true);
-      D3DRenderLMapsDynamicPostDraw(worldRenderParams, lightAndTextureParams, room.tree, true);
+      D3DRenderLMapsDynamicPostDraw(worldRenderParams, flickerParams, room.tree, true);
 
       D3DCacheFill(cacheSystem.lMapCacheSystem, pools.lMapPool, 2);
       D3DCacheFlush(cacheSystem.lMapCacheSystem, pools.lMapPool, 2, D3DPT_TRIANGLESTRIP);
+
+      // Moving lights take the maximum rather than adding, which bounds a surface at the
+      // brightest single one of them so that a crowd of light-emitting monsters cannot sum to
+      // solid white. Costs a second walk of the tree, so it is skipped when the room has none.
+      if (lightAndTextureParams.lightCacheDynamic->numLights > 0)
+      {
+         D3DRenderPoolReset(pools.lMapPool, &D3DMaterialLMapDynamicPool);
+
+         D3DRenderLMapsDynamicPostDraw(worldRenderParams, lightAndTextureParams, room.tree, false);
+         D3DRenderLMapsDynamicPostDraw(worldRenderParams, lightAndTextureParams, room.tree, true);
+
+         D3DCacheFill(cacheSystem.lMapCacheSystemMoving, pools.lMapPool, 2);
+         IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_BLENDOP, D3DBLENDOP_MAX);
+         D3DCacheFlush(cacheSystem.lMapCacheSystemMoving, pools.lMapPool, 2, D3DPT_TRIANGLESTRIP);
+         IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_BLENDOP, D3DBLENDOP_ADD);
+      }
 
       // Restore states for subsequent rendering
       IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, TRUE);  // Restore depth writing

--- a/clientd3d/d3drender_world.h
+++ b/clientd3d/d3drender_world.h
@@ -20,6 +20,7 @@ struct WorldCacheSystemParams {
     d3d_render_cache_system* worldCacheSystemStatic;
 
     d3d_render_cache_system* lMapCacheSystem;
+    d3d_render_cache_system* lMapCacheSystemMoving;
     d3d_render_cache_system* lMapCacheSystemStatic;
 
     d3d_render_cache_system* wallMaskCacheSystem; // geometry
@@ -28,12 +29,14 @@ struct WorldCacheSystemParams {
         d3d_render_cache_system* worldCacheSystemParam,
         d3d_render_cache_system* worldCacheSystemStaticParam,
         d3d_render_cache_system* lMapCacheSystemParam,
+        d3d_render_cache_system* lMapCacheSystemMovingParam,
         d3d_render_cache_system* lMapCacheSystemStaticParam,
         d3d_render_cache_system* wallMaskCacheSystemParam
     )
         : worldCacheSystem(worldCacheSystemParam),
           worldCacheSystemStatic(worldCacheSystemStaticParam),
           lMapCacheSystem(lMapCacheSystemParam),
+          lMapCacheSystemMoving(lMapCacheSystemMovingParam),
           lMapCacheSystemStatic(lMapCacheSystemStaticParam),
           wallMaskCacheSystem(wallMaskCacheSystemParam)
     {}


### PR DESCRIPTION
Several light-emitting monsters standing together (ghosts, ice creatures) each add their own light to the same surfaces, and the sum quickly saturates a room to solid white.

Moving lights are now drawn in their own pass that blends with `D3DBLENDOP_MAX` instead of adding, so a surface ends up as bright as the strongest single light reaching it however many monsters are in the room. A lone monster is unaffected.

The maximum blend suits crowding monsters but not room lighting, where torches are meant to add up and where competing against the destination shifts their colour. Flickering lights therefore move out of the dynamic light cache into a cache of their own and stay in the existing additive pass, leaving the dynamic cache holding just the moving lights. Static room lights are untouched.

  Notes:

-  The second pass needs its own cache system, since a cache system is filled once per frame. It walks the BSP tree again, so it is skipped in rooms with no moving lights.
-  The light budget check now counts against the cache being written rather than the dynamic cache, which after the split would have left the flicker cache unbounded.
-  Objects pick their light from the nearest source across the caches, so the two duplicated search loops in D3DObjectLightingCalc became one helper called once per cache. Without this, flickering torches would no longer light objects.

Tested by spawning crowds of ghosts and ice creatures in a torch-lit room and checking that torch and Glow colour and radius are unchanged.