### PR TITLE
feature: add A-Z sort toggle to client admin property list

### DIFF
--- a/module/admin/admin.h
+++ b/module/admin/admin.h
@@ -46,6 +46,8 @@ extern void AdminNewLine(char *str);
 extern void AdminDisplayOwner(int num);
 extern void AdminDisplayObject(int num, char *class_name);
 extern void AdminShowProperty(int index);
+extern void AdminFillPropertyList(void);
+extern void AdminClearProperties(void);
 
 #endif /* #ifndef _ADMIN_H */
 

--- a/module/admin/admin.rc
+++ b/module/admin/admin.rc
@@ -41,6 +41,8 @@ BEGIN
                     ES_READONLY | WS_VSCROLL
     PUSHBUTTON      "&Go to room",IDC_TELEPORT,1,158,43,11
     PUSHBUTTON      "&Reset data",IDC_INVALIDATE,48,158,43,11
+    CONTROL         "&Sort A-Z",IDC_SORTPROPS,"Button",BS_AUTOCHECKBOX |
+                    WS_TABSTOP,290,159,48,10
     GROUPBOX        "&Users",IDC_USERFRAME,1,170,146,98
     LISTBOX         IDC_USERS,5,180,78,84,LBS_SORT | LBS_NOINTEGRALHEIGHT | 
                     WS_VSCROLL | WS_TABSTOP

--- a/module/admin/admindlg.c
+++ b/module/admin/admindlg.c
@@ -26,6 +26,7 @@ int    current_obj;                      // Object we're currently displaying, i
 static ChildPlacement admin_controls[] = {
 { IDC_ADMINTEXT,   RDI_ALL },
 { IDC_TELEPORT,    RDI_BOTTOM | RDI_LEFT },
+{ IDC_SORTPROPS,   RDI_BOTTOM | RDI_RIGHT },
 
 { IDC_USERFRAME,   RDI_BOTTOM | RDI_LEFT },
 { IDC_INVALIDATE,  RDI_BOTTOM | RDI_LEFT },
@@ -196,6 +197,7 @@ INT_PTR CALLBACK AdminDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM 
       EnableWindow(GetDlgItem(hAdminDlg, IDC_SEND), FALSE);
       AdminDisplayOwner(0);
 
+      AdminClearProperties();
       ListBox_ResetContent(hObjectList);
       ListBox_ResetContent(hUserList);
 
@@ -329,6 +331,10 @@ void AdminDlgCommand(HWND hDlg, int cmd_id, HWND hwndCtl, UINT codeNotify)
 	 sprintf(command, "show object %d", current_obj);
 	 SendMessage(hAdminDlg, BK_SENDCMD, 0, (LPARAM) command);
       }
+      break;
+
+   case IDC_SORTPROPS:
+      AdminFillPropertyList();
       break;
 
 

--- a/module/admin/adminprs.c
+++ b/module/admin/adminprs.c
@@ -92,6 +92,9 @@ static ReturnMessage return_table[] = {
 static char line[MAX_PROPERTYLEN];  // Buffer used to build up a line of a server response
 static int  num_lines;         // # of properties we've gotten for object so far
 
+// Properties of the object we're displaying, in the order the server sent them
+static std::vector<std::string> property_rows;
+
 /* local function prototypes */
 static void AdminStartResponse(int type);
 static void AdminEndResponse(int type);
@@ -199,7 +202,7 @@ void AdminStartResponse(int type)
    switch (type)
    {
    case ADMIN_OBJECT:
-      WindowBeginUpdate(hObjectList);
+      AdminClearProperties();
       ListBox_ResetContent(hObjectList);
       break;
    }
@@ -214,9 +217,9 @@ void AdminEndResponse(int type)
    switch (type)
    {
    case ADMIN_OBJECT:
-      // Add last property of object to list box
+      // Save last property of object, then show them all
       AdminAddProperty(line);
-      WindowEndUpdate(hObjectList);
+      AdminFillPropertyList();
       break;
 
    case ADMIN_RETURN:
@@ -226,7 +229,9 @@ void AdminEndResponse(int type)
 }
 /****************************************************************************/
 /*
- * AdminAddProperty:  Add the given property string to the object list box.
+ * AdminAddProperty:  Save the given property string for the object list box.
+ *   The first property line of a response names the object and its class, and
+ *   sets those instead.
  */
 void AdminAddProperty(char *str)
 {
@@ -251,8 +256,8 @@ void AdminAddProperty(char *str)
    }
    else
    {
-      // Otherwise add property to list box
-      ListBox_AddString(hObjectList, str);
+      // Otherwise save property for the list box
+      property_rows.push_back(str);
 
       prop = AdminNthToken(str, 1);
 
@@ -265,6 +270,55 @@ void AdminAddProperty(char *str)
       }      
    }
    num_lines++;
+}
+/****************************************************************************/
+/*
+ * AdminClearProperties:  Remove all saved properties.
+ */
+void AdminClearProperties(void)
+{
+   property_rows.clear();
+}
+/****************************************************************************/
+/*
+ * AdminFillPropertyList:  Refill the object list box from the saved properties.
+ *   Rows appear in alphabetical order when the sort box is checked, and in the
+ *   order the server sent them otherwise.  Each row's item data is its position
+ *   in the server's order.
+ */
+void AdminFillPropertyList(void)
+{
+   std::vector<int> order(property_rows.size());
+   for (size_t i = 0; i < order.size(); i++)
+      order[i] = (int) i;
+
+   if (IsDlgButtonChecked(hAdminDlg, IDC_SORTPROPS) == BST_CHECKED)
+      std::sort(order.begin(), order.end(), [](int a, int b)
+      {
+         return _stricmp(property_rows[a].c_str(), property_rows[b].c_str()) < 0;
+      });
+
+   // Keep the same property selected across a reorder
+   int selected = -1;
+   int index = ListBox_GetCurSel(hObjectList);
+   if (index != LB_ERR)
+      selected = (int) ListBox_GetItemData(hObjectList, index);
+
+   WindowBeginUpdate(hObjectList);
+   ListBox_ResetContent(hObjectList);
+
+   for (size_t i = 0; i < order.size(); i++)
+   {
+      int pos = ListBox_AddString(hObjectList, property_rows[order[i]].c_str());
+      if (pos < 0)
+         continue;
+
+      ListBox_SetItemData(hObjectList, pos, order[i]);
+      if (order[i] == selected)
+         ListBox_SetCurSel(hObjectList, pos);
+   }
+
+   WindowEndUpdate(hObjectList);
 }
 /****************************************************************************/
 /*
@@ -511,11 +565,16 @@ INT_PTR CALLBACK AdminValueDialogProc(HWND hDlg, UINT message, WPARAM wParam, LP
           
           SendMessage(hAdminDlg, BK_SENDCMD, 0, (LPARAM) command);
           
-          // Change value in object list box
+          // Change value in object list box and in the saved properties
           sprintf(command, "%s = %s %s", property, str, line);
+          int row = (int) ListBox_GetItemData(hObjectList, index);
+          if (row >= 0 && row < (int) property_rows.size())
+            property_rows[row] = command;
+
           WindowBeginUpdate(hObjectList);
           ListBox_DeleteString(hObjectList, index);
           ListBox_InsertString(hObjectList, index, command);
+          ListBox_SetItemData(hObjectList, index, row);
           WindowEndUpdate(hObjectList);
         }
 	    

--- a/module/admin/adminrc.h
+++ b/module/admin/adminrc.h
@@ -61,6 +61,7 @@
 #define IDC_FINECOLEDIT                 1046
 #define IDC_TELEPORT                    1047
 #define IDC_INVALIDATE                  1058
+#define IDC_SORTPROPS                   1059
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
@@ -69,7 +70,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        105
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1059
+#define _APS_NEXT_CONTROL_VALUE         1060
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif


### PR DESCRIPTION
## What

- Added a Sort A-Z checkbox to the client Administration window
  - reorders the object property list alphabetically
  - server order stays the default

## Why

- reduce administrative burden
- `show object` lists properties in class declaration order
  - that is the order the server walks them in
  - reaching one property on a user object means scrolling past many rows
  - the order only makes sense to someone who knows the class hierarchy
- Alphabetical order is the fast way to reach a property whose name is already known
- Declaration order groups inherited properties together and is worth keeping
  - so the order is a choice rather than a replacement
- The list box cannot do this on its own
  - `LBS_SORT` is a creation-time window style
  - setting it on a live control has no effect, so the rows have to be held and refilled

## How

- `adminprs.c` keeps the displayed object's properties in a `std::vector<std::string>`, in
  the order the server sent them
  - `AdminAddProperty` saves each row there instead of adding it to the list box
- `AdminFillPropertyList` fills the list box from that vector
  - a vector of indices is sorted with `_stricmp` when the checkbox is set
  - it runs when a response finishes and when the checkbox changes
- Each row carries its position in server order as list box item data
  - `AdminValueDialogProc` uses that to write an edited value back to the saved row
  - without it, toggling the checkbox after an edit would show the old value
  - the selected row stays selected across a reorder
- `AdminClearProperties` drops the saved rows
  - it runs when a response starts and when the client resets its data
- The checkbox sits on the empty part of the row holding Go to room and Reset data
  - no existing control moves and the dialog keeps its size
- `IDC_SORTPROPS` is a `#define` rather than a `static const int`
  - `admin.rc` includes `adminrc.h`, so the resource compiler reads that header as well as
    the C++ compiler
  - RC substitutes macros only and cannot evaluate a C++ declaration, so an id declared
    `static const int` is undefined by the time RC parses the `CONTROL` line
  - guarding a `static const int` with `#ifndef RC_INVOKED` and keeping a `#define`
    beside it would mean two declarations of one number, which can disagree
  - all 54 ids in `adminrc.h`, this one included, are `#define` for that reason


## Example

### New Sort A-Z checkbox
<img alt="image" src="https://github.com/user-attachments/assets/d267bd83-6af1-4a75-8f39-f26bedb0a4be" />

### Example Usage of Sort A-Z checkbox
<img width="1724" height="1284" alt="meridian_fMvPQzO4ly" src="https://github.com/user-attachments/assets/ecf0da68-ad2b-4691-9f31-4af4ab0a9c48" />