### PR TITLE
fix: update lupogg king hold spell color constant

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
@@ -19,7 +19,7 @@ constants:
    ANIM_BITE = 2
    ANIM_SPIT = 3
 
-   SPIT_COLOR = 82
+   BAD_COLOR = 83
 
 resources:
 
@@ -299,7 +299,7 @@ messages:
       Send(self,@DoCast);
       Send(oSpell,@DoHold,#what=self,#oTarget=oTarget,#iDurationSecs=iRandom);
       Send(oTarget,@MsgSendUser,#message_rsc=lupoggking_cast_spell);
-      Send(oTarget,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,#duration=iRandom*1000,#xlat=SPIT_COLOR); 
+      Send(oTarget,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,#duration=iRandom*1000,#xlat=BAD_COLOR); 
 
       % Do damage?
 


### PR DESCRIPTION
## What

- Rename and fix lupogg king hold effect color
- SPIT_COLOR becomes BAD_COLOR = 83

## Why

- Hold is crowd control (bad spell), should use BAD_COLOR = 83 (bright green)
- Was incorrectly using 82 (good spell color)
- Keeping spell effect coloring consistent makes for a better player experience

## Example

- Before: Lupogg king hold shows dark blue flash (good spell color)
- After: Lupogg king hold shows bright green flash (bad spell color)
