### PR TITLE
Honour the sidedef "Transparent" flag in the hardware renderer

### DIFF
--- a/clientd3d/d3drender_materials.c
+++ b/clientd3d/d3drender_materials.c
@@ -42,7 +42,7 @@ bool D3DMaterialWorldPacket(d3d_render_packet_new *pPacket, d3d_render_cache_sys
     if (pPacket->pTexture)
       pTexture = pPacket->pTexture;
     else if (pPacket->pDib)
-      pTexture = D3DCacheTextureLookupSwizzled(&pCacheSystem->textureCache, pPacket, 0);
+      pTexture = D3DCacheTextureLookupSwizzled(&pCacheSystem->textureCache, pPacket, pPacket->effect);
   }
   else
   {
@@ -245,7 +245,7 @@ bool D3DMaterialLMapDynamicPacket(d3d_render_packet_new *pPacket, d3d_render_cac
 	if (pPacket->pTexture)
 		pTexture = pPacket->pTexture;
 	else if (pPacket->pDib)
-		pTexture = D3DCacheTextureLookupSwizzled(&pCacheSystem->textureCache, pPacket, 0);
+		pTexture = D3DCacheTextureLookupSwizzled(&pCacheSystem->textureCache, pPacket, pPacket->effect);
 
 	if (pTexture)
 		IDirect3DDevice9_SetTexture(gpD3DDevice, 1, (IDirect3DBaseTexture9 *) pTexture);

--- a/clientd3d/d3drender_textures.c
+++ b/clientd3d/d3drender_textures.c
@@ -10,6 +10,8 @@
 // Interfaces
 
 static void D3DRenderPaletteSet(UINT xlatID0, UINT xlatID1, unsigned int flags);
+static unsigned short PaletteIndexToTexel(const PALETTEENTRY* palette, BYTE index, bool bSolid,
+	Color* lastColor);
 
 // Implementations
 
@@ -148,6 +150,33 @@ void D3DRenderPaletteSet(UINT xlatID0, UINT xlatID1, unsigned int flags)
 }
 
 /**
+Convert one palette index to an A1R5G5B5 texel.
+
+Index 254 is the cutout colour, and is written fully transparent unless bSolid is set, in
+which case it has no special meaning and is written as an ordinary opaque colour. A cutout
+texel takes its RGB from lastColor, the most recent opaque colour, so that bilinear
+filtering along a cutout edge blends towards a neighbouring colour rather than producing a
+halo. lastColor is updated by every opaque texel and must persist across a whole row.
+*/
+unsigned short PaletteIndexToTexel(const PALETTEENTRY* palette, BYTE index, bool bSolid,
+	Color* lastColor)
+{
+	if (0 == palette[index].peFlags && !bSolid)
+		return (lastColor->blue >> 3) |
+			((lastColor->green >> 3) << 5) |
+			((lastColor->red >> 3) << 10);
+
+	lastColor->red = palette[index].peRed;
+	lastColor->green = palette[index].peGreen;
+	lastColor->blue = palette[index].peBlue;
+
+	return (palette[index].peBlue >> 3) |
+		((palette[index].peGreen >> 3) << 5) |
+		((palette[index].peRed >> 3) << 10) |
+		(1 << 15);
+}
+
+/**
 / straight texture loader for objects
 */
 LPDIRECT3DTEXTURE9 D3DRenderTextureCreateFromBGF(PDIB pDib, BYTE xLat0, BYTE xLat1,
@@ -237,6 +266,7 @@ LPDIRECT3DTEXTURE9 D3DRenderTextureCreateFromBGF(PDIB pDib, BYTE xLat0, BYTE xLa
 	pPixels16 = (unsigned short*)lockedRect.pBits;
 
 	auto* palette = getPalette();
+	const bool bSolid = (effect & D3DRENDER_TEXTURE_SOLID) != 0;
 
 	for (si = 0, di = 0; di < newHeight; si++, di++)
 	{
@@ -256,29 +286,8 @@ LPDIRECT3DTEXTURE9 D3DRenderTextureCreateFromBGF(PDIB pDib, BYTE xLat0, BYTE xLa
 					k -= newWidth;
 				}
 
-			// 16bit 1555 textures
-			if (palette[pBits[si * pDib->width + sj]].peFlags != 0)
-			{
-				pPixels16[di * pitchHalf + dj] =
-					(palette[pBits[si * pDib->width + sj]].peBlue >> 3) |
-					((palette[pBits[si * pDib->width + sj]].peGreen >> 3) << 5) |
-					((palette[pBits[si * pDib->width + sj]].peRed >> 3) << 10);
-				pPixels16[di * pitchHalf + dj] |=
-					palette[pBits[si * pDib->width + sj]].peFlags ? (1 << 15) : 0;
-
-				lastColor.red = palette[pBits[si * pDib->width + sj]].peRed;
-				lastColor.green = palette[pBits[si * pDib->width + sj]].peGreen;
-				lastColor.blue = palette[pBits[si * pDib->width + sj]].peBlue;
-			}
-			else
-			{
-				pPixels16[di * pitchHalf + dj] =
-					(lastColor.blue >> 3) |
-					((lastColor.green >> 3) << 5) |
-					((lastColor.red >> 3) << 10);
-				pPixels16[di * pitchHalf + dj] |=
-					palette[pBits[si * pDib->width + sj]].peFlags ? (1 << 15) : 0;
-			}
+			pPixels16[di * pitchHalf + dj] =
+				PaletteIndexToTexel(palette, pBits[si * pDib->width + sj], bSolid, &lastColor);
 		}
 	}
 
@@ -395,6 +404,7 @@ LPDIRECT3DTEXTURE9 D3DRenderTextureCreateFromBGFSwizzled(PDIB pDib, BYTE xLat0, 
 	pPixels16 = (unsigned short*)lockedRect.pBits;
 
 	auto* palette = getPalette();
+	const bool bSolid = (effect & D3DRENDER_TEXTURE_SOLID) != 0;
 
 	for (si = 0, di = 0; di < newWidth; si++, di++)
 	{
@@ -414,29 +424,8 @@ LPDIRECT3DTEXTURE9 D3DRenderTextureCreateFromBGFSwizzled(PDIB pDib, BYTE xLat0, 
 					l -= newHeight;
 				}
 
-			// 16bit 1555 textures
-			if (palette[pBits[(sj * pDib->width) + si]].peFlags != 0)
-			{
-				pPixels16[di * pitchHalf + dj] =
-					(palette[pBits[(sj * pDib->width) + si]].peBlue >> 3) |
-					((palette[pBits[(sj * pDib->width) + si]].peGreen >> 3) << 5) |
-					((palette[pBits[(sj * pDib->width) + si]].peRed >> 3) << 10);
-				pPixels16[di * pitchHalf + dj] |=
-					palette[pBits[(sj * pDib->width) + si]].peFlags ? (1 << 15) : 0;
-
-				lastColor.red = palette[pBits[(sj * pDib->width) + si]].peRed;
-				lastColor.green = palette[pBits[(sj * pDib->width) + si]].peGreen;
-				lastColor.blue = palette[pBits[(sj * pDib->width) + si]].peBlue;
-			}
-			else
-			{
-				pPixels16[di * pitchHalf + dj] =
-					(lastColor.blue >> 3) |
-					((lastColor.green >> 3) << 5) |
-					((lastColor.red >> 3) << 10);
-				pPixels16[di * pitchHalf + dj] |=
-					palette[pBits[(sj * pDib->width) + si]].peFlags ? (1 << 15) : 0;
-			}
+			pPixels16[di * pitchHalf + dj] =
+				PaletteIndexToTexel(palette, pBits[(sj * pDib->width) + si], bSolid, &lastColor);
 		}
 	}
 

--- a/clientd3d/d3drender_textures.h
+++ b/clientd3d/d3drender_textures.h
@@ -11,6 +11,11 @@
 #ifndef _D3DRENDERTEXTURES_H
 #define _D3DRENDERTEXTURES_H
 
+// ORed into a render packet's effect field to ask for the solid variant of a bitmap, in
+// which palette index 254 is uploaded as its own colour instead of as a cutout hole.
+// Sits outside OF_EFFECT_MASK so it can never be mistaken for an object drawing effect.
+static const int D3DRENDER_TEXTURE_SOLID = 0x10000000;
+
 LPDIRECT3DTEXTURE9 D3DRenderTextureCreateFromResource(BYTE* ptr, int width, int height);
 LPDIRECT3DTEXTURE9 D3DRenderTextureCreateFromBGF(PDIB pDib, BYTE xLat0, BYTE xLat1,
 	unsigned int effect);

--- a/clientd3d/d3drender_world.c
+++ b/clientd3d/d3drender_world.c
@@ -51,6 +51,32 @@ void D3DRenderSemiTransparentWalls(const WorldRenderParams &worldRenderParams);
 // Implementations
 
 /**
+ * Returns the texture variant pDib must be uploaded as to be drawn on pSideDef, for the
+ * effect field of a render packet. Only a sidedef with the "Transparent" flag treats
+ * palette index 254 as a hole; on every other sidedef it is an ordinary colour, as the
+ * software renderer draws it.
+ *
+ * A hole is a property of the wall rather than of the face it is seen from, so the flag
+ * counts on either face as long as both carry the same bitmap. Rooms often tick the box
+ * only on the face pointing at open ground: the far face of the same wall is still in
+ * view along a corner silhouette, and reading the flag from that face alone would paint
+ * its cutout texels their true cyan for the pixel or two of it that shows.
+ */
+static int SidedefTextureVariant(const WallData *pWall, const Sidedef *pSideDef, PDIB pDib)
+{
+   if (pSideDef->flags & WF_TRANSPARENT)
+      return 0;
+
+   const Sidedef *pOther = (pSideDef == pWall->pos_sidedef) ? pWall->neg_sidedef : pWall->pos_sidedef;
+
+   if (pOther && (pOther->flags & WF_TRANSPARENT) &&
+       ((pOther->normal_bmap == pDib) || (pOther->above_bmap == pDib) || (pOther->below_bmap == pDib)))
+      return 0;
+
+   return D3DRENDER_TEXTURE_SOLID;
+}
+
+/**
  * The main entry point for rendering the 3d game world.
  * Returns the total time taken to render the world.
  */
@@ -1028,7 +1054,7 @@ void D3DRenderPacketWallAdd(WallData *pWall, d3d_render_pool_new *pPool, unsigne
 
    D3DRenderWallExtract(pWall, pDib, &flags, xyz, st, bgra, type, side);
 
-   pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDib, 0, 0, 0);
+   pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDib, 0, 0, SidedefTextureVariant(pWall, pSideDef, pDib));
    if (NULL == pPacket)
       return;
    pChunk = D3DRenderChunkNew(pPacket);
@@ -1190,7 +1216,7 @@ void D3DRenderPacketWallMaskAdd(WallData *pWall, d3d_render_pool_new *pPool, uns
 
    D3DRenderWallExtract(pWall, pDib, &flags, xyz, st, bgra, type, side);
 
-   pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDib, 0, 0, 0);
+   pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDib, 0, 0, SidedefTextureVariant(pWall, pSideDef, pDib));
    if (NULL == pPacket)
       return;
    pChunk = D3DRenderChunkNew(pPacket);
@@ -2065,7 +2091,7 @@ void D3DRenderLMapPostWallAdd(WallData *pWall, d3d_render_pool_new *pPool, unsig
          // The normal is still calculated above because it's used below to determine
          // the wall's major axis for texture coordinate calculation.
 
-         pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDib, 0, 0, 0);
+         pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDib, 0, 0, SidedefTextureVariant(pWall, pSideDef, pDib));
          if (NULL == pPacket)
             return;
          pChunk = D3DRenderChunkNew(pPacket);

--- a/clientd3d/d3drender_world.c
+++ b/clientd3d/d3drender_world.c
@@ -51,29 +51,35 @@ void D3DRenderSemiTransparentWalls(const WorldRenderParams &worldRenderParams);
 // Implementations
 
 /**
- * Returns the texture variant pDib must be uploaded as to be drawn on pSideDef, for the
- * effect field of a render packet. Only a sidedef with the "Transparent" flag treats
- * palette index 254 as a hole; on every other sidedef it is an ordinary colour, as the
- * software renderer draws it.
+ * Whether palette index 254 is a hole where pDib is drawn on pSideDef, rather than the
+ * ordinary colour the software renderer would give it.
  *
- * A hole is a property of the wall rather than of the face it is seen from, so the flag
- * counts on either face as long as both carry the same bitmap. Rooms often tick the box
- * only on the face pointing at open ground: the far face of the same wall is still in
- * view along a corner silhouette, and reading the flag from that face alone would paint
- * its cutout texels their true cyan for the pixel or two of it that shows.
+ * A hole is a property of the wall rather than of the face it is seen from, so the
+ * "Transparent" flag counts on either face as long as both carry the same bitmap. Rooms
+ * often tick the box only on the face pointing at open ground: the far face of the same
+ * wall is still in view along a corner silhouette, and reading the flag from that face
+ * alone would paint its cutout texels their true cyan for the pixel or two of it that
+ * shows.
  */
-static int SidedefTextureVariant(const WallData *pWall, const Sidedef *pSideDef, PDIB pDib)
+static bool SidedefDrawsCutout(const WallData *pWall, const Sidedef *pSideDef, PDIB pDib)
 {
    if (pSideDef->flags & WF_TRANSPARENT)
-      return 0;
+      return true;
 
    const Sidedef *pOther = (pSideDef == pWall->pos_sidedef) ? pWall->neg_sidedef : pWall->pos_sidedef;
 
-   if (pOther && (pOther->flags & WF_TRANSPARENT) &&
-       ((pOther->normal_bmap == pDib) || (pOther->above_bmap == pDib) || (pOther->below_bmap == pDib)))
-      return 0;
+   return pOther && (pOther->flags & WF_TRANSPARENT) &&
+          ((pOther->normal_bmap == pDib) || (pOther->above_bmap == pDib) ||
+           (pOther->below_bmap == pDib));
+}
 
-   return D3DRENDER_TEXTURE_SOLID;
+/**
+ * Returns the texture variant pDib must be uploaded as to be drawn on pSideDef, for the
+ * effect field of a render packet.
+ */
+static int SidedefTextureVariant(const WallData *pWall, const Sidedef *pSideDef, PDIB pDib)
+{
+   return SidedefDrawsCutout(pWall, pSideDef, pDib) ? 0 : D3DRENDER_TEXTURE_SOLID;
 }
 
 /**
@@ -2758,7 +2764,11 @@ int D3DRenderWallExtract(WallData *pWall, PDIB pDib, unsigned int *flags, custom
    switch (type)
    {
    case D3DRENDER_WALL_NORMAL:
-      if (pSideDef->flags & WF_NO_VTILE)
+      // Not tiling vertically leaves the wall above the texture to be filled by whatever
+      // lies behind it, which the clamp below only achieves where the texture's cutout
+      // texels are holes. Drawn solid it would smear the texture's edge row up the wall
+      // instead, so fall back to tiling, which is what the software renderer does.
+      if ((pSideDef->flags & WF_NO_VTILE) && SidedefDrawsCutout(pWall, pSideDef, pDib))
          *flags |= D3DRENDER_NO_VTILE;
       if (pSideDef->flags & WF_NO_HTILE)
          *flags |= D3DRENDER_NO_HTILE;


### PR DESCRIPTION
Palette index 254 is the cutout colour, and the "Transparent" checkbox decides whether it is a hole or an ordinary colour. The software renderer reads the flag per wall, so one bitmap can draw both ways. The hardware renderer decides once per bitmap, at texture upload, where no sidedef exists yet, so every wall using that bitmap got holes punched in it whether or not the box was ticked.

Upload two variants instead, keyed on what the sidedef asked for. D3DRENDER_TEXTURE_SOLID rides in the render packet's effect field, already part of both the packet match key and the texture cache key, so no new plumbing is needed.

Turning alpha testing off per chunk would have been fewer lines, but the colour under a transparent texel is not the cutout colour: the upload fills it with the last opaque colour on the row so bilinear filtering does not halo along cutout edges. Disabling the test would reveal that bleed as a smear.

Two details:

- The flag is read per wall, not per face, since a hole belongs to the wall rather than the side you view it from. Rooms commonly tick the box only on the face facing open ground, and reading the near face alone painted the far face cyan along corner silhouettes.
- "No vertical tile" falls back to tiling where a face is not drawing holes. That flag fills the wall above the texture with what is behind it, which the texture clamp only achieves through holes; drawn solid it smeared the edge row up the wall.

This exposes room data the old behaviour hid: a cutout texture without the box ticked now draws cyan, as it always has in software. 22 shipped rooms have at least one such face - but minimal issues/noticeable areas were found during inspection. Marion was the obvious case and is fixed separately in https://github.com/Meridian59/Meridian59/pull/1486; the rest already look this way to every software renderer player.

Verified with a test room containing three sidedefs carrying the same bitmap with different flags, so any difference between them is purely flag driven.