### PR TITLE
 Fix GPU efficiency checkbox on a fresh install

### DIFF
--- a/clientd3d/config.c
+++ b/clientd3d/config.c
@@ -113,7 +113,6 @@ static char INITechnical[]    = "Technical";
 /* config.ini file entries (preferences) */
 static char config_section[] = "config";  /* Section for configuration stuff */
 static char INIGpuEfficiency[] = "gpuefficiency";
-static char INIGpuEfficiencyOneTimeFlip[] = "gpuefficiencyonetimeflip";
 
 static char INITextAreaSize[] = "TextAreaSize";
 

--- a/clientd3d/preferences.c
+++ b/clientd3d/preferences.c
@@ -336,7 +336,7 @@ static void ReadINIFile()
     GetPrivateProfileString(strSection, "attackontarget", "false", ReturnedString, nSize, strINIFile);
     m_attackontarget = strcmp(ReturnedString, "true") == 0;
 
-    GetPrivateProfileString(strSection, "gpuefficiency", "false", ReturnedString, nSize, strINIFile);
+    GetPrivateProfileString(strSection, "gpuefficiency", "true", ReturnedString, nSize, strINIFile);
     m_gpuefficiency = strcmp(ReturnedString, "true") == 0;
 
     GetPrivateProfileString(strSection, "invertmouse", "false", ReturnedString, nSize, strINIFile);


### PR DESCRIPTION
On a fresh install config.ini has no gpuefficiency entry, and the two places that read it disagreed on what a missing entry means: the client treated it as enabled (correct), the preferences dialog treated it as disabled (bug). The client therefore started in GPU efficiency mode with the box unticked.

Existing installs already have the entry, written either by a preferences save or by the one-time flip that ran until 1.6.0, which is why this only appears on a new install. Removing that flip in #1228 is what left new installs with no entry, so its leftover key name goes with this change.

To reproduce, delete the gpuefficiency line from config.ini and restart.