### PR TITLE
Fix multisample antialiasing and give the graphics settings their own section

### DIFF
--- a/clientd3d/client.rc
+++ b/clientd3d/client.rc
@@ -559,23 +559,26 @@ BEGIN
     CONTROL         "",IDC_TARGETCURSOR,"SysTabControl32",0x0,6,6,464,373
 END
 
-IDD_OPTIONS DIALOGEX 0, 0, 135, 163
+IDD_OPTIONS DIALOGEX 0, 0, 257, 261
 STYLE DS_SETFONT | DS_MODALFRAME | WS_MINIMIZEBOX | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_APPWINDOW
 CAPTION "Editor de comandos do Meridian 59"
 FONT 8, "MS Sans Serif", 0, 0, 0x1
 BEGIN
-    GROUPBOX        "Opções",IDC_STATIC,6,5,124,114
-    CONTROL         "Configuração de teclas clássica",IDC_CLASSIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,19,110,10
-    CONTROL         "Mensagem rápida",IDC_QUICKCHAT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,33,72,10
-    CONTROL         "Sempre correr",IDC_ALWAYSRUN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,47,58,10
-    CONTROL         "Sempre atacar o alvo",IDC_ATTACKONTARGET,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,61,83,10
-    CONTROL         "Luzes dinâmicas",IDC_DYNAMIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,75,95,10
-    CONTROL         "Renderização de software",IDC_SOFTWARE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,89,100,10
-    CONTROL         "Eficiência da GPU",IDC_GPU_EFFICIENCY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,103,75,10
+    GROUPBOX        "Opções",IDC_STATIC,7,7,243,72
+    CONTROL         "Configuração de teclas clássica",IDC_CLASSIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,20,225,10
+    CONTROL         "Mensagem rápida",IDC_QUICKCHAT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,34,225,10
+    CONTROL         "Sempre correr",IDC_ALWAYSRUN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,48,225,10
+    CONTROL         "Sempre atacar o alvo",IDC_ATTACKONTARGET,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,62,225,10
+    GROUPBOX        "Gráficos",IDC_STATIC,7,86,243,72
+    CONTROL         "Renderização de software",IDC_SOFTWARE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,99,225,10
+    CONTROL         "Luzes dinâmicas",IDC_DYNAMIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,113,225,10
+    CONTROL         "Eficiência da GPU",IDC_GPU_EFFICIENCY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,127,225,10
+    CONTROL         "Multisample Anti-Aliasing (MSAA)",IDC_ANTIALIASING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,141,225,10
+    PUSHBUTTON      "Restaurar Padrões",IDC_RESTOREDEFAULTS,171,239,79,15
 END
 
-IDD_COMMUNICATION DIALOG 0, 0, 258, 138
+IDD_COMMUNICATION DIALOG 0, 0, 258, 261
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Comunicação"
 FONT 8, "MS Sans Serif"
@@ -601,9 +604,10 @@ BEGIN
     PUSHBUTTON      "+",IDC_BROADCAST_MOD,116,83,14,14
     PUSHBUTTON      "+",IDC_WHO_MOD,116,102,14,14
     PUSHBUTTON      "+",IDC_EMOTE_MOD,239,7,14,14
+    PUSHBUTTON      "Ajuda",IDC_MAINHELP,180,239,70,15
 END
 
-IDD_INTERACTION DIALOG 0, 0, 258, 138
+IDD_INTERACTION DIALOG 0, 0, 258, 261
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Interações"
 FONT 8, "MS Sans Serif"
@@ -635,9 +639,10 @@ BEGIN
     PUSHBUTTON      "+",IDC_DEPOSIT_MOD,237,7,14,14
     PUSHBUTTON      "+",IDC_WITHDRAW_MOD,237,26,14,14
     PUSHBUTTON      "+",IDC_ATTACK_MOD,237,45,14,14
+    PUSHBUTTON      "Ajuda",IDC_MAINHELP,180,239,70,15
 END
 
-IDD_MAP DIALOG 0, 0, 258, 138
+IDD_MAP DIALOG 0, 0, 258, 261
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Mapa"
 FONT 8, "MS Sans Serif"
@@ -656,9 +661,10 @@ BEGIN
     CONTROL         "Anotações",IDC_MAP_ANNOTATIONS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,91,72,10
     LTEXT           "Limite de Zoom do Texto",IDC_STATIC,13,109,50,10
     CONTROL         "",IDC_ANNOTATION_ZOOM_LIMIT,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,69,106,173,15
+    PUSHBUTTON      "Ajuda",IDC_MAINHELP,180,239,70,15
 END
 
-IDD_MOVEMENT DIALOG 0, 0, 296, 138
+IDD_MOVEMENT DIALOG 0, 0, 296, 261
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Movimentação"
 FONT 8, "MS Sans Serif"
@@ -699,9 +705,10 @@ BEGIN
     PUSHBUTTON      "+",IDC_LOOKSTRAIGHT_MOD,269,64,14,14
     PUSHBUTTON      "+",IDC_FLIP_MOD,269,83,14,14
     PUSHBUTTON      "+",IDC_MOUSELOOKTOGGLE_MOD,269,102,14,14
+    PUSHBUTTON      "Ajuda",IDC_MAINHELP,180,239,70,15
 END
 
-IDD_TARGETING DIALOG 0, 0, 268, 138
+IDD_TARGETING DIALOG 0, 0, 268, 261
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Seleção de alvo"
 FONT 8, "MS Sans Serif"
@@ -727,6 +734,7 @@ BEGIN
     PUSHBUTTON      "+",IDC_TABFORWARD_MOD,123,83,14,14
     PUSHBUTTON      "+",IDC_TABBACKWARD_MOD,123,102,14,14
     PUSHBUTTON      "+",IDC_SELECTTARGET_MOD,254,7,14,14
+    PUSHBUTTON      "Ajuda",IDC_MAINHELP,180,239,70,15
 END
 
 IDD_ASSIGNKEY DIALOG 0, 0, 110, 54
@@ -1032,6 +1040,10 @@ BEGIN
 	IDS_RESTORE_DEFAULTS			"Restaurar Padrões"
 	IDS_THEME_DEFAULT				"Padrão"
 	IDS_THEME_DARK					"Escuro"
+	IDS_TIP_DYNAMIC_LIGHTING		"Faz com que tochas, feitiços e outras fontes de luz iluminem o cenário ao redor. Desligá-lo é um pouco mais rápido em máquinas antigas."
+	IDS_TIP_SOFTWARE_RENDERER		"Desenha o mundo no processador em vez da placa de vídeo. Só é necessário se o renderizador por hardware não iniciar nesta máquina, ou se quiser o visual original dos anos 90."
+	IDS_TIP_GPU_EFFICIENCY			"Troca qualidade de imagem por consumo e temperatura: limita a taxa de quadros a 60, reduz o detalhe das texturas de fundo e aguarda a atualização do monitor. Bom para notebooks."
+	IDS_TIP_ANTIALIASING			"Suaviza as bordas serrilhadas de paredes e objetos usando várias amostras por pixel. Custa desempenho da placa de vídeo e é ignorado por placas que não o suportam."
 END
 
 
@@ -1579,25 +1591,26 @@ BEGIN
     CONTROL         "",IDC_TARGETCURSOR,"SysTabControl32",0x0,6,6,464,373
 END
 
-IDD_OPTIONS DIALOGEX 0, 0, 151, 163
+IDD_OPTIONS DIALOGEX 0, 0, 257, 261
 STYLE DS_SETFONT | DS_MODALFRAME | WS_MINIMIZEBOX | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_APPWINDOW
 CAPTION "Meridian 59 Bind Editor"
 FONT 8, "MS Sans Serif", 0, 0, 0x1
 BEGIN
-    GROUPBOX        "Optionen",IDC_STATIC,5,3,137,102
-    CONTROL         "klassische Tastenbelegung",IDC_CLASSIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,17,102,10
-    CONTROL         "schnelles Chatten",IDC_QUICKCHAT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,29,72,10
-    CONTROL         "immer Laufen",IDC_ALWAYSRUN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,41,58,10
-    CONTROL         "Angriff bei Zielanwahl",IDC_ATTACKONTARGET,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,53,83,10
-    CONTROL         "dynamische Beleuchtung",IDC_DYNAMIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,65,95,10
-    CONTROL         "Software-Grafikmodus",IDC_SOFTWARE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,77,85,10
-    CONTROL         "GPU Efficiency",IDC_GPU_EFFICIENCY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,89,75,10
-    PUSHBUTTON      "Hilfe",IDC_MAINHELP,100,130,42,15
-    PUSHBUTTON      "Standardeinstellungen",IDC_RESTOREDEFAULTS,4,111,79,14
+    GROUPBOX        "Optionen",IDC_STATIC,7,7,243,72
+    CONTROL         "klassische Tastenbelegung",IDC_CLASSIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,20,225,10
+    CONTROL         "schnelles Chatten",IDC_QUICKCHAT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,34,225,10
+    CONTROL         "immer Laufen",IDC_ALWAYSRUN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,48,225,10
+    CONTROL         "Angriff bei Zielanwahl",IDC_ATTACKONTARGET,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,62,225,10
+    GROUPBOX        "Grafik",IDC_STATIC,7,86,243,72
+    CONTROL         "Software-Grafikmodus",IDC_SOFTWARE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,99,225,10
+    CONTROL         "dynamische Beleuchtung",IDC_DYNAMIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,113,225,10
+    CONTROL         "GPU Efficiency",IDC_GPU_EFFICIENCY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,127,225,10
+    CONTROL         "Multisample Anti-Aliasing (MSAA)",IDC_ANTIALIASING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,141,225,10
+    PUSHBUTTON      "Standardeinstellungen",IDC_RESTOREDEFAULTS,171,239,79,15
 END
 
-IDD_COMMUNICATION DIALOG 0, 0, 258, 138
+IDD_COMMUNICATION DIALOG 0, 0, 258, 261
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Kommunikation"
 FONT 8, "MS Sans Serif"
@@ -1623,9 +1636,10 @@ BEGIN
     PUSHBUTTON      "+",IDC_BROADCAST_MOD,106,83,14,14
     PUSHBUTTON      "+",IDC_WHO_MOD,106,102,14,14
     PUSHBUTTON      "+",IDC_EMOTE_MOD,229,7,14,14
+    PUSHBUTTON      "Hilfe",IDC_MAINHELP,180,239,70,15
 END
 
-IDD_INTERACTION DIALOG 0, 0, 258, 138
+IDD_INTERACTION DIALOG 0, 0, 258, 261
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Interaktion"
 FONT 8, "MS Sans Serif"
@@ -1657,9 +1671,10 @@ BEGIN
     PUSHBUTTON      "+",IDC_DEPOSIT_MOD,237,7,14,14
     PUSHBUTTON      "+",IDC_WITHDRAW_MOD,237,26,14,14
     PUSHBUTTON      "+",IDC_ATTACK_MOD,237,45,14,14
+    PUSHBUTTON      "Hilfe",IDC_MAINHELP,180,239,70,15
 END
 
-IDD_MAP DIALOG 0, 0, 258, 138
+IDD_MAP DIALOG 0, 0, 258, 261
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Karte"
 FONT 8, "MS Sans Serif"
@@ -1678,9 +1693,10 @@ BEGIN
     CONTROL         "Kartennotizen",IDC_MAP_ANNOTATIONS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,91,72,10
     LTEXT           "Zoomgrenze für Text",IDC_STATIC,13,109,50,10
     CONTROL         "",IDC_ANNOTATION_ZOOM_LIMIT,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,69,106,173,15
+    PUSHBUTTON      "Hilfe",IDC_MAINHELP,180,239,70,15
 END
 
-IDD_MOVEMENT DIALOG 0, 0, 296, 138
+IDD_MOVEMENT DIALOG 0, 0, 296, 261
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Bewegung"
 FONT 8, "MS Sans Serif"
@@ -1722,9 +1738,10 @@ BEGIN
     PUSHBUTTON      "+",IDC_LOOKSTRAIGHT_MOD,269,64,14,14
     PUSHBUTTON      "+",IDC_FLIP_MOD,269,83,14,14
     PUSHBUTTON      "+",IDC_MOUSELOOKTOGGLE_MOD,269,102,14,14
+    PUSHBUTTON      "Hilfe",IDC_MAINHELP,180,239,70,15
 END
 
-IDD_TARGETING DIALOG 0, 0, 268, 138
+IDD_TARGETING DIALOG 0, 0, 268, 261
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Zielanwahl"
 FONT 8, "MS Sans Serif"
@@ -1750,6 +1767,7 @@ BEGIN
     PUSHBUTTON      "+",IDC_TABFORWARD_MOD,123,83,14,14
     PUSHBUTTON      "+",IDC_TABBACKWARD_MOD,123,102,14,14
     PUSHBUTTON      "+",IDC_SELECTTARGET_MOD,244,7,14,14
+    PUSHBUTTON      "Hilfe",IDC_MAINHELP,180,239,70,15
 END
 
 IDD_ASSIGNKEY DIALOG 0, 0, 110, 54
@@ -2056,6 +2074,10 @@ BEGIN
 	IDS_RESTORE_DEFAULTS			"Standardwerte wiederherstellen"
 	IDS_THEME_DEFAULT				"Standard"
 	IDS_THEME_DARK					"Dunkel"
+	IDS_TIP_DYNAMIC_LIGHTING		"Lässt Fackeln, Zauber und andere Lichtquellen ihre Umgebung erhellen. Ausschalten ist auf älterer Hardware etwas schneller."
+	IDS_TIP_SOFTWARE_RENDERER		"Zeichnet die Welt über den Prozessor statt über die Grafikkarte. Nur nötig, wenn der Hardware-Renderer auf diesem Rechner nicht startet, oder wenn Sie die Optik der 1990er möchten."
+	IDS_TIP_GPU_EFFICIENCY			"Tauscht Bildqualität gegen Strom und Wärme: begrenzt die Bildrate auf 60, senkt die Detailstufe der Hintergrundtexturen und wartet auf die Bildwiederholung des Monitors. Gut für Laptops."
+	IDS_TIP_ANTIALIASING			"Glättet die ausgefransten Kanten von Wänden und Objekten, indem mehrere Proben pro Pixel genommen werden. Kostet Grafikleistung und wird von Karten ohne Unterstützung ignoriert."
 END
 
 
@@ -2613,25 +2635,27 @@ BEGIN
     CONTROL         "",IDC_TARGETCURSOR,"SysTabControl32",0x0,6,6,464,373
 END
 
-IDD_OPTIONS DIALOGEX 0, 0, 124, 163
+IDD_OPTIONS DIALOGEX 0, 0, 257, 261
 STYLE DS_SETFONT | DS_MODALFRAME | WS_MINIMIZEBOX | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_APPWINDOW
 CAPTION "Options"
 FONT 8, "MS Sans Serif", 0, 0, 0x1
 BEGIN
-    GROUPBOX        "Options",IDC_STATIC,7,7,110,114
-    CONTROL         "Classic Key Bindings",IDC_CLASSIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,24,81,10
-    CONTROL         "Quick Chat",IDC_QUICKCHAT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,38,51,10
-    CONTROL         "Always Run",IDC_ALWAYSRUN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,52,53,10
-    CONTROL         "Dynamic Lighting",IDC_DYNAMIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,80,70,10
-    CONTROL         "Software Renderer",IDC_SOFTWARE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,94,75,10
-    CONTROL         "Attack On Target",IDC_ATTACKONTARGET,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,66,73,10
-    PUSHBUTTON      "Help",IDC_MAINHELP,87,140,30,15
-    PUSHBUTTON      "Restore Defaults",IDC_RESTOREDEFAULTS,47,122,70,15
-    CONTROL         "GPU Efficiency",IDC_GPU_EFFICIENCY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,107,75,10
+    GROUPBOX        "Options",IDC_STATIC,7,7,243,72
+    CONTROL         "Classic Key Bindings",IDC_CLASSIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,20,225,10
+    CONTROL         "Quick Chat",IDC_QUICKCHAT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,34,225,10
+    CONTROL         "Always Run",IDC_ALWAYSRUN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,48,225,10
+    CONTROL         "Attack On Target",IDC_ATTACKONTARGET,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,62,225,10
+    GROUPBOX        "Graphics",IDC_STATIC,7,86,243,72
+    CONTROL         "Software Renderer",IDC_SOFTWARE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,99,225,10
+    CONTROL         "Dynamic Lighting",IDC_DYNAMIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,113,225,10
+    CONTROL         "GPU Efficiency",IDC_GPU_EFFICIENCY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,127,225,10
+    CONTROL         "Multisample Anti-Aliasing (MSAA)",IDC_ANTIALIASING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,141,225,10
+    LTEXT           "Hover over a graphics setting for a description of what it does.",IDC_STATIC,7,164,243,10
+    PUSHBUTTON      "Restore Defaults",IDC_RESTOREDEFAULTS,180,239,70,15
 END
 
-IDD_MOVEMENT DIALOG 0, 0, 258, 138
+IDD_MOVEMENT DIALOG 0, 0, 258, 261
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Movement"
 FONT 8, "MS Sans Serif"
@@ -2673,6 +2697,7 @@ BEGIN
     PUSHBUTTON      "+",IDC_LOOKSTRAIGHT_MOD,229,64,14,14
     PUSHBUTTON      "+",IDC_FLIP_MOD,229,83,14,14
     PUSHBUTTON      "+",IDC_MOUSELOOKTOGGLE_MOD,229,102,14,14
+    PUSHBUTTON      "Help",IDC_MAINHELP,180,239,70,15
 END
 
 IDD_ASSIGNKEY DIALOG 0, 0, 110, 54
@@ -2712,7 +2737,7 @@ BEGIN
     CTEXT           "Choose a modifier key:",IDC_STATIC,7,7,50,20
 END
 
-IDD_COMMUNICATION DIALOG 0, 0, 258, 138
+IDD_COMMUNICATION DIALOG 0, 0, 258, 261
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Communication"
 FONT 8, "MS Sans Serif"
@@ -2738,9 +2763,10 @@ BEGIN
     PUSHBUTTON      "+",IDC_BROADCAST_MOD,102,83,14,14
     PUSHBUTTON      "+",IDC_WHO_MOD,102,102,14,14
     PUSHBUTTON      "+",IDC_EMOTE_MOD,229,7,14,14
+    PUSHBUTTON      "Help",IDC_MAINHELP,180,239,70,15
 END
 
-IDD_INTERACTION DIALOG 0, 0, 258, 138
+IDD_INTERACTION DIALOG 0, 0, 258, 261
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Interaction"
 FONT 8, "MS Sans Serif"
@@ -2772,9 +2798,10 @@ BEGIN
     PUSHBUTTON      "+",IDC_DEPOSIT_MOD,229,7,14,14
     PUSHBUTTON      "+",IDC_WITHDRAW_MOD,229,26,14,14
     PUSHBUTTON      "+",IDC_ATTACK_MOD,229,45,14,14
+    PUSHBUTTON      "Help",IDC_MAINHELP,180,239,70,15
 END
 
-IDD_TARGETING DIALOG 0, 0, 258, 138
+IDD_TARGETING DIALOG 0, 0, 258, 261
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Targeting"
 FONT 8, "MS Sans Serif"
@@ -2800,9 +2827,10 @@ BEGIN
     PUSHBUTTON      "+",IDC_TABFORWARD_MOD,118,83,14,14
     PUSHBUTTON      "+",IDC_TABBACKWARD_MOD,118,102,14,14
     PUSHBUTTON      "+",IDC_SELECTTARGET_MOD,229,7,14,14
+    PUSHBUTTON      "Help",IDC_MAINHELP,180,239,70,15
 END
 
-IDD_MAP DIALOG 0, 0, 258, 138
+IDD_MAP DIALOG 0, 0, 258, 261
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Map"
 FONT 8, "MS Sans Serif"
@@ -2821,6 +2849,7 @@ BEGIN
     CONTROL         "Annotations",IDC_MAP_ANNOTATIONS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,91,72,10
     LTEXT           "Text Zoom Limit",IDC_STATIC,13,109,50,10
     CONTROL         "",IDC_ANNOTATION_ZOOM_LIMIT,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,69,106,173,15
+    PUSHBUTTON      "Help",IDC_MAINHELP,180,239,70,15
 END
 
 /////////////////////////////////////////////////////////////////////////////
@@ -3341,6 +3370,10 @@ BEGIN
 	IDS_RESTORE_DEFAULTS			"Restore Defaults"
 	IDS_THEME_DEFAULT				"Default"
 	IDS_THEME_DARK					"Dark"
+	IDS_TIP_DYNAMIC_LIGHTING		"Lets torches, spells and other light sources light up the world around them.  Turning it off is slightly faster on old hardware."
+	IDS_TIP_SOFTWARE_RENDERER		"Draws the world on the processor instead of the graphics card.  Needed only if the hardware renderer will not start on your machine, or if you want the original 1990s look."
+	IDS_TIP_GPU_EFFICIENCY			"Trades image quality for power and heat:  caps the frame rate at 60, lowers background texture detail and waits for the monitor refresh.  Good for laptops."
+	IDS_TIP_ANTIALIASING			"Smooths the jagged edges of walls and objects by taking several samples per pixel.  Costs graphics card performance, and is ignored by cards that do not support it."
 END
 
 

--- a/clientd3d/config.c
+++ b/clientd3d/config.c
@@ -114,6 +114,7 @@ static char INITechnical[]    = "Technical";
 static char config_section[] = "config";  /* Section for configuration stuff */
 static char INIGpuEfficiency[] = "gpuefficiency";
 static char INIGpuEfficiencyOneTimeFlip[] = "gpuefficiencyonetimeflip";
+static char INIAntialiasing[] = "antialiasing";
 
 static char INITextAreaSize[] = "TextAreaSize";
 
@@ -317,6 +318,10 @@ void ConfigLoad(void)
    GetPrivateProfileString(config_section, INIGpuEfficiency, "true", config_value, 
 	   sizeof(config_value), config_ini);
    config.gpuEfficiency = (0 == strcmp(config_value, "true"));
+
+   GetPrivateProfileString(config_section, INIAntialiasing, "false", config_value,
+      sizeof(config_value), config_ini);
+   config.multisampleAntialiasing = (0 == strcmp(config_value, "true"));
 
    TimeSettingsLoad();
 }

--- a/clientd3d/config.h
+++ b/clientd3d/config.h
@@ -130,6 +130,11 @@ typedef struct {
    // and switches D3D present mode to D3DPRESENT_INTERVAL_DEFAULT 
    // for more stable, power-efficient rendering.
    bool gpuEfficiency;
+
+   // Ask the graphics card for multisample antialiasing, which smooths jagged edges
+   // at the cost of fill rate.  Cards that support no multisample level render
+   // without it.
+   bool multisampleAntialiasing;
    bool show_inventory_rarity;   /* Add inventory item rarity symbols? */
 } Config;
 

--- a/clientd3d/d3ddriver.c
+++ b/clientd3d/d3ddriver.c
@@ -111,27 +111,42 @@ bool D3DDriverProfileInit(void)
 	gPresentParam.MultiSampleType = D3DMULTISAMPLE_NONE;
 	gPresentParam.MultiSampleQuality = 0;
 
-	// Push the quality up even higher with multisampling
-	if (!config.gpuEfficiency)
+	// Probing costs a driver round trip per level, so only ask when the player wants it.
+	if (config.multisampleAntialiasing)
 	{
-		// Test for multisample support
-		HRESULT hr;
-		DWORD maxQualityLevels = 0;
+		// Both the render target and the depth stencil must support the level, or
+		// device creation fails and the client falls back to the software renderer.
+		static const D3DMULTISAMPLE_TYPE sampleTypesByPreference[] = {
+			D3DMULTISAMPLE_8_SAMPLES, D3DMULTISAMPLE_4_SAMPLES, D3DMULTISAMPLE_2_SAMPLES };
 
-		hr = IDirect3D9_CheckDeviceMultiSampleType(
-			gpD3D,
-			D3DADAPTER_DEFAULT,
-			D3DDEVTYPE_HAL,
-			gPresentParam.BackBufferFormat,
-			gPresentParam.Windowed,
-			D3DMULTISAMPLE_16_SAMPLES,
-			&maxQualityLevels);
+		for (auto sampleType : sampleTypesByPreference)
+		{
+			DWORD colorQualityLevels = 0;
+			HRESULT colorSupported = IDirect3D9_CheckDeviceMultiSampleType(gpD3D, D3DADAPTER_DEFAULT,
+				D3DDEVTYPE_HAL, gPresentParam.BackBufferFormat, gPresentParam.Windowed,
+				sampleType, &colorQualityLevels);
 
-		if (SUCCEEDED(hr)) {
-			gPresentParam.MultiSampleType = D3DMULTISAMPLE_16_SAMPLES;
-			gPresentParam.MultiSampleQuality = maxQualityLevels - 1;
+			DWORD depthQualityLevels = 0;
+			HRESULT depthSupported = IDirect3D9_CheckDeviceMultiSampleType(gpD3D, D3DADAPTER_DEFAULT,
+				D3DDEVTYPE_HAL, gPresentParam.AutoDepthStencilFormat, gPresentParam.Windowed,
+				sampleType, &depthQualityLevels);
+
+			fprintf(pFile, "Multisample %d samples:  color 0x%08lx, depth 0x%08lx\n",
+				static_cast<int>(sampleType), colorSupported, depthSupported);
+
+			// Quality level 0 is always valid for a supported type and is the cheapest.
+			if (SUCCEEDED(colorSupported) && SUCCEEDED(depthSupported))
+			{
+				gPresentParam.MultiSampleType = sampleType;
+				break;
+			}
 		}
 	}
+
+	// The multisample type is the sample count, so 0 means no antialiasing.
+	fprintf(pFile, "Requesting device:  %d x %d, %d multisample samples, quality level %lu\n",
+		gScreenWidth, gScreenHeight, static_cast<int>(gPresentParam.MultiSampleType),
+		gPresentParam.MultiSampleQuality);
 
 	// first try hardware vertex processing
 	error = IDirect3D9_CreateDevice(gpD3D, D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL,
@@ -177,7 +192,7 @@ bool D3DDriverProfileInit(void)
 	IDirect3D9_GetAdapterIdentifier(gpD3D, D3DADAPTER_DEFAULT, 0,
                                    &gD3DDriverProfile.adapterID);
 
-	fprintf(pFile, "Video Hardware Detected\nDriver:  %s\nDescription:  %s\nProduct:  %d\nVersion:  %d\nSubversion:  %d\nBuild:  %d\nGUID:  %x, %x, %x, %s\n",
+	fprintf(pFile, "Video Hardware Detected\nDriver:  %s\nDescription:  %s\nProduct:  %d\nVersion:  %d\nSubversion:  %d\nBuild:  %d\nGUID:  %08lx-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x\n",
 		gD3DDriverProfile.adapterID.Driver,
 		gD3DDriverProfile.adapterID.Description,
 		HIWORD(gD3DDriverProfile.adapterID.DriverVersion.HighPart),
@@ -187,7 +202,14 @@ bool D3DDriverProfileInit(void)
 		gD3DDriverProfile.adapterID.DeviceIdentifier.Data1,
 		gD3DDriverProfile.adapterID.DeviceIdentifier.Data2,
 		gD3DDriverProfile.adapterID.DeviceIdentifier.Data3,
-		gD3DDriverProfile.adapterID.DeviceIdentifier.Data4);
+		gD3DDriverProfile.adapterID.DeviceIdentifier.Data4[0],
+		gD3DDriverProfile.adapterID.DeviceIdentifier.Data4[1],
+		gD3DDriverProfile.adapterID.DeviceIdentifier.Data4[2],
+		gD3DDriverProfile.adapterID.DeviceIdentifier.Data4[3],
+		gD3DDriverProfile.adapterID.DeviceIdentifier.Data4[4],
+		gD3DDriverProfile.adapterID.DeviceIdentifier.Data4[5],
+		gD3DDriverProfile.adapterID.DeviceIdentifier.Data4[6],
+		gD3DDriverProfile.adapterID.DeviceIdentifier.Data4[7]);
 
 	if ((gD3DDriverProfile.d3dCaps.DevCaps & D3DDEVCAPS_HWTRANSFORMANDLIGHT) == 0)
 	{

--- a/clientd3d/preferences.c
+++ b/clientd3d/preferences.c
@@ -35,6 +35,7 @@ static bool m_quickchat;
 static bool m_software;
 static bool m_attackontarget;
 static bool m_gpuefficiency;
+static bool m_antialiasing;
 
 static char TCBroadcast[MAX_KEYVALUELEN];
 static char TCChat[MAX_KEYVALUELEN];
@@ -89,6 +90,7 @@ static const char* const DEF_DYNAMIC = "true";
 static const char* const DEF_SOFTWARE = "false";
 static const char* const DEF_ATTACKONTARGET = "false";
 static const char* const DEF_GPU_EFFICIENCY = "true";
+static const char* const DEF_ANTIALIASING = "false";
 
 // Communication
 static const char* const DEF_BROADCAST = "b";
@@ -177,6 +179,14 @@ static const std::vector<TabInfo> tabs = {
 };
 
 // Helpers
+static void ShowBindingHelp(HWND hDlg)
+{
+    // The help text is far longer than the strings GetString can return.
+    char bindingHelpText[2048];
+    LoadString(hInst, IDS_BINDING_HELP, bindingHelpText, sizeof(bindingHelpText));
+    MessageBox(hDlg, bindingHelpText, GetString(hInst, IDS_HELP_TITLE), MB_OK | MB_ICONINFORMATION);
+}
+
 static void BoolToString(bool bValue, char *TCValue)
 {
     const char* value = bValue ? "true" : "false";
@@ -237,6 +247,7 @@ static void UpdateINIFile()
     settingsChanged = WritePrivateProfileStringIfChanged(strSection, "softwarerenderer", m_software ? "true" : "false", strINIFile) || settingsChanged;
     settingsChanged = WritePrivateProfileStringIfChanged(strSection, "attackontarget", m_attackontarget ? "true" : "false", strINIFile) || settingsChanged;
     settingsChanged = WritePrivateProfileStringIfChanged(strSection, "gpuefficiency", m_gpuefficiency ? "true" : "false", strINIFile) || settingsChanged;
+    settingsChanged = WritePrivateProfileStringIfChanged(strSection, "antialiasing", m_antialiasing ? "true" : "false", strINIFile) || settingsChanged;
 
     BoolToString(bInvert, Value);
     settingsChanged = WritePrivateProfileStringIfChanged(strSection, "invertmouse", Value, strINIFile) || settingsChanged;
@@ -338,6 +349,9 @@ static void ReadINIFile()
 
     GetPrivateProfileString(strSection, "gpuefficiency", "false", ReturnedString, nSize, strINIFile);
     m_gpuefficiency = strcmp(ReturnedString, "true") == 0;
+
+    GetPrivateProfileString(strSection, "antialiasing", "false", ReturnedString, nSize, strINIFile);
+    m_antialiasing = strcmp(ReturnedString, "true") == 0;
 
     GetPrivateProfileString(strSection, "invertmouse", "false", ReturnedString, nSize, strINIFile);
     bInvert = strcmp(ReturnedString, "true") == 0;
@@ -565,6 +579,15 @@ static void ModifyKey(HWND hDlg, TCHAR* TCString, int nID)
 
 static void RestoreDefaults(HWND hDlg)
 {
+    m_classic = StringToBool(DEF_CLASSIC);
+    m_quickchat = StringToBool(DEF_QUICKCHAT);
+    m_alwaysrun = StringToBool(DEF_ALWAYSRUN);
+    m_attackontarget = StringToBool(DEF_ATTACKONTARGET);
+    m_dynamic = StringToBool(DEF_DYNAMIC);
+    m_software = StringToBool(DEF_SOFTWARE);
+    m_gpuefficiency = StringToBool(DEF_GPU_EFFICIENCY);
+    m_antialiasing = StringToBool(DEF_ANTIALIASING);
+
     bInvert = StringToBool(DEF_INVERT);
 
     iMouselookXscale = DEF_MOUSELOOKXSCALE;
@@ -621,6 +644,7 @@ static void RestoreDefaults(HWND hDlg)
     CheckDlgButton(hDlg, IDC_SOFTWARE, m_software);
     CheckDlgButton(hDlg, IDC_ATTACKONTARGET, m_attackontarget);
     CheckDlgButton(hDlg, IDC_GPU_EFFICIENCY, m_gpuefficiency);
+    CheckDlgButton(hDlg, IDC_ANTIALIASING, m_antialiasing);
 
     // Select the correct options on each preferences tab.
     HWND hParent = GetParent(hDlg);
@@ -725,6 +749,9 @@ static INT_PTR CALLBACK MapPreferencesDlgProc(HWND hDlg, UINT message, WPARAM wP
 
     case WM_COMMAND:
         switch (LOWORD(wParam)) {
+        case IDC_MAINHELP:
+            ShowBindingHelp(hDlg);
+            break;
         case IDC_MAP:
             AssignKey(hDlg, TCMap, IDC_MAP);
             break;
@@ -797,6 +824,9 @@ static INT_PTR CALLBACK TargetingPreferencesDlgProc(HWND hDlg, UINT message, WPA
 
     case WM_COMMAND:
         switch (LOWORD(wParam)) {
+        case IDC_MAINHELP:
+            ShowBindingHelp(hDlg);
+            break;
         case IDC_TABBACKWARD:
             AssignKey(hDlg, TCTabbackward, IDC_TABBACKWARD);
             break;
@@ -889,6 +919,9 @@ static INT_PTR CALLBACK InteractionPreferencesDlgProc(HWND hDlg, UINT message, W
 
     case WM_COMMAND:
         switch (LOWORD(wParam)) {
+        case IDC_MAINHELP:
+            ShowBindingHelp(hDlg);
+            break;
         case IDC_ATTACK:
             AssignKey(hDlg, TCAttack, IDC_ATTACK);
             break;
@@ -959,11 +992,67 @@ static INT_PTR CALLBACK InteractionPreferencesDlgProc(HWND hDlg, UINT message, W
     return (INT_PTR)FALSE;
 }
 
+// The graphics settings need more explanation than their labels can carry, so each
+// one gets a hover tooltip.  The text is held here because the tooltip control asks for
+// it by pointer every time it shows the tip.
+struct GraphicsTooltip {
+    int controlId;
+    int stringId;
+    std::string text;
+};
+
+static GraphicsTooltip graphicsTooltips[] = {
+    { IDC_DYNAMIC,         IDS_TIP_DYNAMIC_LIGHTING  },
+    { IDC_SOFTWARE,        IDS_TIP_SOFTWARE_RENDERER },
+    { IDC_GPU_EFFICIENCY,  IDS_TIP_GPU_EFFICIENCY    },
+    { IDC_ANTIALIASING,    IDS_TIP_ANTIALIASING      }
+};
+
+// The software renderer ignores these, so they are only offered while it is off.
+static const int hardwareRendererOptions[] = { IDC_DYNAMIC, IDC_GPU_EFFICIENCY, IDC_ANTIALIASING };
+
+static void EnableHardwareRendererOptions(HWND hDlg, bool bEnable)
+{
+    for (int controlId : hardwareRendererOptions)
+        EnableWindow(GetDlgItem(hDlg, controlId), bEnable);
+}
+
+// The preferences property sheet runs its own modal message loop, so it cannot use the
+// main window's tooltip control, which is fed from the game's message loop.  TTF_SUBCLASS
+// lets this control pick up the mouse messages itself.
+static void AddGraphicsTooltips(HWND hDlg)
+{
+    HWND hTooltips = CreateWindow(TOOLTIPS_CLASS, NULL, WS_POPUP | TTS_ALWAYSTIP | TTS_NOPREFIX,
+        CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+        hDlg, NULL, hInst, NULL);
+
+    // Tooltips are single line until given a maximum width, in pixels.
+    static const int TOOLTIP_WIDTH = 320;
+    SendMessage(hTooltips, TTM_SETMAXTIPWIDTH, 0, TOOLTIP_WIDTH);
+
+    for (auto &tooltip : graphicsTooltips)
+    {
+        tooltip.text = GetString(hInst, tooltip.stringId);
+
+        TOOLINFO toolInfo = { 0 };
+        toolInfo.cbSize = sizeof(toolInfo);
+        toolInfo.uFlags = TTF_IDISHWND | TTF_SUBCLASS;
+        toolInfo.hwnd = hDlg;
+        toolInfo.uId = reinterpret_cast<UINT_PTR>(GetDlgItem(hDlg, tooltip.controlId));
+        // A tooltip control copies only the first 80 characters of the text handed to
+        // TTM_ADDTOOL, so these tips are supplied on demand instead.
+        toolInfo.lpszText = LPSTR_TEXTCALLBACK;
+        SendMessage(hTooltips, TTM_ADDTOOL, 0, reinterpret_cast<LPARAM>(&toolInfo));
+    }
+}
+
 static INT_PTR CALLBACK OptionsPreferencesDlgProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 {
     switch (message)
     {
     case WM_INITDIALOG:
+        AddGraphicsTooltips(hDlg);
+        // Fall through to pick up the current settings.
     case WM_USER_REINITDIALOG:
         // Initialize dialog with current settings
         CheckDlgButton(hDlg, IDC_ALWAYSRUN, m_alwaysrun);
@@ -973,6 +1062,8 @@ static INT_PTR CALLBACK OptionsPreferencesDlgProc(HWND hDlg, UINT message, WPARA
         CheckDlgButton(hDlg, IDC_SOFTWARE, m_software);
         CheckDlgButton(hDlg, IDC_ATTACKONTARGET, m_attackontarget);
         CheckDlgButton(hDlg, IDC_GPU_EFFICIENCY, m_gpuefficiency);
+        CheckDlgButton(hDlg, IDC_ANTIALIASING, m_antialiasing);
+        EnableHardwareRendererOptions(hDlg, !m_software);
         return (INT_PTR)TRUE;
     case WM_COMMAND:
         switch (LOWORD(wParam))
@@ -987,17 +1078,10 @@ static INT_PTR CALLBACK OptionsPreferencesDlgProc(HWND hDlg, UINT message, WPARA
 
         case IDC_SOFTWARE:
             m_software = IsDlgButtonChecked(hDlg, IDC_SOFTWARE);
+            EnableHardwareRendererOptions(hDlg, !m_software);
             if (!m_software)
             {
                 MessageBox(hDlg, GetString(hInst, IDS_SOFTWARERENDERER_WARN), GetString(hInst, IDS_WARNING_TITLE), MB_OK | MB_ICONEXCLAMATION);
-            }
-            break;
-
-        case IDC_MAINHELP:
-            {
-	            char bindingHelpText[2048];
-	            LoadString (hInst, IDS_BINDING_HELP, bindingHelpText, 2048);
-                MessageBox(hDlg, bindingHelpText, GetString(hInst, IDS_HELP_TITLE), MB_OK | MB_ICONINFORMATION);
             }
             break;
 
@@ -1013,17 +1097,36 @@ static INT_PTR CALLBACK OptionsPreferencesDlgProc(HWND hDlg, UINT message, WPARA
         case IDC_QUICKCHAT:
         case IDC_ATTACKONTARGET:
         case IDC_GPU_EFFICIENCY:
+        case IDC_ANTIALIASING:
             // Update the settings based on the checkbox state
             m_alwaysrun = IsDlgButtonChecked(hDlg, IDC_ALWAYSRUN);
             m_dynamic = IsDlgButtonChecked(hDlg, IDC_DYNAMIC);
             m_quickchat = IsDlgButtonChecked(hDlg, IDC_QUICKCHAT);
             m_attackontarget = IsDlgButtonChecked(hDlg, IDC_ATTACKONTARGET);
             m_gpuefficiency = IsDlgButtonChecked(hDlg, IDC_GPU_EFFICIENCY);
+            m_antialiasing = IsDlgButtonChecked(hDlg, IDC_ANTIALIASING);
             break;
         }
         break;
 
     case WM_NOTIFY:
+        if (reinterpret_cast<LPNMHDR>(lParam)->code == TTN_GETDISPINFO)
+        {
+            NMTTDISPINFO *tooltipInfo = reinterpret_cast<NMTTDISPINFO *>(lParam);
+
+            // The tools were added with TTF_IDISHWND, so idFrom is the control window.
+            int controlId = GetDlgCtrlID(reinterpret_cast<HWND>(tooltipInfo->hdr.idFrom));
+
+            for (auto &tooltip : graphicsTooltips)
+            {
+                if (tooltip.controlId == controlId)
+                {
+                    tooltipInfo->lpszText = tooltip.text.data();
+                    break;
+                }
+            }
+            return (INT_PTR)TRUE;
+        }
         if (((LPNMHDR)lParam)->code == PSN_APPLY)
         {
             // Save settings
@@ -1034,6 +1137,7 @@ static INT_PTR CALLBACK OptionsPreferencesDlgProc(HWND hDlg, UINT message, WPARA
             m_software = IsDlgButtonChecked(hDlg, IDC_SOFTWARE);
             m_attackontarget = IsDlgButtonChecked(hDlg, IDC_ATTACKONTARGET);
             m_gpuefficiency = IsDlgButtonChecked(hDlg, IDC_GPU_EFFICIENCY);
+            m_antialiasing = IsDlgButtonChecked(hDlg, IDC_ANTIALIASING);
 
             UpdateINIFile();
             SetWindowLongPtr(hDlg, DWLP_MSGRESULT, PSNRET_NOERROR);
@@ -1439,6 +1543,9 @@ static INT_PTR CALLBACK CommunicationPreferencesDlgProc(HWND hDlg, UINT message,
 
     case WM_COMMAND:
         switch (LOWORD(wParam)) {
+        case IDC_MAINHELP:
+            ShowBindingHelp(hDlg);
+            break;
         case IDC_BROADCAST:
             AssignKey(hDlg, TCBroadcast, IDC_BROADCAST);
             break;
@@ -1530,12 +1637,16 @@ static void InitializeMovementKeyBindings(HWND hDlg) {
 // Dialog procedure for the Movement Preferences dialog
 static INT_PTR CALLBACK MovementPreferencesDlgProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam) {
     switch (message) {
+    case WM_USER_REINITDIALOG:
     case WM_INITDIALOG:
         InitializeMovementKeyBindings(hDlg);
         return (INT_PTR)TRUE;
 
     case WM_COMMAND:
         switch (LOWORD(wParam)) {
+        case IDC_MAINHELP:
+            ShowBindingHelp(hDlg);
+            break;
         case IDC_FORWARD:
             AssignKey(hDlg, TCForward, IDC_FORWARD);
             break;

--- a/clientd3d/resource.h
+++ b/clientd3d/resource.h
@@ -645,6 +645,11 @@
 #define IDC_ANNOTATION_ZOOM_LIMIT       3653
 #define IDS_THEME_DEFAULT               3654
 #define IDS_THEME_DARK                  3655
+#define IDC_ANTIALIASING                3656
+#define IDS_TIP_DYNAMIC_LIGHTING        3657
+#define IDS_TIP_SOFTWARE_RENDERER       3658
+#define IDS_TIP_GPU_EFFICIENCY          3659
+#define IDS_TIP_ANTIALIASING            3660
 
 // Next default values for new objects
 // 


### PR DESCRIPTION
Multisample antialiasing has never run, for any player. `D3DDriverProfileInit` asked `CheckDeviceMultiSampleType` for `D3DMULTISAMPLE_16_SAMPLES` and nothing else. That is not a level consumer Direct3D 9 hardware offers, so the check failed, `MultiSampleType` stayed `D3DMULTISAMPLE_NONE`, and the device was created without antialiasing. Nothing logged the decision, so it failed silently. Measured on an RTX 4070 Ti: 2x, 4x and 8x all return `S_OK`, 16x returns `D3DERR_NOTAVAILABLE`.

Two more faults in the same block:

 - Only the back buffer format was checked. Direct3D 9 requires the multisample type to be supported for the depth stencil format as well, and `D3DFMT_D24S8` was never tested. All three `CreateDevice` attempts share one `gPresentParam`, so an unsupported combination does not degrade quietly, it fails every attempt and drops the player into the software renderer.
 - `MultiSampleQuality` was set to `maxQualityLevels - 1` on a `DWORD` initialised to 0, so a driver reporting success with no quality levels yields 0xFFFFFFFF, an invalid level, which lands in the failure above.

This walks 8x, 4x, 2x and takes the first level the adapter reports for both formats, leaving quality at 0, which is always valid for a supported type and is the cheapest. Each result and the type the device was actually created with now reach `d3dlog.txt`.

Multisampling becomes a setting rather than something welded to GPU efficiency mode, and it defaults to off, so nobody pays for it who has not asked, and the ladder is only probed when it is on. GPU efficiency mode no longer suppresses it: once a player has asked for antialiasing, silently overriding them only makes the checkbox look broken.

## Options tab

The tab was a single narrow column of unrelated checkboxes. It now spans the page, with the gameplay options at the top and a Graphics section below holding software renderer, dynamic lighting, GPU efficiency and multisampling, each with hover text explaining what it does. The hardware only settings grey out while the software renderer is ticked. That grouping is a fact about the code rather than a UI choice: `config.bDynamicLighting` is read only by the Direct3D renderer, so the software renderer ignores all three.

Two dialog bugs found while working in there: Restore Defaults reset the key bindings but never the option checkboxes, and the Move tab did not refresh after it ran. The binding help has moved off Options onto the five tabs that ctually bind keys. One unrelated one line fix rides along in `d3ddriver.c`: the adapter GUID log line passed `DeviceIdentifier.Data4`, a `BYTE[8]`, to `%s`.

<img width="844" height="784" alt="image" src="https://github.com/user-attachments/assets/e59912fa-3642-4712-86ef-147afe050dad" />
<img width="910" height="815" alt="image" src="https://github.com/user-attachments/assets/48790af4-2014-4f73-b7c7-4d80bb6ac593" />


## Room data follow up

Multisampling did not introduce the seams described below, it removed what was hiding them.

A sidedef without "No horiz tile" is drawn with `D3DTADDRESS_WRAP`. Where a texture genuinely tiles that is correct. Where it is a one off image, bilinear filtering at the wall's edge blends the last texel with the texture's opposite edge, an unrelated colour, and the join between two such walls shows as a thin discoloured line. Without multisampling a pixel is only shaded when its centre lies inside the triangle, so the coordinate stays inside the wall's own range and the error is confined to a half texel band at the extreme edge. With multisampling a pixel is shaded whenever any of its samples is covered, and the coordinate is extrapolated past the polygon edge, so the wrong colour appears at full strength. It also comes and goes with view angle, which is why it reads as a rendering glitch rather than as room data.

This is the same defect fixed in `cave2.roo` by #1429, and it turns up in the same places that needed attention when the world alpha test threshold went in with https://github.com/Meridian59/Meridian59/pull/778: the north and south Barloque gates, and the cave basement cobwebs. Those follow as their own PRs, in the same shape as the room fixes that followed #1489. Multisampling defaulting to off is what lets the engine fix land ahead of them ahead of them.

 ## Testing

Ladder, logging and the new setting exercised against the local client; the options tab verified in the running client for layout, tooltips, the greying behaviour, and Restore Defaults restoring the checkboxes. With multisampling off, which is the default, existing players see no rendering change from this PR.
