### PR TITLE
Pace frames from the frame deadline instead of the last wakeup

### DIFF
--- a/clientd3d/graphics.c
+++ b/clientd3d/graphics.c
@@ -48,10 +48,15 @@ static const int fps_window_size = 60;  // Number of fps values to consider in t
 static int average_fps = 0;
 typedef std::chrono::time_point<std::chrono::steady_clock> steady_clock_time_point;
 static steady_clock_time_point lastEndFrame;
+// Time at which the next frame is due, advanced by one frame period per
+// frame so that rounding and oversleep do not accumulate into drift.
+static steady_clock_time_point nextFrameTarget;
 // The clock to use for fps calculations - updating here will update throughout.
 static auto& chrono_time_now = std::chrono::steady_clock::now;
 
 static const int defaultMaxFps = 60;
+static const long long microsecondsPerSecond = 1000000;
+static const long long microsecondsPerMillisecond = 1000;
 
 /************************************************************************/
 /*
@@ -335,29 +340,41 @@ void RedrawForce(void)
    DrawRoom(hdc, view.x, view.y, &current_room, map);
 
    steady_clock_time_point endFrame = chrono_time_now();
-   std::chrono::duration<double> elapsedTime = endFrame - startFrame;
-   auto elapsedMicroseconds = std::chrono::duration_cast<std::chrono::microseconds>(elapsedTime).count();
-   auto elapsedMilliseconds = elapsedMicroseconds / 1000;
-   msDrawFrame = elapsedMilliseconds;
+   long long drawMicroseconds =
+      std::chrono::duration_cast<std::chrono::microseconds>(endFrame - startFrame).count();
+   msDrawFrame = static_cast<int>(drawMicroseconds / microsecondsPerMillisecond);
 
-   auto maxFPS = config.gpuEfficiency ? defaultMaxFps : config.maxFPS;
-   fps = 1000 / std::max(1LL, elapsedMilliseconds);
-
-   if (maxFPS)
+   int maxFPS = config.gpuEfficiency ? defaultMaxFps : config.maxFPS;
+   if (maxFPS > 0)
    {
-      if (fps > maxFPS)
-      {
-          // Clamp the fps to the maximum.
-          int msSleep = (1000 / maxFPS) - elapsedMilliseconds;
-          Sleep(msSleep);
+      std::chrono::microseconds framePeriod(microsecondsPerSecond / maxFPS);
 
-          // Reclaulate the fps following the sleep.
-          endFrame = chrono_time_now();
-          elapsedTime = (endFrame - lastEndFrame);
-          elapsedMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(elapsedTime).count();
-          fps = 1000 / std::max(1LL, elapsedMilliseconds);
-      }
+      // Sleep until the time this frame was due, rather than for a fixed amount
+      // measured from now, so that a frame that runs long is paid for by the
+      // next one instead of pushing every later frame back by the same amount.
+      nextFrameTarget += framePeriod;
+      steady_clock_time_point now = chrono_time_now();
+      if (nextFrameTarget < now - framePeriod)
+         nextFrameTarget = now;  // More than a frame behind, so stop trying to catch up.
+
+      long long sleepMicroseconds =
+         std::chrono::duration_cast<std::chrono::microseconds>(nextFrameTarget - now).count();
+
+      // Round the wait down, because Sleep only expresses whole milliseconds and
+      // rounding up would overshoot the deadline every frame. The remainder is
+      // smaller than the message loop's own overhead, and the next target
+      // absorbs whatever is left.
+      if (sleepMicroseconds >= microsecondsPerMillisecond)
+         Sleep(static_cast<DWORD>(sleepMicroseconds / microsecondsPerMillisecond));
+
+      endFrame = chrono_time_now();
    }
+
+   long long frameMicroseconds =
+      std::chrono::duration_cast<std::chrono::microseconds>(endFrame - lastEndFrame).count();
+   fps = frameMicroseconds > 0
+      ? static_cast<int>((microsecondsPerSecond + frameMicroseconds / 2) / frameMicroseconds)
+      : 0;
 
    lastEndFrame = endFrame;
 
@@ -377,9 +394,9 @@ void RedrawForce(void)
 
         // Format and display the latest average fps value.
         RECT rc,lagBox;
-        double milliseconds = static_cast<double>(elapsedMicroseconds) / 1000.0;
+        double drawMilliseconds = static_cast<double>(drawMicroseconds) / microsecondsPerMillisecond;
         char buffer[32];
-        snprintf(buffer, sizeof(buffer), "FPS=%d (%.1fms)        ", average_fps, milliseconds);
+        snprintf(buffer, sizeof(buffer), "FPS=%d (%.1fms)        ", average_fps, drawMilliseconds);
         ZeroMemory(&rc,sizeof(rc));
 
         rc.bottom = DrawText(hdc, buffer,-1,&rc,DT_SINGLELINE|DT_CALCRECT);


### PR DESCRIPTION
In game the frame rate never settles. At the default 60 cap the readout flips between 58 and 62 and sags under load, on a machine with capacity to spare. It is not a machine that cannot hold a rate, it is a limiter that never asks for one: it does its timing in whole milliseconds, so it requests a rate it cannot deliver and reports one it cannot express.

`1000 / maxFPS` is integer division: 16 ms at the 60 cap and 8 ms at the 120 cap, so the limiter is really asking for 62.5 and 125 frames per second. It then sleeps for that period minus only the time `DrawRoom` took, so everything else in the frame is added on top of a period meant to cover the whole frame, and nothing anywhere represents when a frame was due - an overrun is simply lost time. The reported rate is `1000 / elapsedMilliseconds`, which near a 60 cap can only produce 62 or 58.

This tracks the deadline for the next frame in microseconds and sleeps until it, so the period is exact, unmeasured work inside a frame shortens the following wait instead of extending the period, and an overrun is paid back by the next frame. If the deadline falls more than a full period behind, after a stall or a room load, it resynchronises rather than rendering a burst of catch-up frames. The frame rate is computed from microseconds.