### PR TITLE
Add weapon cast animation

### DIFF
--- a/clientd3d/d3drender_objects.c
+++ b/clientd3d/d3drender_objects.c
@@ -2292,9 +2292,9 @@ void D3DRenderPlayerOverlayOverlaysDraw(
 				}
 				else
 				{
-					assert(0);
-					// the hotspot wasn't in the base object pdib
-					// must be an overlay on an overlay, so find base overlay
+					// The hotspot wasn't found on this group so it is skipped instead.
+					// Used for animations where not every frame has a hotspot defined.
+					continue;
 				}
 			}
 

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8559,30 +8559,33 @@ messages:
          AddPacket(1,HS_SE);
          AddPacket(4,PWO_RIGHT_HAND);
 
-		 oWeapon = Send(self,@LookupPlayerWeapon);	 
-		 if oWeapon <> $
-		 {
+		 oWeapon = Send(self,@LookupPlayerWeapon);
+
+         % If the right hand is holding a melee weapon, animate casting while wielding it.
+         if oWeapon <> $ AND NOT isClass(oWeapon,&Bow)
+         {
 			AddPacket(4,Send(oWeapon,@GetWindowOverlay));  % Get the weapon graphic filename.
 			AddPacket(4,0, 4,0, 4,0); % Flags + item rarity grade
 			Send(oWeapon,@SendWindowOverlayCastAnimation);
+         }
 
-			AddPacket(1,1);
-		    AddPacket(4,player_window_overlay_glow, 1,HS_CENTER,
-                      1,ANIMATE_ONCE, 4,300, 2,1, 2,3, 2,0);
-		 }
-		 else
-		 {
+         % Otherwise, show the right hand performing the spellcasting animation.
+		 % This also shows while wielding a bow on the left hand.
+         else
+         {
             AddPacket(4,player_window_overlay_hand);
             AddPacket(4,0, 4,0, 4,0); % Flags + item rarity grade
             AddPacket(1,ANIMATE_ONCE, 4,300, 2,4, 2,6, 2,0);
+         }
 
-			AddPacket(1,1);
-		    AddPacket(4,player_window_overlay_glow, 1,HS_RIGHT_HAND,
-                      1,ANIMATE_ONCE, 4,300, 2,1, 2,3, 2,0);
-		 }
-         SendPacket(poSession);    
+         % Display the magic glow on the used animation.
+         AddPacket(1,1);
+         AddPacket(4,player_window_overlay_glow, 1,HS_RIGHT_HAND,
+                   1,ANIMATE_ONCE, 4,300, 2,1, 2,3, 2,0);
+
+         SendPacket(poSession);
       }
-      
+
       return;
    }
 

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8551,31 +8551,35 @@ messages:
 
    DoWindowOverlayHandGlow()
    {
-      local i,iGroup;
+      local oWeapon;
 
       if pbLogged_on
       {
-         iGroup = 0;
-         for i in plWindow_overlays
-         {
-            if Send(i,@GetWindowOverlayID) = PWO_RIGHT_HAND
-            {  
-               % Of right hand overlay already exists, we can't restore it correctly
-               %  yet, so just don't change it
-               return;
-            }
-         }
-         
-         AddPacket(1,BP_PLAYER_OVERLAY);
+		 AddPacket(1,BP_PLAYER_OVERLAY);
          AddPacket(1,HS_SE);
          AddPacket(4,PWO_RIGHT_HAND);
-         AddPacket(4,player_window_overlay_hand);
-         AddPacket(4,0, 4,0, 4,0); % Flags + item rarity grade
-         AddPacket(1,ANIMATE_ONCE,4,300,2,4,2,6,2,iGroup);
-         AddPacket(1,1);
-         AddPacket(4,player_window_overlay_glow, 1,HS_RIGHT_HAND,
-                   1,ANIMATE_ONCE, 4,300, 2,1, 2,3, 2,0);
 
+		 oWeapon = Send(self,@LookupPlayerWeapon);	 
+		 if oWeapon <> $
+		 {
+			AddPacket(4,Send(oWeapon,@GetWindowOverlay));  % Get the weapon graphic filename.
+			AddPacket(4,0, 4,0, 4,0); % Flags + item rarity grade
+			Send(oWeapon,@SendWindowOverlayCastAnimation);
+
+			AddPacket(1,1);
+		    AddPacket(4,player_window_overlay_glow, 1,HS_CENTER,
+                      1,ANIMATE_ONCE, 4,300, 2,1, 2,3, 2,0);
+		 }
+		 else
+		 {
+            AddPacket(4,player_window_overlay_hand);
+            AddPacket(4,0, 4,0, 4,0); % Flags + item rarity grade
+            AddPacket(1,ANIMATE_ONCE, 4,300, 2,4, 2,6, 2,0);
+
+			AddPacket(1,1);
+		    AddPacket(4,player_window_overlay_glow, 1,HS_RIGHT_HAND,
+                      1,ANIMATE_ONCE, 4,300, 2,1, 2,3, 2,0);
+		 }
          SendPacket(poSession);    
       }
       

--- a/kod/object/item/passitem/weapon.kod
+++ b/kod/object/item/passitem/weapon.kod
@@ -115,6 +115,8 @@ classvars:
    vrWeapon_window_attack_start = 1
    vrWeapon_window_attack_end = 4
    vrWeapon_window_hold = 5
+   % End frame for casting while holding a weapon.
+   vrWeapon_window_weapon_cast_end = 3
 
    vrWeapon_overlay = $
 
@@ -726,6 +728,15 @@ messages:
       }
       
       return;      
+   }
+   
+   SendWindowOverlayCastAnimation()
+   "Show a casting animation while wielding a weapon."
+   {
+      AddPacket(1,ANIMATE_ONCE, 4,300, 2,vrWeapon_window_attack_start,
+			     2,vrWeapon_window_weapon_cast_end, 2,vrWeapon_window_hold);
+
+      return;
    }
 
    SendWindowOverlayOverlays()

--- a/kod/object/item/passitem/weapon/ranged/bow.kod
+++ b/kod/object/item/passitem/weapon/ranged/bow.kod
@@ -266,7 +266,14 @@ messages:
       
       propagate;
    }
-   
+
+   GetWindowOverlayID()
+   {
+	  % Setting bows to the offhand means the main hand can be shown casting spells.
+      % Bows require both hands so it isn't possible to equip other offhand items.
+	  return PWO_LEFT_HAND;
+   }
+
    GetWindowOverlayHotspot()
    {
       % turns off the window overlay

--- a/resource/graphics/povaxe.bbg
+++ b/resource/graphics/povaxe.bbg
@@ -3,9 +3,9 @@
 # 1-4 attacking
 # 5 carrying
 5
-axepovA.bmp  [0, 0]
-axepovB.bmp  [0, 0]
-axepovC.bmp  [0, 0]
+axepovA.bmp  [0, 0] :1    -21 [21, 272]
+axepovB.bmp  [0, 0] :1    -21 [25, 38]
+axepovC.bmp  [0, 0] :1    -21 [58, 263]
 axepovD.bmp  [0, 0]
 axepovH.bmp  [0, 0]
 5

--- a/resource/graphics/povbkswd.bbg
+++ b/resource/graphics/povbkswd.bbg
@@ -4,11 +4,11 @@
 # 5 carried
 
 5
-dagpovA.bmp    
-dagpovB.bmp   
-dagpovC.bmp  
-dagpovD.bmp 
-dagpovH.bmp
+dagpovA.bmp  [0, 0] :1    -21 [10, 50]
+dagpovB.bmp  [0, 0] :1    -21 [12, 68]
+dagpovC.bmp  [0, 0] :1    -21 [-5, 127]
+dagpovD.bmp  [0, 0]
+dagpovH.bmp  [0, 0]
 5
  1      1
  1      2

--- a/resource/graphics/povgswrd.bbg
+++ b/resource/graphics/povgswrd.bbg
@@ -4,9 +4,9 @@
 # 5 carried
 
 5
-gswpovA.bmp    
-gswpovB.bmp   
-gswpovC.bmp  
+gswpovA.bmp   [0, 0] :1    -21 [35, 198]
+gswpovB.bmp   [0, 0] :1    -21 [28, 107]
+gswpovC.bmp   [0, 0] :1    -21 [20, 206]
 gswpovD.bmp 
 gswpovH.bmp
 5

--- a/resource/graphics/povhamr.bbg
+++ b/resource/graphics/povhamr.bbg
@@ -4,11 +4,11 @@
 # 5 carried
 
 5
-hampovA.bmp [0, 0]
-hampovB.bmp [0, 0]
-hampovC.bmp [0, 0]
-hampovD.bmp [0, 0]
-hampovH.bmp [0, 0]
+hampovA.bmp   [0, 0] :1    -21 [38, 226]
+hampovB.bmp   [0, 0] :1    -21 [35, 49]
+hampovC.bmp   [0, 0] :1    -21 [38, 232]
+hampovD.bmp   [0, 0]
+hampovH.bmp   [0, 0]
 5
  1      1
  1      2

--- a/resource/graphics/povhunts.bbg
+++ b/resource/graphics/povhunts.bbg
@@ -4,11 +4,11 @@
 # 5 carried
 
 5
-hswpovA.bmp    
-hswpovB.bmp   
-hswpovC.bmp  
-hswpovD.bmp 
-hswpovH.bmp
+hswpovA.bmp   [0, 0] :1    -21 [31, 171]
+hswpovB.bmp   [0, 0] :1    -21 [38, 69]
+hswpovC.bmp   [0, 0] :1    -21 [14, 222]
+hswpovD.bmp   [0, 0]
+hswpovH.bmp   [0, 0]
 5
  1      1
  1      2

--- a/resource/graphics/povmace.bbg
+++ b/resource/graphics/povmace.bbg
@@ -1,10 +1,10 @@
 # Mace - FP attacking
 5
-macpovA.bmp  
-macpovB.bmp 
-macpovC.bmp
-macpovD.bmp  
-macpovH.bmp  
+macpovA.bmp   [0, 0] :1    -21 [21, 234]
+macpovB.bmp   [0, 0] :1    -21 [27, 73]
+macpovC.bmp   [0, 0] :1    -21 [29, 209]
+macpovD.bmp   [0, 0]
+macpovH.bmp   [0, 0]
 5
  1      1
  1      2

--- a/resource/graphics/povmystsw.bbg
+++ b/resource/graphics/povmystsw.bbg
@@ -4,11 +4,11 @@
 # 5 carried
 
 5
-pomystsw_frame0.bmp    
-pomystsw_frame1.bmp   
-pomystsw_frame2.bmp  
-pomystsw_frame3.bmp 
-pomystsw_frame4.bmp
+pomystsw_frame0.bmp   [0, 0] :1    -21 [0, 164]
+pomystsw_frame1.bmp   [0, 0] :1    -21 [18, 83]
+pomystsw_frame2.bmp   [0, 0] :1    -21 [2, 230]
+pomystsw_frame3.bmp   [0, 0]
+pomystsw_frame4.bmp   [0, 0]
 5
  1      1
  1      2

--- a/resource/graphics/povnersw.bbg
+++ b/resource/graphics/povnersw.bbg
@@ -4,11 +4,11 @@
 # 5 carried
 
 5
-nerpovA.bmp    
-nerpovB.bmp   
-nerpovC.bmp  
-nerpovD.bmp 
-nerpovH.bmp
+nerpovA.bmp   [0, 0] :1    -21 [0, 164]
+nerpovB.bmp   [0, 0] :1    -21 [18, 83]
+nerpovC.bmp   [0, 0] :1    -21 [2, 230]
+nerpovD.bmp   [0, 0]
+nerpovH.bmp   [0, 0]
 5
  1      1
  1      2

--- a/resource/graphics/povquswd.bbg
+++ b/resource/graphics/povquswd.bbg
@@ -4,11 +4,11 @@
 # 5 carried
 
 5
-qswpovA.bmp    
-qswpovB.bmp   
-qswpovC.bmp  
-qswpovD.bmp 
-qswpovH.bmp
+qswpovA.bmp   [0, 0] :1    -21 [49, 138]
+qswpovB.bmp   [0, 0] :1    -21 [53, 58]
+qswpovC.bmp   [0, 0] :1    -21 [25, 232]
+qswpovD.bmp   [0, 0]
+qswpovH.bmp   [0, 0]
 5
  1      1
  1      2

--- a/resource/graphics/povscim.bbg
+++ b/resource/graphics/povscim.bbg
@@ -3,11 +3,11 @@
 # 1-4 attacking
 # 5 carrying
 5
-scipovA.bmp  
-scipovB.bmp 
-scipovC.bmp
-scipovD.bmp  
-scipovH.bmp 
+scipovA.bmp   [0, 0] :1    -21 [47, 77]
+scipovB.bmp   [0, 0] :1    -21 [53, 57]
+scipovC.bmp   [0, 0] :1    -21 [18, 239]
+scipovD.bmp   [0, 0]
+scipovH.bmp   [0, 0]
 5
  1      1
  1      2

--- a/resource/graphics/povshswd.bbg
+++ b/resource/graphics/povshswd.bbg
@@ -3,11 +3,11 @@
 # 1-4 attacking
 # 5 carried
 5
-sswpovA.bmp   
-sswpovB.bmp  
-sswpovC.bmp 
-sswpovD.bmp
-sswpovH.bmp  
+sswpovA.bmp   [0, 0] :1    -21 [27, 101]
+sswpovB.bmp   [0, 0] :1    -21 [29, 97]
+sswpovC.bmp   [0, 0] :1    -21 [20, 178]
+sswpovD.bmp   [0, 0]
+sswpovH.bmp   [0, 0]
 5
  1      1
  1      2

--- a/resource/graphics/povsword.bbg
+++ b/resource/graphics/povsword.bbg
@@ -4,11 +4,11 @@
 # 5 carried
 
 5
-lswpovA.bmp    
-lswpovB.bmp   
-lswpovC.bmp  
-lswpovD.bmp 
-lswpovH.bmp
+lswpovA.bmp   [0, 0] :1    -21 [30, 172]
+lswpovB.bmp   [0, 0] :1    -21 [37, 99]
+lswpovC.bmp   [0, 0] :1    -21 [22, 242]
+lswpovD.bmp   [0, 0]
+lswpovH.bmp   [0, 0]
 5
  1      1
  1      2


### PR DESCRIPTION
This PR adds spellcasting animations while wielding weapons.  It uses the first three bitmap groups of each melee weapon's POV overlay to show the casting swing effect.  This PR also plans to add hotspots to those three frames so that the casting glow can be attached to them.

This PR also allows the casting hand to be shown along with the bow.  This is done by changing the bow's hotspot definition to PWO_LEFT_HAND, and the only other item that uses that hotspot definition is a shield, which can't be used along with bows anyways.

I asked Claude on how to address a crash that occurs in hardware rendering if at least one bitmap group is missing a hotspot while the rest of the groups in the animation have hotspots.  It suggests that in the definition for D3DRenderPlayerOverlayOverlaysDraw(), I can replace assert(0) with continue, which appears to skip the setup for rendering overlays that attach to other overlays.  Software rendering meanwhile appears to play the animation fine without crashing.

The .bbg files were updated to include the new hotspots near the weapon hilt areas for the casting glow, and the new .bgf files are ready to be sent in a .zip file.  Currently there is a minor graphical bug that occurs once when a player casts their first spell in the session using a melee weapon.  I consider it a minor bug since subsequent casts doesn't show it for the rest of the game session.

<img width="640" height="360" alt="weaponcasttest1" src="https://github.com/user-attachments/assets/0b682729-d914-4b2a-9d52-0a7c5a00c89c" />