### PR TITLE
fix: stop guild shield mining stage from auto-scheduling

### DIFF
--- a/kod/util/questengine.kod
+++ b/kod/util/questengine.kod
@@ -1688,7 +1688,7 @@ Recreate()
 			      [ 18, 19 ],\
 			      30,\
 			      [],\
-			      100,\
+			      0,\
 			      [ [ Q_R2_QN_ASSIGNABLE, FALSE ], [ Q_R2_IS_GUILD_MEMBER_OF, $ ] ]
 			                                    ], plQuestTemplates );
    % QST_ID_GUILDSHIELD_INTRO


### PR DESCRIPTION
This PR sets the guild shield mining stage (template 12) schedule chance to 0 so that stage is only created when the guildmaster intro unlocks it. That stage starts unassignable and was never meant to spawn on its own, _as far as I can tell_. Chance 100 meant every 5-minute quest engine tick added another instance. Those sit and wait for players, and never time out, filling the cap so the intro cannot hand off. Thus, the bartender line fails and cancels with no speech.

### Production cleanup

Note: Do not run `Reset()` or `DeleteActiveQuests()` as they cancel every quest type.

The max active is currently 50, we can set it back to its default as it was probably set to 50 to combat this problem. Set the success percentage to 0 as well.
```
send o <QuestEngine> SetQuestMaxActive index int 12 new_max int 30
send o <QuestEngine> SetQuestScheduleChance index int 12 new_pct int 0
```

Dump all of the existing quest instances:
```
send o <QuestEngine> GetQuestTemplate index int 12
show list <id>
```

Then for each instance id:
```
send object <id> Cancel
```