### PR TITLE
fix: safety not turning on after switching characters

### DIFF
--- a/module/merintr/mermain.c
+++ b/module/merintr/mermain.c
@@ -32,6 +32,19 @@ static bool safety_flipped;
 
 /****************************************************************************/
 /*
+ * SendConfiguredSafety:  Send the configured safety state to the server and
+ *   record it in pinfo.aggressive.
+ */
+static void SendConfiguredSafety(void)
+{
+   pinfo.aggressive = cinfo->config->aggressive;
+   if (pinfo.aggressive)
+      SendSafety(0);
+   else
+      SendSafety(1);
+}
+/****************************************************************************/
+/*
  * InterfaceInit:  Called on startup.  Initialize interface.
  */
 void InterfaceInit(void)
@@ -71,10 +84,7 @@ void InterfaceInit(void)
       RequestRest();
    else
       RequestStand();
-   if (cinfo->config->aggressive)
-      SendSafety(0);
-   else
-      SendSafety(1);
+   SendConfiguredSafety();
 }
 /****************************************************************************/
 /*
@@ -175,10 +185,7 @@ void InterfaceResetData(void)
       RequestRest();
    else
       RequestStand();
-   if (cinfo->config->aggressive)
-      SendSafety(0);
-   else
-      SendSafety(1);
+   SendConfiguredSafety();
 
    RequestSpells();
    RequestSkills();
@@ -416,7 +423,7 @@ void InterfaceUserChanged(void)
       if (cinfo->config->aggressive)
       {
          if (!safety_flipped)
-            SendSafety(0);
+            SendConfiguredSafety();
          safety_flipped = true;
       }
       else 
@@ -430,7 +437,7 @@ void InterfaceUserChanged(void)
       if (!cinfo->config->aggressive)
       {
          if (!safety_flipped)
-            SendSafety(1);
+            SendConfiguredSafety();
          safety_flipped = true;
       }
       else 


### PR DESCRIPTION
## What

- Record the safety value in `pinfo.aggressive` every time the client sends one to the server, so the two stay synchronized 

## Why

- Multiple reports of players switching characters under the impression that their safety is set one way, when it is actually the reverse, leading them to become orange (and sometimes red) by accident.
- The client keeps two copies of the safety, and they do not live the same length of time
  - `config.aggressive` is the saved preference, and it survives a quit to the character select screen
  - `pinfo.aggressive` is the client's note of what it last told the server, and `ModulesClose` wipes it on logoff
  - so the second character starts with the two already disagreeing
- Three of the places that send the safety never wrote down what they sent
  - `InterfaceInit` and both mismatch branches of `InterfaceUserChanged` called `SendSafety` and left the note alone
  - `InterfaceConfigChanged` sends only when the setting differs from that note, so a stale note makes a real change look like no change
- You hear nothing when it happens
  - the server plays the sound when it receives a safety change, so silence means the client sent nothing

## How

- Added `SendConfiguredSafety`, which sends the setting and writes it down in one place
- Replaced the three sends that did not
  - the two that already did, in `InterfaceConfigChanged` and the `safetyon` and `safetyoff` commands, are untouched
- No server change

## The values involved

Only one of these is the actual safety.  Two of the others are named against it.

| Value | Where | What it holds | Set means |
|---|---|---|---|
| `PFLAG_SAFETY` | Server, per character | The real safety, and the only value that decides whether an attack lands | This character cannot attack innocents |
| `config.aggressive` | Client, saved to the INI | The Preferences box, shared by every character on the installation | Safety off.  The box reads "Can attack innocent players", so it is inverted against the game term |
| `pinfo.aggressive` | Client, memory only | The last value the client sent.  Its only reader is the check for whether a Preferences edit is a real change | The server was last told safety off |
| `safety_flipped` | Client, memory only | Not a safety state.  A note that a correction has already been sent, so the client does not resend in a loop | Do not send another correction |

Only `UC_SAFETY` crosses the wire.  Everything else is the client talking to itself.

## Example

Both characters on the account start with the safety on.  The client stays open throughout, and step 2 is a quit to character select rather than a log off.

1. Log on to the first character and turn the safety off
2. Quit to the character select screen
3. Log on to the second character
4. Turn the safety on, which means clearing the "Can attack innocent players" box

Only `UC_SAFETY` crosses the wire.  Everything else is the client talking to itself.

### Before

<img  src="https://github.com/user-attachments/assets/1eacbdf3-de72-4322-944b-3c22dbed9980" />

Step 4 does nothing.  No message, no sound, and the server still has the safety off.

```mermaid
sequenceDiagram
    autonumber
    actor P as Player
    participant C as Client
    participant S as Server

    Note over C: config = safety on<br/>note = safety on
    P->>C: log on to character A
    P->>C: tick the box, safety off
    C->>S: UC_SAFETY, safety off
    S->>P: "your safety is now off" and the sound
    Note over C: config = safety off<br/>note = safety off

    P->>C: quit to the character select screen
    Note over C: ModulesClose wipes the note back to safety on<br/>config is saved elsewhere and survives

    P->>C: log on to character B
    Note over C: config = safety off<br/>note = safety on, they now disagree
    C->>S: UC_SAFETY, safety off
    S->>P: "your safety is now off" and the sound
    C->>S: UC_SAFETY, safety off, the client correcting the mismatch it sees
    S->>P: "your safety is now off" and the sound
    Note over C: neither send updated the note

    P->>C: untick the box, safety on
    Note over C: config = safety on<br/>note = safety on<br/>they match, so the client sends nothing
    Note over S: safety is still off
    S->>P: a reflection attacks an innocent, you turn murderer
```

### After

<img  src="https://github.com/user-attachments/assets/456d12df-b5ed-488e-99e0-4b548240c682" />

Each send updates the note, so step 4 finds a real change and sends it.

```mermaid
sequenceDiagram
    autonumber
    actor P as Player
    participant C as Client
    participant S as Server

    Note over C: config = safety on<br/>note = safety on
    P->>C: log on to character A
    P->>C: tick the box, safety off
    C->>S: UC_SAFETY, safety off
    Note over C: the send updates the note to safety off
    S->>P: "your safety is now off" and the sound

    P->>C: quit to the character select screen
    Note over C: ModulesClose wipes the note back to safety on<br/>config is saved elsewhere and survives

    P->>C: log on to character B
    Note over C: config = safety off<br/>note = safety on, they now disagree
    C->>S: UC_SAFETY, safety off
    S->>P: "your safety is now off" and the sound
    C->>S: UC_SAFETY, safety off, the client correcting the mismatch it sees
    S->>P: "your safety is now off" and the sound
    Note over C: both sends updated the note to safety off

    P->>C: untick the box, safety on
    Note over C: config = safety on<br/>note = safety off<br/>they differ, so send
    C->>S: UC_SAFETY, safety on
    S->>P: "your safety is now on" and the sound
    Note over S: safety is on, the reflection cannot attack
```